### PR TITLE
[ Widget Previews ] Support projects containing libraries with part files

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -542,7 +542,7 @@ Future<void> verifyToolTestsEndInTestDart(String workingDirectory) async {
 
   // detect files that contains calls to test(), testUsingContext(), and testWithoutContext()
   final RegExp callsTestFunctionPattern = RegExp(
-    r'(test\(.*\)|testUsingContext\(.*\)|testWithoutContext\(.*\))',
+    r'^ *(test\(.*\)|testUsingContext\(.*\)|testWithoutContext\(.*\))',
   );
 
   await for (final File file in _allFiles(toolsTestPath, 'dart', minimumMatches: 300)) {
@@ -566,6 +566,7 @@ Future<void> verifyToolTestsEndInTestDart(String workingDirectory) async {
       continue;
     }
 
+    print(callsTestFunctionPattern.allMatches(file.readAsStringSync()).map((e) => e.group(0)));
     violations.add(file.path);
   }
   if (violations.isNotEmpty) {

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -566,7 +566,6 @@ Future<void> verifyToolTestsEndInTestDart(String workingDirectory) async {
       continue;
     }
 
-    print(callsTestFunctionPattern.allMatches(file.readAsStringSync()).map((e) => e.group(0)));
     violations.add(file.path);
   }
   if (violations.isNotEmpty) {

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -381,6 +381,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
           ),
           // Don't try and download canvaskit from the CDN.
           useLocalCanvasKit: true,
+          webEnableHotReload: true,
         ),
         webEnableExposeUrl: false,
         webRunHeadless: boolArg(kHeadless),

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -15,7 +15,7 @@ import '../project.dart';
 import 'dependency_graph.dart';
 import 'preview_details.dart';
 
-typedef _PreviewMappingEntry = MapEntry<PreviewPath, PreviewDependencyNode>;
+typedef _PreviewMappingEntry = MapEntry<PreviewPath, LibraryPreviewNode>;
 
 /// Generates the Dart source responsible for importing widget previews from the developer's project
 /// into the widget preview scaffold.
@@ -124,16 +124,16 @@ class PreviewCodeGenerator {
         });
     for (final _PreviewMappingEntry(
           key: (path: String _, :Uri uri),
-          value: PreviewDependencyNode fileDetails,
+          value: LibraryPreviewNode libraryDetails,
         )
         in sortedPreviews) {
-      for (final PreviewDetails preview in fileDetails.filePreviews) {
+      for (final PreviewDetails preview in libraryDetails.previews) {
         previewExpressions.add(
           _buildPreviewWidget(
             allocator: allocator,
             preview: preview,
             uri: uri,
-            fileDetails: fileDetails,
+            libraryDetails: libraryDetails,
           ),
         );
       }
@@ -154,15 +154,15 @@ class PreviewCodeGenerator {
     required cb.Allocator allocator,
     required PreviewDetails preview,
     required Uri uri,
-    required PreviewDependencyNode fileDetails,
+    required LibraryPreviewNode libraryDetails,
   }) {
     cb.Expression previewWidget;
     // TODO(bkonyi): clean up the error related code.
-    if (fileDetails.hasErrors) {
+    if (libraryDetails.hasErrors) {
       previewWidget = cb.refer('Text', 'package:flutter/material.dart').newInstance(<cb.Expression>[
         cb.literalString('$uri has errors!'),
       ]);
-    } else if (fileDetails.dependencyHasErrors) {
+    } else if (libraryDetails.dependencyHasErrors) {
       previewWidget = cb.refer('Text', 'package:flutter/material.dart').newInstance(<cb.Expression>[
         cb.literalString('Dependency of $uri has errors!'),
       ]);
@@ -192,7 +192,8 @@ class PreviewCodeGenerator {
       <cb.Expression>[],
       <String, cb.Expression>{
         // TODO(bkonyi): try to display the preview name, even if the preview can't be displayed.
-        if (!fileDetails.dependencyHasErrors && !fileDetails.hasErrors) ...<String, cb.Expression>{
+        if (!libraryDetails.dependencyHasErrors &&
+            !libraryDetails.hasErrors) ...<String, cb.Expression>{
           ...?_generateCodeFromAnalyzerExpression(
             allocator: allocator,
             key: PreviewDetails.kName,

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -8,6 +8,7 @@ import 'package:analyzer/dart/analysis/analysis_context.dart';
 import 'package:analyzer/dart/analysis/analysis_context_collection.dart';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/file_system/physical_file_system.dart';
+import 'package:meta/meta.dart';
 import 'package:watcher/watcher.dart';
 
 import '../base/file_system.dart';
@@ -33,6 +34,9 @@ class PreviewDetector {
 
   StreamSubscription<WatchEvent>? _fileWatcher;
   final PreviewDetectorMutex _mutex = PreviewDetectorMutex();
+
+  @visibleForTesting
+  PreviewDependencyGraph get dependencyGraph => _dependencyGraph;
   final PreviewDependencyGraph _dependencyGraph = PreviewDependencyGraph();
 
   late final AnalysisContextCollection collection = AnalysisContextCollection(
@@ -125,21 +129,22 @@ class PreviewDetector {
     }
 
     if (filePreviewsMapping.isNotEmpty) {
-      // The set of previews has changed, but there are still previews in the file.
-      final MapEntry<PreviewPath, PreviewDependencyNode>(
+      // The set of previews has changed, but there are still previews in the library.
+      final MapEntry<PreviewPath, LibraryPreviewNode>(
         key: PreviewPath location,
-        value: PreviewDependencyNode fileDetails,
+        value: LibraryPreviewNode libraryDetails,
       ) = filePreviewsMapping.entries.single;
-      logger.printStatus('Updated previews for ${location.uri}: ${fileDetails.filePreviews}');
-      _dependencyGraph[location] = fileDetails;
+      logger.printStatus('Updated previews for ${location.uri}: ${libraryDetails.previews}');
+      _dependencyGraph[location] = libraryDetails;
     } else {
       // Why is this working with an empty file system on Linux?
-      final PreviewPath removedPath = _dependencyGraph.keys.firstWhere(
-        (PreviewPath element) => element.path == eventPath,
-      );
-      // The file previously had previews that were removed.
+      final PreviewPath removedLibraryPath =
+          _dependencyGraph.values
+              .firstWhere((LibraryPreviewNode element) => element.files.contains(eventPath))
+              .path;
+      // The library previously had previews that were removed.
       logger.printStatus('Previews removed from $eventPath');
-      _dependencyGraph.remove(removedPath);
+      _dependencyGraph.remove(removedLibraryPath);
     }
   }
 
@@ -155,33 +160,42 @@ class PreviewDetector {
         logger.printTrace('Skipping $filePath');
         continue;
       }
-      final SomeResolvedLibraryResult lib = await context.currentSession.getResolvedLibrary(
-        filePath,
-      );
-      // TODO(bkonyi): ensure this can handle part files.
+      SomeResolvedLibraryResult lib = await context.currentSession.getResolvedLibrary(filePath);
+      // If filePath points to a file that's part of a library, retrieve its compilation unit first
+      // in order to get the actual path to the library.
+      if (lib is NotLibraryButPartResult) {
+        final ResolvedUnitResult unit =
+            (await context.currentSession.getResolvedUnit(filePath)) as ResolvedUnitResult;
+        lib = await context.currentSession.getResolvedLibrary(
+          unit.libraryElement2.firstFragment.source.fullName,
+        );
+      }
       if (lib is ResolvedLibraryResult) {
-        for (final ResolvedUnitResult libUnit in lib.units) {
-          final PreviewPath previewPath = libUnit.toPreviewPath();
-          final PreviewDependencyNode previewForFile = _dependencyGraph.putIfAbsent(
-            previewPath,
-            () => PreviewDependencyNode(previewPath: previewPath, logger: logger),
-          );
-          previewForFile.updateDependencyGraph(graph: _dependencyGraph, unit: libUnit);
-          updatedPreviews[previewPath] = previewForFile;
-
-          // Check for errors in the compilation unit.
-          await previewForFile.populateErrors(context: context);
-
-          // Iterate over the compilation unit's AST to find previews.
-          previewForFile.findPreviews(compilationUnit: libUnit.unit);
+        final ResolvedLibraryResult resolvedLib = lib;
+        final PreviewPath previewPath = lib.element2.toPreviewPath();
+        // This library has already been processed.
+        if (updatedPreviews.containsKey(previewPath)) {
+          continue;
         }
-      } else {
-        logger.printWarning('Unknown library type at $filePath: $lib');
+
+        final LibraryPreviewNode previewsForLibrary = _dependencyGraph.putIfAbsent(
+          previewPath,
+          () => LibraryPreviewNode(library: resolvedLib.element2, logger: logger),
+        );
+
+        previewsForLibrary.updateDependencyGraph(graph: _dependencyGraph, units: lib.units);
+        updatedPreviews[previewPath] = previewsForLibrary;
+
+        // Check for errors in the library.
+        await previewsForLibrary.populateErrors(context: context);
+
+        // Iterate over each compilation unit's AST to find previews.
+        previewsForLibrary.findPreviews(units: lib.units);
       }
     }
     final int previewCount = updatedPreviews.values.fold<int>(
       0,
-      (int count, PreviewDependencyNode value) => count + value.filePreviews.length,
+      (int count, LibraryPreviewNode value) => count + value.previews.length,
     );
     logger.printStatus('Found $previewCount ${pluralize('preview', previewCount)}.');
     return updatedPreviews;
@@ -189,70 +203,75 @@ class PreviewDetector {
 
   /// Handles the deletion of a file from the target project.
   ///
-  /// This involves removing the relevant [PreviewDependencyNode] from the dependency graph as well
+  /// This involves removing the relevant [LibraryPreviewNode] from the dependency graph as well
   /// as checking for newly introduced errors in files which had a transitive dependency on the
   /// removed file.
   Future<void> _fileRemoved({required AnalysisContext context, required String eventPath}) async {
     final File file = fs.file(eventPath);
-    final PreviewPath previewPath = _dependencyGraph.keys.firstWhere(
-      (PreviewPath e) => e.path == file.path,
+    final LibraryPreviewNode node = _dependencyGraph.values.firstWhere(
+      (LibraryPreviewNode e) => e.files.contains(file.path),
     );
 
-    final Set<PreviewDependencyNode> visitedNodes = <PreviewDependencyNode>{};
-    Future<void> populateErrorsDownstream({required PreviewDependencyNode node}) async {
+    final Set<LibraryPreviewNode> visitedNodes = <LibraryPreviewNode>{};
+    Future<void> populateErrorsDownstream({required LibraryPreviewNode node}) async {
       visitedNodes.add(node);
       await node.populateErrors(context: context);
-      for (final PreviewDependencyNode downstream in node.dependedOnBy) {
+      for (final LibraryPreviewNode downstream in node.dependedOnBy) {
         if (!visitedNodes.contains(downstream)) {
           await populateErrorsDownstream(node: downstream);
         }
       }
     }
 
-    final PreviewDependencyNode node = _dependencyGraph.remove(previewPath)!;
+    node.files.remove(eventPath);
 
-    // Removing a file can cause errors to be introduced down the dependency chain, so all
-    // downstream dependencies need to be checked for errors.
-    for (final PreviewDependencyNode downstream in node.dependedOnBy) {
-      downstream.dependsOn.remove(node);
-      await populateErrorsDownstream(node: node);
-    }
-    for (final PreviewDependencyNode upstream in node.dependsOn) {
-      upstream.dependedOnBy.remove(node);
+    // If the library node contains no files, the library has been completely deleted.
+    if (node.files.isEmpty) {
+      _dependencyGraph.remove(node.path)!;
+
+      // Removing a library can cause errors to be introduced down the dependency chain, so all
+      // downstream dependencies need to be checked for errors.
+      for (final LibraryPreviewNode downstream in node.dependedOnBy) {
+        downstream.dependsOn.remove(node);
+        await populateErrorsDownstream(node: node);
+      }
+      for (final LibraryPreviewNode upstream in node.dependsOn) {
+        upstream.dependedOnBy.remove(node);
+      }
     }
   }
 
-  /// Determines which files in the project have transitive dependencies containing compile time
-  /// errors, setting [PreviewDependencyNode.dependencyHasErrors] to true for files which
+  /// Determines which libraries in the project have transitive dependencies containing compile
+  /// time errors, setting [LibraryPreviewNode.dependencyHasErrors] to true for libraries which
   /// would cause errors if imported into the previewer.
   // TODO(bkonyi): allow for processing a subset of files.
   void _propagateErrors() {
     final PreviewDependencyGraph previews = _dependencyGraph;
 
     // Reset the error state for all dependencies.
-    for (final PreviewDependencyNode fileDetails in previews.values) {
-      if (fileDetails.errors.isEmpty) {
-        fileDetails.dependencyHasErrors = false;
+    for (final LibraryPreviewNode libraryDetails in previews.values) {
+      if (libraryDetails.errors.isEmpty) {
+        libraryDetails.dependencyHasErrors = false;
       }
     }
 
-    void propagateErrorsHelper(PreviewDependencyNode errorContainingNode) {
-      for (final PreviewDependencyNode importer in errorContainingNode.dependedOnBy) {
+    void propagateErrorsHelper(LibraryPreviewNode errorContainingNode) {
+      for (final LibraryPreviewNode importer in errorContainingNode.dependedOnBy) {
         if (importer.dependencyHasErrors) {
           // This dependency path has already been processed.
           continue;
         }
-        logger.printWarning('Propagating errors to: ${importer.previewPath.path}');
+        logger.printWarning('Propagating errors to: ${importer.path.path}');
         importer.dependencyHasErrors = true;
         propagateErrorsHelper(importer);
       }
     }
 
-    // Find the files that have errors and mark each of their downstream dependencies as having
+    // Find the libraries that have errors and mark each of their downstream dependencies as having
     // a dependency containing errors.
-    for (final PreviewDependencyNode nodeDetails in previews.values) {
+    for (final LibraryPreviewNode nodeDetails in previews.values) {
       if (nodeDetails.errors.isNotEmpty) {
-        logger.printWarning('${nodeDetails.previewPath.path} has errors.');
+        logger.printWarning('${nodeDetails.path.path} has errors.');
         propagateErrorsHelper(nodeDetails);
       }
     }

--- a/packages/flutter_tools/lib/src/widget_preview/utils.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/utils.dart
@@ -8,6 +8,7 @@ import 'dart:collection';
 import 'package:analyzer/dart/analysis/results.dart';
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/token.dart';
+import 'package:analyzer/dart/element/element2.dart';
 import 'package:analyzer/source/source.dart';
 
 import 'dependency_graph.dart';
@@ -30,6 +31,11 @@ extension StringExtension on String {
   bool get isDartFile => endsWith('.dart');
   bool get isPubspec => endsWith('pubspec.yaml');
   bool get doesContainDartTool => contains('.dart_tool');
+}
+
+extension LibraryElement2Extension on LibraryElement2 {
+  /// Convenience method to package path and [uri] into a [PreviewPath]
+  PreviewPath toPreviewPath() => (path: firstFragment.source.fullName, uri: uri);
 }
 
 extension ParsedUnitResultExtension on ParsedUnitResult {

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -259,7 +259,7 @@ List<_i1.WidgetPreview> previews() => [
 
         // Regenerate the generated file with no previews.
         codeGenerator.populatePreviewsInGeneratedPreviewScaffold(
-          const <PreviewPath, PreviewDependencyNode>{},
+          const <PreviewPath, LibraryPreviewNode>{},
         );
         expect(generatedPreviewFile, exists);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_graph_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_graph_test.dart
@@ -60,21 +60,21 @@ import 'src/lib.dart';
 void main() {}
 ''',
       );
-      const WidgetPreviewSourceFile lib = (
-        path: 'src/lib.dart',
+      final WidgetPreviewSourceFile lib = (
+        path: platformPath(<String>['src', 'lib.dart']),
         source: '''
 library lib;
 part 'lib_part1.dart';
 part 'lib_part2.dart';''',
       );
-      const WidgetPreviewSourceFile libPart1 = (
-        path: 'src/lib_part1.dart',
+      final WidgetPreviewSourceFile libPart1 = (
+        path: platformPath(<String>['src', 'lib_part1.dart']),
         source: '''
 part of 'lib.dart';
 ''',
       );
-      const WidgetPreviewSourceFile libPart2 = (
-        path: 'src/lib_part2.dart',
+      final WidgetPreviewSourceFile libPart2 = (
+        path: platformPath(<String>['src', 'lib_part2.dart']),
         source: '''
 part of 'lib.dart';
 ''',

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_graph_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_graph_test.dart
@@ -1,0 +1,276 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
+import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
+import 'package:test/test.dart';
+
+import '../../../src/common.dart';
+import '../../../src/context.dart';
+import 'utils/preview_detector_test_utils.dart';
+import 'utils/preview_project.dart';
+
+// Note: this test isn't under the general.shard since tests under that directory
+// have a 2000ms time out and these tests write to the real file system and watch
+// directories for changes. This can be slow on heavily loaded machines and cause
+// flaky failures.
+
+WidgetPreviewSourceFile withUpdatedSource(WidgetPreviewSourceFile original, String source) => (
+  path: original.path,
+  source: source,
+);
+
+void main() {
+  initializeTestPreviewDetectorState();
+  group('$PreviewDependencyGraph', () {
+    // Note: we don't use a MemoryFileSystem since we don't have a way to
+    // provide it to package:analyzer APIs without writing a significant amount
+    // of wrapper logic.
+    late PreviewDetector previewDetector;
+    late WidgetPreviewProject project;
+
+    setUp(() {
+      previewDetector = createTestPreviewDetector();
+      project = WidgetPreviewProject(projectRoot: previewDetector.projectRoot);
+    });
+
+    tearDown(() async {
+      await previewDetector.dispose();
+    });
+
+    testUsingContext('dependency graph cycle smoke test', () async {
+      // Simple test to ensure graph cycles don't cause infinite recursion during traversal.
+      <WidgetPreviewSourceFile>[
+        (path: 'foo.dart', source: "import 'bar.dart';"),
+        (path: 'bar.dart', source: "import 'foo.dart';"),
+      ].forEach(project.writeFile);
+      final PreviewDependencyGraph graph = await previewDetector.initialize();
+      expect(graph.keys, containsAll(project.paths));
+      expectPreviewDependencyGraphIsWellFormed(graph);
+    });
+
+    group('library parts', () {
+      const WidgetPreviewSourceFile main = (
+        path: 'main.dart',
+        source: '''
+import 'src/lib.dart';
+
+void main() {}
+''',
+      );
+      const WidgetPreviewSourceFile lib = (
+        path: 'src/lib.dart',
+        source: '''
+library lib;
+part 'lib_part1.dart';
+part 'lib_part2.dart';''',
+      );
+      const WidgetPreviewSourceFile libPart1 = (
+        path: 'src/lib_part1.dart',
+        source: '''
+part of 'lib.dart';
+''',
+      );
+      const WidgetPreviewSourceFile libPart2 = (
+        path: 'src/lib_part2.dart',
+        source: '''
+part of 'lib.dart';
+''',
+      );
+
+      setUp(() {
+        <WidgetPreviewSourceFile>[main, lib, libPart1, libPart2].forEach(project.writeFile);
+      });
+
+      testUsingContext('smoke test', () async {
+        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
+
+        // Ensure that projects with libraries containing parts are handled correctly.
+        expect(
+          initialGraph.keys,
+          containsAll(<PreviewPath>{
+            project.toPreviewPath(main.path),
+            project.toPreviewPath(lib.path),
+          }),
+        );
+        expectPreviewDependencyGraphIsWellFormed(initialGraph);
+        expect(initialGraph[project.toPreviewPath(lib.path)]!.files, hasLength(3));
+      });
+
+      testUsingContext('with errors in parts', () async {
+        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
+        expectPreviewDependencyGraphIsWellFormed(initialGraph);
+
+        // Introduce a compilation error into one of the library parts and verify that the library
+        // and libraries that depend on it have errors.
+        await expectHasErrors(
+          changeOperation:
+              () => project.writeFile(
+                withUpdatedSource(libPart1, '${libPart1.source}\ninvalid-symbol;'),
+              ),
+          filesWithErrors: <WidgetPreviewSourceFile>{main, lib},
+        );
+
+        // Fix the compilation error and verify that there's no longer any errors.
+        await expectHasNoErrors(changeOperation: () => project.writeFile(libPart1));
+      });
+    });
+
+    group('dependency errors', () {
+      const WidgetPreviewSourceFile main = (
+        path: 'main.dart',
+        source: '''
+import 'foo.dart';
+void main() => foo();
+''',
+      );
+      const WidgetPreviewSourceFile foo = (
+        path: 'foo.dart',
+        source: '''
+import 'bar.dart';
+void foo() => bar();
+''',
+      );
+
+      const WidgetPreviewSourceFile bar = (
+        path: 'bar.dart',
+        source: '''
+void bar() => null;
+''',
+      );
+      WidgetPreviewSourceFile toInvalidSource(WidgetPreviewSourceFile original) =>
+          withUpdatedSource(original, 'invalid-symbol');
+
+      setUp(() {
+        <WidgetPreviewSourceFile>[main, foo, bar].forEach(project.writeFile);
+      });
+
+      testUsingContext('entire directory removed', () async {
+        String platformPath(List<String> pathSegments) =>
+            pathSegments.join(const LocalPlatform().pathSeparator);
+        final WidgetPreviewSourceFile a = (
+          path: platformPath(<String>['dir', 'a.dart']),
+          source: "import 'b.dart';",
+        );
+        final WidgetPreviewSourceFile b = (
+          path: platformPath(<String>['dir', 'b.dart']),
+          source: "import 'c.dart';",
+        );
+        final WidgetPreviewSourceFile c = (
+          path: platformPath(<String>['dir', 'c.dart']),
+          source: 'void foo() {}',
+        );
+        project
+          ..writeFile(a)
+          ..writeFile(b)
+          ..writeFile(c);
+
+        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
+        expect(initialGraph.keys, containsAll(project.paths));
+
+        // Validate the files in dir/ all have transistive errors.
+        await expectHasErrors(
+          changeOperation: () => project.writeFile(toInvalidSource(c)),
+          filesWithErrors: <WidgetPreviewSourceFile>{a, b, c},
+        );
+
+        // Delete dir/. This will cause 3 change events to be reported, one for each file in the
+        // deleted directory. Until all 3 events have been processed, the dependency graph will not
+        // be consistent as the files have already been deleted on disk.
+        await waitForNChangesDetected(
+          n: 3,
+          changeOperation: () => project.removeDirectoryContaining(a),
+        );
+
+        // Verify the graph is well formed once the deletion events have been processed.
+        expectPreviewDependencyGraphIsWellFormed(initialGraph);
+      });
+
+      testUsingContext('smoke test', () async {
+        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
+        expect(initialGraph.keys, containsAll(project.paths));
+
+        // Verify there's no errors in the project.
+        for (final LibraryPreviewNode node in initialGraph.values) {
+          expect(node.dependencyHasErrors, false);
+          expect(node.hasErrors, false);
+        }
+
+        // Introduce an error into bar.dart and verify files that have transitive dependencies on
+        // bar.dart are marked as having errors.
+        await expectHasErrors(
+          changeOperation: () => project.writeFile(toInvalidSource(bar)),
+          filesWithErrors: project.currentSources,
+        );
+
+        // Remove the error from bar.dart and ensure no files have errors.
+        await expectHasNoErrors(changeOperation: () => project.writeFile(bar));
+      });
+
+      testUsingContext('file with error added and removed', () async {
+        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
+        expect(initialGraph.keys, containsAll(project.paths));
+
+        // Verify there's no errors in the project.
+        for (final LibraryPreviewNode node in initialGraph.values) {
+          expect(node.dependencyHasErrors, false);
+          expect(node.hasErrors, false);
+        }
+
+        // Add baz.dart, which contains errors. Since no other files import baz.dart, it should be
+        // the only file with errors.
+        const WidgetPreviewSourceFile baz = (path: 'baz.dart', source: 'invalid.symbol');
+        await expectHasErrors(
+          changeOperation: () => project.writeFile(baz),
+          filesWithErrors: <WidgetPreviewSourceFile>{baz},
+        );
+
+        // Update main.dart to import baz.dart. All files in the project should now have transitive
+        // errors.
+        await expectHasErrors(
+          changeOperation:
+              () => project.writeFile((
+                path: main.path,
+                source: "import '${baz.path}';\n${main.source}",
+              )),
+          filesWithErrors: <WidgetPreviewSourceFile>{main, baz},
+        );
+
+        // Delete baz.dart. main.dart should continue to have an error.
+        await expectHasErrors(
+          changeOperation: () => project.removeFile(baz),
+          filesWithErrors: <WidgetPreviewSourceFile>{main},
+        );
+
+        // Restore main.dart to remove the baz.dart import and clear the errors.
+        await expectHasNoErrors(changeOperation: () => project.writeFile(main));
+      });
+
+      testUsingContext(
+        'error added into dependency in the middle of the graph and removed',
+        () async {
+          final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
+          expect(initialGraph.keys, containsAll(project.paths));
+
+          // Verify there's no errors in the project.
+          for (final LibraryPreviewNode node in initialGraph.values) {
+            expect(node.dependencyHasErrors, false);
+            expect(node.hasErrors, false);
+          }
+
+          // Add baz.dart, which contains errors. Since no other files import baz.dart, it should be
+          // the only file with errors.
+          await expectHasErrors(
+            changeOperation: () => project.writeFile(toInvalidSource(foo)),
+            filesWithErrors: <WidgetPreviewSourceFile>{foo, main},
+          );
+
+          // Delete baz.dart. main.dart should continue to have an error.
+          await expectHasNoErrors(changeOperation: () => project.writeFile(foo));
+        },
+      );
+    });
+  });
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_test.dart
@@ -2,30 +2,23 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
-import 'package:analyzer/dart/ast/ast.dart';
-import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
-import 'package:flutter_tools/src/widget_preview/preview_details.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
 import 'package:test/test.dart';
 
+import '../../../integration.shard/gen_l10n_test.dart';
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import 'utils/preview_details_matcher.dart';
+import 'utils/preview_detector_test_utils.dart';
+import 'utils/preview_project.dart';
 
 // Note: this test isn't under the general.shard since tests under that directory
 // have a 2000ms time out and these tests write to the real file system and watch
 // directories for changes. This can be slow on heavily loaded machines and cause
 // flaky failures.
-
-Directory createBasicProjectStructure(FileSystem fs) {
-  return fs.systemTempDirectory.createTempSync('root');
-}
 
 String platformPath(List<String> pathSegments) =>
     pathSegments.join(const LocalPlatform().pathSeparator);
@@ -36,18 +29,114 @@ void populatePubspec(Directory projectRoot, String contents) {
     ..writeAsStringSync(contents);
 }
 
-extension on PreviewDependencyGraph {
-  Map<PreviewPath, PreviewDependencyNode> get nodesWithPreviews {
-    return Map<PreviewPath, PreviewDependencyNode>.fromEntries(
-      entries.where(
-        (MapEntry<PreviewPath, PreviewDependencyNode> element) =>
-            element.value.filePreviews.isNotEmpty,
-      ),
-    );
+/// Creates a project with files containing previews that attempt to use as many widget preview
+/// properties as possible.
+class BasicProjectWithExhaustivePreviews extends WidgetPreviewProject {
+  BasicProjectWithExhaustivePreviews({
+    required super.projectRoot,
+    required List<String> pathsWithPreviews,
+    required List<String> pathsWithoutPreviews,
+  }) {
+    final List<WidgetPreviewSourceFile> initialSources = <WidgetPreviewSourceFile>[];
+    for (final String path in pathsWithPreviews) {
+      initialSources.add((path: path, source: _previewContainingFileContents));
+      librariesWithPreviews.add(toPreviewPath(path));
+    }
+    for (final String path in pathsWithoutPreviews) {
+      initialSources.add((path: path, source: _nonPreviewContainingFileContents));
+      librariesWithoutPreviews.add(toPreviewPath(path));
+    }
+    initialSources.forEach(writeFile);
   }
-}
 
-const String previewContainingFileContents = '''
+  Map<PreviewPath, List<PreviewDetailsMatcher>> get matcherMapping =>
+      <PreviewPath, List<PreviewDetailsMatcher>>{
+        for (final PreviewPath path in librariesWithPreviews) path: _expectedPreviewDetails,
+      };
+
+  final Set<PreviewPath> librariesWithPreviews = <PreviewPath>{};
+  final Set<PreviewPath> librariesWithoutPreviews = <PreviewPath>{};
+
+  /// Adds a file containing previews at [path].
+  void addPreviewContainingFile({required String path}) {
+    writeFile((path: path, source: _previewContainingFileContents));
+    final PreviewPath previewPath = toPreviewPath(path);
+    librariesWithoutPreviews.remove(previewPath);
+    librariesWithPreviews.add(previewPath);
+  }
+
+  /// Adds a file with no previews at [path].
+  void addNonPreviewContainingFile({required String path}) {
+    writeFile((path: path, source: _nonPreviewContainingFileContents));
+    final PreviewPath previewPath = toPreviewPath(path);
+    librariesWithPreviews.remove(previewPath);
+    librariesWithoutPreviews.add(previewPath);
+  }
+
+  /// Adds a new library with a part at [path].
+  ///
+  /// If the file name specified by [path] is 'path.dart', the part file will be named
+  /// 'path_part.dart'.
+  void addLibraryWithPartsContainingPreviews({required String path}) {
+    final String partPath = path.replaceAll('.dart', '_part.dart');
+    writeFile((
+      path: partPath,
+      source: '''
+part of '$path';
+
+$_previewContainingFileContents
+''',
+    ));
+
+    writeFile((
+      path: path,
+      source: '''
+part '$partPath';
+''',
+    ));
+    final PreviewPath previewPath = toPreviewPath(path);
+    librariesWithoutPreviews.remove(previewPath);
+    librariesWithPreviews.add(previewPath);
+  }
+
+  @override
+  // ignore: must_call_super, always throws
+  void removeDirectoryContaining(WidgetPreviewSourceFile file) {
+    throw UnimplementedError('Not supported for $BasicProjectWithExhaustivePreviews');
+  }
+
+  final List<PreviewDetailsMatcher> _expectedPreviewDetails = <PreviewDetailsMatcher>[
+    PreviewDetailsMatcher(functionName: 'previews', isBuilder: false, name: 'Top-level preview'),
+    PreviewDetailsMatcher(functionName: 'builderPreview', isBuilder: true, name: 'Builder preview'),
+    PreviewDetailsMatcher(
+      functionName: 'attributesPreview',
+      isBuilder: false,
+      nameSymbol: 'kAttributesPreview',
+      size: 'Size(100.0, 100)',
+      textScaleFactor: '2.0',
+      wrapper: 'testWrapper',
+      theme: 'theming',
+      brightness: 'Brightness.dark',
+      localizations: 'localizations',
+    ),
+    PreviewDetailsMatcher(
+      functionName: 'MyWidget.preview',
+      isBuilder: false,
+      name: 'Constructor preview',
+    ),
+    PreviewDetailsMatcher(
+      functionName: 'MyWidget.factoryPreview',
+      isBuilder: false,
+      name: 'Factory constructor preview',
+    ),
+    PreviewDetailsMatcher(
+      functionName: 'MyWidget.previewStatic',
+      isBuilder: false,
+      name: 'Static preview',
+    ),
+  ];
+
+  static const String _previewContainingFileContents = '''
 @Preview(name: 'Top-level preview')
 Widget previews() => Text('Foo');
 
@@ -118,248 +207,72 @@ class MyWidget extends StatelessWidget {
 }
 ''';
 
-const String nonPreviewContainingFileContents = '''
+  static const String _nonPreviewContainingFileContents = '''
 String foo() => 'bar';
 ''';
+}
 
-typedef TestSource = ({String name, String source});
+extension on PreviewDependencyGraph {
+  PreviewDependencyGraph get nodesWithPreviews {
+    return PreviewDependencyGraph.fromEntries(
+      entries.where(
+        (MapEntry<PreviewPath, LibraryPreviewNode> element) => element.value.previews.isNotEmpty,
+      ),
+    );
+  }
+}
 
 void main() {
+  initializeTestPreviewDetectorState();
   group('$PreviewDetector', () {
     // Note: we don't use a MemoryFileSystem since we don't have a way to
     // provide it to package:analyzer APIs without writing a significant amount
     // of wrapper logic.
-    late LocalFileSystem fs;
-    late Logger logger;
     late PreviewDetector previewDetector;
-    late Directory projectRoot;
-    void Function(PreviewDependencyGraph)? onChangeDetectedImpl;
-    void Function()? onPubspecChangeDetected;
-
-    void onChangeDetectedRoot(PreviewDependencyGraph mapping) {
-      onChangeDetectedImpl!(mapping);
-    }
-
-    void onPubspecChangeDetectedRoot() {
-      onPubspecChangeDetected!();
-    }
-
-    PreviewPath previewPathForFile(String path) {
-      final File file = projectRoot.childDirectory('lib').childFile(path);
-      return (path: file.path, uri: file.uri);
-    }
-
-    PreviewPath addProjectFile(Object path, String contents) {
-      final PreviewPath previewPath = switch (path) {
-        final String previewPath => previewPathForFile(previewPath),
-        final PreviewPath previewPath => previewPath,
-        _ => throw StateError('path must be either PreviewPath or String: ${path.runtimeType}'),
-      };
-
-      fs.file(previewPath.path)
-        ..createSync(recursive: true)
-        ..writeAsStringSync(contents);
-      return previewPath;
-    }
-
-    void removeProjectFile(Object path) {
-      final PreviewPath previewPath = switch (path) {
-        final String previewPath => previewPathForFile(previewPath),
-        final PreviewPath previewPath => previewPath,
-        _ => throw StateError('path must be either PreviewPath or String: ${path.runtimeType}'),
-      };
-
-      fs.file(previewPath.path).deleteSync();
-    }
-
-    void removeProjectDirectory(String path) {
-      fs.directory(path).deleteSync(recursive: true);
-    }
-
-    PreviewPath addPreviewContainingFile(Object previewPath) =>
-        addProjectFile(previewPath, previewContainingFileContents);
-
-    PreviewPath addNonPreviewContainingFile(Object previewPath) =>
-        addProjectFile(previewPath, nonPreviewContainingFileContents);
-
-    Future<void> waitForChangeDetected({
-      required void Function(PreviewDependencyGraph) onChangeDetected,
-      required void Function() changeOperation,
-    }) async {
-      final Completer<void> completer = Completer<void>();
-      onChangeDetectedImpl = (PreviewDependencyGraph updated) {
-        if (completer.isCompleted) {
-          return;
-        }
-        onChangeDetected(updated);
-        completer.complete();
-      };
-      changeOperation();
-      await completer.future;
-    }
-
-    void expectPreviewDependencyGraphIsWellFormed(
-      PreviewDependencyGraph graph, {
-      Set<PreviewPath> expectedFilesWithErrors = const <PreviewPath>{},
-    }) {
-      final Set<PreviewDependencyNode> nodesWithErrors = <PreviewDependencyNode>{};
-      for (final PreviewDependencyNode node in graph.values) {
-        expect(fs.file(node.previewPath.path), exists);
-        if (node.hasErrors) {
-          nodesWithErrors.add(node);
-        }
-        for (final PreviewDependencyNode upstream in node.dependedOnBy) {
-          expect(upstream.dependsOn, contains(node));
-        }
-        for (final PreviewDependencyNode downstream in node.dependsOn) {
-          expect(downstream.dependedOnBy, contains(node));
-        }
-      }
-
-      // Validates that all upstream dependencies are marked as having a transitive dependency
-      // containing errors.
-      final Set<PreviewPath> filesWithTransitiveErrors = <PreviewPath>{};
-      void dependencyHasErrorsValidator(PreviewDependencyNode node) {
-        filesWithTransitiveErrors.add(node.previewPath);
-        expect(node.dependencyHasErrors, true);
-        node.dependedOnBy.forEach(dependencyHasErrorsValidator);
-      }
-
-      for (final PreviewDependencyNode node in nodesWithErrors) {
-        filesWithTransitiveErrors.add(node.previewPath);
-        node.dependedOnBy.forEach(dependencyHasErrorsValidator);
-      }
-
-      // Verify we've found all the files expected to have transitive errors.
-      expect(filesWithTransitiveErrors, expectedFilesWithErrors);
-    }
-
-    Future<void> expectHasErrors({
-      required void Function() changeOperation,
-      required Set<PreviewPath> filesWithErrors,
-    }) async {
-      await waitForChangeDetected(
-        onChangeDetected:
-            (PreviewDependencyGraph updated) => expectPreviewDependencyGraphIsWellFormed(
-              updated,
-              expectedFilesWithErrors: filesWithErrors,
-            ),
-        changeOperation: changeOperation,
-      );
-    }
-
-    Future<void> expectHasNoErrors({required void Function() changeOperation}) async {
-      await expectHasErrors(
-        changeOperation: changeOperation,
-        filesWithErrors: const <PreviewPath>{},
-      );
-    }
-
-    void expectContainsPreviews(
-      Map<PreviewPath, PreviewDependencyNode> actual,
-      Map<PreviewPath, List<PreviewDetailsMatcher>> expected,
-    ) {
-      for (final MapEntry<PreviewPath, List<PreviewDetailsMatcher>>(
-            key: PreviewPath previewPath,
-            value: List<PreviewDetailsMatcher> filePreviews,
-          )
-          in expected.entries) {
-        expect(actual.containsKey(previewPath), true);
-        expect(actual[previewPath]!.filePreviews, filePreviews);
-      }
-    }
+    late BasicProjectWithExhaustivePreviews project;
 
     setUp(() {
-      fs = LocalFileSystem.test(signals: Signals.test());
-      projectRoot = createBasicProjectStructure(fs);
-      logger = BufferLogger.test();
-      previewDetector = PreviewDetector(
-        projectRoot: projectRoot,
-        logger: logger,
-        fs: fs,
-        onChangeDetected: onChangeDetectedRoot,
-        onPubspecChangeDetected: onPubspecChangeDetectedRoot,
-      );
+      previewDetector = createTestPreviewDetector();
     });
 
     tearDown(() async {
       await previewDetector.dispose();
-      projectRoot.deleteSync(recursive: true);
-      onChangeDetectedImpl = null;
     });
 
     testUsingContext('can detect previews in existing files', () async {
-      final List<PreviewPath> previewFiles = <PreviewPath>[
-        addPreviewContainingFile('foo.dart'),
-        addPreviewContainingFile(platformPath(<String>['src', 'bar.dart'])),
-      ];
-      addNonPreviewContainingFile('baz.dart');
+      project = BasicProjectWithExhaustivePreviews(
+        projectRoot: previewDetector.projectRoot,
+        pathsWithPreviews: <String>[
+          'foo.dart',
+          platformPath(<String>['src', 'bar.dart']),
+        ],
+        pathsWithoutPreviews: <String>['baz'],
+      );
       final PreviewDependencyGraph mapping = await previewDetector.initialize();
-      expect(mapping.nodesWithPreviews.keys, unorderedMatches(previewFiles));
+      expect(mapping.nodesWithPreviews.keys, unorderedMatches(project.librariesWithPreviews));
     });
 
     testUsingContext('can detect previews in updated files', () async {
-      final List<PreviewDetailsMatcher> expectedPreviewDetails = <PreviewDetailsMatcher>[
-        PreviewDetailsMatcher(
-          functionName: 'previews',
-          isBuilder: false,
-          name: 'Top-level preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'builderPreview',
-          isBuilder: true,
-          name: 'Builder preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'attributesPreview',
-          isBuilder: false,
-          nameSymbol: 'kAttributesPreview',
-          size: 'Size(100.0, 100)',
-          textScaleFactor: '2.0',
-          wrapper: 'testWrapper',
-          theme: 'theming',
-          brightness: 'Brightness.dark',
-          localizations: 'localizations',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'MyWidget.preview',
-          isBuilder: false,
-          name: 'Constructor preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'MyWidget.factoryPreview',
-          isBuilder: false,
-          name: 'Factory constructor preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'MyWidget.previewStatic',
-          isBuilder: false,
-          name: 'Static preview',
-        ),
-      ];
-
       // Create two files with existing previews and one without.
-      final Map<PreviewPath, List<PreviewDetailsMatcher>> expectedInitialMapping =
-          <PreviewPath, List<PreviewDetailsMatcher>>{
-            addPreviewContainingFile('foo.dart'): expectedPreviewDetails,
-            addPreviewContainingFile(platformPath(<String>['src', 'bar.dart'])):
-                expectedPreviewDetails,
-          };
-      final PreviewPath nonPreviewContainingFile = addNonPreviewContainingFile('baz.dart');
+      project = BasicProjectWithExhaustivePreviews(
+        projectRoot: previewDetector.projectRoot,
+        pathsWithPreviews: <String>[
+          'foo.dart',
+          platformPath(<String>['src', 'bar.dart']),
+        ],
+        pathsWithoutPreviews: <String>['baz'],
+      );
 
       // Initialize the file watcher.
       final PreviewDependencyGraph initialPreviews = await previewDetector.initialize();
-      expectContainsPreviews(initialPreviews, expectedInitialMapping);
+      expectContainsPreviews(initialPreviews, project.matcherMapping);
 
       await waitForChangeDetected(
         onChangeDetected: (PreviewDependencyGraph updated) {
           // The new preview in baz.dart should be included in the preview mapping.
-          expectContainsPreviews(updated, <PreviewPath, List<PreviewDetailsMatcher>>{
-            ...expectedInitialMapping,
-            nonPreviewContainingFile: expectedPreviewDetails,
-          });
+          expectContainsPreviews(updated, project.matcherMapping);
         },
-        changeOperation: () => addPreviewContainingFile('baz.dart'),
+        changeOperation: () => project.addPreviewContainingFile(path: 'baz.dart'),
       );
 
       // Update the file with an existing preview to remove the preview and ensure it triggers
@@ -367,56 +280,20 @@ void main() {
       await waitForChangeDetected(
         onChangeDetected: (PreviewDependencyGraph updated) {
           // The removed preview in baz.dart should not longer be included in the preview mapping.
-          expectContainsPreviews(updated, expectedInitialMapping);
+          expectContainsPreviews(updated, project.matcherMapping);
         },
-        changeOperation: () => addNonPreviewContainingFile('baz.dart'),
+        changeOperation: () => project.addNonPreviewContainingFile(path: 'baz.dart'),
       );
     });
 
     testUsingContext('can detect previews in newly added files', () async {
-      final List<PreviewDetailsMatcher> expectedPreviewDetails = <PreviewDetailsMatcher>[
-        PreviewDetailsMatcher(
-          functionName: 'previews',
-          isBuilder: false,
-          name: 'Top-level preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'builderPreview',
-          isBuilder: true,
-          name: 'Builder preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'attributesPreview',
-          isBuilder: false,
-          nameSymbol: 'kAttributesPreview',
-          size: 'Size(100.0, 100)',
-          textScaleFactor: '2.0',
-          wrapper: 'testWrapper',
-          theme: 'theming',
-          brightness: 'Brightness.dark',
-          localizations: 'localizations',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'MyWidget.preview',
-          isBuilder: false,
-          name: 'Constructor preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'MyWidget.factoryPreview',
-          isBuilder: false,
-          name: 'Factory constructor preview',
-        ),
-        PreviewDetailsMatcher(
-          functionName: 'MyWidget.previewStatic',
-          isBuilder: false,
-          name: 'Static preview',
-        ),
-      ];
-
+      project = BasicProjectWithExhaustivePreviews(
+        projectRoot: previewDetector.projectRoot,
+        pathsWithPreviews: <String>[],
+        pathsWithoutPreviews: <String>[],
+      );
       // The initial mapping should be empty as there's no files containing previews.
-      final PreviewDependencyGraph expectedInitialMapping = <PreviewPath, PreviewDependencyNode>{};
-
-      late final PreviewPath previewContainingFilePath;
+      const PreviewDependencyGraph expectedInitialMapping = <PreviewPath, LibraryPreviewNode>{};
 
       // Initialize the file watcher.
       final PreviewDependencyGraph initialPreviews = await previewDetector.initialize();
@@ -425,311 +302,58 @@ void main() {
       await waitForChangeDetected(
         onChangeDetected: (PreviewDependencyGraph updated) {
           // The new previews in baz.dart should be included in the preview mapping.
-          expectContainsPreviews(updated, <PreviewPath, List<PreviewDetailsMatcher>>{
-            previewContainingFilePath: expectedPreviewDetails,
-          });
+          expectContainsPreviews(updated, project.matcherMapping);
         },
         // Create baz.dart, which contains previews.
-        changeOperation: () => previewContainingFilePath = addPreviewContainingFile('baz.dart'),
+        changeOperation: () => project.addPreviewContainingFile(path: 'baz.dart'),
       );
+    });
+
+    testUsingContext('can detect previews in existing libraries with parts', () async {
+      project = BasicProjectWithExhaustivePreviews(
+        projectRoot: previewDetector.projectRoot,
+        pathsWithPreviews: <String>[],
+        pathsWithoutPreviews: <String>[],
+      )..addLibraryWithPartsContainingPreviews(path: 'foo.dart');
+      final PreviewDependencyGraph mapping = await previewDetector.initialize();
+      expect(mapping.nodesWithPreviews.keys, unorderedMatches(project.librariesWithPreviews));
+    });
+
+    testUsingContext('can detect previews in newly added libraries with parts', () async {
+      project = BasicProjectWithExhaustivePreviews(
+        projectRoot: previewDetector.projectRoot,
+        pathsWithPreviews: <String>[],
+        pathsWithoutPreviews: <String>[],
+      );
+      // The initial mapping should be empty as there's no files containing previews.
+      const PreviewDependencyGraph expectedInitialMapping = <PreviewPath, LibraryPreviewNode>{};
+
+      final PreviewDependencyGraph mapping = await previewDetector.initialize();
+      expect(mapping.nodesWithPreviews, expectedInitialMapping);
+
+      // Add a library with a part file, which will cause a change detected event for each file.
+      await waitForNChangesDetected(
+        n: 2,
+        changeOperation: () => project.addLibraryWithPartsContainingPreviews(path: 'foo.dart'),
+      );
+      final PreviewDependencyGraph nodesWithPreviews =
+          previewDetector.dependencyGraph.nodesWithPreviews;
+      expect(nodesWithPreviews, isNotEmpty);
+      expect(nodesWithPreviews.keys, unorderedMatches(project.librariesWithPreviews));
     });
 
     testUsingContext('can detect changes in the pubspec.yaml', () async {
       // Create an initial pubspec.
-      populatePubspec(projectRoot, 'abc');
+      populatePubspec(previewDetector.projectRoot, 'abc');
 
-      final Completer<void> completer = Completer<void>();
-      onPubspecChangeDetected = () {
-        completer.complete();
-      };
       // Initialize the file watcher.
       final PreviewDependencyGraph initialPreviews = await previewDetector.initialize();
       expect(initialPreviews, isEmpty);
 
       // Change the contents of the pubspec and verify the callback is invoked.
-      populatePubspec(projectRoot, 'foo');
-      await completer.future;
-    });
-
-    testUsingContext('dependency graph cycle smoke test', () async {
-      // Simple test to ensure graph cycles don't cause infinite recursion during traversal.
-      const TestSource a = (name: 'foo.dart', source: "import 'bar.dart';");
-      const TestSource b = (name: 'bar.dart', source: "import 'foo.dart';");
-
-      final Set<PreviewPath> projectFiles = <PreviewPath>{
-        addProjectFile(a.name, a.source),
-        addProjectFile(b.name, b.source),
-      };
-      final PreviewDependencyGraph graph = await previewDetector.initialize();
-      expect(graph.keys, containsAll(projectFiles));
-      expectPreviewDependencyGraphIsWellFormed(graph);
-    });
-
-    group('dependency errors', () {
-      const TestSource main = (
-        name: 'main.dart',
-        source: '''
-import 'foo.dart';
-void main() => foo();
-''',
-      );
-      const TestSource foo = (
-        name: 'foo.dart',
-        source: '''
-import 'bar.dart';
-void foo() => bar();
-''',
-      );
-
-      const TestSource bar = (
-        name: 'bar.dart',
-        source: '''
-void bar() => null;
-''',
-      );
-
-      late Set<PreviewPath> initialProjectFiles;
-
-      setUp(() {
-        initialProjectFiles = <PreviewPath>{
-          addProjectFile(main.name, main.source),
-          addProjectFile(foo.name, foo.source),
-          addProjectFile(bar.name, bar.source),
-        };
-      });
-
-      testUsingContext('entire directory removed', () async {
-        final PreviewPath c = addProjectFile(
-          platformPath(<String>['dir', 'c.dart']),
-          'void foo() {}',
-        );
-        final Set<PreviewPath> directoryFiles = <PreviewPath>{
-          addProjectFile(platformPath(<String>['dir', 'a.dart']), "import 'b.dart';"),
-          addProjectFile(platformPath(<String>['dir', 'b.dart']), "import 'c.dart';"),
-          c,
-        };
-
-        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
-        expect(
-          initialGraph.keys,
-          containsAll(<PreviewPath>{...initialProjectFiles, ...directoryFiles}),
-        );
-
-        // Validate the files in dir/ all have transistive errors.
-        await expectHasErrors(
-          changeOperation: () => addProjectFile(c, 'invalid-symbol'),
-          filesWithErrors: directoryFiles,
-        );
-
-        // Delete dir/. This will cause 3 change events to be reported, one for each file in the
-        // deleted directory. Until all 3 events have been processed, the dependency graph will not
-        // be consistent as the files have already been deleted on disk.
-        int changeCount = 0;
-        final Completer<void> completer = Completer<void>();
-        onChangeDetectedImpl = (PreviewDependencyGraph _) {
-          changeCount++;
-          if (changeCount >= 3) {
-            completer.complete();
-          }
-        };
-        removeProjectDirectory(fs.path.dirname(directoryFiles.first.path));
-        await completer.future;
-
-        // Verify the graph is well formed once the deletion events have been processed.
-        expectPreviewDependencyGraphIsWellFormed(initialGraph);
-      });
-
-      testUsingContext('smoke test', () async {
-        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
-        expect(initialGraph.keys, containsAll(initialProjectFiles));
-
-        // Verify there's no errors in the project.
-        for (final PreviewDependencyNode node in initialGraph.values) {
-          expect(node.dependencyHasErrors, false);
-          expect(node.hasErrors, false);
-        }
-
-        // Introduce an error into bar.dart and verify files that have transitive dependencies on
-        // bar.dart are marked as having errors.
-        await expectHasErrors(
-          changeOperation: () => addProjectFile(bar.name, 'invalid-symbol'),
-          filesWithErrors: initialProjectFiles,
-        );
-
-        // Remove the error from bar.dart and ensure no files have errors.
-        await expectHasNoErrors(changeOperation: () => addProjectFile(bar.name, bar.source));
-      });
-
-      testUsingContext('file with error added and removed', () async {
-        final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
-        expect(initialGraph.keys, containsAll(initialProjectFiles));
-
-        // Verify there's no errors in the project.
-        for (final PreviewDependencyNode node in initialGraph.values) {
-          expect(node.dependencyHasErrors, false);
-          expect(node.hasErrors, false);
-        }
-
-        // Add baz.dart, which contains errors. Since no other files import baz.dart, it should be
-        // the only file with errors.
-        const TestSource baz = (name: 'baz.dart', source: 'invalid.symbol');
-        final PreviewPath bazPath = previewPathForFile(baz.name);
-        await expectHasErrors(
-          changeOperation: () => addProjectFile(bazPath, baz.source),
-          filesWithErrors: <PreviewPath>{bazPath},
-        );
-
-        // Update main.dart to import baz.dart. All files in the project should now have transitive
-        // errors.
-        await expectHasErrors(
-          changeOperation: () => addProjectFile(main.name, "import '${baz.name}';\n${main.source}"),
-          filesWithErrors: <PreviewPath>{previewPathForFile(main.name), bazPath},
-        );
-
-        // Delete baz.dart. main.dart should continue to have an error.
-        await expectHasErrors(
-          changeOperation: () => removeProjectFile(baz.name),
-          filesWithErrors: <PreviewPath>{previewPathForFile(main.name)},
-        );
-
-        // Restore main.dart to remove the baz.dart import and clear the errors.
-        await expectHasNoErrors(changeOperation: () => addProjectFile(main.name, main.source));
-      });
-
-      testUsingContext(
-        'error added into dependency in the middle of the graph and removed',
-        () async {
-          final PreviewDependencyGraph initialGraph = await previewDetector.initialize();
-          expect(initialGraph.keys, containsAll(initialProjectFiles));
-
-          // Verify there's no errors in the project.
-          for (final PreviewDependencyNode node in initialGraph.values) {
-            expect(node.dependencyHasErrors, false);
-            expect(node.hasErrors, false);
-          }
-
-          // Add baz.dart, which contains errors. Since no other files import baz.dart, it should be
-          // the only file with errors.
-          final PreviewPath fooPath = previewPathForFile(foo.name);
-          final PreviewPath mainPath = previewPathForFile(main.name);
-          await expectHasErrors(
-            changeOperation: () => addProjectFile(fooPath, 'invalid-symbol;${foo.source}'),
-            filesWithErrors: <PreviewPath>{fooPath, mainPath},
-          );
-
-          // Delete baz.dart. main.dart should continue to have an error.
-          await expectHasNoErrors(changeOperation: () => addProjectFile(fooPath, foo.source));
-        },
+      await waitForPubspecChangeDetected(
+        changeOperation: () => populatePubspec(previewDetector.projectRoot, 'foo'),
       );
     });
   });
-}
-
-typedef _PreviewDetailsMatcherMismatchPair = ({Object? expected, Object? actual});
-
-class PreviewDetailsMatcher extends Matcher {
-  PreviewDetailsMatcher({
-    required this.functionName,
-    required this.isBuilder,
-    this.name,
-    this.nameSymbol,
-    this.size,
-    this.textScaleFactor,
-    this.wrapper,
-    this.theme,
-    this.brightness,
-    this.localizations,
-  }) {
-    if (name != null && nameSymbol != null) {
-      fail('name and nameSymbol cannot both be provided.');
-    }
-  }
-
-  final String functionName;
-  final bool isBuilder;
-
-  // Proivde when the expected expression for 'name' is a literal.
-  final String? name;
-
-  // Provide when the expected expression for 'name' is not a literal.
-  final String? nameSymbol;
-  final String? size;
-  final String? textScaleFactor;
-  final String? wrapper;
-  final String? theme;
-  final String? brightness;
-  final String? localizations;
-
-  @override
-  Description describe(Description description) {
-    description.add('PreviewDetailsMatcher');
-    return description;
-  }
-
-  @override
-  Description describeMismatch(
-    dynamic item,
-    Description mismatchDescription,
-    Map<Object?, Object?> matchState,
-    bool verbose,
-  ) {
-    mismatchDescription.add('has the following mismatches:\n\n');
-    for (final MapEntry<String, _PreviewDetailsMatcherMismatchPair>(
-          :String key,
-          value: _PreviewDetailsMatcherMismatchPair(:Object? actual, :Object? expected),
-        )
-        in matchState.cast<String, _PreviewDetailsMatcherMismatchPair>().entries) {
-      mismatchDescription.add("- $key = '$actual' differs from the expected value '$expected'\n");
-    }
-    return mismatchDescription;
-  }
-
-  @override
-  bool matches(dynamic item, Map<Object?, Object?> matchState) {
-    if (item is! PreviewDetails) {
-      return false;
-    }
-
-    bool matches = true;
-    void checkPropertyMatch({
-      required String name,
-      required Object? actual,
-      required Object? expected,
-    }) {
-      if (actual is Expression) {
-        actual = actual.toSource();
-      }
-      if (actual != expected) {
-        matchState[name] = (actual: actual, expected: expected);
-        matches = false;
-      }
-    }
-
-    checkPropertyMatch(name: 'functionName', actual: item.functionName, expected: functionName);
-    checkPropertyMatch(name: 'isBuilder', actual: item.isBuilder, expected: isBuilder);
-    checkPropertyMatch(
-      name: PreviewDetails.kName,
-      actual: item.name,
-      expected: name != null ? "'$name'" : nameSymbol,
-    );
-    checkPropertyMatch(name: PreviewDetails.kSize, actual: item.size, expected: size);
-    checkPropertyMatch(
-      name: PreviewDetails.kTextScaleFactor,
-      actual: item.textScaleFactor,
-      expected: textScaleFactor,
-    );
-    checkPropertyMatch(name: PreviewDetails.kWrapper, actual: item.wrapper, expected: wrapper);
-    checkPropertyMatch(name: PreviewDetails.kTheme, actual: item.theme, expected: theme);
-    checkPropertyMatch(
-      name: PreviewDetails.kBrightness,
-      actual: item.brightness,
-      expected: brightness,
-    );
-    checkPropertyMatch(
-      name: PreviewDetails.kLocalizations,
-      actual: item.localizations,
-      expected: localizations,
-    );
-    return matches;
-  }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector_test.dart
@@ -3,12 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
 import 'package:test/test.dart';
 
-import '../../../integration.shard/gen_l10n_test.dart';
 import '../../../src/common.dart';
 import '../../../src/context.dart';
 import 'utils/preview_details_matcher.dart';
@@ -19,9 +17,6 @@ import 'utils/preview_project.dart';
 // have a 2000ms time out and these tests write to the real file system and watch
 // directories for changes. This can be slow on heavily loaded machines and cause
 // flaky failures.
-
-String platformPath(List<String> pathSegments) =>
-    pathSegments.join(const LocalPlatform().pathSeparator);
 
 void populatePubspec(Directory projectRoot, String contents) {
   projectRoot.childFile('pubspec.yaml')

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_details_matcher.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_details_matcher.dart
@@ -1,0 +1,132 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
+import 'package:flutter_tools/src/widget_preview/preview_details.dart';
+import 'package:test/test.dart';
+
+typedef _PreviewDetailsMatcherMismatchPair = ({Object? expected, Object? actual});
+
+/// A [Matcher] that verifies each property of a `@Preview` declaration matches an expected value.
+class PreviewDetailsMatcher extends Matcher {
+  PreviewDetailsMatcher({
+    required this.functionName,
+    required this.isBuilder,
+    this.name,
+    this.nameSymbol,
+    this.size,
+    this.textScaleFactor,
+    this.wrapper,
+    this.theme,
+    this.brightness,
+    this.localizations,
+  }) {
+    if (name != null && nameSymbol != null) {
+      fail('name and nameSymbol cannot both be provided.');
+    }
+  }
+
+  final String functionName;
+  final bool isBuilder;
+
+  // Proivde when the expected expression for 'name' is a literal.
+  final String? name;
+
+  // Provide when the expected expression for 'name' is not a literal.
+  final String? nameSymbol;
+  final String? size;
+  final String? textScaleFactor;
+  final String? wrapper;
+  final String? theme;
+  final String? brightness;
+  final String? localizations;
+
+  @override
+  Description describe(Description description) {
+    description.add('PreviewDetailsMatcher');
+    return description;
+  }
+
+  @override
+  Description describeMismatch(
+    dynamic item,
+    Description mismatchDescription,
+    Map<Object?, Object?> matchState,
+    bool verbose,
+  ) {
+    mismatchDescription.add('has the following mismatches:\n\n');
+    for (final MapEntry<String, _PreviewDetailsMatcherMismatchPair>(
+          :String key,
+          value: _PreviewDetailsMatcherMismatchPair(:Object? actual, :Object? expected),
+        )
+        in matchState.cast<String, _PreviewDetailsMatcherMismatchPair>().entries) {
+      mismatchDescription.add("- $key = '$actual' differs from the expected value '$expected'\n");
+    }
+    return mismatchDescription;
+  }
+
+  @override
+  bool matches(dynamic item, Map<Object?, Object?> matchState) {
+    if (item is! PreviewDetails) {
+      return false;
+    }
+
+    bool matches = true;
+    void checkPropertyMatch({
+      required String name,
+      required Object? actual,
+      required Object? expected,
+    }) {
+      if (actual is Expression) {
+        actual = actual.toSource();
+      }
+      if (actual != expected) {
+        matchState[name] = (actual: actual, expected: expected);
+        matches = false;
+      }
+    }
+
+    checkPropertyMatch(name: 'functionName', actual: item.functionName, expected: functionName);
+    checkPropertyMatch(name: 'isBuilder', actual: item.isBuilder, expected: isBuilder);
+    checkPropertyMatch(
+      name: PreviewDetails.kName,
+      actual: item.name,
+      expected: name != null ? "'$name'" : nameSymbol,
+    );
+    checkPropertyMatch(name: PreviewDetails.kSize, actual: item.size, expected: size);
+    checkPropertyMatch(
+      name: PreviewDetails.kTextScaleFactor,
+      actual: item.textScaleFactor,
+      expected: textScaleFactor,
+    );
+    checkPropertyMatch(name: PreviewDetails.kWrapper, actual: item.wrapper, expected: wrapper);
+    checkPropertyMatch(name: PreviewDetails.kTheme, actual: item.theme, expected: theme);
+    checkPropertyMatch(
+      name: PreviewDetails.kBrightness,
+      actual: item.brightness,
+      expected: brightness,
+    );
+    checkPropertyMatch(
+      name: PreviewDetails.kLocalizations,
+      actual: item.localizations,
+      expected: localizations,
+    );
+    return matches;
+  }
+}
+
+void expectContainsPreviews(
+  Map<PreviewPath, LibraryPreviewNode> actual,
+  Map<PreviewPath, List<PreviewDetailsMatcher>> expected,
+) {
+  for (final MapEntry<PreviewPath, List<PreviewDetailsMatcher>>(
+        key: PreviewPath previewPath,
+        value: List<PreviewDetailsMatcher> filePreviews,
+      )
+      in expected.entries) {
+    expect(actual.containsKey(previewPath), true);
+    expect(actual[previewPath]!.previews, filePreviews);
+  }
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -1,0 +1,185 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/signals.dart';
+import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
+import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
+import 'package:test/test.dart';
+
+import 'preview_project.dart';
+
+bool _stateInitialized = false;
+
+// Global state that must be cleaned up by `tearDown` in initializeTestPreviewDetectorState.
+void Function(PreviewDependencyGraph)? _onChangeDetectedImpl;
+void Function()? _onPubspecChangeDetected;
+Directory? _projectRoot;
+late FileSystem _fs;
+
+/// Registers setup and tear down logic for [PreviewDetector] tests.
+///
+/// Must be called before [createTestPreviewDetector] is invoked.
+void initializeTestPreviewDetectorState() {
+  setUp(() {
+    _fs = LocalFileSystem.test(signals: Signals.test());
+  });
+
+  tearDown(() {
+    _onChangeDetectedImpl = null;
+    _onPubspecChangeDetected = null;
+    _projectRoot?.deleteSync(recursive: true);
+    _projectRoot = null;
+  });
+
+  _stateInitialized = true;
+}
+
+PreviewDetector createTestPreviewDetector() {
+  if (!_stateInitialized) {
+    throw StateError('$initializeTestPreviewDetectorState was not called!');
+  }
+  _projectRoot = _fs.systemTempDirectory.createTempSync('root');
+  return PreviewDetector(
+    projectRoot: _projectRoot!,
+    logger: BufferLogger.test(),
+    fs: _fs,
+    onChangeDetected: _onChangeDetectedRoot,
+    onPubspecChangeDetected: _onPubspecChangeDetectedRoot,
+  );
+}
+
+void _onChangeDetectedRoot(PreviewDependencyGraph mapping) {
+  _onChangeDetectedImpl!(mapping);
+}
+
+void _onPubspecChangeDetectedRoot() {
+  _onPubspecChangeDetected!();
+}
+
+/// Test the files included in [filesWithErrors] contain errors after executing [changeOperation].
+Future<void> expectHasErrors({
+  required void Function() changeOperation,
+  required Set<WidgetPreviewSourceFile> filesWithErrors,
+}) async {
+  await waitForChangeDetected(
+    onChangeDetected:
+        (PreviewDependencyGraph updated) => expectPreviewDependencyGraphIsWellFormed(
+          updated,
+          expectedFilesWithErrors: filesWithErrors,
+        ),
+    changeOperation: changeOperation,
+  );
+}
+
+/// Test dependency graph generated as a result of [changeOperation] contains no compile time
+/// errors.
+Future<void> expectHasNoErrors({required void Function() changeOperation}) async {
+  await expectHasErrors(
+    changeOperation: changeOperation,
+    filesWithErrors: const <WidgetPreviewSourceFile>{},
+  );
+}
+
+/// Waits for a pubspec changed event to be detected after executing [changeOperation].
+Future<void> waitForPubspecChangeDetected({required void Function() changeOperation}) async {
+  final Completer<void> completer = Completer<void>();
+  _onPubspecChangeDetected = () {
+    if (completer.isCompleted) {
+      return;
+    }
+    completer.complete();
+  };
+  changeOperation();
+  await completer.future;
+}
+
+/// Waits for a change detected event after executing [changeOperation].
+///
+/// Invokes [onChangeDetected] when a change is detected before the returned future is completed.
+Future<void> waitForChangeDetected({
+  required void Function(PreviewDependencyGraph) onChangeDetected,
+  required void Function() changeOperation,
+}) async {
+  final Completer<void> completer = Completer<void>();
+  _onChangeDetectedImpl = (PreviewDependencyGraph updated) {
+    if (completer.isCompleted) {
+      return;
+    }
+    onChangeDetected(updated);
+    completer.complete();
+  };
+  changeOperation();
+  await completer.future;
+}
+
+/// Waits for [n] change detected events after executing [changeOperation].
+Future<void> waitForNChangesDetected({
+  required int n,
+  required void Function() changeOperation,
+}) async {
+  int changeCount = 0;
+  final Completer<void> completer = Completer<void>();
+  _onChangeDetectedImpl = (PreviewDependencyGraph updated) {
+    if (completer.isCompleted) {
+      return;
+    }
+    changeCount++;
+    if (changeCount == n) {
+      completer.complete();
+    }
+  };
+  changeOperation();
+  await completer.future;
+}
+
+/// Walks the [graph] to verify its structure and that all files contained in
+/// [expectedFilesWithErrors] actually contain errors.
+void expectPreviewDependencyGraphIsWellFormed(
+  PreviewDependencyGraph graph, {
+  Set<WidgetPreviewSourceFile> expectedFilesWithErrors = const <WidgetPreviewSourceFile>{},
+}) {
+  final Set<LibraryPreviewNode> nodesWithErrors = <LibraryPreviewNode>{};
+  for (final LibraryPreviewNode node in graph.values) {
+    expect(_fs.file(node.path.path), exists);
+    if (node.hasErrors) {
+      nodesWithErrors.add(node);
+    }
+    for (final LibraryPreviewNode upstream in node.dependedOnBy) {
+      expect(upstream.dependsOn, contains(node));
+    }
+    for (final LibraryPreviewNode downstream in node.dependsOn) {
+      expect(downstream.dependedOnBy, contains(node));
+    }
+  }
+
+  // Validates that all upstream dependencies are marked as having a transitive dependency
+  // containing errors.
+  final Set<PreviewPath> filesWithTransitiveErrors = <PreviewPath>{};
+  void dependencyHasErrorsValidator(LibraryPreviewNode node) {
+    filesWithTransitiveErrors.add(node.path);
+    expect(node.dependencyHasErrors, true);
+    node.dependedOnBy.forEach(dependencyHasErrorsValidator);
+  }
+
+  for (final LibraryPreviewNode node in nodesWithErrors) {
+    filesWithTransitiveErrors.add(node.path);
+    node.dependedOnBy.forEach(dependencyHasErrorsValidator);
+  }
+
+  // Verify we've found all the files expected to have transitive errors.
+  expect(
+    filesWithTransitiveErrors,
+    expectedFilesWithErrors
+        .map(
+          (WidgetPreviewSourceFile file) =>
+              previewPathForFile(projectRoot: _projectRoot!, path: file.path),
+        )
+        .toSet(),
+  );
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
@@ -183,3 +184,6 @@ void expectPreviewDependencyGraphIsWellFormed(
         .toSet(),
   );
 }
+
+String platformPath(List<String> pathSegments) =>
+    pathSegments.join(const LocalPlatform().pathSeparator);

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_project.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_project.dart
@@ -8,7 +8,8 @@ library;
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
 import 'package:meta/meta.dart';
-import 'package:path/path.dart';
+
+import '../../../../src/common.dart';
 
 typedef WidgetPreviewSourceFile = ({String path, String source});
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_project.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_project.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'package:flutter_tools/src/widget_preview/preview_detector.dart';
+library;
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
+import 'package:meta/meta.dart';
+import 'package:path/path.dart';
+
+typedef WidgetPreviewSourceFile = ({String path, String source});
+
+PreviewPath previewPathForFile({required Directory projectRoot, required String path}) {
+  final File file = projectRoot.childDirectory('lib').childFile(path);
+  return (path: file.path, uri: file.uri);
+}
+
+/// A utility class used to manage a fake Flutter project for widget preview testing.
+class WidgetPreviewProject {
+  WidgetPreviewProject({required this.projectRoot})
+    : _libDirectory = projectRoot.childDirectory('lib')..createSync(recursive: true);
+
+  /// The root of the fake project.
+  ///
+  /// This should always be set to [PreviewDetector.projectRoot].
+  late final Directory projectRoot;
+  late final Directory _libDirectory;
+
+  Set<WidgetPreviewSourceFile> get currentSources => _currentSources.values.toSet();
+  final Map<String, WidgetPreviewSourceFile> _currentSources = <String, WidgetPreviewSourceFile>{};
+
+  Set<PreviewPath> get paths => _currentSources.keys.map(toPreviewPath).toSet();
+
+  /// Builds a [PreviewPath] based on [path] using the [projectRoot]'s `lib/` directory as the
+  /// path root.
+  PreviewPath toPreviewPath(String path) =>
+      previewPathForFile(projectRoot: projectRoot, path: path);
+
+  /// Writes the contents of [file] to the file system.
+  @mustCallSuper
+  void writeFile(WidgetPreviewSourceFile file) {
+    _libDirectory.childFile(file.path)
+      ..createSync(recursive: true)
+      ..writeAsStringSync(file.source);
+    _currentSources[file.path] = file;
+  }
+
+  /// Removes the contents of [file] from the file system.
+  @mustCallSuper
+  void removeFile(WidgetPreviewSourceFile file) {
+    _libDirectory.fileSystem.file(_libDirectory.childFile(file.path).path).deleteSync();
+    _currentSources.remove(file.path);
+  }
+
+  /// Recursively deletes the parent directory of [file].
+  @mustCallSuper
+  void removeDirectoryContaining(WidgetPreviewSourceFile file) {
+    final Context context = _libDirectory.fileSystem.path;
+    final Directory dir = _libDirectory.childDirectory(context.dirname(file.path));
+    _currentSources.removeWhere((String path, _) => path.startsWith(dir.path));
+    dir.deleteSync(recursive: true);
+  }
+}


### PR DESCRIPTION
Reworked the dependency model to be library based instead of script based in order to support libraries spanning multiple scripts.

Also refactored test logic to improve maintainability and simply writing tests against the `PreviewDetector`.