### PR TITLE
Re-combine reload error and restart test cases

### DIFF
--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_errors_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_errors_common.dart
@@ -8,7 +8,6 @@ import 'package:flutter_tools/src/web/web_device.dart' show GoogleChromeDevice;
 import 'package:vm_service/vm_service.dart';
 
 import '../../src/common.dart';
-import '../../web.shard/test_data/expression_evaluation_web_common.dart';
 import '../test_driver.dart';
 import '../test_utils.dart';
 import 'hot_reload_const_project.dart';
@@ -69,9 +68,21 @@ void testAll({
           additionalCommandArgs: additionalCommandArgs,
         );
         project.removeFieldFromConstClass();
-        final LibraryRef library = await getRootLibrary(flutter);
+
+        final LibraryRef library = (await flutter.getFlutterIsolate()).libraries!.firstWhere(
+          (LibraryRef l) => l.uri!.contains('package:test/main.dart'),
+        );
         final ObjRef result = await flutter.evaluate(library.id!, '42.isEven');
-        expectInstance(result, InstanceKind.kBool, true.toString());
+        expect(
+          result,
+          const TypeMatcher<InstanceRef>()
+              .having((InstanceRef instance) => instance.kind, 'kind', InstanceKind.kBool)
+              .having(
+                (InstanceRef instance) => instance.valueAsString,
+                'valueAsString',
+                true.toString(),
+              ),
+        );
       },
     );
   });

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_errors_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_errors_common.dart
@@ -68,7 +68,16 @@ void testAll({
           additionalCommandArgs: additionalCommandArgs,
         );
         project.removeFieldFromConstClass();
-
+        await expectLater(
+          flutter.hotReload(),
+          throwsA(
+            isA<Exception>().having(
+              (Exception e) => e.toString(),
+              'message',
+              contains('Try performing a hot restart instead.'),
+            ),
+          ),
+        );
         final LibraryRef library = (await flutter.getFlutterIsolate()).libraries!.firstWhere(
           (LibraryRef l) => l.uri!.contains('package:test/main.dart'),
         );


### PR DESCRIPTION
Also add an explicit test case for reload rejection error followed by an expression evaluation.

These cases should work as expected now that this Dart SDK change has been rolled into Flutter https://dart-review.googlesource.com/c/sdk/+/434522.

Closes https://github.com/flutter/flutter/issues/170062
