### PR TITLE
Revert "[skwasm] Use `transferToImageBitmap` instead of `createImageBitmap` (#163251)"

### DIFF
--- a/engine/src/flutter/lib/web_ui/skwasm/library_skwasm_support.js
+++ b/engine/src/flutter/lib/web_ui/skwasm/library_skwasm_support.js
@@ -176,13 +176,14 @@ mergeInto(LibraryManager.library, {
       canvas.width = width;
       canvas.height = height;
     };
-    _skwasm_captureImageBitmap = function(contextHandle, images) {
-      if (!images) images = Array();
+    _skwasm_captureImageBitmap = function(contextHandle, width, height, imagePromises) {
+      if (!imagePromises) imagePromises = Array();
       const canvas = handleToCanvasMap.get(contextHandle);
-      images.push(canvas.transferToImageBitmap());
-      return images;
+      imagePromises.push(createImageBitmap(canvas, 0, 0, width, height));
+      return imagePromises;
     };
-    _skwasm_postImages = async function(surfaceHandle, imageBitmaps, rasterStart, callbackId) {
+    _skwasm_resolveAndPostImages = async function(surfaceHandle, imagePromises, rasterStart, callbackId) {
+      const imageBitmaps = imagePromises ? await Promise.all(imagePromises) : [];
       const rasterEnd = skwasm_getCurrentTimestamp();
       skwasm_postMessage({
         skwasmMessage: 'onRenderComplete',
@@ -262,8 +263,8 @@ mergeInto(LibraryManager.library, {
   skwasm_resizeCanvas__deps: ['$skwasm_support_setup'],
   skwasm_captureImageBitmap: function () {},
   skwasm_captureImageBitmap__deps: ['$skwasm_support_setup'],
-  skwasm_postImages: function () {},
-  skwasm_postImages__deps: ['$skwasm_support_setup'],
+  skwasm_resolveAndPostImages: function () {},
+  skwasm_resolveAndPostImages__deps: ['$skwasm_support_setup'],
   skwasm_createGlTextureFromTextureSource: function () {},
   skwasm_createGlTextureFromTextureSource__deps: ['$skwasm_support_setup'],
   skwasm_dispatchDisposeSurface: function() {},

--- a/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
@@ -29,11 +29,13 @@ extern void skwasm_dispatchRenderPictures(unsigned long threadId,
 extern uint32_t skwasm_createOffscreenCanvas(int width, int height);
 extern void skwasm_resizeCanvas(uint32_t contextHandle, int width, int height);
 extern SkwasmObject skwasm_captureImageBitmap(uint32_t contextHandle,
+                                              int width,
+                                              int height,
                                               SkwasmObject imagePromises);
-extern void skwasm_postImages(Skwasm::Surface* surface,
-                              SkwasmObject imageBitmaps,
-                              double rasterStart,
-                              uint32_t callbackId);
+extern void skwasm_resolveAndPostImages(Skwasm::Surface* surface,
+                                        SkwasmObject imagePromises,
+                                        double rasterStart,
+                                        uint32_t callbackId);
 extern unsigned int skwasm_createGlTextureFromTextureSource(
     SkwasmObject textureSource,
     int width,


### PR DESCRIPTION
This reverts commit 7d22606cda72accc2232e6b9a1f6fee4c6ea1c9c.

It turns out that in many scenarios, resizing the OffscreenCanvas multiple times per frame is prohibitively expensive. It also turns out that neither API works well enough on non-Chrome browsers to make it viable anyway, so we should switch back to `createImageBitmap`.