### PR TITLE
Revert "Move `web_long_running_tests_{1,5}_5` to `bringup`."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1761,7 +1761,6 @@ targets:
   - name: Linux web_long_running_tests_1_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/171025
     properties:
       dependencies: >-
         [
@@ -1858,7 +1857,6 @@ targets:
   - name: Linux web_long_running_tests_5_5
     recipe: flutter/flutter_drone
     timeout: 60
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/171025
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
Reverts flutter/flutter#171026

These tasks have been consistently [green](https://flutter-dashboard.appspot.com/#/build?taskFilter=Linux+web_long_running_tests_&repo=flutter&branch=master&showBringup=true) since https://github.com/flutter/flutter/pull/170939. Let's take them out of bringup.

Closes https://github.com/flutter/flutter/issues/171025