### PR TITLE
remove `x86` in CI  builder linux_android_emulator

### DIFF
--- a/engine/src/flutter/ci/builders/linux_android_emulator.json
+++ b/engine/src/flutter/ci/builders/linux_android_emulator.json
@@ -68,69 +68,6 @@
                     "max_attempts": 1
                 }
             ]
-        },
-        {
-            "drone_dimensions": [
-                "device_type=none",
-                "os=Linux",
-                "kvm=1",
-                "cores=8"
-            ],
-            "gclient_variables": {
-                "use_rbe": true
-            },
-            "gn": [
-                "--android",
-                "--android-cpu=x86",
-                "--no-lto",
-                "--rbe",
-                "--no-goma",
-                "--target-dir",
-                "ci/android_emulator_debug_x86"
-            ],
-            "dependencies": [
-                {
-                    "dependency": "goldctl",
-                    "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
-                }
-            ],
-            "name": "ci/android_emulator_debug_x86",
-            "description": "Build for debug mode x86 Android emulator tests.",
-            "ninja": {
-                "config": "ci/android_emulator_debug_x86",
-                "targets": [
-                    "flutter/impeller/renderer/backend/vulkan:vulkan_android_unittests",
-                    "flutter/impeller/renderer/backend/vulkan:vulkan_android_apk_unittests",
-                    "flutter/impeller/toolkit/android:unittests",
-                    "flutter/shell/platform/android:flutter_shell_native_unittests"
-                ]
-            },
-            "tests": [
-                {
-                    "language": "python3",
-                    "name": "Android Unit Tests (API 28)",
-                    "test_dependencies": [
-                        {
-                            "dependency": "android_virtual_device",
-                            "version": "android_28_google_apis_x86.textpb"
-                        },
-                        {
-                            "dependency": "avd_cipd_version",
-                            "version": "build_id:8733065022087935185"
-                        }
-                    ],
-                    "contexts": [
-                        "android_virtual_device"
-                    ],
-                    "script": "flutter/testing/run_tests.py",
-                    "parameters": [
-                        "--android-variant",
-                        "ci/android_emulator_debug_x86",
-                        "--type",
-                        "android"
-                    ]
-                }
-            ]
         }
     ]
 }


### PR DESCRIPTION
based on [this comment](https://github.com/flutter/flutter/pull/170191#pullrequestreview-2910139454)
Towards #170142

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
