### PR TITLE
[CP] Include dev_dependencies in all builds for iOS and macOS (#171015)

### DIFF
--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2649,7 +2649,7 @@ flutter:
       );
 
       testUsingContext(
-        'excludes dev dependencies from iOS plugin registrant',
+        'includes dev dependencies from iOS plugin registrant',
         () async {
           createPlugin(
             name: testPluginName,
@@ -2682,7 +2682,7 @@ flutter:
             releaseMode: true,
           );
           expect(generatedPluginRegistrantImpl, exists);
-          expect(generatedPluginRegistrantImpl.readAsStringSync(), isNot(contains(devDepImport)));
+          expect(generatedPluginRegistrantImpl.readAsStringSync(), contains(devDepImport));
         },
         overrides: <Type, Generator>{
           FileSystem: () => fs,
@@ -2729,7 +2729,7 @@ flutter:
       );
 
       testUsingContext(
-        'excludes dev dependencies from MacOS plugin registrant',
+        'includes dev dependencies from MacOS plugin registrant',
         () async {
           createPlugin(
             name: testPluginName,
@@ -2767,7 +2767,7 @@ flutter:
           expect(generatedPluginRegistrant, exists);
           expect(
             generatedPluginRegistrant.readAsStringSync(),
-            isNot(contains(expectedDevDepRegistration)),
+            contains(expectedDevDepRegistration),
           );
         },
         overrides: <Type, Generator>{


### PR DESCRIPTION
Impacted Users: iOS and macOS Flutter developers
Impact Description: iOS/macOS workflows may not behave as expected due to missing dev dependencies.
Workaround: Yes, run in debug mode, such as `flutter build ios --debug --config-only`
Risk: low
Test Coverage: yes
Validation Steps: Run `flutter build ios` on a project with dev dependencies and should see them in the GeneratedPluginRegistrant