### PR TITLE
Restrict menu layout to be within safe area

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2918,6 +2918,7 @@ class _MenuLayout extends SingleChildLayoutDelegate {
     required this.menuPosition,
     required this.menuPadding,
     required this.avoidBounds,
+    required this.safeArea,
     required this.orientation,
     required this.parentOrientation,
   });
@@ -2945,6 +2946,9 @@ class _MenuLayout extends SingleChildLayoutDelegate {
   // List of rectangles that we should avoid overlapping. Unusable screen area.
   final Set<Rect> avoidBounds;
 
+  // Media query padding at the context of the rendering Overlay.
+  final EdgeInsets safeArea;
+
   // The orientation of this menu.
   final Axis orientation;
 
@@ -2957,7 +2961,7 @@ class _MenuLayout extends SingleChildLayoutDelegate {
     // pixels in each direction.
     return BoxConstraints.loose(
       constraints.biggest,
-    ).deflate(const EdgeInsets.all(_kMenuViewPadding));
+    ).deflate(safeArea).deflate(const EdgeInsets.all(_kMenuViewPadding));
   }
 
   @override
@@ -2994,8 +2998,14 @@ class _MenuLayout extends SingleChildLayoutDelegate {
       y = adjustedPosition.dy;
     }
 
+    final Rect safeRect = Rect.fromLTRB(
+      overlayRect.left + safeArea.left,
+      overlayRect.top + safeArea.top,
+      overlayRect.right - safeArea.right,
+      overlayRect.bottom - safeArea.bottom,
+    );
     final Iterable<Rect> subScreens = DisplayFeatureSubScreen.subScreensInBounds(
-      overlayRect,
+      safeRect,
       avoidBounds,
     );
     final Rect allowedRect = _closestScreen(subScreens, anchorRect.center);
@@ -3353,6 +3363,8 @@ class _Submenu extends StatelessWidget {
             )
             : Rect.zero;
 
+    final EdgeInsets safeArea = MediaQuery.paddingOf(Overlay.of(context).context);
+
     final Widget menuPanel = TapRegion(
       groupId: menuPosition.tapRegionGroupId,
       consumeOutsideTaps: anchor._root._menuController.isOpen && anchor.widget.consumeOutsideTap,
@@ -3396,6 +3408,7 @@ class _Submenu extends StatelessWidget {
                 anchorRect: anchorRect,
                 textDirection: textDirection,
                 avoidBounds: DisplayFeatureSubScreen.avoidBounds(mediaQuery).toSet(),
+                safeArea: safeArea,
                 menuPadding: resolvedPadding,
                 alignment: alignment,
                 alignmentOffset: alignmentOffset,

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2957,8 +2957,8 @@ class _MenuLayout extends SingleChildLayoutDelegate {
 
   @override
   BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
-    // The menu can be at most the size of the overlay minus _kMenuViewPadding
-    // pixels in each direction.
+    // The menu can be at most the size of the overlay minus the safe area and
+    // _kMenuViewPadding pixels in each direction.
     return BoxConstraints.loose(
       constraints.biggest,
     ).deflate(safeArea).deflate(const EdgeInsets.all(_kMenuViewPadding));
@@ -3363,6 +3363,9 @@ class _Submenu extends StatelessWidget {
             )
             : Rect.zero;
 
+    // Get the device padding using the Overlay's context because there
+    // may be a SafeArea between it and the portal, so the current context
+    // would have zero padding.
     final EdgeInsets safeArea = MediaQuery.paddingOf(Overlay.of(context).context);
 
     final Widget menuPanel = TapRegion(

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3250,6 +3250,48 @@ void main() {
       return menuRects;
     }
 
+    testWidgets('menu does not go out of safe area', (WidgetTester tester) async {
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+        tester.view.resetPadding();
+      });
+
+      const Size size = Size.square(500);
+      tester.view.physicalSize = size;
+      tester.view.devicePixelRatio = 1;
+
+      const double padding = 50;
+      tester.view.padding = const FakeViewPadding(top: padding, bottom: padding);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SafeArea(
+              child: Center(
+                child: DropdownMenu<int>(
+                  dropdownMenuEntries: <DropdownMenuEntry<int>>[
+                    for (final int item in Iterable<int>.generate(20))
+                      DropdownMenuEntry<int>(value: item, label: 'Item $item'),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(DropdownMenu<int>));
+      await tester.pumpAndSettle();
+
+      final Finder menuFinder = find.byType(SingleChildScrollView);
+      expect(menuFinder, findsOneWidget);
+
+      final Rect menuRect = tester.getRect(menuFinder);
+      expect(menuRect.top >= padding, isTrue);
+      expect(menuRect.bottom <= size.height - padding, isTrue);
+    });
+
     testWidgets('unconstrained menus show up in the right place in LTR', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Menus should now apply any padding at the context of the rendering overlay: #171066 

Menu anchors use an `OverlayPortal`, which may use an `Overlay` above an existing `SafeArea` to render the menu. This change checks for yet to be applied padding at the level of the rendering `Overlay` and applies it to the menu.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
