### PR TITLE
Reland: Fix InputDecoration.floatingLabelBehavior is not inherited

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1924,12 +1924,8 @@ class InputDecorator extends StatefulWidget {
   /// Whether the label needs to get out of the way of the input, either by
   /// floating or disappearing.
   ///
-  /// Will withdraw when not empty, when focused while enabled, or when
-  /// floating behavior is [FloatingLabelBehavior.always].
-  bool get _labelShouldWithdraw =>
-      !isEmpty ||
-      (isFocused && decoration.enabled) ||
-      decoration.floatingLabelBehavior == FloatingLabelBehavior.always;
+  /// Will withdraw when not empty or when focused while enabled.
+  bool get _labelShouldWithdraw => !isEmpty || (isFocused && decoration.enabled);
 
   @override
   State<InputDecorator> createState() => _InputDecoratorState();
@@ -1980,15 +1976,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   void initState() {
     super.initState();
 
-    final bool labelIsInitiallyFloating =
-        widget.decoration.floatingLabelBehavior != FloatingLabelBehavior.never &&
-        widget._labelShouldWithdraw;
-
-    _floatingLabelController = AnimationController(
-      duration: _kTransitionDuration,
-      vsync: this,
-      value: labelIsInitiallyFloating ? 1.0 : 0.0,
-    );
+    _floatingLabelController = AnimationController(duration: _kTransitionDuration, vsync: this);
     _floatingLabelController.addListener(_handleChange);
     _floatingLabelAnimation = CurvedAnimation(
       parent: _floatingLabelController,
@@ -2003,6 +1991,10 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   void didChangeDependencies() {
     super.didChangeDependencies();
     _effectiveDecoration = null;
+
+    final bool labelIsInitiallyFloating =
+        decoration.floatingLabelBehavior != FloatingLabelBehavior.never && labelShouldWithdraw;
+    _floatingLabelController.value = labelIsInitiallyFloating ? 1.0 : 0.0;
   }
 
   @override
@@ -2034,6 +2026,10 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     return decoration.floatingLabelBehavior != FloatingLabelBehavior.never;
   }
 
+  bool get labelShouldWithdraw =>
+      widget._labelShouldWithdraw ||
+      decoration.floatingLabelBehavior == FloatingLabelBehavior.always;
+
   @override
   void didUpdateWidget(InputDecorator old) {
     super.didUpdateWidget(old);
@@ -2045,7 +2041,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior;
 
     if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviorChanged) {
-      if (_floatingLabelEnabled && widget._labelShouldWithdraw) {
+      if (_floatingLabelEnabled && labelShouldWithdraw) {
         _floatingLabelController.forward();
       } else {
         _floatingLabelController.reverse();
@@ -2131,8 +2127,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   // floatingLabelBehavior isn't set to always, then the label appears where the
   // hint would.
   bool get _hasInlineLabel {
-    return !widget._labelShouldWithdraw &&
-        (decoration.labelText != null || decoration.label != null);
+    return !labelShouldWithdraw && (decoration.labelText != null || decoration.label != null);
   }
 
   // If the label is a floating placeholder, it's always shown.
@@ -2357,10 +2352,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
           child: AnimatedDefaultTextStyle(
             duration: _kTransitionDuration,
             curve: _kTransitionCurve,
-            style:
-                widget._labelShouldWithdraw
-                    ? _getFloatingLabelStyle(themeData, defaults)
-                    : labelStyle,
+            style: labelShouldWithdraw ? _getFloatingLabelStyle(themeData, defaults) : labelStyle,
             child:
                 decoration.label ??
                 Text(decoration.labelText!, overflow: TextOverflow.ellipsis, textAlign: textAlign),
@@ -2376,13 +2368,13 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     // If at least two out of the three are visible, it needs semantics sort
     // order.
     final bool needsSemanticsSortOrder =
-        widget._labelShouldWithdraw &&
+        labelShouldWithdraw &&
         (input != null ? (hasPrefix || hasSuffix) : (hasPrefix && hasSuffix));
 
     final Widget? prefix =
         hasPrefix
             ? _AffixText(
-              labelIsFloating: widget._labelShouldWithdraw,
+              labelIsFloating: labelShouldWithdraw,
               text: decoration.prefixText,
               style:
                   MaterialStateProperty.resolveAs(decoration.prefixStyle, materialState) ??
@@ -2396,7 +2388,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final Widget? suffix =
         hasSuffix
             ? _AffixText(
-              labelIsFloating: widget._labelShouldWithdraw,
+              labelIsFloating: labelShouldWithdraw,
               text: decoration.suffixText,
               style:
                   MaterialStateProperty.resolveAs(decoration.suffixStyle, materialState) ??

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -2944,10 +2944,31 @@ void main() {
         );
 
         expect(getDecoratorRect(tester).size, const Size(800.0, 56.0));
+        // Label line height is forced to 1.0 and font size is 16.0,
+        // the label should be vertically centered (20 pixels above and below).
         expect(getLabelRect(tester).top, 20.0);
         expect(getLabelRect(tester).bottom, 36.0);
       },
     );
+
+    // Regression test for https://github.com/flutter/flutter/issues/71813.
+    testWidgets('Ambient theme floatingLabelBehavior is used', (WidgetTester tester) async {
+      const FloatingLabelBehavior floatingLabelBehavior = FloatingLabelBehavior.never;
+      await tester.pumpWidget(
+        buildInputDecorator(
+          inputDecorationTheme: const InputDecorationThemeData(
+            floatingLabelBehavior: floatingLabelBehavior,
+          ),
+          decoration: const InputDecoration(label: customLabel),
+        ),
+      );
+
+      expect(getDecoratorRect(tester).size, const Size(800.0, 56.0));
+      // Label line height is forced to 1.0 and font size is 16.0,
+      // the label should be vertically centered (20 pixels above and below).
+      expect(getCustomLabelRect(tester).top, 20.0);
+      expect(getCustomLabelRect(tester).bottom, 36.0);
+    });
 
     testWidgets('Floating label animation duration and curve', (WidgetTester tester) async {
       Future<void> pumpInputDecorator({required bool isFocused}) async {


### PR DESCRIPTION
## Description

Reland https://github.com/flutter/flutter/pull/170905 which was reverted in https://github.com/flutter/flutter/pull/170994

The change from https://github.com/flutter/flutter/pull/170905 had to be adjusted with a change which landed just before (https://github.com/flutter/flutter/pull/168981).