### PR TITLE
feat: upload artifacts to content_hash if signaled

### DIFF
--- a/engine/src/flutter/ci/builders/linux_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/linux_android_aot_engine.json
@@ -9,7 +9,8 @@
     ],
     "luci_flags": {
       "delay_collect_builds": true,
-      "parallel_download_builds": true
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/linux_android_aot_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/linux_android_aot_engine_ddm.json
@@ -7,6 +7,11 @@
         "Tests to run on linux hosts should go in one of the other linux_ build ",
         "definition files."
     ],
+    "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/linux_android_debug_engine.json
+++ b/engine/src/flutter/ci/builders/linux_android_debug_engine.json
@@ -9,7 +9,8 @@
     ],
     "luci_flags": {
       "delay_collect_builds": true,
-      "parallel_download_builds": true
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/linux_android_debug_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/linux_android_debug_engine_ddm.json
@@ -7,6 +7,11 @@
         "Tests to run on linux hosts should go in one of the other linux_ build ",
         "definition files."
     ],
+    "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/linux_arm_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_arm_host_engine.json
@@ -7,6 +7,9 @@
         "Tests to run on linux hosts should go in one of the other linux_ build ",
         "definition files."
     ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/linux_fuchsia.json
+++ b/engine/src/flutter/ci/builders/linux_fuchsia.json
@@ -9,7 +9,8 @@
     ],
     "luci_flags": {
       "delay_collect_builds": true,
-      "parallel_download_builds": true
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/linux_host_desktop_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_desktop_engine.json
@@ -7,6 +7,9 @@
         "Tests to run on linux hosts should go in one of the other linux_ build ",
         "definition files."
     ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/linux_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine.json
@@ -9,7 +9,8 @@
     ],
     "luci_flags": {
       "delay_collect_builds": true,
-      "parallel_download_builds": true
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/linux_web_engine_build.json
+++ b/engine/src/flutter/ci/builders/linux_web_engine_build.json
@@ -1,4 +1,15 @@
 {
+  "_comment": [
+      "The builds defined in this file should not contain tests, ",
+      "and the file should not contain builds that are essentially tests. ",
+      "The only builds in this file should be the builds necessary to produce ",
+      "release artifacts. ",
+      "Tests to run on linux hosts should go in one of the other linux_ build ",
+      "definition files."
+  ],
+  "luci_flags": {
+    "upload_content_hash": true
+  },
   "builds": [
     {
       "name": "ci/wasm_release",

--- a/engine/src/flutter/ci/builders/mac_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/mac_android_aot_engine.json
@@ -7,6 +7,9 @@
         "Tests to run on mac hosts should go in one of the other mac_ build ",
         "definition files."
     ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/mac_host_engine.json
+++ b/engine/src/flutter/ci/builders/mac_host_engine.json
@@ -12,7 +12,8 @@
     ],
     "luci_flags": {
       "delay_collect_builds": true,
-      "parallel_download_builds": true
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/mac_ios_engine.json
+++ b/engine/src/flutter/ci/builders/mac_ios_engine.json
@@ -9,7 +9,8 @@
     ],
     "luci_flags": {
       "delay_collect_builds": true,
-      "parallel_download_builds": true
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/mac_ios_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/mac_ios_engine_ddm.json
@@ -9,7 +9,8 @@
   ],
   "luci_flags": {
     "delay_collect_builds": true,
-    "parallel_download_builds": true
+    "parallel_download_builds": true,
+    "upload_content_hash": true
   },
   "builds": [
     {

--- a/engine/src/flutter/ci/builders/windows_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/windows_android_aot_engine.json
@@ -1,4 +1,7 @@
 {
+    "luci_flags": {
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/windows_arm_host_engine.json
+++ b/engine/src/flutter/ci/builders/windows_arm_host_engine.json
@@ -1,4 +1,7 @@
 {
+    "luci_flags": {
+        "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [

--- a/engine/src/flutter/ci/builders/windows_host_engine.json
+++ b/engine/src/flutter/ci/builders/windows_host_engine.json
@@ -7,6 +7,9 @@
         "Tests to run on windows hosts should go in one of the other windows_ build ",
         "definition files."
     ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
     "builds": [
         {
             "archives": [


### PR DESCRIPTION
part of #167780

`upload_content_hash` is paired with
[cocoon's](https://github.com/flutter/cocoon/blob/2a5f4afa3d27d701357b4101da672ce346865073/app_dart/config.yaml#L12-L15) `waitOnContentHash` flag. When enabled, cocoon will add the `content_hash` solution to the luci build properties when scheduling [merge group
targets](https://github.com/flutter/cocoon/blob/2a5f4afa3d27d701357b4101da672ce346865073/app_dart/lib/src/service/scheduler.dart#L703-L706).

If `upload_content_hash` is present and the `content_hash` is passed, the [engine_v2 & builder recipie](https://flutter-review.googlesource.com/c/recipes/+/66780) will upload to a second location. This upload should happen only once; for the first matching engine change.

> [!IMPORTANT]
> [`windows_arm_host_engine`](https://flutter-dashboard.appspot.com/#/build?taskFilter=windows_arm_host_engine&repo=flutter&branch=master) is not built in the merge queue and won't get the content_hash value passed down to it, so it will not get uploaded today. This should be fine given we're still testing; but Cocoon would need to schedule limited post submits so this eventually only builds and uploads once.