### PR TITLE
feat(cupertino): Add selectableDayPredicate parameter to CupertinoDatePicker for selectable day control #171332

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -369,7 +369,7 @@ class CupertinoDatePicker extends StatefulWidget {
          selectableDayPredicate == null ||
              initialDateTime == null ||
              selectableDayPredicate(initialDateTime),
-         '${initialDateTime} must satisfy provided selectableDayPredicate.',
+         '$initialDateTime must satisfy provided selectableDayPredicate.',
        );
 
   /// The mode of the date picker as one of [CupertinoDatePickerMode]. Defaults

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -308,7 +308,7 @@ class CupertinoDatePicker extends StatefulWidget {
     this.showTimeSeparator = false,
     this.itemExtent = _kItemExtent,
     this.selectionOverlayBuilder,
-    this.selectableDatePredicate,
+    this.selectableDayPredicate,
     this.changeReportingBehavior = ChangeReportingBehavior.onScrollUpdate,
   }) : initialDateTime = initialDateTime ?? DateTime.now(),
        assert(itemExtent > 0, 'item extent should be greater than 0'),
@@ -366,8 +366,8 @@ class CupertinoDatePicker extends StatefulWidget {
          'showTimeSeparator is only supported in time or dateAndTime modes',
        ),
        assert(
-         selectableDatePredicate == null ||
-             selectableDatePredicate(initialDateTime ?? DateTime.now()),
+         selectableDayPredicate == null ||
+             selectableDayPredicate(initialDateTime ?? DateTime.now()),
          '${initialDateTime ?? DateTime.now()} must satisfy provided selectableDayPredicate.',
        );
 
@@ -464,7 +464,7 @@ class CupertinoDatePicker extends StatefulWidget {
   final bool showTimeSeparator;
 
   /// Function to provide full control over which [DateTime] can be selected.
-  final SelectableDayPredicate? selectableDatePredicate;
+  final SelectableDayPredicate? selectableDayPredicate;
 
   /// {@macro flutter.cupertino.picker.itemExtent}
   ///
@@ -832,7 +832,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
 
     if (isDateInvalid) {
       return;
-    } else if (widget.selectableDatePredicate?.call(selected) == false) {
+    } else if (widget.selectableDayPredicate?.call(selected) == false) {
       return;
     }
 
@@ -883,10 +883,10 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
           );
 
           final bool isValidDate;
-          if (widget.selectableDatePredicate == null) {
+          if (widget.selectableDayPredicate == null) {
             isValidDate = true;
           } else {
-            isValidDate = widget.selectableDatePredicate!.call(rangeStart);
+            isValidDate = widget.selectableDayPredicate!.call(rangeStart);
           }
           final DateTime now = DateTime.now();
 
@@ -1128,7 +1128,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
     final DateTime selectedDate = selectedDateTime;
     final bool minCheck = widget.minimumDate?.isAfter(selectedDate) ?? false;
 
-    if (widget.selectableDatePredicate?.call(selectedDate) == false) {
+    if (widget.selectableDayPredicate?.call(selectedDate) == false) {
       const int daysThreshold = 1;
       final DateTime targetDate = selectedDate.add(const Duration(days: daysThreshold));
 

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -366,7 +366,8 @@ class CupertinoDatePicker extends StatefulWidget {
          'showTimeSeparator is only supported in time or dateAndTime modes',
        ),
        assert(
-         selectableDatePredicate == null || selectableDatePredicate(initialDateTime ?? DateTime.now()),
+         selectableDatePredicate == null ||
+             selectableDatePredicate(initialDateTime ?? DateTime.now()),
          '${initialDateTime ?? DateTime.now()} must satisfy provided selectableDayPredicate.',
        );
 
@@ -900,7 +901,10 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
               ? localizations.todayLabel
               : localizations.datePickerMediumDate(rangeStart);
 
-          return itemPositioningBuilder(context, Text(dateText, style: _themeTextStyle(context, isValid: isValidDate)));
+          return itemPositioningBuilder(
+            context,
+            Text(dateText, style: _themeTextStyle(context, isValid: isValidDate)),
+          );
         },
         selectionOverlay: selectionOverlay,
       ),

--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -437,12 +437,6 @@ enum DatePickerMode {
   year,
 }
 
-/// Signature for predicating dates for enabled date selections.
-///
-/// See [showDatePicker], which has a [SelectableDayPredicate] parameter used
-/// to specify allowable days in the date picker.
-typedef SelectableDayPredicate = bool Function(DateTime day);
-
 /// Encapsulates a start and end [DateTime] that represent the range of dates.
 ///
 /// The range includes the [start] and [end] dates. The [start] and [end] dates

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -71,12 +71,6 @@ abstract class Intent with Diagnosticable {
   static const DoNothingIntent doNothing = DoNothingIntent._();
 }
 
-/// Signature for predicating dates for enabled date selections.
-///
-/// See [showDatePicker], which has a [SelectableDayPredicate] parameter used
-/// to specify allowable days in the date picker.
-typedef SelectableDayPredicate = bool Function(DateTime day);
-
 /// The kind of callback that an [Action] uses to notify of changes to the
 /// action's state.
 ///

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -71,6 +71,12 @@ abstract class Intent with Diagnosticable {
   static const DoNothingIntent doNothing = DoNothingIntent._();
 }
 
+/// Signature for predicating dates for enabled date selections.
+///
+/// See [showDatePicker], which has a [SelectableDayPredicate] parameter used
+/// to specify allowable days in the date picker.
+typedef SelectableDayPredicate = bool Function(DateTime day);
+
 /// The kind of callback that an [Action] uses to notify of changes to the
 /// action's state.
 ///

--- a/packages/flutter/lib/src/widgets/date.dart
+++ b/packages/flutter/lib/src/widgets/date.dart
@@ -1,5 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 /// Signature for predicating dates for enabled date selections.
 ///
-/// See [showDatePicker], which has a [SelectableDayPredicate] parameter used
+/// See [showDatePicker] and [showCupertinoModalPopup],
+/// which have a [SelectableDayPredicate] parameter used
 /// to specify allowable days in the date picker.
 typedef SelectableDayPredicate = bool Function(DateTime day);

--- a/packages/flutter/lib/src/widgets/date.dart
+++ b/packages/flutter/lib/src/widgets/date.dart
@@ -1,0 +1,5 @@
+/// Signature for predicating dates for enabled date selections.
+///
+/// See [showDatePicker], which has a [SelectableDayPredicate] parameter used
+/// to specify allowable days in the date picker.
+typedef SelectableDayPredicate = bool Function(DateTime day);

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -38,6 +38,7 @@ export 'src/widgets/color_filter.dart';
 export 'src/widgets/container.dart';
 export 'src/widgets/context_menu_button_item.dart';
 export 'src/widgets/context_menu_controller.dart';
+export 'src/widgets/date.dart';
 export 'src/widgets/debug.dart';
 export 'src/widgets/decorated_sliver.dart';
 export 'src/widgets/default_selection_style.dart';

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -2594,14 +2594,14 @@ void main() {
     expect(find.text(':'), findsNothing);
   });
 
-  test('CupertinoDatePicker selectableDatePredicate parameter validation', () async {
+  test('CupertinoDatePicker selectableDayPredicate parameter validation', () async {
     expect(() => CupertinoDatePicker(onDateTimeChanged: (DateTime _) {}), returnsNormally);
 
     expect(
       () => CupertinoDatePicker(
         initialDateTime: DateTime(2025),
         onDateTimeChanged: (DateTime _) {},
-        selectableDatePredicate: (DateTime date) {
+        selectableDayPredicate: (DateTime date) {
           return date.year == 2025;
         },
       ),
@@ -2611,7 +2611,7 @@ void main() {
     expect(
       () => CupertinoDatePicker(
         onDateTimeChanged: (DateTime _) {},
-        selectableDatePredicate: (DateTime date) {
+        selectableDayPredicate: (DateTime date) {
           return date.year == 2025;
         },
       ),
@@ -2622,7 +2622,7 @@ void main() {
       () => CupertinoDatePicker(
         initialDateTime: DateTime(2025, 7, 4),
         onDateTimeChanged: (DateTime _) {},
-        selectableDatePredicate: (DateTime date) {
+        selectableDayPredicate: (DateTime date) {
           return date.month == 6;
         },
       ),
@@ -2645,7 +2645,7 @@ void main() {
         home: Center(
           child: CupertinoDatePicker(
             initialDateTime: initialDateTime,
-            selectableDatePredicate: (DateTime date) {
+            selectableDayPredicate: (DateTime date) {
               return date.weekday >= DateTime.monday && date.weekday <= DateTime.friday;
             },
             onDateTimeChanged: (DateTime dateTime) {
@@ -2670,7 +2670,7 @@ void main() {
         home: Center(
           child: CupertinoDatePicker(
             initialDateTime: initialDateTime,
-            selectableDatePredicate: (DateTime date) {
+            selectableDayPredicate: (DateTime date) {
               return date.weekday == DateTime.saturday || date.weekday == DateTime.sunday;
             },
             onDateTimeChanged: (DateTime dateTime) {
@@ -2698,7 +2698,7 @@ void main() {
         home: Center(
           child: CupertinoDatePicker(
             initialDateTime: initialDateTime,
-            selectableDatePredicate: (DateTime date) {
+            selectableDayPredicate: (DateTime date) {
               return date.day >= 16;
             },
             onDateTimeChanged: (DateTime dateTime) {


### PR DESCRIPTION
### Description

This PR enhances the CupertinoDatePicker by introducing a weekType parameter, giving developers more control over which days users can select.

### Solution

To address this, I've added a new weekType parameter to the CupertinoDatePicker widget. This parameter offers a declarative way to control the set of selectable days displayed in the picker, with options defined in a new WeekType enum:

WeekType.workDays (Monday-Friday)

WeekType.weekends (Saturday-Sunday)

WeekType.fullWeek (all days, current default behavior)

WeekType.custom (allows developers to provide a List<int> representing the DateTime.weekday values that should be visible and selectable).

### Example
```dart
// Example: Display only work days (Monday-Friday)
CupertinoDatePicker(
  mode: CupertinoDatePickerMode.date,
  initialDateTime: DateTime.now(),
  minimumDate: DateTime(2023, 1, 1),
  maximumDate: DateTime(2024, 12, 31),
  weekType: WeekType.workDays,
  onDateTimeChanged: (DateTime newDateTime) {
    // Handle date change
  },
);
```

### Screenshots

https://github.com/user-attachments/assets/8b1290c9-0d01-4199-921a-f86cd9d281a5

https://github.com/user-attachments/assets/e2bc4d6a-889e-4a47-89bc-535d7f57c04e

https://github.com/user-attachments/assets/475fa1e1-a56a-4a15-945d-890bb1ff51da


Here's the linked issue to this PR #171332 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
