### PR TITLE
Add missing M3 tests for InputDecoration.isDense

### DIFF
--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7635,6 +7635,10 @@ void main() {
 
       final Rect containerRect = getContainerRect(tester);
       final Rect inputRect = getInputRect(tester);
+
+      // Content padding is EdgeInsetsDirectional.fromSTEB(12.0, 16.0, 12.0, 8.0).
+      // Vertical padding affects the container height not the input vertical
+      // position as the input is centered.
       expect(containerRect.height, 48.0);
       expect(inputRect.center.dy, containerRect.center.dy);
       expect(inputRect.left, containerRect.left + 12.0 + kInputExtraPadding);
@@ -7653,6 +7657,8 @@ void main() {
       final Rect containerRect = getContainerRect(tester);
       final Rect inputRect = getInputRect(tester);
       final Rect labelRect = getLabelRect(tester);
+
+      // Content padding is EdgeInsetsDirectional.fromSTEB(12.0, 4.0, 12.0, 4.0).
       expect(containerRect.height, 48.0);
       expect(labelRect.top, containerRect.top + 4.0);
       expect(inputRect.bottom, containerRect.bottom - 4.0);
@@ -7670,6 +7676,8 @@ void main() {
       final Rect containerRect = getContainerRect(tester);
       final Rect inputRect = getInputRect(tester);
       final Rect labelRect = getLabelRect(tester);
+
+      // Content padding is EdgeInsetsDirectional.fromSTEB(0.0, 4.0, 0.0, 4.0).
       expect(containerRect.height, 48.0);
       expect(labelRect.top, containerRect.top + 4.0);
       expect(inputRect.bottom, containerRect.bottom - 4.0);

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -7618,6 +7618,77 @@ void main() {
     });
   });
 
+  group('Material3 - InputDecoration isDense', () {
+    // M3 extra horizontal padding.
+    const double kInputExtraPadding = 4.0;
+
+    testWidgets('Dense layout for an outlined decoration', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildInputDecorator(
+          decoration: const InputDecoration(
+            border: OutlineInputBorder(),
+            labelText: labelText,
+            isDense: true,
+          ),
+        ),
+      );
+
+      final Rect containerRect = getContainerRect(tester);
+      final Rect inputRect = getInputRect(tester);
+      expect(containerRect.height, 48.0);
+      expect(inputRect.center.dy, containerRect.center.dy);
+      expect(inputRect.left, containerRect.left + 12.0 + kInputExtraPadding);
+      expect(inputRect.right, containerRect.right - 12.0 - kInputExtraPadding);
+    });
+
+    testWidgets('Dense layout for a filled and non-outlined decoration', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildInputDecorator(
+          decoration: const InputDecoration(filled: true, labelText: labelText, isDense: true),
+        ),
+      );
+
+      final Rect containerRect = getContainerRect(tester);
+      final Rect inputRect = getInputRect(tester);
+      final Rect labelRect = getLabelRect(tester);
+      expect(containerRect.height, 48.0);
+      expect(labelRect.top, containerRect.top + 4.0);
+      expect(inputRect.bottom, containerRect.bottom - 4.0);
+      expect(inputRect.left, containerRect.left + 12.0 + kInputExtraPadding);
+      expect(inputRect.right, containerRect.right - 12.0 - kInputExtraPadding);
+    });
+
+    testWidgets('Dense layout for a non-filled and non-outlined decoration', (
+      WidgetTester tester,
+    ) async {
+      await tester.pumpWidget(
+        buildInputDecorator(decoration: const InputDecoration(labelText: labelText, isDense: true)),
+      );
+
+      final Rect containerRect = getContainerRect(tester);
+      final Rect inputRect = getInputRect(tester);
+      final Rect labelRect = getLabelRect(tester);
+      expect(containerRect.height, 48.0);
+      expect(labelRect.top, containerRect.top + 4.0);
+      expect(inputRect.bottom, containerRect.bottom - 4.0);
+      expect(inputRect.left, containerRect.left);
+      expect(inputRect.right, containerRect.right);
+    });
+
+    testWidgets('Ambient theme is used', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildInputDecorator(
+          inputDecorationTheme: const InputDecorationThemeData(isDense: true),
+          decoration: const InputDecoration(labelText: labelText),
+        ),
+      );
+
+      expect(getContainerRect(tester).height, 48.0);
+    });
+  });
+
   testWidgets('InputDecorator counter text, widget, and null', (WidgetTester tester) async {
     Widget buildFrame({
       InputCounterWidgetBuilder? buildCounter,
@@ -9309,6 +9380,17 @@ void main() {
       );
 
       expect(getDecoratorRect(tester).size, const Size(800.0, inputHeight));
+    });
+
+    testWidgets('isDense', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        buildInputDecorator(
+          localInputDecorationTheme: const InputDecorationThemeData(isDense: true),
+          decoration: const InputDecoration(labelText: labelText),
+        ),
+      );
+
+      expect(getContainerRect(tester).height, 48.0);
     });
 
     testWidgets('iconColor', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR adds missing M3 tests for `InputDecoration.isDense`.

## Related Issue

Related to https://github.com/flutter/flutter/pull/168981

## Tests

Adds 4 tests.