### PR TITLE
Un-bringup `Linux web_tool_tests`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2264,7 +2264,6 @@ targets:
 
   - name: Linux web_tool_tests
     recipe: flutter/flutter_drone
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/169574
     timeout: 90 # https://github.com/flutter/flutter/issues/169634
     properties:
       dependencies: >-


### PR DESCRIPTION
Since https://github.com/flutter/flutter/pull/170565 the `Linux web_tool_tests` task has been green:
- https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.staging/Linux%20web_tool_tests?limit=100
- https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux+web_tool&showBringup=true

Fixes https://github.com/flutter/flutter/issues/169574