### PR TITLE
Activate microtask profiling in `dart:async` when `Switch::ProfileMicrotasks` is set

### DIFF
--- a/engine/src/flutter/lib/ui/dart_runtime_hooks.h
+++ b/engine/src/flutter/lib/ui/dart_runtime_hooks.h
@@ -13,7 +13,9 @@ namespace flutter {
 
 class DartRuntimeHooks {
  public:
-  static void Install(bool is_ui_isolate, const std::string& script_uri);
+  static void Install(bool is_ui_isolate,
+                      bool enable_microtask_profiling,
+                      const std::string& script_uri);
 
   static void Logger_PrintDebugString(const std::string& message);
 

--- a/engine/src/flutter/runtime/dart_isolate.cc
+++ b/engine/src/flutter/runtime/dart_isolate.cc
@@ -674,11 +674,14 @@ bool DartIsolate::LoadLibraries() {
   DartIO::InitForIsolate(may_insecurely_connect_to_all_domains_,
                          domain_network_policy_);
 
-  DartUI::InitForIsolate(GetIsolateGroupData().GetSettings());
+  const auto& settings = GetIsolateGroupData().GetSettings();
+
+  DartUI::InitForIsolate(settings);
 
   const bool is_service_isolate = Dart_IsServiceIsolate(isolate());
 
   DartRuntimeHooks::Install(IsRootIsolate() && !is_service_isolate,
+                            settings.profile_microtasks,
                             GetAdvisoryScriptURI());
 
   if (!is_service_isolate) {

--- a/engine/src/flutter/testing/dart/vm_service/BUILD.gn
+++ b/engine/src/flutter/testing/dart/vm_service/BUILD.gn
@@ -5,6 +5,7 @@
 import("//flutter/build/dart/rules.gni")
 
 tests = [
+  "microtask_profiling_test.dart",
   "skp_test.dart",
   "tracing_test.dart",
   "shader_reload_test.dart",

--- a/engine/src/flutter/testing/dart/vm_service/microtask_profiling_test.dart
+++ b/engine/src/flutter/testing/dart/vm_service/microtask_profiling_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:collection' show HashMap;
+import 'dart:convert' show base64Decode;
+import 'dart:developer' as developer;
+
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart' as vms;
+import 'package:vm_service/vm_service_io.dart';
+import 'package:vm_service_protos/vm_service_protos.dart';
+
+void main() {
+  test('microtask profiling is enabled by the --profile-microtasks CLI '
+      'flag', () async {
+    final developer.ServiceProtocolInfo info = await developer.Service.getInfo();
+
+    if (info.serverUri == null) {
+      fail('This test must not be run with --disable-vm-service.');
+    }
+
+    final vms.VmService vmService = await vmServiceConnectUri(
+      'ws://localhost:${info.serverUri!.port}${info.serverUri!.path}ws',
+    );
+    await vmService.clearVMTimeline();
+
+    final vms.PerfettoTimeline response = await vmService.getPerfettoVMTimeline();
+    final List<TracePacket> packets = Trace.fromBuffer(base64Decode(response.trace!)).packet;
+    final Iterable<TrackEvent> microtaskEvents = packets
+        .where((TracePacket packet) => packet.hasTrackEvent())
+        .map((TracePacket packet) => packet.trackEvent)
+        .where(
+          (TrackEvent event) =>
+              event.type == TrackEvent_Type.TYPE_SLICE_BEGIN && event.name == 'Microtask',
+        );
+
+    expect(microtaskEvents.length, isPositive);
+
+    for (final TrackEvent event in microtaskEvents) {
+      final Map<String, String> debugAnnotations = HashMap.fromEntries(
+        event.debugAnnotations.map((a) => MapEntry(a.name, a.stringValue)),
+      );
+
+      expect(debugAnnotations['microtaskId'], isNotNull);
+      expect(debugAnnotations['stack trace captured when microtask was enqueued'], isNotNull);
+    }
+
+    await vmService.dispose();
+  });
+}

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -609,7 +609,7 @@ def run_engine_benchmarks(build_dir, executable_filter):
 
 class FlutterTesterOptions():
 
-  def __init__(
+  def __init__( # pylint: disable=too-many-arguments
       self,
       multithreaded=False,
       enable_impeller=False,

--- a/engine/src/flutter/testing/run_tests.py
+++ b/engine/src/flutter/testing/run_tests.py
@@ -614,11 +614,13 @@ class FlutterTesterOptions():
       multithreaded=False,
       enable_impeller=False,
       enable_vm_service=False,
+      enable_microtask_profiling=False,
       expect_failure=False
   ):
     self.multithreaded = multithreaded
     self.enable_impeller = enable_impeller
     self.enable_vm_service = enable_vm_service
+    self.enable_microtask_profiling = enable_microtask_profiling
     self.expect_failure = expect_failure
 
   def apply_args(self, command_args):
@@ -632,6 +634,9 @@ class FlutterTesterOptions():
 
     if self.multithreaded:
       command_args.insert(0, '--force-multithreading')
+
+    if self.enable_microtask_profiling:
+      command_args.append('--profile-microtasks')
 
   def threading_description(self):
     if self.multithreaded:
@@ -873,7 +878,8 @@ def gather_dart_tests(build_dir, test_filter):
 
   if 'release' not in build_dir:
     for dart_test_file in dart_vm_service_tests:
-      if test_filter is not None and os.path.basename(dart_test_file) not in test_filter:
+      dart_test_basename = os.path.basename(dart_test_file)
+      if test_filter is not None and dart_test_basename not in test_filter:
         logger.info("Skipping '%s' due to filter.", dart_test_file)
       else:
         logger.info("Gathering dart test '%s' with VM service enabled", dart_test_file)
@@ -884,7 +890,9 @@ def gather_dart_tests(build_dir, test_filter):
                 FlutterTesterOptions(
                     multithreaded=multithreaded,
                     enable_impeller=enable_impeller,
-                    enable_vm_service=True
+                    enable_vm_service=True,
+                    enable_microtask_profiling=dart_test_basename ==
+                    'microtask_profiling_test.dart',
                 )
             )
 


### PR DESCRIPTION
Here is the logic in the Dart VM that is analogous to the logic in this PR: https://github.com/dart-lang/sdk/blob/2be548666d99b5dbfcd558cb6d6a8076a25274e9/runtime/bin/dartutils.cc#L540-L561.