### PR TITLE
Deprecate DropdownButtonFormField "value" parameter in favor of "initialValue"

### DIFF
--- a/examples/api/lib/widgets/autocomplete/raw_autocomplete.2.dart
+++ b/examples/api/lib/widgets/autocomplete/raw_autocomplete.2.dart
@@ -44,7 +44,7 @@ class AutocompleteFormExampleState extends State<AutocompleteFormExample> {
       child: Column(
         children: <Widget>[
           DropdownButtonFormField<String>(
-            value: _dropdownValue,
+            initialValue: _dropdownValue,
             icon: const Icon(Icons.arrow_downward),
             hint: const Text('This is a regular DropdownButtonFormField'),
             elevation: 16,

--- a/packages/flutter/lib/fix_data/fix_material/fix_dropdown_button.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_dropdown_button.yaml
@@ -1,0 +1,33 @@
+# Copyright 2014 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# For details regarding the *Flutter Fix* feature, see
+# https://flutter.dev/to/flutter-fix
+
+# Please add new fixes to the top of the file, separated by one blank line
+# from other fixes. In a comment, include a link to the PR where the change
+# requiring the fix was made.
+
+# Every fix must be tested. See the flutter/packages/flutter/test_fixes/README.md
+# file for instructions on testing these data driven fixes.
+
+# For documentation about this file format, see
+# https://dart.dev/go/data-driven-fixes.
+
+# * Fixes in this file are for DropdownButton and DropdownButtonFormField from the Material library. *
+version: 1
+transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/170805.
+  - title: "Migrate to 'initialValue'"
+    date: 2025-06-18
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'DropdownButtonFormField'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'value'
+        newName: 'initialValue'
+
+# Before adding a new fix: read instructions at the top of this file.

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1748,7 +1748,13 @@ class DropdownButtonFormField<T> extends FormField<T> {
     super.key,
     required List<DropdownMenuItem<T>>? items,
     DropdownButtonBuilder? selectedItemBuilder,
+    @Deprecated(
+      'Use initialValue instead. '
+      'This will set the initial value for the form field. '
+      'This feature was deprecated after v3.33.0-1.0.pre.',
+    )
     T? value,
+    T? initialValue,
     Widget? hint,
     Widget? disabledHint,
     required this.onChanged,
@@ -1783,17 +1789,20 @@ class DropdownButtonFormField<T> extends FormField<T> {
   }) : assert(
          items == null ||
              items.isEmpty ||
-             value == null ||
-             items.where((DropdownMenuItem<T> item) => item.value == value).length == 1,
+             (initialValue == null && value == null) ||
+             items
+                     .where((DropdownMenuItem<T> item) => item.value == (initialValue ?? value))
+                     .length ==
+                 1,
          "There should be exactly one item with [DropdownButton]'s value: "
-         '$value. \n'
+         '${initialValue ?? value}. \n'
          'Either zero or 2 or more [DropdownMenuItem]s were detected '
          'with the same value',
        ),
        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
        decoration = decoration ?? const InputDecoration(),
        super(
-         initialValue: value,
+         initialValue: initialValue ?? value,
          autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
          builder: (FormFieldState<T> field) {
            final _DropdownButtonFormFieldState<T> state = field as _DropdownButtonFormFieldState<T>;

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -44,7 +44,7 @@ Widget buildFormFrame({
             key: buttonKey,
             autovalidateMode: autovalidateMode,
             elevation: elevation,
-            value: value,
+            initialValue: value,
             hint: hint,
             disabledHint: disabledHint,
             onChanged: onChanged,
@@ -145,7 +145,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             hint: const Text('Hint'),
             onChanged: (int? newValue) {
               value = newValue;
@@ -185,7 +185,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             onChanged: null, // this disables the menu and shows the disabledHint.
             disabledHint: const Text('disabledHint'),
             items: const <DropdownMenuItem<int?>>[
@@ -214,7 +214,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             disabledHint: const Text('disabledHint'),
             onChanged: (_) {},
             items: null,
@@ -239,7 +239,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             disabledHint: const Text('disabledHint'),
             onChanged: (_) {},
             items: const <DropdownMenuItem<int?>>[],
@@ -262,7 +262,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             hint: const Text('hint'),
             onChanged: (_) {},
             items: const <DropdownMenuItem<int?>>[],
@@ -287,7 +287,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             disabledHint: const Text('disabledHint'),
             onChanged: (_) {},
             items: const <DropdownMenuItem<int?>>[
@@ -316,7 +316,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             hint: const Text('hint'),
             onChanged: null, // disabled
             disabledHint: const Text('disabledHint'),
@@ -345,7 +345,7 @@ void main() {
         child: Material(
           child: DropdownButtonFormField<int?>(
             decoration: const InputDecoration(labelText: 'labelText'),
-            value: value,
+            initialValue: value,
             onChanged: (int? newValue) {
               value = newValue;
             },
@@ -385,7 +385,7 @@ void main() {
           return MaterialApp(
             home: Material(
               child: DropdownButtonFormField<String>(
-                value: value,
+                initialValue: value,
                 hint: const Text('Select Value'),
                 decoration: const InputDecoration(prefixIcon: Icon(Icons.fastfood)),
                 items:
@@ -517,7 +517,7 @@ void main() {
                 child: Center(
                   child: DropdownButtonFormField<String>(
                     key: buttonKey,
-                    value: value,
+                    initialValue: value,
                     onChanged: onChanged,
                     items: dropdownItems,
                   ),
@@ -560,7 +560,7 @@ void main() {
                   child: Center(
                     child: DropdownButtonFormField<String>(
                       key: buttonKey,
-                      value: value,
+                      initialValue: value,
                       onChanged: onChanged,
                       style: const TextStyle(fontSize: fontSize, height: fontHeight),
                       items:
@@ -598,7 +598,7 @@ void main() {
           child: Center(
             child: DropdownButtonFormField<String>(
               key: buttonKey,
-              value: value,
+              initialValue: value,
               onChanged: onChanged,
               items:
                   menuItems.map<DropdownMenuItem<String>>((String item) {
@@ -627,7 +627,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Material(
           child: DropdownButtonFormField<String>(
-            value: value,
+            initialValue: value,
             items: <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(key: itemKey, value: 'foo', child: const Text(value)),
             ],
@@ -883,7 +883,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: DropdownButtonFormField<String>(
-              value: 'c',
+              initialValue: 'c',
               onChanged: (String? newValue) {},
               items: itemsWithDuplicateValues,
             ),
@@ -942,7 +942,7 @@ void main() {
           return MaterialApp(
             home: Scaffold(
               body: DropdownButtonFormField<String>(
-                value: selectedItem,
+                initialValue: selectedItem,
                 onChanged: (String? string) => setState(() => selectedItem = string),
                 selectedItemBuilder: (BuildContext context) {
                   int index = 0;
@@ -1015,7 +1015,7 @@ void main() {
     expect(dropdownButtonTapCounter, 2); // Should not change.
   });
 
-  testWidgets('DropdownButtonFormField should re-render if value param changes', (
+  testWidgets('DropdownButtonFormField should re-render if initialValue parameter changes', (
     WidgetTester tester,
   ) async {
     String currentValue = 'two';
@@ -1026,7 +1026,7 @@ void main() {
           return MaterialApp(
             home: Material(
               child: DropdownButtonFormField<String>(
-                value: currentValue,
+                initialValue: currentValue,
                 onChanged: onChanged,
                 items:
                     menuItems.map((String value) {
@@ -1127,7 +1127,7 @@ void main() {
             key: formKey,
             child: DropdownButtonFormField<String>(
               key: stateKey,
-              value: 'One',
+              initialValue: 'One',
               items:
                   <String>['One', 'Two', 'Free', 'Four'].map<DropdownMenuItem<String>>((
                     String value,
@@ -1175,7 +1175,7 @@ void main() {
             key: formKey,
             child: DropdownButtonFormField<String>(
               key: stateKey,
-              value: 'One',
+              initialValue: 'One',
               items:
                   <String>['One', 'Two', 'Free', 'Four'].map<DropdownMenuItem<String>>((
                     String value,
@@ -1265,7 +1265,7 @@ void main() {
             alignedDropdown: alignedDropdown,
             child: Material(
               child: DropdownButtonFormField<String>(
-                value: menuItems.first,
+                initialValue: menuItems.first,
                 items:
                     menuItems.map((String value) {
                       return DropdownMenuItem<String>(value: value, child: Text(value));
@@ -1388,7 +1388,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: DropdownButtonFormField<String>(
-            value: 'first',
+            initialValue: 'first',
             items: const <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(enabled: false, child: Text('disabled')),
               DropdownMenuItem<String>(value: 'first', child: Text('first')),
@@ -1419,7 +1419,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: DropdownButtonFormField<String>(
-            value: 'first',
+            initialValue: 'first',
             barrierDismissible: false,
             items: const <DropdownMenuItem<String>>[
               DropdownMenuItem<String>(enabled: false, child: Text('disabled')),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -42,7 +42,7 @@ Finder _iconRichText(Key iconKey) {
 Widget buildDropdown({
   required bool isFormField,
   Key? buttonKey,
-  String? value = 'two',
+  String? initialValue = 'two',
   ValueChanged<String?>? onChanged,
   VoidCallback? onTap,
   Widget? icon,
@@ -82,7 +82,7 @@ Widget buildDropdown({
     return Form(
       child: DropdownButtonFormField<String>(
         key: buttonKey,
-        value: value,
+        initialValue: initialValue,
         hint: hint,
         disabledHint: disabledHint,
         onChanged: onChanged,
@@ -110,7 +110,7 @@ Widget buildDropdown({
   }
   return DropdownButton<String>(
     key: buttonKey,
-    value: value,
+    value: initialValue,
     hint: hint,
     disabledHint: disabledHint,
     onChanged: onChanged,
@@ -138,7 +138,7 @@ Widget buildDropdown({
 
 Widget buildFrame({
   Key? buttonKey,
-  String? value = 'two',
+  String? initialValue = 'two',
   ValueChanged<String?>? onChanged,
   VoidCallback? onTap,
   Widget? icon,
@@ -180,7 +180,7 @@ Widget buildFrame({
             child: buildDropdown(
               isFormField: isFormField,
               buttonKey: buttonKey,
-              value: value,
+              initialValue: initialValue,
               hint: hint,
               disabledHint: disabledHint,
               onChanged: onChanged,
@@ -318,7 +318,7 @@ Future<void> checkDropdownColor(
                 ? Form(
                   child: DropdownButtonFormField<String>(
                     dropdownColor: color,
-                    value: text,
+                    initialValue: text,
                     items: const <DropdownMenuItem<String>>[
                       DropdownMenuItem<String>(value: text, child: Text(text)),
                     ],
@@ -386,7 +386,7 @@ void main() {
       value = newValue;
     }
 
-    Widget build() => buildFrame(value: value, onChanged: didChangeValue);
+    Widget build() => buildFrame(initialValue: value, onChanged: didChangeValue);
 
     await tester.pumpWidget(build());
 
@@ -436,7 +436,9 @@ void main() {
               return MaterialPageRoute<void>(
                 settings: settings,
                 builder: (BuildContext context) {
-                  return Material(child: buildFrame(value: 'one', onChanged: didChangeValue));
+                  return Material(
+                    child: buildFrame(initialValue: 'one', onChanged: didChangeValue),
+                  );
                 },
               );
             },
@@ -547,7 +549,7 @@ void main() {
                 key: formKey,
                 child: DropdownButtonFormField<String>(
                   key: buttonKey,
-                  value: value,
+                  initialValue: value,
                   hint: const Text('Select Value'),
                   decoration: const InputDecoration(prefixIcon: Icon(Icons.fastfood)),
                   items:
@@ -588,54 +590,55 @@ void main() {
     expect(value, equals('three'));
   });
 
-  testWidgets('Dropdown form field only uses value parameter when first built and when reset', (
-    WidgetTester tester,
-  ) async {
-    final GlobalKey<FormFieldState<String>> fieldKey = GlobalKey<FormFieldState<String>>();
-    await tester.pumpWidget(
-      StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          return MaterialApp(
-            home: Material(
-              child: DropdownButtonFormField<String>(
-                key: fieldKey,
-                value: 'one',
-                hint: const Text('Select Value'),
-                items:
-                    menuItems.map((String val) {
-                      return DropdownMenuItem<String>(value: val, child: Text(val));
-                    }).toList(),
-                onChanged: (String? newValue) {
-                  setState(() {
-                    // Do nothing, just to trigger a rebuild.
-                  });
-                },
+  testWidgets(
+    'Dropdown form field only uses initialValue parameter when first built and when reset',
+    (WidgetTester tester) async {
+      final GlobalKey<FormFieldState<String>> fieldKey = GlobalKey<FormFieldState<String>>();
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return MaterialApp(
+              home: Material(
+                child: DropdownButtonFormField<String>(
+                  key: fieldKey,
+                  initialValue: 'one',
+                  hint: const Text('Select Value'),
+                  items:
+                      menuItems.map((String val) {
+                        return DropdownMenuItem<String>(value: val, child: Text(val));
+                      }).toList(),
+                  onChanged: (String? newValue) {
+                    setState(() {
+                      // Do nothing, just to trigger a rebuild.
+                    });
+                  },
+                ),
               ),
-            ),
-          );
-        },
-      ),
-    );
-    expect(fieldKey.currentState!.value, 'one');
+            );
+          },
+        ),
+      );
+      expect(fieldKey.currentState!.value, 'one');
 
-    // Open the dropdown menu.
-    await tester.tap(find.text('one'));
-    await tester.pumpAndSettle();
+      // Open the dropdown menu.
+      await tester.tap(find.text('one'));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('three').last);
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('three').last);
+      await tester.pumpAndSettle();
 
-    // The value should update to selected, not the initial value.
-    expect(find.text('three'), findsOneWidget);
-    expect(fieldKey.currentState!.value, 'three');
+      // The value should update to selected, not the initial value.
+      expect(find.text('three'), findsOneWidget);
+      expect(fieldKey.currentState!.value, 'three');
 
-    fieldKey.currentState!.reset();
-    await tester.pump();
+      fieldKey.currentState!.reset();
+      await tester.pump();
 
-    // Reset to the initial value.
-    expect(find.text('one'), findsOneWidget);
-    expect(fieldKey.currentState!.value, 'one');
-  });
+      // Reset to the initial value.
+      expect(find.text('one'), findsOneWidget);
+      expect(fieldKey.currentState!.value, 'one');
+    },
+  );
 
   testWidgets('Dropdown in ListView', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/12053
@@ -1027,7 +1030,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         buttonKey: buttonKey,
-        value: null, // nothing selected
+        initialValue: null, // nothing selected
         items: List<String>.generate(/*length=*/ 100, (int index) => index.toString()),
         onChanged: onChanged,
       ),
@@ -1060,7 +1063,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         buttonKey: buttonKey,
-        value: '50',
+        initialValue: '50',
         items: List<String>.generate(/*length=*/ 100, (int index) => index.toString()),
         onChanged: onChanged,
       ),
@@ -1089,7 +1092,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         buttonKey: buttonKey,
-        value: '99',
+        initialValue: '99',
         items: List<String>.generate(/*length=*/ 100, (int index) => index.toString()),
         onChanged: onChanged,
       ),
@@ -1125,7 +1128,7 @@ void main() {
     final Key buttonKey = UniqueKey();
     String? value;
 
-    Widget build() => buildFrame(buttonKey: buttonKey, value: value, onChanged: onChanged);
+    Widget build() => buildFrame(buttonKey: buttonKey, initialValue: value, onChanged: onChanged);
 
     await tester.pumpWidget(build());
     final RenderBox buttonBoxNullValue = tester.renderObject<RenderBox>(find.byKey(buttonKey));
@@ -1183,7 +1186,7 @@ void main() {
       value = newValue;
     }
 
-    Widget build() => buildFrame(buttonKey: buttonKey, value: value, onChanged: onChanged);
+    Widget build() => buildFrame(buttonKey: buttonKey, initialValue: value, onChanged: onChanged);
 
     await tester.pumpWidget(build());
     final RenderBox buttonBox = tester.renderObject<RenderBox>(find.byKey(buttonKey));
@@ -1209,7 +1212,7 @@ void main() {
 
     // The hint will define the dropdown's width
     Widget build() =>
-        buildFrame(buttonKey: buttonKey, value: value, hint: const Text('onetwothree'));
+        buildFrame(buttonKey: buttonKey, initialValue: value, hint: const Text('onetwothree'));
 
     await tester.pumpWidget(build());
     expect(find.text('onetwothree'), findsOneWidget);
@@ -1259,7 +1262,11 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(dropdownAlignment: Alignment.topLeft, value: menuItems.last, onChanged: onChanged),
+      buildFrame(
+        dropdownAlignment: Alignment.topLeft,
+        initialValue: menuItems.last,
+        onChanged: onChanged,
+      ),
     );
     expect(menuRect.topLeft, Offset.zero);
     expect(menuRect.topRight, Offset(menuRect.width, 0.0));
@@ -1267,7 +1274,7 @@ void main() {
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.topCenter,
-        value: menuItems.last,
+        initialValue: menuItems.last,
         onChanged: onChanged,
       ),
     );
@@ -1277,7 +1284,7 @@ void main() {
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.topRight,
-        value: menuItems.last,
+        initialValue: menuItems.last,
         onChanged: onChanged,
       ),
     );
@@ -1291,21 +1298,21 @@ void main() {
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.centerLeft,
-        value: menuItems.first,
+        initialValue: menuItems.first,
         onChanged: onChanged,
       ),
     );
     expect(menuRect.topLeft, Offset(0.0, buttonRect.top));
     expect(menuRect.topRight, Offset(menuRect.width, buttonRect.top));
 
-    await popUpAndDown(buildFrame(value: menuItems.first, onChanged: onChanged));
+    await popUpAndDown(buildFrame(initialValue: menuItems.first, onChanged: onChanged));
     expect(menuRect.topLeft, buttonRect.topLeft);
     expect(menuRect.topRight, buttonRect.topRight);
 
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.centerRight,
-        value: menuItems.first,
+        initialValue: menuItems.first,
         onChanged: onChanged,
       ),
     );
@@ -1319,7 +1326,7 @@ void main() {
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.bottomLeft,
-        value: menuItems.first,
+        initialValue: menuItems.first,
         onChanged: onChanged,
       ),
     );
@@ -1329,7 +1336,7 @@ void main() {
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.bottomCenter,
-        value: menuItems.first,
+        initialValue: menuItems.first,
         onChanged: onChanged,
       ),
     );
@@ -1339,7 +1346,7 @@ void main() {
     await popUpAndDown(
       buildFrame(
         dropdownAlignment: Alignment.bottomRight,
-        value: menuItems.first,
+        initialValue: menuItems.first,
         onChanged: onChanged,
       ),
     );
@@ -1388,7 +1395,12 @@ void main() {
     final SemanticsHandle handle = tester.ensureSemantics();
     const Key key = Key('test');
     await tester.pumpWidget(
-      buildFrame(buttonKey: key, value: null, onChanged: (String? _) {}, hint: const Text('test')),
+      buildFrame(
+        buttonKey: key,
+        initialValue: null,
+        onChanged: (String? _) {},
+        hint: const Text('test'),
+      ),
     );
 
     // By default the hint contributes the label.
@@ -1405,7 +1417,12 @@ void main() {
     );
 
     await tester.pumpWidget(
-      buildFrame(buttonKey: key, value: 'three', onChanged: onChanged, hint: const Text('test')),
+      buildFrame(
+        buttonKey: key,
+        initialValue: 'three',
+        onChanged: onChanged,
+        hint: const Text('test'),
+      ),
     );
 
     // Displays label of select item.
@@ -1426,7 +1443,7 @@ void main() {
   testWidgets('Dropdown menu includes semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
     const Key key = Key('test');
-    await tester.pumpWidget(buildFrame(buttonKey: key, value: null, onChanged: onChanged));
+    await tester.pumpWidget(buildFrame(buttonKey: key, initialValue: null, onChanged: onChanged));
     await tester.tap(find.byKey(key));
     await tester.pumpAndSettle();
 
@@ -1532,7 +1549,7 @@ void main() {
       items: items,
       onChanged: onChanged,
       buttonKey: buttonKey,
-      value: null,
+      initialValue: null,
       hint: const Text('enabled'),
       disabledHint: const Text('disabled'),
     );
@@ -1577,7 +1594,7 @@ void main() {
     }) => buildFrame(
       items: items,
       onChanged: onChanged,
-      value: value,
+      initialValue: value,
       hint: hint,
       disabledHint: disabledHint,
     );
@@ -1643,7 +1660,7 @@ void main() {
                     DropdownMenuItem<String>(value: 'one', child: Text('one')),
                     DropdownMenuItem<String>(value: 'two', child: Text('two')),
                   ],
-                  value: value,
+                  initialValue: value,
                   onChanged: onChanged,
                 ),
               ],
@@ -1681,7 +1698,7 @@ void main() {
       return buildFrame(
         items: items,
         buttonKey: buttonKey,
-        value: null,
+        initialValue: null,
         hint: const Text('hint used when disabled'),
       );
     }
@@ -1702,7 +1719,7 @@ void main() {
       return buildFrame(
         items: items,
         buttonKey: buttonKey,
-        value: null,
+        initialValue: null,
         hint: const Text('hint used when disabled'),
       );
     }
@@ -1727,7 +1744,7 @@ void main() {
           // To test the size constraints, the selected item should not be the
           // largest item. This validates that the button sizes itself according
           // to the largest item regardless of which one is selected.
-          value: selectedItem,
+          initialValue: selectedItem,
           items: items,
           itemHeight: null,
           selectedItemBuilder: (BuildContext context) {
@@ -1761,7 +1778,7 @@ void main() {
 
       await tester.pumpWidget(
         buildFrame(
-          value: null,
+          initialValue: null,
           // [hint] widget is smaller than largest selected item widget
           hint: const SizedBox(height: 50, width: 50, child: Text('hint')),
           items: items,
@@ -1801,7 +1818,7 @@ void main() {
           // To test the size constraints, the selected item should not be the
           // largest item. This validates that the button sizes itself according
           // to the largest item regardless of which one is selected.
-          value: selectedItem,
+          initialValue: selectedItem,
           // [hint] widget is larger than largest selected item widget
           hint: const SizedBox(height: 125, width: 125, child: Text('hint')),
           items: items,
@@ -1837,7 +1854,7 @@ void main() {
 
       await tester.pumpWidget(
         buildFrame(
-          value: null,
+          initialValue: null,
           // [hint] widget is smaller than largest selected item widget
           hint: const SizedBox(height: 50, width: 50, child: Text('hint')),
           items: items,
@@ -1872,7 +1889,7 @@ void main() {
 
       await tester.pumpWidget(
         buildFrame(
-          value: null,
+          initialValue: null,
           // [hint] widget is larger than largest selected item widget
           hint: const SizedBox(height: 125, width: 125, child: Text('hint')),
           items: items,
@@ -1907,7 +1924,7 @@ void main() {
 
       await tester.pumpWidget(
         buildFrame(
-          value: null,
+          initialValue: null,
           // [hint] widget is smaller than largest selected item widget
           disabledHint: const SizedBox(height: 50, width: 50, child: Text('hint')),
           items: items,
@@ -1942,7 +1959,7 @@ void main() {
 
       await tester.pumpWidget(
         buildFrame(
-          value: null,
+          initialValue: null,
           // [hint] widget is larger than largest selected item widget
           disabledHint: const SizedBox(height: 125, width: 125, child: Text('hint')),
           items: items,
@@ -1976,7 +1993,7 @@ void main() {
 
     await tester.pumpWidget(
       buildFrame(
-        value: selectedItem,
+        initialValue: selectedItem,
         items: items,
         menuWidth: 200,
         selectedItemBuilder: (BuildContext context) {
@@ -3232,7 +3249,7 @@ void main() {
       dropdownButtonTapCounter += 1;
     }
 
-    Widget build() => buildFrame(value: value, onChanged: onChanged, onTap: onTap);
+    Widget build() => buildFrame(initialValue: value, onChanged: onChanged, onTap: onTap);
     await tester.pumpWidget(build());
 
     expect(dropdownButtonTapCounter, 0);
@@ -3421,7 +3438,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       buildFrame(
-        value: '0',
+        initialValue: '0',
         // menu is short enough to fit onto the screen.
         items: List<String>.generate(/*length=*/ 10, (int index) => index.toString()),
         onChanged: onChanged,
@@ -3441,7 +3458,7 @@ void main() {
     await tester.pumpAndSettle();
     await tester.pumpWidget(
       buildFrame(
-        value: '0',
+        initialValue: '0',
         // menu is too long to fit onto the screen.
         items: List<String>.generate(/*length=*/ 100, (int index) => index.toString()),
         onChanged: onChanged,
@@ -3461,7 +3478,7 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         buildFrame(
-          value: '0',
+          initialValue: '0',
           items: List<String>.generate(/*length=*/ 64, (int index) => index.toString()),
           onChanged: onChanged,
         ),
@@ -3483,7 +3500,7 @@ void main() {
       // Set menuMaxHeight which is less than defaultMenuHeight
       await tester.pumpWidget(
         buildFrame(
-          value: '0',
+          initialValue: '0',
           items: List<String>.generate(/*length=*/ 64, (int index) => index.toString()),
           onChanged: onChanged,
           menuMaxHeight: 7 * kMinInteractiveDimension,
@@ -3503,7 +3520,7 @@ void main() {
       // Set menuMaxHeight which is greater than defaultMenuHeight
       await tester.pumpWidget(
         buildFrame(
-          value: '0',
+          initialValue: '0',
           items: List<String>.generate(/*length=*/ 64, (int index) => index.toString()),
           onChanged: onChanged,
           menuMaxHeight: mediaHeight,
@@ -3524,7 +3541,7 @@ void main() {
     await tester.pumpWidget(
       buildFrame(
         buttonKey: buttonKey,
-        value: '6',
+        initialValue: '6',
         items: List<String>.generate(/*length=*/ 64, (int index) => index.toString()),
         onChanged: onChanged,
         menuMaxHeight: 2 * kMinInteractiveDimension,
@@ -3900,7 +3917,7 @@ void main() {
       await tester.pumpWidget(
         buildFrame(
           buttonKey: buttonKey,
-          value: null, // nothing selected
+          initialValue: null, // nothing selected
           items: List<String>.generate(100, (int index) => index.toString()),
           onChanged: onChanged,
         ),
@@ -4036,7 +4053,7 @@ void main() {
           body: Center(
             child: DropdownButtonFormField<String>(
               borderRadius: BorderRadius.circular(radius),
-              value: 'One',
+              initialValue: 'One',
               items:
                   <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((
                     String value,
@@ -4393,7 +4410,7 @@ void main() {
           body: Center(
             child: DropdownButtonFormField<String>(
               borderRadius: BorderRadius.circular(radius),
-              value: 'One',
+              initialValue: 'One',
               items:
                   <String>['One', 'Two', 'Three', 'Four'].map<DropdownMenuItem<String>>((
                     String value,
@@ -4560,5 +4577,33 @@ void main() {
       expect(decoration.color, selectedColor);
     },
     variant: TargetPlatformVariant.mobile(),
+  );
+
+  testWidgets(
+    'DropdownButtonFormField deprecated "value" parameter can still be used to set the initial value',
+    (WidgetTester tester) async {
+      final GlobalKey<FormFieldState<String>> fieldKey = GlobalKey<FormFieldState<String>>();
+      await tester.pumpWidget(
+        StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return MaterialApp(
+              home: Material(
+                child: DropdownButtonFormField<String>(
+                  key: fieldKey,
+                  value: 'one',
+                  hint: const Text('Select Value'),
+                  items:
+                      menuItems.map((String val) {
+                        return DropdownMenuItem<String>(value: val, child: Text(val));
+                      }).toList(),
+                  onChanged: (_) {},
+                ),
+              ),
+            );
+          },
+        ),
+      );
+      expect(fieldKey.currentState!.value, 'one');
+    },
   );
 }

--- a/packages/flutter/test_fixes/material/dropdown_button.dart
+++ b/packages/flutter/test_fixes/material/dropdown_button.dart
@@ -1,0 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/170805.
+  DropdownButtonFormField(value: 'one');
+}

--- a/packages/flutter/test_fixes/material/dropdown_button.dart.expect
+++ b/packages/flutter/test_fixes/material/dropdown_button.dart.expect
@@ -1,0 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+void main() {
+  // Changes made in https://github.com/flutter/flutter/pull/170805.
+  DropdownButtonFormField(initialValue: 'one');
+}


### PR DESCRIPTION
## Description

This PR renames the DropdownButtonFormField constuctor parameter 'value' to 'initialValue'.
See https://github.com/flutter/flutter/pull/170050#issuecomment-2965486000 and https://github.com/flutter/flutter/pull/170050#issuecomment-2971920009 for some context.

## Related Issue

Fixes [DropdownButtonFormField retains selected value even after setting value to null](https://github.com/flutter/flutter/issues/169983#top)

## Tests

Adds 2 tests (one to validate the deprecated parameter can still be used, one for the dart fix).
Updates many (renaming the confusing parameter).