### PR TITLE
Make service worker tests more lenient.

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -30,6 +30,13 @@ final String _targetWithBlockedServiceWorkers = path.join(
 );
 final String _targetPath = path.join(_testAppDirectory, _target);
 
+// Some paths are not guaranteed to actually be requested by the time we finish the test, so we just
+// ignore them and not make them part of the tracked requests or expectations.
+final Set<String> _ignoreRequestPaths = {
+  'canvaskit/chromium/canvaskit.js',
+  'canvaskit/chromium/canvaskit.wasm',
+};
+
 enum ServiceWorkerTestType {
   // Mocks how FF disables service workers.
   blockedServiceWorkers,
@@ -297,6 +304,9 @@ Future<void> runWebServiceWorkerTest({
       additionalRequestHandlers: <Handler>[
         (Request request) {
           final String requestedPath = request.url.path;
+          if (_ignoreRequestPaths.contains(requestedPath)) {
+            return Response.ok('OK');
+          }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
           if (requestedPath == 'CLOSE') {
@@ -367,8 +377,6 @@ Future<void> runWebServiceWorkerTest({
       'assets/FontManifest.json': 1,
       'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},
@@ -423,8 +431,6 @@ Future<void> runWebServiceWorkerTest({
       'flutter_bootstrap.js': 1,
       'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},
@@ -513,6 +519,9 @@ Future<void> runWebServiceWorkerTestWithCachingResources({
       additionalRequestHandlers: <Handler>[
         (Request request) {
           final String requestedPath = request.url.path;
+          if (_ignoreRequestPaths.contains(requestedPath)) {
+            return Response.ok('OK');
+          }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
           if (requestedPath == 'assets/fonts/MaterialIcons-Regular.otf') {
@@ -562,8 +571,6 @@ Future<void> runWebServiceWorkerTestWithCachingResources({
       'assets/FontManifest.json': 1,
       'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},
     });
@@ -659,6 +666,9 @@ Future<void> runWebServiceWorkerTestWithBlockedServiceWorkers({required bool hea
       additionalRequestHandlers: <Handler>[
         (Request request) {
           final String requestedPath = request.url.path;
+          if (_ignoreRequestPaths.contains(requestedPath)) {
+            return Response.ok('OK');
+          }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
           if (requestedPath == 'CLOSE') {
@@ -693,8 +703,6 @@ Future<void> runWebServiceWorkerTestWithBlockedServiceWorkers({required bool hea
       'main.dart.js': 1,
       'assets/FontManifest.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},
@@ -734,6 +742,9 @@ Future<void> runWebServiceWorkerTestWithCustomServiceWorkerVersion({required boo
       additionalRequestHandlers: <Handler>[
         (Request request) {
           final String requestedPath = request.url.path;
+          if (_ignoreRequestPaths.contains(requestedPath)) {
+            return Response.ok('OK');
+          }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
           if (requestedPath == 'CLOSE') {
@@ -776,8 +787,6 @@ Future<void> runWebServiceWorkerTestWithCustomServiceWorkerVersion({required boo
       'assets/FontManifest.json': 1,
       'assets/AssetManifest.bin.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},
     });
@@ -791,8 +800,6 @@ Future<void> runWebServiceWorkerTestWithCustomServiceWorkerVersion({required boo
       'main.dart.js': 1,
       'assets/FontManifest.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},
@@ -812,8 +819,6 @@ Future<void> runWebServiceWorkerTestWithCustomServiceWorkerVersion({required boo
       'main.dart.js': 1,
       'assets/FontManifest.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
-      'canvaskit/chromium/canvaskit.js': 1,
-      'canvaskit/chromium/canvaskit.wasm': 1,
       'CLOSE': 1,
       // In headless mode Chrome does not load 'manifest.json' and 'favicon.png'.
       if (!headless) ...<String, int>{'manifest.json': 1, 'favicon.png': 1},

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -307,7 +307,7 @@ Future<void> runWebServiceWorkerTest({
         (Request request) {
           final String requestedPath = request.url.path;
           if (_ignoreRequestPaths.contains(requestedPath)) {
-            return Response.ok('OK');
+            return Response.notFound('');
           }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
@@ -522,7 +522,7 @@ Future<void> runWebServiceWorkerTestWithCachingResources({
         (Request request) {
           final String requestedPath = request.url.path;
           if (_ignoreRequestPaths.contains(requestedPath)) {
-            return Response.ok('OK');
+            return Response.notFound('');
           }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
@@ -669,7 +669,7 @@ Future<void> runWebServiceWorkerTestWithBlockedServiceWorkers({required bool hea
         (Request request) {
           final String requestedPath = request.url.path;
           if (_ignoreRequestPaths.contains(requestedPath)) {
-            return Response.ok('OK');
+            return Response.notFound('');
           }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
@@ -745,7 +745,7 @@ Future<void> runWebServiceWorkerTestWithCustomServiceWorkerVersion({required boo
         (Request request) {
           final String requestedPath = request.url.path;
           if (_ignoreRequestPaths.contains(requestedPath)) {
-            return Response.ok('OK');
+            return Response.notFound('');
           }
           requestedPathCounts.putIfAbsent(requestedPath, () => 0);
           requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -33,6 +33,8 @@ final String _targetPath = path.join(_testAppDirectory, _target);
 // Some paths are not guaranteed to actually be requested by the time we finish the test, so we just
 // ignore them and not make them part of the tracked requests or expectations.
 final Set<String> _ignoreRequestPaths = <String>{
+  'canvaskit/canvaskit.js',
+  'canvaskit/canvaskit.wasm',
   'canvaskit/chromium/canvaskit.js',
   'canvaskit/chromium/canvaskit.wasm',
 };

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -32,7 +32,7 @@ final String _targetPath = path.join(_testAppDirectory, _target);
 
 // Some paths are not guaranteed to actually be requested by the time we finish the test, so we just
 // ignore them and not make them part of the tracked requests or expectations.
-final Set<String> _ignoreRequestPaths = {
+final Set<String> _ignoreRequestPaths = <String>{
   'canvaskit/chromium/canvaskit.js',
   'canvaskit/chromium/canvaskit.wasm',
 };


### PR DESCRIPTION
Some of these request paths are not guaranteed to be requested by the time the test is finished, which makes this test somewhat flaky. We don't really care about verifying these requests specifically anyway, so just don't track them or compare them to our expectations.

This fixes https://github.com/flutter/flutter/issues/171025