### PR TITLE
fix: ColorScheme will removeListener on imageStream twice if there is error loading the image.

### DIFF
--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -2144,8 +2144,9 @@ class ColorScheme with Diagnosticable {
         imageCompleter.complete(info.image);
       },
       onError: (Object exception, StackTrace? stackTrace) {
+        loadFailureTimeout?.cancel();
         stream.removeListener(listener);
-        throw Exception('Failed to render image: $exception');
+        imageCompleter.completeError(TimeoutException('Failed to render image: $exception'));
       },
     );
 

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -673,24 +673,27 @@ void main() {
     );
   });
 
-  test('fromImageProvider() propagates TimeoutException when image cannot be rendered', () async {
-    final Uint8List blueSquareBytes = Uint8List.fromList(kBlueSquarePng);
+  test(
+    'fromImageProvider() propagates TimeoutException or Failed to render image when image cannot be rendered',
+    () async {
+      final Uint8List blueSquareBytes = Uint8List.fromList(kBlueSquarePng);
 
-    // Corrupt the image's bytelist so it cannot be read.
-    final Uint8List corruptImage = blueSquareBytes.sublist(5);
-    final ImageProvider image = MemoryImage(corruptImage);
+      // Corrupt the image's bytelist so it cannot be read.
+      final Uint8List corruptImage = blueSquareBytes.sublist(5);
+      final ImageProvider image = MemoryImage(corruptImage);
 
-    expect(
-      () async => ColorScheme.fromImageProvider(provider: image),
-      throwsA(
-        isA<Exception>().having(
-          (Exception e) => e.toString(),
-          'Timeout occurred trying to load image',
-          contains('TimeoutException'),
+      expect(
+        () async => ColorScheme.fromImageProvider(provider: image),
+        throwsA(
+          isA<Exception>().having(
+            (Exception e) => e.toString(),
+            'image',
+            anyOf(contains('Failed to render image'), contains('TimeoutException')),
+          ),
         ),
-      ),
-    );
-  });
+      );
+    },
+  );
 
   testWidgets(
     'generated scheme "on" colors meet a11y contrast guidelines',


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/170413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
