### PR TITLE
Ensure disabling text fields' interactive selection disables shortcuts

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1721,8 +1721,9 @@ class EditableText extends StatefulWidget {
   /// cut/copy/paste menu, and tapping to move the text caret.
   ///
   /// When this is false, the text selection cannot be adjusted by
-  /// the user, the cut/copy/paste menu is hidden, and shortcuts to
-  /// cut/copy/paste text from the clipboard are disabled.
+  /// the user, the cut/copy/paste menu is hidden, and the shortcuts to
+  /// cut/copy/paste text do nothing but stop propagation of the key event
+  /// to other key event handlers in the focus chain.
   ///
   /// Defaults to true.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5640,10 +5640,6 @@ class EditableTextState extends State<EditableText>
     SelectAllTextIntent: _makeOverridable(_SelectAllAction(this)),
     CopySelectionTextIntent: _makeOverridable(_CopySelectionAction(this)),
     PasteTextIntent: _makeOverridable(_PasteSelectionAction(this)),
-    //   CallbackAction<PasteTextIntent>(
-    //     onInvoke: (PasteTextIntent intent) => pasteText(intent.cause),
-    //   ),
-    // ),
 
     TransposeCharactersIntent: _makeOverridable(_transposeCharactersAction),
     EditableTextTapOutsideIntent: _makeOverridable(_EditableTextTapOutsideAction()),

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -6638,6 +6638,10 @@ class _SelectAllAction extends ContextAction<SelectAllTextIntent> {
 
   @override
   Object? invoke(SelectAllTextIntent intent, [BuildContext? context]) {
+    if (!state.widget.selectionEnabled) {
+      return null;
+    }
+
     return Actions.invoke(
       context!,
       UpdateSelectionIntent(
@@ -6647,9 +6651,6 @@ class _SelectAllAction extends ContextAction<SelectAllTextIntent> {
       ),
     );
   }
-
-  @override
-  bool get isActionEnabled => state.widget.selectionEnabled;
 }
 
 class _CopySelectionAction extends ContextAction<CopySelectionTextIntent> {
@@ -6659,15 +6660,20 @@ class _CopySelectionAction extends ContextAction<CopySelectionTextIntent> {
 
   @override
   void invoke(CopySelectionTextIntent intent, [BuildContext? context]) {
+    if (!state._value.selection.isValid || state._value.selection.isCollapsed) {
+      return;
+    }
+
+    if (!state.widget.selectionEnabled) {
+      return;
+    }
+
     if (intent.collapseSelection) {
       state.cutSelection(intent.cause);
     } else {
       state.copySelection(intent.cause);
     }
   }
-
-  @override
-  bool get isActionEnabled => state._value.selection.isValid && !state._value.selection.isCollapsed;
 }
 
 class _PasteSelectionAction extends ContextAction<PasteTextIntent> {
@@ -6677,11 +6683,12 @@ class _PasteSelectionAction extends ContextAction<PasteTextIntent> {
 
   @override
   void invoke(PasteTextIntent intent, [BuildContext? context]) {
+    if (!state.widget.selectionEnabled) {
+      return;
+    }
+
     state.pasteText(intent.cause);
   }
-
-  @override
-  bool get isActionEnabled => state.widget.selectionEnabled;
 }
 
 /// A [ClipboardStatusNotifier] whose [value] is hardcoded to

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1721,8 +1721,8 @@ class EditableText extends StatefulWidget {
   /// cut/copy/paste menu, and tapping to move the text caret.
   ///
   /// When this is false, the text selection cannot be adjusted by
-  /// the user, text cannot be copied, and the user cannot paste into
-  /// the text field from the clipboard.
+  /// the user, the cut/copy/paste menu is hidden, and shortcuts to
+  /// cut/copy/paste text from the clipboard are disabled.
   ///
   /// Defaults to true.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5639,11 +5639,11 @@ class EditableTextState extends State<EditableText>
     // Copy Paste
     SelectAllTextIntent: _makeOverridable(_SelectAllAction(this)),
     CopySelectionTextIntent: _makeOverridable(_CopySelectionAction(this)),
-    PasteTextIntent: _makeOverridable(
-      CallbackAction<PasteTextIntent>(
-        onInvoke: (PasteTextIntent intent) => pasteText(intent.cause),
-      ),
-    ),
+    PasteTextIntent: _makeOverridable(_PasteSelectionAction(this)),
+    //   CallbackAction<PasteTextIntent>(
+    //     onInvoke: (PasteTextIntent intent) => pasteText(intent.cause),
+    //   ),
+    // ),
 
     TransposeCharactersIntent: _makeOverridable(_transposeCharactersAction),
     EditableTextTapOutsideIntent: _makeOverridable(_EditableTextTapOutsideAction()),
@@ -6668,6 +6668,20 @@ class _CopySelectionAction extends ContextAction<CopySelectionTextIntent> {
 
   @override
   bool get isActionEnabled => state._value.selection.isValid && !state._value.selection.isCollapsed;
+}
+
+class _PasteSelectionAction extends ContextAction<PasteTextIntent> {
+  _PasteSelectionAction(this.state);
+
+  final EditableTextState state;
+
+  @override
+  void invoke(PasteTextIntent intent, [BuildContext? context]) {
+    state.pasteText(intent.cause);
+  }
+
+  @override
+  bool get isActionEnabled => state.widget.selectionEnabled;
 }
 
 /// A [ClipboardStatusNotifier] whose [value] is hardcoded to

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17468,6 +17468,76 @@ void main() {
     await tester.tap(find.text('Outside'));
     expect(tapOutsideCount, 0);
   });
+
+  testWidgets('Disabling interactive selection disables shortcuts', (
+    WidgetTester tester,
+  ) async {
+    controller.text = 'Hello world';
+
+    TextSelection? selection;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: EditableText(
+            controller: controller,
+            autofocus: true,
+            focusNode: focusNode,
+            enableInteractiveSelection: false,
+            style: textStyle,
+            cursorColor: Colors.blue,
+            backgroundCursorColor: Colors.grey,
+            onSelectionChanged: (TextSelection newSelection, SelectionChangedCause? newCause) {
+              selection = newSelection;
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(selection?.start, 11);
+    expect(selection?.end, 11);
+
+    // Select all shortcut should be ignored
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.keyA],
+      shortcutModifier: true,
+      targetPlatform: defaultTargetPlatform,
+    );
+    expect(selection?.start, 11);
+    expect(selection?.end, 11);
+
+    // Select all programatically
+    controller.selection = TextSelection(
+      baseOffset: 0,
+      extentOffset: controller.text.length,
+    );
+
+    // Set the clipboard
+    await Clipboard.setData(const ClipboardData(text: 'foo'));
+
+    // Paste shortcut should be ignored
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.keyV],
+      shortcutModifier: true,
+      targetPlatform: defaultTargetPlatform,
+    );
+    expect(controller.text, 'Hello world');
+
+    // Copy shortcut
+    await sendKeys(
+      tester,
+      <LogicalKeyboardKey>[LogicalKeyboardKey.keyC],
+      shortcutModifier: true,
+      targetPlatform: defaultTargetPlatform,
+    );
+
+    final ClipboardData? data = await Clipboard.getData('text/plain');
+    expect(controller.text, 'Hello world');
+    expect(data?.text, 'foo');
+  });
 }
 
 class UnsettableController extends TextEditingController {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17496,7 +17496,7 @@ void main() {
     expect(selection?.start, 11);
     expect(selection?.end, 11);
 
-    // Select all shortcut should be ignored
+    // Select all shortcut should be ignored.
     await sendKeys(
       tester,
       <LogicalKeyboardKey>[LogicalKeyboardKey.keyA],
@@ -17506,13 +17506,13 @@ void main() {
     expect(selection?.start, 11);
     expect(selection?.end, 11);
 
-    // Select all programatically
+    // Select all programatically.
     controller.selection = TextSelection(baseOffset: 0, extentOffset: controller.text.length);
 
-    // Set the clipboard
+    // Set the clipboard.
     await Clipboard.setData(const ClipboardData(text: 'foo'));
 
-    // Paste shortcut should be ignored
+    // Paste shortcut should be ignored.
     await sendKeys(
       tester,
       <LogicalKeyboardKey>[LogicalKeyboardKey.keyV],
@@ -17521,7 +17521,7 @@ void main() {
     );
     expect(controller.text, 'Hello world');
 
-    // Copy shortcut
+    // Copy shortcut.
     await sendKeys(
       tester,
       <LogicalKeyboardKey>[LogicalKeyboardKey.keyC],

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17469,9 +17469,7 @@ void main() {
     expect(tapOutsideCount, 0);
   });
 
-  testWidgets('Disabling interactive selection disables shortcuts', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('Disabling interactive selection disables shortcuts', (WidgetTester tester) async {
     controller.text = 'Hello world';
 
     TextSelection? selection;
@@ -17509,10 +17507,7 @@ void main() {
     expect(selection?.end, 11);
 
     // Select all programatically
-    controller.selection = TextSelection(
-      baseOffset: 0,
-      extentOffset: controller.text.length,
-    );
+    controller.selection = TextSelection(baseOffset: 0, extentOffset: controller.text.length);
 
     // Set the clipboard
     await Clipboard.setData(const ClipboardData(text: 'foo'));


### PR DESCRIPTION
[`EditableText.enableInteractiveSelection`](https://api.flutter.dev/flutter/widgets/EditableText/enableInteractiveSelection.html) can be used to disable text selection and shortcuts in a text field.

Previously, `EditableText` would disable the shortcut actions using [`Action.isEnabled`](https://api.flutter.dev/flutter/widgets/Action/isEnabled.html). As a result, the action would ignore the key event, and the key event would propagate. On some platforms, the key event would propagate to the native text view, causing weird behaviors like text getting copied.

Now, the text field shortcuts stop propagation of the key event when `enableInteractiveSelection` is `false`. This ensures that the text field "consumes" the key events and prevents a parent of the text field or native views from receiving the key event.

Partially addresses https://github.com/flutter/flutter/issues/157611

⚠️ Note: This does not fix the bug on Flutter Web as it handles text field shortcuts separately. This will be fixed in a separate pull request.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
