### PR TITLE
Add `--no-web-resources-cdn` to all web integration tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -548,6 +548,7 @@ final class FlutterRunTestDriver extends FlutterTestDriver {
         deviceArgs = <String>[
           GoogleChromeDevice.kChromeDeviceId,
           '--web-run-headless',
+          '--no-web-resources-cdn',
           if (!expressionEvaluation) '--no-web-enable-expression-evaluation',
         ];
       default:

--- a/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/debugger_stepping_web_test.dart
@@ -31,7 +31,7 @@ void main() {
       withDebugger: true,
       startPaused: true,
       device: GoogleChromeDevice.kChromeDeviceId,
-      additionalCommandArgs: <String>['--verbose'],
+      additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
     );
     await flutter.addBreakpoint(project.breakpointUri, project.breakpointLine);
     await flutter.resume(waitForNextPause: true); // Now we should be on the breakpoint.

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_errors_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_errors_test.dart
@@ -9,5 +9,8 @@ import '../integration.shard/test_data/hot_reload_errors_common.dart';
 import '../src/common.dart';
 
 void main() {
-  testAll(chrome: true, additionalCommandArgs: <String>['--web-experimental-hot-reload']);
+  testAll(
+    chrome: true,
+    additionalCommandArgs: <String>['--web-experimental-hot-reload', '--no-web-resources-cdn'],
+  );
 }

--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -10,5 +10,8 @@ import '../integration.shard/test_data/hot_reload_test_common.dart';
 import '../src/common.dart';
 
 void main() {
-  testAll(chrome: true, additionalCommandArgs: <String>['--web-experimental-hot-reload']);
+  testAll(
+    chrome: true,
+    additionalCommandArgs: <String>['--web-experimental-hot-reload', '--no-web-resources-cdn'],
+  );
 }

--- a/packages/flutter_tools/test/web.shard/hot_reload_with_asset_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_with_asset_web_test.dart
@@ -10,5 +10,8 @@ import '../integration.shard/test_data/hot_reload_with_asset_test_common.dart';
 import '../src/common.dart';
 
 void main() {
-  testAll(chrome: true, additionalCommandArgs: <String>['--web-experimental-hot-reload']);
+  testAll(
+    chrome: true,
+    additionalCommandArgs: <String>['--web-experimental-hot-reload', '--no-web-resources-cdn'],
+  );
 }

--- a/packages/flutter_tools/test/web.shard/output_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/output_web_test.dart
@@ -37,7 +37,7 @@ void main() {
     await flutter.run(
       withDebugger: true,
       device: GoogleChromeDevice.kChromeDeviceId,
-      additionalCommandArgs: <String>[if (verbose) '--verbose'],
+      additionalCommandArgs: <String>[if (verbose) '--verbose', '--no-web-resources-cdn'],
     );
   }
 

--- a/packages/flutter_tools/test/web.shard/stateless_stateful_hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/stateless_stateful_hot_reload_web_test.dart
@@ -10,5 +10,8 @@ import '../integration.shard/test_data/stateless_stateful_hot_reload_test_common
 import '../src/common.dart';
 
 void main() {
-  testAll(chrome: true, additionalCommandArgs: <String>['--web-experimental-hot-reload']);
+  testAll(
+    chrome: true,
+    additionalCommandArgs: <String>['--web-experimental-hot-reload', '--no-web-resources-cdn'],
+  );
 }

--- a/packages/flutter_tools/test/web.shard/test_data/expression_evaluation_web_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/expression_evaluation_web_common.dart
@@ -45,6 +45,7 @@ Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
         expressionEvaluation: expressionEvaluation,
         additionalCommandArgs: <String>[
           '--verbose',
+          '--no-web-resources-cdn',
           if (useDDCLibraryBundleFormat)
             '--web-experimental-hot-reload'
           else
@@ -139,6 +140,7 @@ Future<void> testAll({required bool useDDCLibraryBundleFormat}) async {
         script: project.testFilePath,
         additionalCommandArgs: <String>[
           '--verbose',
+          '--no-web-resources-cdn',
           if (useDDCLibraryBundleFormat)
             '--web-experimental-hot-reload'
           else

--- a/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_restart_web_test_common.dart
@@ -91,6 +91,7 @@ Future<void> _testProject(
         device: GoogleChromeDevice.kChromeDeviceId,
         additionalCommandArgs: <String>[
           '--verbose',
+          '--no-web-resources-cdn',
           if (useDDCLibraryBundleFormat)
             '--web-experimental-hot-reload'
           else

--- a/packages/flutter_tools/test/web.shard/vm_service_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/vm_service_web_test.dart
@@ -40,7 +40,7 @@ void main() {
       await flutter.run(
         withDebugger: true,
         device: GoogleChromeDevice.kChromeDeviceId,
-        additionalCommandArgs: <String>['--verbose'],
+        additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
       );
 
       expect(flutter.vmServiceWsUri, isNotNull);
@@ -53,7 +53,7 @@ void main() {
       await flutter.run(
         withDebugger: true,
         device: GoogleChromeDevice.kChromeDeviceId,
-        additionalCommandArgs: <String>['--verbose'],
+        additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
       );
 
       expect(flutter.vmServiceWsUri, isNotNull);
@@ -85,7 +85,7 @@ void main() {
       await flutter.run(
         withDebugger: true,
         device: GoogleChromeDevice.kChromeDeviceId,
-        additionalCommandArgs: <String>['--verbose'],
+        additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
       );
 
       expect(flutter.vmServiceWsUri, isNotNull);

--- a/packages/flutter_tools/test/web.shard/web_run_chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/web_run_chrome_test.dart
@@ -33,7 +33,7 @@ void main() {
   testWithoutContext('flutter run works on chrome devices with a unary main function', () async {
     await flutter.run(
       device: GoogleChromeDevice.kChromeDeviceId,
-      additionalCommandArgs: <String>['--verbose'],
+      additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
     );
   });
 }

--- a/packages/flutter_tools/test/web.shard/web_run_web_server_test.dart
+++ b/packages/flutter_tools/test/web.shard/web_run_web_server_test.dart
@@ -33,7 +33,7 @@ void main() {
   testWithoutContext('flutter run works on web-server device with a unary main function', () async {
     await flutter.run(
       device: WebServerDevice.kWebServerDeviceId,
-      additionalCommandArgs: <String>['--verbose'],
+      additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
     );
   });
 }


### PR DESCRIPTION
Let's avoid downloading canvaskit from the CDN in our integration tests.

Closes https://github.com/flutter/flutter/issues/110879