### PR TITLE
Feat: Add foreground color for cupertino button

### DIFF
--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -479,13 +479,13 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
                         : kCupertinoButtonTintedOpacityDark
                   : widget.color?.opacity ?? 1.0,
             );
-    final Color effectiveForegroundColor = widget.foregroundColor != null
-        ? widget.foregroundColor!
-        : widget._style == _CupertinoButtonStyle.filled
-        ? themeData.primaryContrastingColor
-        : enabled
-        ? primaryColor
-        : CupertinoDynamicColor.resolve(CupertinoColors.tertiaryLabel, context);
+    final Color effectiveForegroundColor =
+        widget.foregroundColor ??
+        switch ((widget._style, enabled)) {
+          (_CupertinoButtonStyle.filled, _) => themeData.primaryContrastingColor,
+          (_, true) => primaryColor,
+          (_, false) => CupertinoDynamicColor.resolve(CupertinoColors.tertiaryLabel, context),
+        };
 
     final Color effectiveFocusOutlineColor =
         widget.focusColor ??

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -192,7 +192,7 @@ class CupertinoButton extends StatefulWidget {
   /// specified.
   final Color disabledColor;
 
-  /// The color of the button's foreground.
+  /// The color of the button's text and icons.
   ///
   /// Defaults to the [CupertinoTheme]'s `primaryColor` when the
   /// [CupertinoButton.filled] constructor is used.

--- a/packages/flutter/lib/src/cupertino/button.dart
+++ b/packages/flutter/lib/src/cupertino/button.dart
@@ -76,6 +76,7 @@ class CupertinoButton extends StatefulWidget {
     this.sizeStyle = CupertinoButtonSize.large,
     this.padding,
     this.color,
+    this.foregroundColor,
     this.disabledColor = CupertinoColors.quaternarySystemFill,
     @Deprecated(
       'Use minimumSize instead. '
@@ -112,6 +113,7 @@ class CupertinoButton extends StatefulWidget {
     this.sizeStyle = CupertinoButtonSize.large,
     this.padding,
     this.color,
+    this.foregroundColor,
     this.disabledColor = CupertinoColors.tertiarySystemFill,
     @Deprecated(
       'Use minimumSize instead. '
@@ -143,6 +145,7 @@ class CupertinoButton extends StatefulWidget {
     this.padding,
     this.color,
     this.disabledColor = CupertinoColors.tertiarySystemFill,
+    this.foregroundColor,
     @Deprecated(
       'Use minimumSize instead. '
       'This feature was deprecated after v3.28.0-3.0.pre.',
@@ -188,6 +191,12 @@ class CupertinoButton extends StatefulWidget {
   /// Defaults to [CupertinoColors.quaternarySystemFill] when [color] is
   /// specified.
   final Color disabledColor;
+
+  /// The color of the button's foreground.
+  ///
+  /// Defaults to the [CupertinoTheme]'s `primaryColor` when the
+  /// [CupertinoButton.filled] constructor is used.
+  final Color? foregroundColor;
 
   /// The callback that is called when the button is tapped or otherwise activated.
   ///
@@ -470,7 +479,9 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
                         : kCupertinoButtonTintedOpacityDark
                   : widget.color?.opacity ?? 1.0,
             );
-    final Color foregroundColor = widget._style == _CupertinoButtonStyle.filled
+    final Color effectiveForegroundColor = widget.foregroundColor != null
+        ? widget.foregroundColor!
+        : widget._style == _CupertinoButtonStyle.filled
         ? themeData.primaryContrastingColor
         : enabled
         ? primaryColor
@@ -491,9 +502,9 @@ class _CupertinoButtonState extends State<CupertinoButton> with SingleTickerProv
         (widget.sizeStyle == CupertinoButtonSize.small
                 ? themeData.textTheme.actionSmallTextStyle
                 : themeData.textTheme.actionTextStyle)
-            .copyWith(color: foregroundColor);
+            .copyWith(color: effectiveForegroundColor);
     final IconThemeData iconTheme = IconTheme.of(context).copyWith(
-      color: foregroundColor,
+      color: effectiveForegroundColor,
       size: textStyle.fontSize != null
           ? textStyle.fontSize! * 1.2
           : kCupertinoButtonDefaultIconSize,

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1021,7 +1021,7 @@ void main() {
     await gesture.removePointer();
   });
 
-  testWidgets('CupertinoButton respects foregroundColor', (WidgetTester tester) async {
+  testWidgets('CupertinoButton foregroundColor applies to its text', (WidgetTester tester) async {
     const Color customForegroundColor = Color(0xFF5500FF);
 
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1020,6 +1020,136 @@ void main() {
     await gesture.up();
     await gesture.removePointer();
   });
+
+  testWidgets('CupertinoButton respects foregroundColor', (WidgetTester tester) async {
+    const Color customForegroundColor = Color(0xFF5500FF);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: CupertinoButton(
+          onPressed: () {},
+          foregroundColor: customForegroundColor,
+          child: const Text('Button'),
+        ),
+      ),
+    );
+
+    // Check that the text has the custom foreground color
+    final RichText text = tester.widget(
+      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(RichText)),
+    );
+    expect(text.text.style?.color, customForegroundColor);
+  });
+
+  testWidgets('CupertinoButton foregroundColor applies to Icon', (WidgetTester tester) async {
+    const Color customForegroundColor = Color(0xFF5500FF);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: CupertinoButton(
+          onPressed: () {},
+          foregroundColor: customForegroundColor,
+          child: const Icon(IconData(0xE000)),
+        ),
+      ),
+    );
+
+    // Check that the icon has the custom foreground color
+    final IconTheme iconTheme = tester.widget(
+      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(IconTheme)),
+    );
+    expect(iconTheme.data.color, customForegroundColor);
+  });
+
+  testWidgets('CupertinoButton foregroundColor applies to both Text and Icon', (
+    WidgetTester tester,
+  ) async {
+    const Color customForegroundColor = Color(0xFF5500FF);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: CupertinoButton(
+          onPressed: () {},
+          foregroundColor: customForegroundColor,
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [Icon(IconData(0xE000)), SizedBox(width: 8), Text('Button')],
+          ),
+        ),
+      ),
+    );
+
+    // Check that the icon has the custom foreground color
+    final IconTheme iconTheme = tester.widget(
+      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(IconTheme)),
+    );
+    expect(iconTheme.data.color, customForegroundColor);
+
+    // Check that the text has the custom foreground color
+    final RichText text = tester.widget(
+      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(RichText)),
+    );
+    expect(text.text.style?.color, customForegroundColor);
+  });
+
+  testWidgets('CupertinoButton uses default color when foregroundColor not specified', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(child: CupertinoButton(onPressed: () {}, child: const Text('Button'))),
+      ),
+    );
+
+    // The default color should be the primary color from the theme
+    final BuildContext context = tester.element(find.text('Button'));
+    final Color primaryColor = CupertinoTheme.of(context).primaryColor;
+
+    final RichText text = tester.widget(find.byType(RichText));
+    expect(text.text.style?.color, primaryColor);
+  });
+
+  testWidgets('CupertinoButton.filled respects foregroundColor', (WidgetTester tester) async {
+    const Color customForegroundColor = Color(0xFF5500FF);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: CupertinoButton.filled(
+          onPressed: () {},
+          foregroundColor: customForegroundColor,
+          child: const Text('Button'),
+        ),
+      ),
+    );
+
+    // Check that the text has the custom foreground color
+    final RichText text = tester.widget(
+      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(RichText)),
+    );
+    expect(text.text.style?.color, customForegroundColor);
+  });
+
+  testWidgets('CupertinoButton respects foregroundColor when disabled', (
+    WidgetTester tester,
+  ) async {
+    const Color customForegroundColor = Color(0xFF5500FF);
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: CupertinoButton(
+          onPressed: null, // disabled button
+          foregroundColor: customForegroundColor,
+          child: const Text('Button'),
+        ),
+      ),
+    );
+
+    // Check that the text has the custom foreground color even when disabled
+    final RichText text = tester.widget(
+      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(RichText)),
+    );
+    expect(text.text.style?.color, customForegroundColor);
+  });
 }
 
 Widget boilerplate({required Widget child}) {

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1041,7 +1041,7 @@ void main() {
     expect(text.text.style?.color, customForegroundColor);
   });
 
-  testWidgets('CupertinoButton foregroundColor applies to Icon', (WidgetTester tester) async {
+  testWidgets('CupertinoButton foregroundColor applies to its icon', (WidgetTester tester) async {
     const Color customForegroundColor = Color(0xFF5500FF);
 
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1061,37 +1061,6 @@ void main() {
     expect(iconTheme.data.color, customForegroundColor);
   });
 
-  testWidgets('CupertinoButton foregroundColor applies to both its text and its icon', (
-    WidgetTester tester,
-  ) async {
-    const Color customForegroundColor = Color(0xFF5500FF);
-
-    await tester.pumpWidget(
-      boilerplate(
-        child: CupertinoButton(
-          onPressed: () {},
-          foregroundColor: customForegroundColor,
-          child: const Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [Icon(IconData(0xE000)), SizedBox(width: 8), Text('Button')],
-          ),
-        ),
-      ),
-    );
-
-    // Check that the icon has the custom foreground color
-    final IconTheme iconTheme = tester.widget(
-      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(IconTheme)),
-    );
-    expect(iconTheme.data.color, customForegroundColor);
-
-    // Check that the text has the custom foreground color
-    final RichText text = tester.widget(
-      find.descendant(of: find.byType(CupertinoButton), matching: find.byType(RichText)),
-    );
-    expect(text.text.style?.color, customForegroundColor);
-  });
-
   testWidgets('CupertinoButton uses the theme's primaryColor when foregroundColor is not specified', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1129,7 +1129,7 @@ void main() {
     expect(text.text.style?.color, customForegroundColor);
   });
 
-  testWidgets('CupertinoButton respects foregroundColor when disabled', (
+  testWidgets('CupertinoButton foregroundColor applies to its text when disabled', (
     WidgetTester tester,
   ) async {
     const Color customForegroundColor = Color(0xFF5500FF);

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1061,7 +1061,7 @@ void main() {
     expect(iconTheme.data.color, customForegroundColor);
   });
 
-  testWidgets('CupertinoButton foregroundColor applies to both Text and Icon', (
+  testWidgets('CupertinoButton foregroundColor applies to both its text and its icon', (
     WidgetTester tester,
   ) async {
     const Color customForegroundColor = Color(0xFF5500FF);

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1109,7 +1109,7 @@ void main() {
     expect(text.text.style?.color, primaryColor);
   });
 
-  testWidgets('CupertinoButton.filled respects foregroundColor', (WidgetTester tester) async {
+  testWidgets('CupertinoButton.filled foregroundColor applies to its text', (WidgetTester tester) async {
     const Color customForegroundColor = Color(0xFF5500FF);
 
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1092,7 +1092,7 @@ void main() {
     expect(text.text.style?.color, customForegroundColor);
   });
 
-  testWidgets('CupertinoButton uses default color when foregroundColor not specified', (
+  testWidgets('CupertinoButton uses the theme's primaryColor when foregroundColor is not specified', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/button_test.dart
+++ b/packages/flutter/test/cupertino/button_test.dart
@@ -1061,24 +1061,29 @@ void main() {
     expect(iconTheme.data.color, customForegroundColor);
   });
 
-  testWidgets('CupertinoButton uses the theme's primaryColor when foregroundColor is not specified', (
+  testWidgets(
+    "CupertinoButton uses the theme's primaryColor when foregroundColor is not specified",
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: CupertinoButton(onPressed: () {}, child: const Text('Button')),
+          ),
+        ),
+      );
+
+      // The default color should be the primary color from the theme
+      final BuildContext context = tester.element(find.text('Button'));
+      final Color primaryColor = CupertinoTheme.of(context).primaryColor;
+
+      final RichText text = tester.widget(find.byType(RichText));
+      expect(text.text.style?.color, primaryColor);
+    },
+  );
+
+  testWidgets('CupertinoButton.filled foregroundColor applies to its text', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      CupertinoApp(
-        home: Center(child: CupertinoButton(onPressed: () {}, child: const Text('Button'))),
-      ),
-    );
-
-    // The default color should be the primary color from the theme
-    final BuildContext context = tester.element(find.text('Button'));
-    final Color primaryColor = CupertinoTheme.of(context).primaryColor;
-
-    final RichText text = tester.widget(find.byType(RichText));
-    expect(text.text.style?.color, primaryColor);
-  });
-
-  testWidgets('CupertinoButton.filled foregroundColor applies to its text', (WidgetTester tester) async {
     const Color customForegroundColor = Color(0xFF5500FF);
 
     await tester.pumpWidget(
@@ -1105,10 +1110,10 @@ void main() {
 
     await tester.pumpWidget(
       boilerplate(
-        child: CupertinoButton(
+        child: const CupertinoButton(
           onPressed: null, // disabled button
           foregroundColor: customForegroundColor,
-          child: const Text('Button'),
+          child: Text('Button'),
         ),
       ),
     );


### PR DESCRIPTION
Feat: Add foreground color for cupertino button
fixes: #169507 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.