### PR TITLE
Fix crash when editableText is not mounted

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2929,7 +2929,9 @@ class TextSelectionGestureDetectorBuilder {
   }
 
   void _onSingleLongTapEndOrCancel() {
-    if(!_isEditableTextMounted) return;
+    if(!_isEditableTextMounted) {
+      return;
+    }
     _hideMagnifierIfSupportedByPlatform();
     _longPressStartedWithoutFocus = false;
     _dragStartViewportOffset = 0.0;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2933,8 +2933,8 @@ class TextSelectionGestureDetectorBuilder {
     _longPressStartedWithoutFocus = false;
     _dragStartViewportOffset = 0.0;
     _dragStartScrollOffset = 0.0;
-    if (defaultTargetPlatform == TargetPlatform.iOS &&
-        _isEditableTextMounted &&
+    if (_isEditableTextMounted &&
+        defaultTargetPlatform == TargetPlatform.iOS &&
         delegate.selectionEnabled &&
         editableText.textEditingValue.selection.isCollapsed) {
       // Update the floating cursor.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2929,7 +2929,7 @@ class TextSelectionGestureDetectorBuilder {
   }
 
   void _onSingleLongTapEndOrCancel() {
-    if(!_isEditableTextMounted) {
+    if (!_isEditableTextMounted) {
       return;
     }
     _hideMagnifierIfSupportedByPlatform();

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2929,14 +2929,12 @@ class TextSelectionGestureDetectorBuilder {
   }
 
   void _onSingleLongTapEndOrCancel() {
-    if (!_isEditableTextMounted) {
-      return;
-    }
     _hideMagnifierIfSupportedByPlatform();
     _longPressStartedWithoutFocus = false;
     _dragStartViewportOffset = 0.0;
     _dragStartScrollOffset = 0.0;
     if (defaultTargetPlatform == TargetPlatform.iOS &&
+        _isEditableTextMounted &&
         delegate.selectionEnabled &&
         editableText.textEditingValue.selection.isCollapsed) {
       // Update the floating cursor.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2929,6 +2929,7 @@ class TextSelectionGestureDetectorBuilder {
   }
 
   void _onSingleLongTapEndOrCancel() {
+    if(!_isEditableTextMounted) return;
     _hideMagnifierIfSupportedByPlatform();
     _longPressStartedWithoutFocus = false;
     _dragStartViewportOffset = 0.0;


### PR DESCRIPTION
Fix issue when text_selection crashes due to editableText not being mounted.

No issue filled (internal b/425840577)

Likely introduced by https://github.com/flutter/flutter/pull/167881

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
