### PR TITLE
Update FormField.initialValue documentation

### DIFF
--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -534,9 +534,6 @@ class FormField<T> extends StatefulWidget {
 
   /// An optional value to initialize the form field to, or null otherwise.
   ///
-  /// This is called `value` in the [DropdownButtonFormField] constructor to be
-  /// consistent with [DropdownButton].
-  ///
   /// The `initialValue` affects the form field's state in two cases:
   /// 1. When the form field is first built, `initialValue` determines the field's initial state.
   /// 2. When [FormFieldState.reset] is called (either directly or by calling


### PR DESCRIPTION
## Description

This PR updates `FormField.initialValue` documentation to remove a sentence which is obsolete since https://github.com/flutter/flutter/pull/170805.

## Tests

Documentation only PR.