### PR TITLE
Fix NaN/Infinity crash in RenderSliverFixedExtentBoxAdaptor

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
+++ b/packages/flutter/lib/src/rendering/sliver_fixed_extent_list.dart
@@ -113,8 +113,11 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
   ) {
     if (itemExtentBuilder == null) {
       itemExtent = this.itemExtent!;
-      if (itemExtent > 0.0) {
+      if (itemExtent > 0.0 && scrollOffset.isFinite && itemExtent.isFinite) {
         final double actual = scrollOffset / itemExtent;
+        if (!actual.isFinite) {
+          return 0;
+        }
         final int round = actual.round();
         if ((actual * itemExtent - round * itemExtent).abs() < precisionErrorTolerance) {
           return round;
@@ -146,8 +149,11 @@ abstract class RenderSliverFixedExtentBoxAdaptor extends RenderSliverMultiBoxAda
   ) {
     if (itemExtentBuilder == null) {
       itemExtent = this.itemExtent!;
-      if (itemExtent > 0.0) {
+      if (itemExtent > 0.0 && scrollOffset.isFinite && itemExtent.isFinite) {
         final double actual = scrollOffset / itemExtent - 1;
+        if (!actual.isFinite) {
+          return 0;
+        }
         final int round = actual.round();
         if ((actual * itemExtent - round * itemExtent).abs() < precisionErrorTolerance) {
           return math.max(0, round);

--- a/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
+++ b/packages/flutter/test/rendering/sliver_fixed_extent_layout_test.dart
@@ -116,6 +116,66 @@ void main() {
       );
       expect(actual, 0);
     });
+
+    test('should handle NaN scroll offset gracefully', () {
+      final int actual = testGetMaxChildIndexForScrollOffset(double.nan, genericItemExtent);
+      expect(actual, 0);
+    });
+
+    test('should handle infinite scroll offset gracefully', () {
+      final int actual = testGetMaxChildIndexForScrollOffset(double.infinity, genericItemExtent);
+      expect(actual, 0);
+    });
+
+    test('should handle negative infinite scroll offset gracefully', () {
+      final int actual = testGetMaxChildIndexForScrollOffset(
+        double.negativeInfinity,
+        genericItemExtent,
+      );
+      expect(actual, 0);
+    });
+
+    test('should handle NaN item extent gracefully', () {
+      final int actual = testGetMaxChildIndexForScrollOffset(genericItemExtent, double.nan);
+      expect(actual, 0);
+    });
+
+    test('should handle infinite item extent gracefully', () {
+      final int actual = testGetMaxChildIndexForScrollOffset(genericItemExtent, double.infinity);
+      expect(actual, 0);
+    });
+  });
+
+  group('getMinChildIndexForScrollOffset', () {
+    const double genericItemExtent = 600.0;
+
+    test('should handle NaN scroll offset gracefully', () {
+      final int actual = testGetMinChildIndexForScrollOffset(double.nan, genericItemExtent);
+      expect(actual, 0);
+    });
+
+    test('should handle infinite scroll offset gracefully', () {
+      final int actual = testGetMinChildIndexForScrollOffset(double.infinity, genericItemExtent);
+      expect(actual, 0);
+    });
+
+    test('should handle negative infinite scroll offset gracefully', () {
+      final int actual = testGetMinChildIndexForScrollOffset(
+        double.negativeInfinity,
+        genericItemExtent,
+      );
+      expect(actual, 0);
+    });
+
+    test('should handle NaN item extent gracefully', () {
+      final int actual = testGetMinChildIndexForScrollOffset(genericItemExtent, double.nan);
+      expect(actual, 0);
+    });
+
+    test('should handle infinite item extent gracefully', () {
+      final int actual = testGetMinChildIndexForScrollOffset(genericItemExtent, double.infinity);
+      expect(actual, 0);
+    });
   });
 
   test('Implements paintsChild correctly', () {
@@ -372,6 +432,13 @@ int testGetMaxChildIndexForScrollOffset(double scrollOffset, double itemExtent) 
   return renderSliver.getMaxChildIndexForScrollOffset(scrollOffset, itemExtent);
 }
 
+int testGetMinChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
+  final TestRenderSliverFixedExtentBoxAdaptor renderSliver = TestRenderSliverFixedExtentBoxAdaptor(
+    itemExtent: itemExtent,
+  );
+  return renderSliver.getMinChildIndexForScrollOffset(scrollOffset, itemExtent);
+}
+
 class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
   TestRenderSliverBoxChildManager({required this.children});
 
@@ -449,6 +516,11 @@ class TestRenderSliverFixedExtentBoxAdaptor extends RenderSliverFixedExtentBoxAd
   @override
   int getMaxChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
     return super.getMaxChildIndexForScrollOffset(scrollOffset, itemExtent);
+  }
+
+  @override
+  int getMinChildIndexForScrollOffset(double scrollOffset, double itemExtent) {
+    return super.getMinChildIndexForScrollOffset(scrollOffset, itemExtent);
   }
 
   @override


### PR DESCRIPTION
## Summary

Fixes production crashes in `RenderSliverFixedExtentBoxAdaptor` caused by `NaN` or `Infinity` values being passed to `.round()` and `.floor()` operations.

## Changes

- Added finite value validation in `getMinChildIndexForScrollOffset()` and `getMaxChildIndexForScrollOffset()` 
- Added comprehensive tests for `NaN` and `Infinity` edge cases
- Returns safe default value (0) when non-finite values are encountered

## Test Plan

- [x] All existing tests pass (26/26)
- [x] New edge case tests pass (10/10) covering:
  - NaN scroll offset
  - Infinite scroll offset (positive and negative)  
  - NaN item extent
  - Infinite item extent
- [x] Code analysis shows no issues

## Breaking Change

No breaking changes. This fix maintains existing behavior for all valid inputs while preventing crashes on invalid inputs.

Fixes #105630