### PR TITLE
Fix InputDecoration.floatingLabelBehavior is not inherited

### DIFF
--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2944,6 +2944,7 @@ void main() {
       },
     );
 
+    // Regression test for https://github.com/flutter/flutter/issues/71813.
     testWidgets('Ambient theme floatingLabelBehavior is used', (WidgetTester tester) async {
       const FloatingLabelBehavior floatingLabelBehavior = FloatingLabelBehavior.never;
       await tester.pumpWidget(

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2937,10 +2937,30 @@ void main() {
         );
 
         expect(getDecoratorRect(tester).size, const Size(800.0, 56.0));
+        // Label line height is forced to 1.0 and font size is 16.0,
+        // the label should be vertically centered (20 pixels above and below).
         expect(getLabelRect(tester).top, 20.0);
         expect(getLabelRect(tester).bottom, 36.0);
       },
     );
+
+    testWidgets('Ambient theme floatingLabelBehavior is used', (WidgetTester tester) async {
+      const FloatingLabelBehavior floatingLabelBehavior = FloatingLabelBehavior.never;
+      await tester.pumpWidget(
+        buildInputDecorator(
+          inputDecorationTheme: const InputDecorationTheme(
+            floatingLabelBehavior: floatingLabelBehavior,
+          ),
+          decoration: const InputDecoration(label: customLabel),
+        ),
+      );
+
+      expect(getDecoratorRect(tester).size, const Size(800.0, 56.0));
+      // Label line height is forced to 1.0 and font size is 16.0,
+      // the label should be vertically centered (20 pixels above and below).
+      expect(getCustomLabelRect(tester).top, 20.0);
+      expect(getCustomLabelRect(tester).bottom, 36.0);
+    });
 
     testWidgets('Floating label animation duration and curve', (WidgetTester tester) async {
       Future<void> pumpInputDecorator({required bool isFocused}) async {


### PR DESCRIPTION
## Description

This PR fixes `InputDecoration.floatingLabelBehavior` logic to query ambient InputDecorationTheme.floatingLabelBehavior, previously it was ignored.

## Related Issue

Fixes [InputDecorationTheme and IconTheme isn't fully inherited](https://github.com/flutter/flutter/issues/71813)
Will help to complete https://github.com/flutter/flutter/pull/168981

## Tests

Adds 1 test