### PR TITLE
feat: add "stamp" to et and create build-time engine_stamp.json

### DIFF
--- a/engine/src/flutter/ci/builders/linux_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine.json
@@ -125,6 +125,14 @@
                     "out/docs"
                 ],
                 "script": "flutter/tools/gen_docs.py"
+            },
+            {
+                "name": "engine-stamp",
+                "parameters": [
+                    "stamp"
+                ],
+                "script": "flutter/tools/engine_tool/bin/et.dart",
+                "language": "dart"
             }
         ]
     },
@@ -152,6 +160,11 @@
         {
             "source": "out/docs/impeller-docs.zip",
             "destination": "impeller-docs.zip",
+            "realm": "production"
+        },
+        {
+            "source": "out/engine_stamp.json",
+            "destination": "engine_stamp.json",
             "realm": "production"
         }
     ]

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/command_runner.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/command_runner.dart
@@ -14,6 +14,7 @@ import 'format_command.dart';
 import 'lint_command.dart';
 import 'query_command.dart';
 import 'run_command.dart';
+import 'stamp_command.dart';
 import 'test_command.dart';
 
 const int _usageLineLength = 100;
@@ -55,6 +56,7 @@ final class ToolCommandRunner extends CommandRunner<int> {
         help: help,
         usageLineLength: _usageLineLength,
       ),
+      StampCommand(environment: environment),
     ];
     commands.forEach(addCommand);
 

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/stamp_command.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/stamp_command.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -13,7 +13,7 @@ import 'flags.dart';
 
 /// The `stamp` command for recording engine build info.
 final class StampCommand extends CommandBase {
-  /// Constructs the `cleanup` command.
+  /// Constructs the `stamp` command.
   StampCommand({required super.environment, super.help = false, super.usageLineLength}) {
     argParser.addFlag(
       dryRunFlag,
@@ -71,20 +71,18 @@ final class StampCommand extends CommandBase {
 
   Future<String> _getGitRevisionDate(String revision) async {
     final result = await environment.processRunner.runProcess(
-      'git show -s --pretty=format:%ad --date=iso'.split(' '),
+      'git show -s --pretty=format:%ad --date=iso-strict'.split(' '),
       workingDirectory: environment.engine.srcDir,
     );
     if (result.exitCode != 0) {
-      throw Exception(
-        'git show -s --format=%ci $revision failed with exit code ${result.exitCode}',
-      );
+      throw Exception('git show failed with exit code ${result.exitCode}');
     }
     return result.stdout.trim();
   }
 
   Future<String> _getContentHash() async {
     final result = await environment.processRunner.runProcess([
-      '${environment.engine.srcDir.path}/../../bin/internal/content_aware_hash.sh',
+      '${environment.flutterBinInternal}/content_aware_hash.sh',
     ], workingDirectory: environment.engine.srcDir);
     if (result.exitCode != 0) {
       throw Exception('content_aware_hash.sh failed with exit code ${result.exitCode}');

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/stamp_command.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/stamp_command.dart
@@ -64,7 +64,12 @@ final class StampCommand extends CommandBase {
       workingDirectory: environment.engine.srcDir,
     );
     if (result.exitCode != 0) {
-      throw Exception('git rev-parse HEAD failed with exit code ${result.exitCode}');
+      environment.logger.error(
+        'git rev-parse HEAD failed with exit code ${result.exitCode}'
+        '\n\n'
+        'STDOUT:\n${result.stdout}\n'
+        'STDERR:\n${result.stderr}\n',
+      );
     }
     return result.stdout.trim();
   }
@@ -75,7 +80,12 @@ final class StampCommand extends CommandBase {
       workingDirectory: environment.engine.srcDir,
     );
     if (result.exitCode != 0) {
-      throw Exception('git show failed with exit code ${result.exitCode}');
+      environment.logger.error(
+        'git show failed with exit code ${result.exitCode}'
+        '\n\n'
+        'STDOUT:\n${result.stdout}\n'
+        'STDERR:\n${result.stderr}\n',
+      );
     }
     return result.stdout.trim();
   }
@@ -85,7 +95,12 @@ final class StampCommand extends CommandBase {
       '${environment.flutterBinInternal}/content_aware_hash.sh',
     ], workingDirectory: environment.engine.srcDir);
     if (result.exitCode != 0) {
-      throw Exception('content_aware_hash.sh failed with exit code ${result.exitCode}');
+      environment.logger.error(
+        'content_aware_hash.sh failed with exit code ${result.exitCode}'
+        '\n\n'
+        'STDOUT:\n${result.stdout}\n'
+        'STDERR:\n${result.stderr}\n',
+      );
     }
     return result.stdout.trim();
   }

--- a/engine/src/flutter/tools/engine_tool/lib/src/commands/stamp_command.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/commands/stamp_command.dart
@@ -1,0 +1,94 @@
+// Copyright 2025 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'command.dart';
+import 'flags.dart';
+
+/// The `stamp` command for recording engine build info.
+final class StampCommand extends CommandBase {
+  /// Constructs the `cleanup` command.
+  StampCommand({required super.environment, super.help = false, super.usageLineLength}) {
+    argParser.addFlag(
+      dryRunFlag,
+      abbr: 'd',
+      help: 'Write changes to stdout without modifying the file system.',
+      negatable: false,
+    );
+  }
+
+  @override
+  String get name => 'stamp';
+
+  @override
+  String get description => 'Records build information for later consumption.';
+
+  @override
+  Future<int> run() async {
+    final dryRun = argResults!.flag('dry-run');
+    final engine = environment.engine;
+
+    final revision = await _getGitRevision();
+    final revisionDate = await _getGitRevisionDate(revision);
+    final now = environment.now();
+
+    final stamp = <String, Object?>{
+      'build_date': now.toIso8601String(),
+      'build_time_ms': now.millisecondsSinceEpoch,
+      'git_revision': revision,
+      'git_revision_date': revisionDate,
+      'content_hash': await _getContentHash(),
+    };
+
+    final stampPath = p.join(engine.outDir.path, 'engine_stamp.json');
+    if (dryRun) {
+      environment.logger.status('The following would have been written to $stampPath:');
+      environment.logger.status(json.encode(stamp));
+      return 0;
+    }
+    final stampFile = File(stampPath);
+    stampFile.createSync(recursive: true);
+    stampFile.writeAsStringSync(json.encode(stamp));
+    return 0;
+  }
+
+  Future<String> _getGitRevision() async {
+    final result = await environment.processRunner.runProcess(
+      'git rev-parse HEAD'.split(' '),
+      workingDirectory: environment.engine.srcDir,
+    );
+    if (result.exitCode != 0) {
+      throw Exception('git rev-parse HEAD failed with exit code ${result.exitCode}');
+    }
+    return result.stdout.trim();
+  }
+
+  Future<String> _getGitRevisionDate(String revision) async {
+    final result = await environment.processRunner.runProcess(
+      'git show -s --pretty=format:%ad --date=iso'.split(' '),
+      workingDirectory: environment.engine.srcDir,
+    );
+    if (result.exitCode != 0) {
+      throw Exception(
+        'git show -s --format=%ci $revision failed with exit code ${result.exitCode}',
+      );
+    }
+    return result.stdout.trim();
+  }
+
+  Future<String> _getContentHash() async {
+    final result = await environment.processRunner.runProcess([
+      '${environment.engine.srcDir.path}/../../bin/internal/content_aware_hash.sh',
+    ], workingDirectory: environment.engine.srcDir);
+    if (result.exitCode != 0) {
+      throw Exception('content_aware_hash.sh failed with exit code ${result.exitCode}');
+    }
+    return result.stdout.trim();
+  }
+}

--- a/engine/src/flutter/tools/engine_tool/lib/src/environment.dart
+++ b/engine/src/flutter/tools/engine_tool/lib/src/environment.dart
@@ -51,6 +51,12 @@ final class Environment {
   /// Returns the current [Datetime].
   final DateTime Function() now;
 
+  /// Returns the root of the Flutter tree.
+  String get flutterRoot => p.normalize(p.join(engine.srcDir.path, '..', '..'));
+
+  /// Returns the internal "bin" folder of Flutter.
+  String get flutterBinInternal => p.join(flutterRoot, 'bin', 'internal');
+
   /// Whether it appears that the current environment supports remote builds.
   ///
   /// This is a heuristic based on the presence of certain directories in the

--- a/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
+++ b/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
@@ -1,0 +1,170 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:ffi' show Abi;
+import 'dart:io' as io;
+
+import 'package:args/command_runner.dart';
+import 'package:engine_repo_tools/engine_repo_tools.dart';
+import 'package:engine_tool/src/commands/command.dart';
+import 'package:engine_tool/src/commands/stamp_command.dart';
+import 'package:engine_tool/src/environment.dart';
+import 'package:engine_tool/src/logger.dart';
+import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
+import 'package:process_fakes/process_fakes.dart';
+import 'package:process_runner/process_runner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late io.Directory tempRoot;
+  late TestEngine testEngine;
+
+  setUp(() {
+    tempRoot = io.Directory.systemTemp.createTempSync('engine_tool_test');
+    testEngine = TestEngine.createTemp(rootDir: tempRoot);
+    print('test root: $tempRoot');
+  });
+
+  tearDown(() {
+    tempRoot.deleteSync(recursive: true);
+  });
+
+  group('creates stamp', () {
+    late CommandRunner<int> et;
+
+    var commandsRun = <List<String>>[];
+    var testLogs = <LogRecord>[];
+    var interceptCommands = <(String, FakeProcess? Function(List<String>))>[];
+
+    setUp(() {
+      // Be very permissive on process execution, and check usage below instead.
+      final permissiveProcessManager = FakeProcessManager(
+        canRun: (_, {workingDirectory}) => true,
+        onRun: (FakeCommandLogEntry entry) {
+          commandsRun.add(entry.command);
+          return io.ProcessResult(81, 0, '', '');
+        },
+        onStart: (FakeCommandLogEntry entry) {
+          commandsRun.add(entry.command);
+          for (final intercept in interceptCommands) {
+            if (entry.command.first.endsWith(intercept.$1)) {
+              final result = intercept.$2(entry.command);
+              if (result != null) {
+                return result;
+              }
+            }
+          }
+          switch (entry.command) {
+            case ['git', 'rev-parse', 'HEAD']:
+              return FakeProcess(stdout: 'a' * 40);
+            case ['git', 'show', '-s', '--pretty=format:%ad', '--date=iso']:
+              return FakeProcess(stdout: '2025-06-27 15:51:55 -0700');
+            default:
+              if (entry.command.first.endsWith('content_aware_hash.sh')) {
+                return FakeProcess(stdout: '1' * 40);
+              }
+              return FakeProcess();
+          }
+        },
+      );
+
+      // Set up the environment for the test.
+      final testEnvironment = Environment(
+        abi: Abi.linuxX64,
+        engine: testEngine,
+        logger: Logger.test((log) {
+          testLogs.add(log);
+        }),
+        platform: _fakePlatform(Platform.linux),
+        processRunner: ProcessRunner(
+          defaultWorkingDirectory: tempRoot,
+          processManager: permissiveProcessManager,
+        ),
+        now: () => DateTime(2025, 6, 27, 12, 30),
+      );
+
+      // Set up the Flutter tool for the test.
+      et = _engineTool(StampCommand(environment: testEnvironment));
+
+      // Reset logs.
+      commandsRun = [];
+      testLogs = [];
+      interceptCommands = [];
+    });
+
+    tearDown(() {
+      printOnFailure('Commands run:\n${commandsRun.map((c) => c.join('\n'))}');
+      printOnFailure('Logs:\n${testLogs.map((l) => l.message).join('\n')}');
+    });
+
+    test('dry-run output', () async {
+      await et.run(['stamp', '--dry-run']);
+
+      expect(
+        commandsRun,
+        containsAllInOrder([
+          containsAllInOrder(['git', contains('rev-parse'), contains('HEAD')]),
+          containsAllInOrder([
+            'git',
+            contains('show'),
+            contains('-s'),
+            contains('--pretty=format:%ad'),
+            contains('--date=iso'),
+          ]),
+          containsAllInOrder([endsWith('content_aware_hash.sh')]),
+        ]),
+      );
+      final logStrings = [for (final log in testLogs) log.message.trim()];
+
+      expect(
+        logStrings,
+        containsAllInOrder([
+          endsWith('src/out/engine_stamp.json:'),
+          contains(
+            '{"build_date":"2025-06-27T12:30:00.000","build_time_ms":1751052600000,"git_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","git_revision_date":"2025-06-27 15:51:55 -0700","content_hash":"1111111111111111111111111111111111111111"}',
+          ),
+        ]),
+      );
+    });
+
+    test('writes to engine_stamp.json', () async {
+      await et.run(['stamp']);
+
+      expect(
+        commandsRun,
+        containsAllInOrder([
+          containsAllInOrder(['git', contains('rev-parse'), contains('HEAD')]),
+          containsAllInOrder([
+            'git',
+            contains('show'),
+            contains('-s'),
+            contains('--pretty=format:%ad'),
+            contains('--date=iso'),
+          ]),
+          containsAllInOrder([endsWith('content_aware_hash.sh')]),
+        ]),
+      );
+      expect(testLogs, isEmpty);
+      expect(io.File(p.join(tempRoot.path, 'src/out/engine_stamp.json')).existsSync(), isTrue);
+      expect(
+        io.File(p.join(tempRoot.path, 'src/out/engine_stamp.json')).readAsStringSync().trim(),
+        '{"build_date":"2025-06-27T12:30:00.000","build_time_ms":1751052600000,"git_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","git_revision_date":"2025-06-27 15:51:55 -0700","content_hash":"1111111111111111111111111111111111111111"}',
+      );
+    });
+  });
+}
+
+CommandRunner<int> _engineTool(CommandBase command) {
+  return CommandRunner<int>('et', 'Fake tool with a single instrumented command.')
+    ..addCommand(command);
+}
+
+Platform _fakePlatform(String os, {int numberOfProcessors = 32, String pathSeparator = '/'}) {
+  return FakePlatform(
+    operatingSystem: os,
+    resolvedExecutable: io.Platform.resolvedExecutable,
+    numberOfProcessors: numberOfProcessors,
+    pathSeparator: pathSeparator,
+  );
+}

--- a/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
+++ b/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2025 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'dart:ffi' show Abi;
@@ -58,8 +58,8 @@ void main() {
           switch (entry.command) {
             case ['git', 'rev-parse', 'HEAD']:
               return FakeProcess(stdout: 'a' * 40);
-            case ['git', 'show', '-s', '--pretty=format:%ad', '--date=iso']:
-              return FakeProcess(stdout: '2025-06-27 15:51:55 -0700');
+            case ['git', 'show', '-s', '--pretty=format:%ad', '--date=iso-strict']:
+              return FakeProcess(stdout: '2025-06-27T17:11:53-07:00');
             default:
               if (entry.command.first.endsWith('content_aware_hash.sh')) {
                 return FakeProcess(stdout: '1' * 40);

--- a/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
+++ b/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
@@ -122,7 +122,7 @@ void main() {
         containsAllInOrder([
           endsWith('src/out/engine_stamp.json:'),
           contains(
-            '{"build_date":"2025-06-27T12:30:00.000","build_time_ms":1751052600000,"git_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","git_revision_date":"2025-06-27 15:51:55 -0700","content_hash":"1111111111111111111111111111111111111111"}',
+            '{"build_date":"2025-06-27T12:30:00.000","build_time_ms":1751052600000,"git_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","git_revision_date":"2025-06-27T17:11:53-07:00","content_hash":"1111111111111111111111111111111111111111"}',
           ),
         ]),
       );
@@ -149,7 +149,7 @@ void main() {
       expect(io.File(p.join(tempRoot.path, 'src/out/engine_stamp.json')).existsSync(), isTrue);
       expect(
         io.File(p.join(tempRoot.path, 'src/out/engine_stamp.json')).readAsStringSync().trim(),
-        '{"build_date":"2025-06-27T12:30:00.000","build_time_ms":1751052600000,"git_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","git_revision_date":"2025-06-27 15:51:55 -0700","content_hash":"1111111111111111111111111111111111111111"}',
+        '{"build_date":"2025-06-27T12:30:00.000","build_time_ms":1751052600000,"git_revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","git_revision_date":"2025-06-27T17:11:53-07:00","content_hash":"1111111111111111111111111111111111111111"}',
       );
     });
   });

--- a/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
+++ b/engine/src/flutter/tools/engine_tool/test/commands/stamp_command_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2025 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'dart:ffi' show Abi;


### PR DESCRIPTION
Writes a stamp file, engine_stamp.json, containing interesting information about this build:

```json
{
  "build_date": "2025-06-27T16:35:13.279188",
  "build_time_ms": 1751067313279,
  "git_revision": "e68e105667e9e5cace56b0431781062b773e4831",
  "git_revision_date": "2025-06-27 15:51:55 -0700",
  "content_hash": "23542e452fc55890626fd1c5eb77c4788c19f983"
}
```

Later; I'll update to the flutter tool to download this artifact to bin/cache so it can be used instead of git commands.