### PR TITLE
Fix the issue where calling showOnScreen on a sliver after a pinned child in SliverMainAxisGroup does not reveal it.

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -8,6 +8,7 @@
 /// @docImport 'proxy_sliver.dart';
 /// @docImport 'sliver_fill.dart';
 /// @docImport 'sliver_grid.dart';
+/// @docImport 'sliver_group.dart';
 /// @docImport 'sliver_list.dart';
 /// @docImport 'sliver_padding.dart';
 /// @docImport 'sliver_persistent_header.dart';
@@ -1664,6 +1665,10 @@ abstract class RenderSliver extends RenderObject {
   /// Returns the scroll offset for the leading edge of the given child.
   ///
   /// The `child` must be a child of this sliver.
+  ///
+  /// If there are pinned slivers before [child], the offset should be reduced
+  /// by the extent of the pinned children. This can occur in [RenderSliver]s
+  /// that have multiple sliver children, such as [RenderSliverMainAxisGroup].
   ///
   /// This method differs from [childMainAxisPosition] in that
   /// [childMainAxisPosition] gives the distance from the leading _visible_ edge

--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -223,24 +223,48 @@ class RenderSliverMainAxisGroup extends RenderSliver
   @override
   double? childScrollOffset(RenderObject child) {
     assert(child.parent == this);
+    assert(child is RenderSliver);
+    final double extentOfPinnedSlivers = _maxScrollObstructionExtentBefore(child as RenderSliver);
     final GrowthDirection growthDirection = constraints.growthDirection;
     switch (growthDirection) {
       case GrowthDirection.forward:
         double childScrollOffset = 0.0;
-        RenderSliver? current = childBefore(child as RenderSliver);
+        RenderSliver? current = childBefore(child);
         while (current != null) {
           childScrollOffset += current.geometry!.scrollExtent;
           current = childBefore(current);
         }
-        return childScrollOffset;
+        return childScrollOffset - extentOfPinnedSlivers;
       case GrowthDirection.reverse:
         double childScrollOffset = 0.0;
-        RenderSliver? current = childAfter(child as RenderSliver);
+        RenderSliver? current = childAfter(child);
         while (current != null) {
           childScrollOffset -= current.geometry!.scrollExtent;
           current = childAfter(current);
         }
-        return childScrollOffset;
+        return childScrollOffset - extentOfPinnedSlivers;
+    }
+  }
+
+  double _maxScrollObstructionExtentBefore(RenderSliver child) {
+    final GrowthDirection growthDirection = child.constraints.growthDirection;
+    switch (growthDirection) {
+      case GrowthDirection.forward:
+        double pinnedExtent = 0.0;
+        RenderSliver? current = firstChild;
+        while (current != child) {
+          pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
+          current = childAfter(current);
+        }
+        return pinnedExtent;
+      case GrowthDirection.reverse:
+        double pinnedExtent = 0.0;
+        RenderSliver? current = lastChild;
+        while (current != child) {
+          pinnedExtent += current!.geometry!.maxScrollObstructionExtent;
+          current = childBefore(current);
+        }
+        return pinnedExtent;
     }
   }
 

--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -1125,6 +1125,30 @@ void main() {
     expect(tester.getTopLeft(find.text('2')), const Offset(0, 101));
     expect(tester.getTopLeft(find.text('-2')), const Offset(0, -49));
   });
+
+  testWidgets('showOnScreen reveals the Sliver after a pinned child in SliverMainAxisGroup', (
+    WidgetTester tester,
+  ) async {
+    final ScrollController controller = ScrollController();
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      _buildSliverMainAxisGroup(
+        viewportHeight: 100,
+        controller: controller,
+        slivers: <Widget>[
+          const PinnedHeaderSliver(child: SizedBox(height: 50)),
+          const SliverToBoxAdapter(child: SizedBox(height: 50, child: Text('1'))),
+          const SliverToBoxAdapter(child: SizedBox(height: 400)),
+        ],
+      ),
+    );
+    controller.jumpTo(200);
+    await tester.pumpAndSettle();
+    final RenderObject renderObject = tester.renderObject(find.text('1', skipOffstage: false));
+    renderObject.showOnScreen();
+    await tester.pumpAndSettle();
+    expect(tester.getTopLeft(find.text('1')), const Offset(0.0, 50.0));
+  });
 }
 
 Widget _buildSliverList({


### PR DESCRIPTION
Fixes: #154615

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
