### PR TITLE
Set the background in the Linux template

### DIFF
--- a/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
+++ b/packages/flutter_tools/templates/app/linux.tmpl/runner/my_application.cc.tmpl
@@ -54,6 +54,10 @@ static void my_application_activate(GApplication* application) {
   fl_dart_project_set_dart_entrypoint_arguments(project, self->dart_entrypoint_arguments);
 
   FlView* view = fl_view_new(project);
+  GdkRGBA background_color;
+  // Background defaults to black, override it here if necessary, e.g. #00000000 for transparent.
+  gdk_rgba_parse(&background_color, "#000000");
+  fl_view_set_background_color(view, &background_color);
   gtk_widget_show(GTK_WIDGET(view));
   gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(view));
 


### PR DESCRIPTION
Defaults to the same black as before, but this makes it easier for this to be overridden if necessary.

