### PR TITLE
Add `side` to `Radio`

### DIFF
--- a/examples/api/lib/material/radio/radio.1.dart
+++ b/examples/api/lib/material/radio/radio.1.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-/// Flutter code sample for [Radio].
+/// Flutter code sample for [Radio] to showcase how to customize radio style.
 
 void main() => runApp(const RadioExampleApp());
 

--- a/examples/api/lib/material/radio/radio.1.dart
+++ b/examples/api/lib/material/radio/radio.1.dart
@@ -1,0 +1,99 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for [Radio].
+
+void main() => runApp(const RadioExampleApp());
+
+class RadioExampleApp extends StatelessWidget {
+  const RadioExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Radio Sample')),
+        body: const Center(child: RadioExample()),
+      ),
+    );
+  }
+}
+
+enum RadioType { fillColor, backgroundColor, side }
+
+class RadioExample extends StatefulWidget {
+  const RadioExample({super.key});
+
+  @override
+  State<RadioExample> createState() => _RadioExampleState();
+}
+
+class _RadioExampleState extends State<RadioExample> {
+  RadioType? _radioType = RadioType.fillColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return RadioGroup<RadioType>(
+      groupValue: _radioType,
+      onChanged: (RadioType? value) {
+        setState(() {
+          _radioType = value;
+        });
+      },
+      child: Column(
+        children: <Widget>[
+          ListTile(
+            title: const Text('Fill color'),
+            leading: Radio<RadioType>(
+              value: RadioType.fillColor,
+              fillColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
+                if (states.contains(WidgetState.selected)) {
+                  return Colors.deepPurple;
+                } else {
+                  return Colors.deepPurple.shade200;
+                }
+              }),
+            ),
+          ),
+          ListTile(
+            title: const Text('Background color'),
+            leading: Radio<RadioType>(
+              value: RadioType.backgroundColor,
+              backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
+                if (states.contains(WidgetState.selected)) {
+                  return Colors.greenAccent.withOpacity(0.5);
+                } else {
+                  return Colors.grey.shade300.withOpacity(0.3);
+                }
+              }),
+            ),
+          ),
+          ListTile(
+            title: const Text('Side'),
+            leading: Radio<RadioType>(
+              value: RadioType.side,
+              side: WidgetStateBorderSide.resolveWith((Set<WidgetState> states) {
+                if (states.contains(MaterialState.selected)) {
+                  return const BorderSide(
+                    color: Colors.red,
+                    width: 4,
+                    strokeAlign: BorderSide.strokeAlignCenter,
+                  );
+                } else {
+                  return const BorderSide(
+                    color: Colors.grey,
+                    width: 1.5,
+                    strokeAlign: BorderSide.strokeAlignCenter,
+                  );
+                }
+              }),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/api/test/material/radio/radio.1_test.dart
+++ b/examples/api/test/material/radio/radio.1_test.dart
@@ -1,0 +1,51 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/radio/radio.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Radio colors can be changed', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.RadioExampleApp());
+
+    expect(find.widgetWithText(AppBar, 'Radio Sample'), findsOne);
+    expect(find.widgetWithText(ListTile, 'Fill color'), findsOne);
+    expect(find.widgetWithText(ListTile, 'Background color'), findsOne);
+    expect(find.widgetWithText(ListTile, 'Side'), findsOne);
+
+    final Radio<example.RadioType> radioFillColor = tester.widget<Radio<example.RadioType>>(
+      find.byType(Radio<example.RadioType>).first,
+    );
+    expect(
+      radioFillColor.fillColor!.resolve(const <WidgetState>{WidgetState.selected}),
+      Colors.deepPurple,
+    );
+    expect(radioFillColor.fillColor!.resolve(const <WidgetState>{}), Colors.deepPurple.shade200);
+
+    final Radio<example.RadioType> radioBackgroundColor = tester.widget<Radio<example.RadioType>>(
+      find.byType(Radio<example.RadioType>).at(1),
+    );
+    expect(
+      radioBackgroundColor.backgroundColor!.resolve(const <WidgetState>{WidgetState.selected}),
+      Colors.greenAccent.withOpacity(0.5),
+    );
+    expect(
+      radioBackgroundColor.backgroundColor!.resolve(const <WidgetState>{}),
+      Colors.grey.shade300.withOpacity(0.3),
+    );
+
+    final Radio<example.RadioType> radioSide = tester.widget<Radio<example.RadioType>>(
+      find.byType(Radio<example.RadioType>).last,
+    );
+    expect(
+      (radioSide.side! as WidgetStateBorderSide).resolve(const <WidgetState>{WidgetState.selected}),
+      const BorderSide(color: Colors.red, width: 4, strokeAlign: BorderSide.strokeAlignCenter),
+    );
+    expect(
+      (radioSide.side! as WidgetStateBorderSide).resolve(const <WidgetState>{}),
+      const BorderSide(color: Colors.grey, width: 1.5, strokeAlign: BorderSide.strokeAlignCenter),
+    );
+  });
+}

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -64,6 +64,20 @@ const double _kInnerRadius = 4.5;
 /// ** See code in examples/api/lib/material/radio/radio.0.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// Here is an example of how the you can override the default theme of a
+/// [Radio] with [WidgetStateProperty].
+///
+/// In this example:
+/// - The first [Radio] uses a custom [fillColor] that changes depending on whether
+///   the radio button is selected.
+/// - The second [Radio] applies a different [backgroundColor] based on its selection state.
+/// - The third [Radio] customizes the [side] property to display a different border color
+///   when selected or unselected.
+///
+/// ** See code in examples/api/lib/material/radio/radio.1.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [RadioListTile], which combines this widget with a [ListTile] so that
@@ -413,7 +427,11 @@ class Radio<T> extends StatefulWidget {
   /// If null, then it is transparent in all states.
   final WidgetStateProperty<Color?>? backgroundColor;
 
-  /// The side of the radio button, in all [WidgetState]s.
+  /// The side for the circular border of the radio button, in all
+  /// [WidgetState]s.
+  ///
+  /// This property can be a [BorderSide] or a [WidgetStateBorderSide] to leverage
+  /// widget state resolution.
   ///
   /// Resolves in the following states:
   ///  * [WidgetState.selected].

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -2328,7 +2328,7 @@ void main() {
       Material.of(tester.element(find.byKey(radioKey))),
       paints
         ..rect()
-        ..circle(color: theme.colorScheme.primary.withOpacity(0.1))
+        ..circle(color: theme.colorScheme.primary.withValues(alpha: 0.1))
         ..circle(color: focusedBackgroundColor),
     );
 
@@ -2346,8 +2346,211 @@ void main() {
           color: const Color(0xffffffff),
           rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
         )
-        ..circle(color: theme.colorScheme.primary.withOpacity(0.08))
+        ..circle(color: theme.colorScheme.primary.withValues(alpha: 0.08))
         ..circle(color: hoveredBackgroundColor),
+    );
+
+    focusNode.dispose();
+  });
+
+  testWidgets('Radio button side resolves in enabled/disabled states', (WidgetTester tester) async {
+    const BorderSide activeEnabledSide = BorderSide(color: Color(0xFF000001));
+    const BorderSide activeDisabledSide = BorderSide(color: Color(0xFF000002), width: 2);
+    const BorderSide inactiveEnabledSide = BorderSide(color: Color(0xFF000003), width: 3);
+    const BorderSide inactiveDisabledSide = BorderSide(color: Color(0xFF000004), width: 4);
+
+    BorderSide getSide(Set<WidgetState> states) {
+      if (states.contains(WidgetState.disabled)) {
+        if (states.contains(WidgetState.selected)) {
+          return activeDisabledSide;
+        }
+        return inactiveDisabledSide;
+      }
+      if (states.contains(WidgetState.selected)) {
+        return activeEnabledSide;
+      }
+      return inactiveEnabledSide;
+    }
+
+    final WidgetStateBorderSide side = WidgetStateBorderSide.resolveWith(getSide);
+
+    int? groupValue = 0;
+    const Key radioKey = Key('radio');
+    Widget buildApp({required bool enabled}) {
+      return MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return Container(
+                  width: 100,
+                  height: 100,
+                  color: Colors.white,
+                  child: RadioGroup<int>(
+                    groupValue: groupValue,
+                    onChanged: (int? newValue) {
+                      setState(() {
+                        groupValue = newValue;
+                      });
+                    },
+                    child: Radio<int>(key: radioKey, value: 0, side: side, enabled: enabled),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(enabled: true));
+
+    // Selected and enabled.
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+          color: const Color(0xffffffff),
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        )
+        ..circle(color: Colors.transparent)
+        ..circle(color: activeEnabledSide.color, strokeWidth: activeEnabledSide.width),
+    );
+
+    // Check when the radio isn't selected.
+    groupValue = 1;
+    await tester.pumpWidget(buildApp(enabled: true));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+          color: const Color(0xffffffff),
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        )
+        ..circle(color: Colors.transparent)
+        ..circle(color: inactiveEnabledSide.color, strokeWidth: inactiveEnabledSide.width),
+    );
+
+    // Check when the radio is selected, but disabled.
+    groupValue = 0;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+          color: const Color(0xffffffff),
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        )
+        ..circle(color: Colors.transparent)
+        ..circle(color: activeDisabledSide.color, strokeWidth: activeDisabledSide.width),
+    );
+
+    // Check when the radio is unselected and disabled.
+    groupValue = 1;
+    await tester.pumpWidget(buildApp(enabled: false));
+    await tester.pumpAndSettle();
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+          color: const Color(0xffffffff),
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        )
+        ..circle(color: Colors.transparent)
+        ..circle(color: inactiveDisabledSide.color, strokeWidth: inactiveDisabledSide.width),
+    );
+  });
+
+  testWidgets('Radio background color resolves in hovered/focused states', (
+    WidgetTester tester,
+  ) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'radio');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    const BorderSide hoveredSide = BorderSide(color: Color(0xFF000001));
+    const BorderSide focusedSide = BorderSide(color: Color(0xFF000002), width: 2);
+
+    BorderSide? getSide(Set<WidgetState> states) {
+      if (states.contains(WidgetState.hovered)) {
+        return hoveredSide;
+      }
+      if (states.contains(WidgetState.focused)) {
+        return focusedSide;
+      }
+      return null;
+    }
+
+    final WidgetStateBorderSide side = WidgetStateBorderSide.resolveWith(getSide);
+
+    int? groupValue = 0;
+    const Key radioKey = Key('radio');
+    final ThemeData theme = ThemeData();
+    Widget buildApp() {
+      return MaterialApp(
+        theme: theme,
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return Container(
+                  width: 100,
+                  height: 100,
+                  color: Colors.white,
+                  child: RadioGroup<int>(
+                    groupValue: groupValue,
+                    onChanged: (int? newValue) {
+                      setState(() {
+                        groupValue = newValue;
+                      });
+                    },
+                    child: Radio<int>(
+                      autofocus: true,
+                      focusNode: focusNode,
+                      key: radioKey,
+                      value: 0,
+                      side: side,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect()
+        ..circle(color: theme.colorScheme.primary.withValues(alpha: 0.1))
+        ..circle(color: Colors.transparent)
+        ..circle(color: focusedSide.color, strokeWidth: focusedSide.width),
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    await gesture.moveTo(tester.getCenter(find.byKey(radioKey)));
+    await tester.pumpAndSettle();
+
+    expect(
+      Material.of(tester.element(find.byKey(radioKey))),
+      paints
+        ..rect(
+          color: const Color(0xffffffff),
+          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
+        )
+        ..circle(color: theme.colorScheme.primary.withValues(alpha: 0.08))
+        ..circle(color: Colors.transparent)
+        ..circle(color: hoveredSide.color, strokeWidth: hoveredSide.width),
     );
 
     focusNode.dispose();


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/168787

This PR adds `side` parameter to `Radio` to be able to control its color and width.

This allows me to implement something like:

https://github.com/user-attachments/assets/8065df9b-4cea-48b6-ba34-21379a831a2e

In order to make it non breaking, when absent, it uses the `fillColor`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
