### PR TITLE
Clear background in the GTK layer, instead of OpenGL

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -615,12 +615,10 @@ FlCompositorOpenGL* fl_compositor_opengl_new(FlEngine* engine) {
 void fl_compositor_opengl_render(FlCompositorOpenGL* self,
                                  FlutterViewId view_id,
                                  int width,
-                                 int height,
-                                 const GdkRGBA* background_color) {
+                                 int height) {
   g_return_if_fail(FL_IS_COMPOSITOR_OPENGL(self));
 
-  glClearColor(background_color->red, background_color->green,
-               background_color->blue, background_color->alpha);
+  glClearColor(0.0, 0.0, 0.0, 0.0);
   glClear(GL_COLOR_BUFFER_BIT);
 
   GPtrArray* framebuffers = reinterpret_cast<GPtrArray*>((g_hash_table_lookup(

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.h
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.h
@@ -41,15 +41,13 @@ FlCompositorOpenGL* fl_compositor_opengl_new(FlEngine* engine);
  * @view_id: view to render.
  * @width: width of the window in pixels.
  * @height: height of the window in pixels.
- * @background_color: color to use for background.
  *
  * Performs OpenGL commands to render current Flutter view.
  */
 void fl_compositor_opengl_render(FlCompositorOpenGL* compositor,
                                  FlutterViewId view_id,
                                  int width,
-                                 int height,
-                                 const GdkRGBA* background_color);
+                                 int height);
 
 /**
  * fl_compositor_opengl_cleanup:

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -487,6 +487,24 @@ static void secondary_realize_cb(FlView* self) {
   setup_cursor(self);
 }
 
+static void paint_background(FlView* self, cairo_t* cr) {
+  // Don't both drawing if fully transparent - the widget above this will
+  // already be drawn by GTK.
+  if (self->background_color->red == 0 && self->background_color->green == 0 &&
+      self->background_color->blue == 0 && self->background_color->alpha == 0) {
+    return;
+  }
+
+  gdk_cairo_set_source_rgba(cr, self->background_color);
+  cairo_paint(cr);
+}
+
+static gboolean opengl_draw_cb(FlView* self, cairo_t* cr) {
+  paint_background(self, cr);
+
+  return FALSE;
+}
+
 static gboolean render_cb(FlView* self, GdkGLContext* context) {
   if (gtk_gl_area_get_error(GTK_GL_AREA(self->render_area)) != NULL) {
     return FALSE;
@@ -497,13 +515,14 @@ static gboolean render_cb(FlView* self, GdkGLContext* context) {
   gint scale_factor = gtk_widget_get_scale_factor(self->render_area);
   fl_compositor_opengl_render(
       FL_COMPOSITOR_OPENGL(fl_engine_get_compositor(self->engine)),
-      self->view_id, width * scale_factor, height * scale_factor,
-      self->background_color);
+      self->view_id, width * scale_factor, height * scale_factor);
 
   return TRUE;
 }
 
-static gboolean draw_cb(FlView* self, cairo_t* cr) {
+static gboolean software_draw_cb(FlView* self, cairo_t* cr) {
+  paint_background(self, cr);
+
   return fl_compositor_software_render(
       FL_COMPOSITOR_SOFTWARE(fl_engine_get_compositor(self->engine)),
       self->view_id, cr, gtk_widget_get_scale_factor(GTK_WIDGET(self)));
@@ -677,6 +696,8 @@ static void setup_engine(FlView* self) {
     case kOpenGL:
       self->render_area = gtk_gl_area_new();
       gtk_gl_area_set_has_alpha(GTK_GL_AREA(self->render_area), TRUE);
+      g_signal_connect_swapped(self->render_area, "draw",
+                               G_CALLBACK(opengl_draw_cb), self);
       g_signal_connect_swapped(self->render_area, "render",
                                G_CALLBACK(render_cb), self);
       g_signal_connect_swapped(self->render_area, "create-context",
@@ -686,8 +707,8 @@ static void setup_engine(FlView* self) {
       break;
     case kSoftware:
       self->render_area = gtk_drawing_area_new();
-      g_signal_connect_swapped(self->render_area, "draw", G_CALLBACK(draw_cb),
-                               self);
+      g_signal_connect_swapped(self->render_area, "draw",
+                               G_CALLBACK(software_draw_cb), self);
       break;
     default:
       self->render_area = gtk_label_new("Unsupported Flutter renderer type");

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -488,7 +488,7 @@ static void secondary_realize_cb(FlView* self) {
 }
 
 static void paint_background(FlView* self, cairo_t* cr) {
-  // Don't both drawing if fully transparent - the widget above this will
+  // Don't bother drawing if fully transparent - the widget above this will
   // already be drawn by GTK.
   if (self->background_color->red == 0 && self->background_color->green == 0 &&
       self->background_color->blue == 0 && self->background_color->alpha == 0) {


### PR DESCRIPTION
Since OpenGL was being blitted, it would overwrite the color set with clear color anyway. Also fix the software rendering case that was not setting any background.

This could cause a black screen to show by default, if you want the previous behaviour set the view background to transparent with:
```
GdkRGBA background_color;
gdk_rgba_parse(&background_color, "#00000000");
fl_view_set_background_color(view, &background_color);
```
