### PR TITLE
Add missing M3 tests for InputDecoration.floatingLabelAlignment

### DIFF
--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7767,7 +7767,7 @@ void main() {
             alignment: FloatingLabelAlignment.center,
           ),
         );
-        // (decorator (800) / icon (40)) / 2
+        // (decorator (800) - icon (40)) / 2
         expect(getLabelCenter(tester).dx, 380.0);
 
         await tester.pumpWidget(
@@ -7778,7 +7778,7 @@ void main() {
             borderIsOutline: true,
           ),
         );
-        // (decorator (800) / icon (40)) / 2
+        // (decorator (800) - icon (40)) / 2
         expect(getLabelCenter(tester).dx, 380.0);
       });
     });

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7618,6 +7618,220 @@ void main() {
     });
   });
 
+  group('Material3 - InputDecoration floatingLabelAlignment', () {
+    Widget buildInputDecoratorWithFloatingLabel({
+      required TextDirection textDirection,
+      required bool hasIcon,
+      required FloatingLabelAlignment alignment,
+      bool borderIsOutline = false,
+    }) {
+      return buildInputDecorator(
+        textDirection: textDirection,
+        decoration: InputDecoration(
+          contentPadding: const EdgeInsetsDirectional.only(start: 40.0, top: 12.0, bottom: 12.0),
+          floatingLabelAlignment: alignment,
+          icon: hasIcon ? const Icon(Icons.insert_link) : null,
+          labelText: labelText,
+          hintText: hintText,
+          filled: true,
+          border: borderIsOutline ? const OutlineInputBorder() : null,
+        ),
+      );
+    }
+
+    group('LTR with icon aligned', () {
+      testWidgets('start', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.start,
+          ),
+        );
+        // icon (40) + contentPadding (40) + _kInputExtraPadding
+        expect(getLabelRect(tester).left, 84.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.start,
+            borderIsOutline: true,
+          ),
+        );
+        // icon (40) + contentPadding (40) + _kInputExtraPadding
+        expect(getLabelRect(tester).left, 84.0);
+      });
+
+      testWidgets('center', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.center,
+          ),
+        );
+        // icon (40) + (decorator (800) - icon (40)) / 2
+        expect(getLabelCenter(tester).dx, 420.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.center,
+            borderIsOutline: true,
+          ),
+        );
+        // icon (40) + (decorator (800) - icon (40)) / 2
+        expect(getLabelCenter(tester).dx, 420.0);
+      });
+    });
+
+    group('LTR without icon aligned', () {
+      testWidgets('start', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.start,
+          ),
+        );
+        // contentPadding (40) + _kInputExtraPadding
+        expect(getLabelRect(tester).left, 44.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.start,
+            borderIsOutline: true,
+          ),
+        );
+        // contentPadding (40) + _kInputExtraPadding
+        expect(getLabelRect(tester).left, 44.0);
+      });
+
+      testWidgets('center', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.center,
+          ),
+        );
+        // decorator (800) / 2
+        expect(getLabelCenter(tester).dx, 400.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.ltr,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.center,
+            borderIsOutline: true,
+          ),
+        );
+        // decorator (800) / 2
+        expect(getLabelCenter(tester).dx, 400.0);
+      });
+    });
+
+    group('RTL with icon aligned', () {
+      testWidgets('start', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.start,
+          ),
+        );
+        // decorator (800) - icon (40) - contentPadding (40) - _kInputExtraPadding
+        expect(getLabelRect(tester).right, 716.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.start,
+            borderIsOutline: true,
+          ),
+        );
+        // decorator (800) - icon (40) - contentPadding (40) - _kInputExtraPadding
+        expect(getLabelRect(tester).right, 716.0);
+      });
+
+      testWidgets('center', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.center,
+          ),
+        );
+        // (decorator (800) / icon (40)) / 2
+        expect(getLabelCenter(tester).dx, 380.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: true,
+            alignment: FloatingLabelAlignment.center,
+            borderIsOutline: true,
+          ),
+        );
+        // (decorator (800) / icon (40)) / 2
+        expect(getLabelCenter(tester).dx, 380.0);
+      });
+    });
+
+    group('RTL without icon aligned', () {
+      testWidgets('start', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.start,
+          ),
+        );
+        // decorator (800) - contentPadding (40) - _kInputExtraPadding
+        expect(getLabelRect(tester).right, 756.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.start,
+            borderIsOutline: true,
+          ),
+        );
+        // decorator (800) - contentPadding (40) - _kInputExtraPadding
+        expect(getLabelRect(tester).right, 756.0);
+      });
+
+      testWidgets('center', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.center,
+          ),
+        );
+        // decorator (800) / 2
+        expect(getLabelCenter(tester).dx, 400.0);
+
+        await tester.pumpWidget(
+          buildInputDecoratorWithFloatingLabel(
+            textDirection: TextDirection.rtl,
+            hasIcon: false,
+            alignment: FloatingLabelAlignment.center,
+            borderIsOutline: true,
+          ),
+        );
+        // decorator (800) / 2
+        expect(getLabelCenter(tester).dx, 400.0);
+      });
+    });
+  });
+
   group('Material3 - InputDecoration isDense', () {
     // M3 extra horizontal padding.
     const double kInputExtraPadding = 4.0;


### PR DESCRIPTION
## Description

This PR adds missing M3 tests for InputDecoration.floatingLabelAlignment.

## Related Issue

Will help to complete https://github.com/flutter/flutter/pull/168981

## Tests

Adds 8 tests (based on existing M2 tests).