### PR TITLE
Update `CupertinoPicker` docs

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -191,7 +191,7 @@ class CupertinoPicker extends StatefulWidget {
 
   /// The behavior of reporting the selected item index.
   ///
-  /// This determines when the `onSelectedItemChanged` callback is called.
+  /// This determines when the [onSelectedItemChanged] callback is called.
   ///
   /// Native iOS 18 behavior is [ChangeReportingBehavior.onScrollEnd], which
   /// calls the callback only when the scrolling stops.
@@ -199,13 +199,9 @@ class CupertinoPicker extends StatefulWidget {
   /// Defaults to [ChangeReportingBehavior.onScrollUpdate].
   final ChangeReportingBehavior changeReportingBehavior;
 
-  /// An option callback when the currently centered item changes.
+  /// Called when the selected item changes.
   ///
-  /// Value changes when the item closest to the center changes.
-  ///
-  /// This can be called during scrolls and during ballistic flings. To get the
-  /// value only when the scrolling settles, use a [NotificationListener],
-  /// listen for [ScrollEndNotification] and read its [FixedExtentMetrics].
+  /// The timing of this callback is controlled by [changeReportingBehavior].
   final ValueChanged<int>? onSelectedItemChanged;
 
   /// A delegate that lazily instantiates children.


### PR DESCRIPTION
This PR updates the docs after the changes introduced in https://github.com/flutter/flutter/pull/170202.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
