### PR TITLE
Remove a doctor event from the `package:usage`-era.

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -36,7 +36,6 @@ import 'linux/linux_workflow.dart';
 import 'macos/macos_workflow.dart';
 import 'macos/xcode_validator.dart';
 import 'proxy_validator.dart';
-import 'reporting/reporting.dart';
 import 'tester/flutter_tester.dart';
 import 'version.dart';
 import 'vscode/vscode_validator.dart';

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -432,9 +432,6 @@ class Doctor {
             ),
           );
         }
-        // TODO(eliasyishak): remove this after migrating from package:usage,
-        //  https://github.com/flutter/flutter/issues/128251
-        DoctorResultEvent(validator: validator, result: result).send();
       }
 
       final String executionDuration = () {


### PR DESCRIPTION
No test because it's just unused.