### PR TITLE
[ Tool ] Change name of test classes that don't extend `Mock` from `Mock*` to `Fake*`

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/flutter_web_platform_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/flutter_web_platform_test.dart
@@ -19,7 +19,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fakes.dart';
 
-class MockServer implements shelf.Server {
+class FakeServer implements shelf.Server {
   shelf.Handler? mountedHandler;
 
   @override
@@ -77,7 +77,7 @@ void main() {
         browserFinder: (Platform platform, FileSystem filesystem) => 'chrome',
         logger: logger,
       );
-      final MockServer server = MockServer();
+      final FakeServer server = FakeServer();
       final FlutterWebPlatform webPlatform = await FlutterWebPlatform.start(
         'ProjectRoot',
         flutterProject: FlutterProject.fromDirectoryTest(tempDir),
@@ -123,7 +123,7 @@ void main() {
         browserFinder: (Platform platform, FileSystem filesystem) => 'chrome',
         logger: logger,
       );
-      final MockServer server = MockServer();
+      final FakeServer server = FakeServer();
       final FlutterWebPlatform webPlatform = await FlutterWebPlatform.start(
         'ProjectRoot',
         flutterProject: FlutterProject.fromDirectoryTest(tempDir),

--- a/packages/flutter_tools/test/commands.shard/hermetic/ios_analyze_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/ios_analyze_test.dart
@@ -65,8 +65,8 @@ void main() {
     });
 
     testWithoutContext('can output json file', () async {
-      final MockIosProject ios = MockIosProject();
-      final MockFlutterProject project = MockFlutterProject(ios);
+      final FakeIosProject ios = FakeIosProject();
+      final FakeFlutterProject project = FakeFlutterProject(ios);
       const String expectedConfig = 'someConfig';
       const String expectedTarget = 'someTarget';
       const String expectedOutputFile = '/someFile';
@@ -84,8 +84,8 @@ void main() {
     });
 
     testWithoutContext('can list build options', () async {
-      final MockIosProject ios = MockIosProject();
-      final MockFlutterProject project = MockFlutterProject(ios);
+      final FakeIosProject ios = FakeIosProject();
+      final FakeFlutterProject project = FakeFlutterProject(ios);
       const List<String> targets = <String>['target1', 'target2'];
       const List<String> configs = <String>['config1', 'config2'];
       ios.expectedProjectInfo = XcodeProjectInfo(targets, configs, const <String>[], logger);
@@ -136,14 +136,14 @@ void main() {
   });
 }
 
-class MockFlutterProject extends Fake implements FlutterProject {
-  MockFlutterProject(this.ios);
+class FakeFlutterProject extends Fake implements FlutterProject {
+  FakeFlutterProject(this.ios);
 
   @override
   final IosProject ios;
 }
 
-class MockIosProject extends Fake implements IosProject {
+class FakeIosProject extends Fake implements IosProject {
   String? outputConfiguration;
   String? outputTarget;
   late String outputFileLocation;

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -46,7 +46,7 @@ void main() {
       processManager: FakeProcessManager.any(),
     );
 
-    MockCrashReportSender.sendCalls = 0;
+    FakeCrashReportSender.sendCalls = 0;
     stackTrace = StackTrace.fromString('''
 #0      _File.open.<anonymous closure> (dart:io/file_impl.dart:366:9)
 #1      _rootRunUnary (dart:async/zone.dart:1141:38)''');
@@ -135,7 +135,7 @@ void main() {
       final RequestInfo requestInfo = RequestInfo();
 
       final CrashReportSender crashReportSender = CrashReportSender(
-        client: MockCrashReportSender(requestInfo),
+        client: FakeCrashReportSender(requestInfo),
         platform: platform,
         logger: logger,
         operatingSystemUtils: operatingSystemUtils,
@@ -222,7 +222,7 @@ void main() {
       final RequestInfo requestInfo = RequestInfo();
 
       final CrashReportSender crashReportSender = CrashReportSender(
-        client: MockCrashReportSender(requestInfo),
+        client: FakeCrashReportSender(requestInfo),
         platform: platform,
         logger: logger,
         operatingSystemUtils: operatingSystemUtils,
@@ -257,7 +257,7 @@ void main() {
         command: 'crash',
       );
 
-      expect(MockCrashReportSender.sendCalls, 1);
+      expect(FakeCrashReportSender.sendCalls, 1);
       await verifyCrashReportSent(requestInfo, crashes: 4);
     });
 
@@ -346,10 +346,10 @@ class RequestInfo {
   Map<String, String>? fields;
 }
 
-class MockCrashReportSender extends MockClient {
-  MockCrashReportSender(RequestInfo crashInfo)
+class FakeCrashReportSender extends MockClient {
+  FakeCrashReportSender(RequestInfo crashInfo)
     : super((Request request) async {
-        MockCrashReportSender.sendCalls++;
+        FakeCrashReportSender.sendCalls++;
         crashInfo.method = request.method;
         crashInfo.uri = request.url;
 

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -37,7 +37,7 @@ void main() {
 
     group('launchRequest', () {
       test('runs "flutter run" with --machine', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -48,15 +48,15 @@ void main() {
           program: 'foo.dart',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.processArgs, containsAllInOrder(<String>['run', '--machine']));
       });
 
       test('includes env variables', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -68,15 +68,15 @@ void main() {
           env: <String, String>{'MY_TEST_ENV': 'MY_TEST_VALUE'},
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.env!['MY_TEST_ENV'], 'MY_TEST_VALUE');
       });
 
       test('does not record the VMs PID for terminating', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -87,8 +87,8 @@ void main() {
           program: 'foo.dart',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         // Trigger a fake debuggerConnected with a pid that we expect the
@@ -102,7 +102,7 @@ void main() {
       group('supportsRestartRequest', () {
         void testRestartSupport(bool supportsRestart) {
           test('notifies client for supportsRestart: $supportsRestart', () async {
-            final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+            final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
               fileSystem: MemoryFileSystem.test(style: fsStyle),
               platform: platform,
               supportsRestart: supportsRestart,
@@ -124,9 +124,9 @@ void main() {
                   (CapabilitiesEventBody body) => body.capabilities.supportsRestartRequest != null,
                 );
 
-            await adapter.configurationDoneRequest(MockRequest(), null, () {});
+            await adapter.configurationDoneRequest(FakeRequest(), null, () {});
             final Completer<void> launchCompleter = Completer<void>();
-            await adapter.launchRequest(MockRequest(), args, launchCompleter.complete);
+            await adapter.launchRequest(FakeRequest(), args, launchCompleter.complete);
             await launchCompleter.future;
 
             // Ensure the Capabilities update has the expected value.
@@ -139,7 +139,7 @@ void main() {
       });
 
       test('calls "app.stop" on terminateRequest', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -149,14 +149,14 @@ void main() {
           program: 'foo.dart',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
         final Completer<void> launchCompleter = Completer<void>();
-        await adapter.launchRequest(MockRequest(), args, launchCompleter.complete);
+        await adapter.launchRequest(FakeRequest(), args, launchCompleter.complete);
         await launchCompleter.future;
 
         final Completer<void> terminateCompleter = Completer<void>();
         await adapter.terminateRequest(
-          MockRequest(),
+          FakeRequest(),
           TerminateArguments(restart: false),
           terminateCompleter.complete,
         );
@@ -166,7 +166,7 @@ void main() {
       });
 
       test('does not call "app.stop" on terminateRequest if app was not started', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
           simulateAppStarted: false,
@@ -177,14 +177,14 @@ void main() {
           program: 'foo.dart',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
         final Completer<void> launchCompleter = Completer<void>();
-        await adapter.launchRequest(MockRequest(), args, launchCompleter.complete);
+        await adapter.launchRequest(FakeRequest(), args, launchCompleter.complete);
         await launchCompleter.future;
 
         final Completer<void> terminateCompleter = Completer<void>();
         await adapter.terminateRequest(
-          MockRequest(),
+          FakeRequest(),
           TerminateArguments(restart: false),
           terminateCompleter.complete,
         );
@@ -194,7 +194,7 @@ void main() {
       });
 
       test('does not call "app.restart" before app has been started', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
           simulateAppStarted: false,
@@ -208,17 +208,17 @@ void main() {
         final Completer<void> restartCompleter = Completer<void>();
         final RestartArguments restartArgs = RestartArguments();
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), launchArgs, launchCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), launchArgs, launchCompleter.complete);
         await launchCompleter.future;
-        await adapter.restartRequest(MockRequest(), restartArgs, restartCompleter.complete);
+        await adapter.restartRequest(FakeRequest(), restartArgs, restartCompleter.complete);
         await restartCompleter.future;
 
         expect(adapter.dapToFlutterRequests, isNot(contains('app.restart')));
       });
 
       test('includes build progress updates', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -243,12 +243,12 @@ void main() {
 
         // Initialize with progress support.
         await adapter.initializeRequest(
-          MockRequest(),
+          FakeRequest(),
           DartInitializeRequestArguments(adapterID: 'test', supportsProgressReporting: true),
           (_) {},
         );
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         // Ensure we got the expected events prior to the progressEnd.
@@ -265,10 +265,10 @@ void main() {
       });
 
       test('includes Dart Debug extension progress update', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
-          preAppStart: (MockFlutterDebugAdapter adapter) {
+          preAppStart: (FakeFlutterDebugAdapter adapter) {
             adapter.simulateRawStdout('Waiting for connection from Dart debug extension…');
           },
         );
@@ -293,12 +293,12 @@ void main() {
 
         // Initialize with progress support.
         await adapter.initializeRequest(
-          MockRequest(),
+          FakeRequest(),
           DartInitializeRequestArguments(adapterID: 'test', supportsProgressReporting: true),
           (_) {},
         );
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         // Ensure we got the expected events prior to the progressEnd.
@@ -317,7 +317,7 @@ void main() {
       });
 
       test('handles app.stop errors during launch', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
           simulateAppStarted: false,
@@ -356,12 +356,12 @@ void main() {
 
         // Initialize with progress support.
         await adapter.initializeRequest(
-          MockRequest(),
+          FakeRequest(),
           DartInitializeRequestArguments(adapterID: 'test', supportsProgressReporting: true),
           (_) {},
         );
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
         await pumpEventQueue(); // Allow async events to be processed.
         await progressEventsSubscription.cancel();
@@ -384,7 +384,7 @@ void main() {
 
     group('attachRequest', () {
       test('runs "flutter attach" with --machine', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -392,15 +392,15 @@ void main() {
 
         final FlutterAttachRequestArguments args = FlutterAttachRequestArguments(cwd: '.');
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.processArgs, containsAllInOrder(<String>['attach', '--machine']));
       });
 
       test('runs "flutter attach" with program if passed in', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -411,8 +411,8 @@ void main() {
           program: 'program/main.dart',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(
@@ -422,7 +422,7 @@ void main() {
       });
 
       test('runs "flutter attach" with --debug-uri if vmServiceUri is passed', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -434,8 +434,8 @@ void main() {
           vmServiceUri: 'ws://1.2.3.4/ws',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(
@@ -452,7 +452,7 @@ void main() {
       });
 
       test('runs "flutter attach" with --debug-uri if vmServiceInfoFile exists', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -470,8 +470,8 @@ void main() {
         // Write the service info file before trying to attach:
         serviceInfoFile.writeAsStringSync('{ "uri": "ws://1.2.3.4/ws" }');
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(
@@ -490,7 +490,7 @@ void main() {
       test(
         'runs "flutter attach" with --debug-uri if vmServiceInfoFile is created later',
         () async {
-          final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
             fileSystem: MemoryFileSystem.test(style: fsStyle),
             platform: platform,
           );
@@ -505,9 +505,9 @@ void main() {
             vmServiceInfoFile: serviceInfoFile.path,
           );
 
-          await adapter.configurationDoneRequest(MockRequest(), null, () {});
+          await adapter.configurationDoneRequest(FakeRequest(), null, () {});
           final Future<void> attachResponseFuture = adapter.attachRequest(
-            MockRequest(),
+            FakeRequest(),
             args,
             responseCompleter.complete,
           );
@@ -532,7 +532,7 @@ void main() {
       );
 
       test('does not record the VMs PID for terminating', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -540,8 +540,8 @@ void main() {
 
         final FlutterAttachRequestArguments args = FlutterAttachRequestArguments(cwd: '.');
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.attachRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.attachRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         // Trigger a fake debuggerConnected with a pid that we expect the
@@ -553,21 +553,21 @@ void main() {
       });
 
       test('calls "app.detach" on terminateRequest', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
 
         final FlutterAttachRequestArguments args = FlutterAttachRequestArguments(cwd: '.');
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
         final Completer<void> attachCompleter = Completer<void>();
-        await adapter.attachRequest(MockRequest(), args, attachCompleter.complete);
+        await adapter.attachRequest(FakeRequest(), args, attachCompleter.complete);
         await attachCompleter.future;
 
         final Completer<void> terminateCompleter = Completer<void>();
         await adapter.terminateRequest(
-          MockRequest(),
+          FakeRequest(),
           TerminateArguments(restart: false),
           terminateCompleter.complete,
         );
@@ -579,7 +579,7 @@ void main() {
 
     group('forwards events', () {
       test('app.webLaunchUrl', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -608,7 +608,7 @@ void main() {
 
     group('handles reverse requests', () {
       test('app.exposeUrl', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -638,7 +638,7 @@ void main() {
 
     group('--start-paused', () {
       test('is passed for debug mode', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -649,15 +649,15 @@ void main() {
           program: 'foo.dart',
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.processArgs, contains('--start-paused'));
       });
 
       test('is not passed for noDebug mode', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -669,15 +669,15 @@ void main() {
           noDebug: true,
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.processArgs, isNot(contains('--start-paused')));
       });
 
       test('is not passed if toolArgs contains --profile', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -689,15 +689,15 @@ void main() {
           toolArgs: <String>['--profile'],
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.processArgs, isNot(contains('--start-paused')));
       });
 
       test('is not passed if toolArgs contains --release', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -709,8 +709,8 @@ void main() {
           toolArgs: <String>['--release'],
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.processArgs, isNot(contains('--start-paused')));
@@ -718,7 +718,7 @@ void main() {
     });
 
     test('includes toolArgs', () async {
-      final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+      final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
         fileSystem: MemoryFileSystem.test(style: fsStyle),
         platform: platform,
       );
@@ -731,8 +731,8 @@ void main() {
         noDebug: true,
       );
 
-      await adapter.configurationDoneRequest(MockRequest(), null, () {});
-      await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+      await adapter.configurationDoneRequest(FakeRequest(), null, () {});
+      await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
       await responseCompleter.future;
 
       expect(adapter.executable, equals(expectedFlutterExecutable));
@@ -744,7 +744,7 @@ void main() {
       late FlutterDebugAdapter adapter;
       setUp(() {
         fs = MemoryFileSystem.test(style: fsStyle);
-        adapter = MockFlutterDebugAdapter(fileSystem: fs, platform: platform);
+        adapter = FakeFlutterDebugAdapter(fileSystem: fs, platform: platform);
       });
 
       test('dart:ui URI to file path', () async {
@@ -821,7 +821,7 @@ void main() {
 
     group('includes customTool', () {
       test('with no args replaced', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -832,9 +832,9 @@ void main() {
           noDebug: true,
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
         final Completer<void> responseCompleter = Completer<void>();
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.executable, equals('/custom/flutter'));
@@ -843,7 +843,7 @@ void main() {
       });
 
       test('with all args replaced', () async {
-        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+        final FakeFlutterDebugAdapter adapter = FakeFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
@@ -856,9 +856,9 @@ void main() {
           toolArgs: <String>['tool_args'], // should still be in args
         );
 
-        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.configurationDoneRequest(FakeRequest(), null, () {});
         final Completer<void> responseCompleter = Completer<void>();
-        await adapter.launchRequest(MockRequest(), args, responseCompleter.complete);
+        await adapter.launchRequest(FakeRequest(), args, responseCompleter.complete);
         await responseCompleter.future;
 
         expect(adapter.executable, equals('/custom/flutter'));

--- a/packages/flutter_tools/test/general.shard/dap/flutter_test_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_test_adapter_test.dart
@@ -28,12 +28,12 @@ void main() {
     });
 
     test('includes toolArgs', () async {
-      final MockFlutterTestDebugAdapter adapter = MockFlutterTestDebugAdapter(
+      final FakeFlutterTestDebugAdapter adapter = FakeFlutterTestDebugAdapter(
         fileSystem: MemoryFileSystem.test(style: fsStyle),
         platform: platform,
       );
       final Completer<void> responseCompleter = Completer<void>();
-      final MockRequest request = MockRequest();
+      final FakeRequest request = FakeRequest();
       final FlutterLaunchRequestArguments args = FlutterLaunchRequestArguments(
         cwd: '.',
         program: 'foo.dart',
@@ -50,12 +50,12 @@ void main() {
     });
 
     test('includes env variables', () async {
-      final MockFlutterTestDebugAdapter adapter = MockFlutterTestDebugAdapter(
+      final FakeFlutterTestDebugAdapter adapter = FakeFlutterTestDebugAdapter(
         fileSystem: MemoryFileSystem.test(style: fsStyle),
         platform: platform,
       );
       final Completer<void> responseCompleter = Completer<void>();
-      final MockRequest request = MockRequest();
+      final FakeRequest request = FakeRequest();
       final FlutterLaunchRequestArguments args = FlutterLaunchRequestArguments(
         cwd: '.',
         program: 'foo.dart',
@@ -71,12 +71,12 @@ void main() {
 
     group('includes customTool', () {
       test('with no args replaced', () async {
-        final MockFlutterTestDebugAdapter adapter = MockFlutterTestDebugAdapter(
+        final FakeFlutterTestDebugAdapter adapter = FakeFlutterTestDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
         final Completer<void> responseCompleter = Completer<void>();
-        final MockRequest request = MockRequest();
+        final FakeRequest request = FakeRequest();
         final FlutterLaunchRequestArguments args = FlutterLaunchRequestArguments(
           cwd: '.',
           program: 'foo.dart',
@@ -94,12 +94,12 @@ void main() {
       });
 
       test('with all args replaced', () async {
-        final MockFlutterTestDebugAdapter adapter = MockFlutterTestDebugAdapter(
+        final FakeFlutterTestDebugAdapter adapter = FakeFlutterTestDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),
           platform: platform,
         );
         final Completer<void> responseCompleter = Completer<void>();
-        final MockRequest request = MockRequest();
+        final FakeRequest request = FakeRequest();
         final FlutterLaunchRequestArguments args = FlutterLaunchRequestArguments(
           cwd: '.',
           program: 'foo.dart',

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -12,14 +12,14 @@ import 'package:flutter_tools/src/debug_adapters/flutter_adapter.dart';
 import 'package:flutter_tools/src/debug_adapters/flutter_test_adapter.dart';
 
 /// A [FlutterDebugAdapter] that captures what process/args will be launched.
-class MockFlutterDebugAdapter extends FlutterDebugAdapter {
-  factory MockFlutterDebugAdapter({
+class FakeFlutterDebugAdapter extends FlutterDebugAdapter {
+  factory FakeFlutterDebugAdapter({
     required FileSystem fileSystem,
     required Platform platform,
     bool simulateAppStarted = true,
     bool simulateAppStopError = false,
     bool supportsRestart = true,
-    FutureOr<void> Function(MockFlutterDebugAdapter adapter)? preAppStart,
+    FutureOr<void> Function(FakeFlutterDebugAdapter adapter)? preAppStart,
   }) {
     final StreamController<List<int>> stdinController = StreamController<List<int>>();
     final StreamController<List<int>> stdoutController = StreamController<List<int>>();
@@ -34,7 +34,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
       null,
     );
 
-    return MockFlutterDebugAdapter._(
+    return FakeFlutterDebugAdapter._(
       channel,
       clientChannel: clientChannel,
       fileSystem: fileSystem,
@@ -46,7 +46,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     );
   }
 
-  MockFlutterDebugAdapter._(
+  FakeFlutterDebugAdapter._(
     super.channel, {
     required this.clientChannel,
     required super.fileSystem,
@@ -66,7 +66,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   final bool simulateAppStarted;
   final bool simulateAppStopError;
   final bool supportsRestart;
-  final FutureOr<void> Function(MockFlutterDebugAdapter adapter)? preAppStart;
+  final FutureOr<void> Function(FakeFlutterDebugAdapter adapter)? preAppStart;
 
   late String executable;
   late List<String> processArgs;
@@ -224,8 +224,8 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
 }
 
 /// A [FlutterTestDebugAdapter] that captures what process/args will be launched.
-class MockFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
-  factory MockFlutterTestDebugAdapter({
+class FakeFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
+  factory FakeFlutterTestDebugAdapter({
     required FileSystem fileSystem,
     required Platform platform,
   }) {
@@ -237,7 +237,7 @@ class MockFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
       null,
     );
 
-    return MockFlutterTestDebugAdapter._(
+    return FakeFlutterTestDebugAdapter._(
       stdinController.sink,
       stdoutController.stream,
       channel,
@@ -246,7 +246,7 @@ class MockFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
     );
   }
 
-  MockFlutterTestDebugAdapter._(
+  FakeFlutterTestDebugAdapter._(
     this.stdin,
     this.stdout,
     ByteStreamServerChannel channel, {
@@ -281,8 +281,8 @@ class MockFlutterTestDebugAdapter extends FlutterTestDebugAdapter {
   }
 }
 
-class MockRequest extends Request {
-  MockRequest()
+class FakeRequest extends Request {
+  FakeRequest()
     : super.fromMap(<String, Object?>{
         'command': 'mock_command',
         'type': 'mock_type',

--- a/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/protocol_discovery_test.dart
@@ -347,7 +347,7 @@ void main() {
         final FakeDeviceLogReader logReader = FakeDeviceLogReader();
         final ProtocolDiscovery discoverer = ProtocolDiscovery.vmService(
           logReader,
-          portForwarder: MockPortForwarder(99),
+          portForwarder: FakePortForwarder(99),
           ipv6: false,
           logger: BufferLogger.test(),
         );
@@ -369,7 +369,7 @@ void main() {
         final FakeDeviceLogReader logReader = FakeDeviceLogReader();
         final ProtocolDiscovery discoverer = ProtocolDiscovery.vmService(
           logReader,
-          portForwarder: MockPortForwarder(99),
+          portForwarder: FakePortForwarder(99),
           hostPort: 1243,
           ipv6: false,
           logger: BufferLogger.test(),
@@ -392,7 +392,7 @@ void main() {
         final FakeDeviceLogReader logReader = FakeDeviceLogReader();
         final ProtocolDiscovery discoverer = ProtocolDiscovery.vmService(
           logReader,
-          portForwarder: MockPortForwarder(99),
+          portForwarder: FakePortForwarder(99),
           hostPort: 0,
           ipv6: false,
           logger: BufferLogger.test(),
@@ -415,7 +415,7 @@ void main() {
         final FakeDeviceLogReader logReader = FakeDeviceLogReader();
         final ProtocolDiscovery discoverer = ProtocolDiscovery.vmService(
           logReader,
-          portForwarder: MockPortForwarder(99),
+          portForwarder: FakePortForwarder(99),
           hostPort: 54777,
           ipv6: true,
           logger: BufferLogger.test(),
@@ -438,7 +438,7 @@ void main() {
         final FakeDeviceLogReader logReader = FakeDeviceLogReader();
         final ProtocolDiscovery discoverer = ProtocolDiscovery.vmService(
           logReader,
-          portForwarder: MockPortForwarder(99),
+          portForwarder: FakePortForwarder(99),
           hostPort: 54777,
           ipv6: true,
           logger: BufferLogger.test(),
@@ -460,8 +460,8 @@ void main() {
   });
 }
 
-class MockPortForwarder extends DevicePortForwarder {
-  MockPortForwarder([this.availablePort]);
+class FakePortForwarder extends DevicePortForwarder {
+  FakePortForwarder([this.availablePort]);
 
   final int? availablePort;
 

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -50,7 +50,7 @@ void main() {
   testWithoutContext('VM Service registers reloadSources', () async {
     Future<void> reloadSources(String isolateId, {bool? pause, bool? force}) async {}
 
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     await setUpVmService(reloadSources: reloadSources, vmService: mockVMService);
 
     expect(mockVMService.services, containsPair(kReloadSourcesServiceName, kFlutterToolAlias));
@@ -59,14 +59,14 @@ void main() {
   testWithoutContext('VM Service registers flutterMemoryInfo service', () async {
     final FakeDevice mockDevice = FakeDevice();
 
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     await setUpVmService(device: mockDevice, vmService: mockVMService);
 
     expect(mockVMService.services, containsPair(kFlutterMemoryInfoServiceName, kFlutterToolAlias));
   });
 
   testWithoutContext('VM Service registers flutterPrintStructuredErrorLogMethod', () async {
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     await setUpVmService(
       printStructuredErrorLogMethod: (vm_service.Event event) async => 'hello',
       vmService: mockVMService,
@@ -75,7 +75,7 @@ void main() {
   });
 
   testWithoutContext('VM Service returns correct FlutterVersion', () async {
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     await setUpVmService(vmService: mockVMService);
 
     expect(mockVMService.services, containsPair(kFlutterVersionServiceName, kFlutterToolAlias));
@@ -113,7 +113,7 @@ void main() {
   );
 
   testWithoutContext('setAssetDirectory forwards arguments correctly', () async {
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     final FlutterVmService flutterVmService = FlutterVmService(mockVMService);
 
     await flutterVmService.setAssetDirectory(
@@ -130,7 +130,7 @@ void main() {
   });
 
   testWithoutContext('setAssetDirectory forwards arguments correctly - windows', () async {
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     final FlutterVmService flutterVmService = FlutterVmService(mockVMService);
 
     await flutterVmService.setAssetDirectory(
@@ -157,7 +157,7 @@ void main() {
   });
 
   testWithoutContext('flushUIThreadTasks forwards arguments correctly', () async {
-    final MockVMService mockVMService = MockVMService();
+    final FakeVMService mockVMService = FakeVMService();
     final FlutterVmService flutterVmService = FlutterVmService(mockVMService);
 
     await flutterVmService.flushUIThreadTasks(uiIsolateId: 'def');
@@ -651,7 +651,7 @@ void main() {
   });
 }
 
-class MockVMService extends Fake implements vm_service.VmService {
+class FakeVMService extends Fake implements vm_service.VmService {
   final Map<String, String> services = <String, String>{};
   final Map<String, vm_service.ServiceCallback> serviceCallBacks =
       <String, vm_service.ServiceCallback>{};


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/33274