### PR TITLE
Enable interpretation fallback when unable to JIT on iOS.

### DIFF
--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -530,6 +530,14 @@ def to_gn_args(args):
     gn_args['ios_use_simulator'] = gn_args['use_ios_simulator']
     gn_args.update(setup_apple_sdks())
 
+  # Make the Dart VM include a simulator, even though it is generating arm64
+  # code on an arm64 device, so that it can fall back to interpreting the arm64
+  # code if the device does not support JITing.
+  if runtime_mode == 'debug' and gn_args[
+      'target_os'] == 'ios' and not gn_args['use_ios_simulator'] and gn_args[
+          'target_cpu'] == 'arm64' and gn_args['dart_target_arch'] == 'arm64':
+    gn_args['dart_force_simulator'] = True
+
   if args.dart_debug:
     gn_args['dart_debug'] = True
 


### PR DESCRIPTION
Bug: https://github.com/flutter/flutter/issues/163984