### PR TITLE
Android gradle use lowercase instead of toLowerCase in preparation for removal in v9

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPluginUtils.kt
@@ -58,12 +58,8 @@ object FlutterPluginUtils {
     @Suppress("DEPRECATION")
     internal fun capitalize(string: String): String = string.capitalize()
 
-    // Kotlin's toLowerCase function is deprecated, but the suggested replacement is not supported
-    // by the minimum version of Kotlin that we support. Centralize the use to one place, so that
-    // when our minimum version does support the replacement we can replace by changing a single
-    // line.
-    @Suppress("DEPRECATION")
-    internal fun lowercase(string: String): String = string.toLowerCase()
+    @OptIn(ExperimentalStdlibApi::class)
+    internal fun lowercase(string: String): String = string.lowercase()
 
     // compareTo implementation of version strings in the format of ints and periods
     // Will not crash on RC candidate strings but considers all RC candidates the same version.


### PR DESCRIPTION
partial resolution for #170791 (lowercase but not filemode) 

This is the first time I have used the experimental api annotation. Most users should have lowercase available without the annotation only the oldest kotlin/agp versions should need the annotation. 

to test with different gradle versions I ran `sed -i '' 's/gradle-.*-bin\.zip/gradle-VERSION-bin.zip/g' gradle/wrapper/gradle-wrapper.properties; JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home/ ./gradlew test` 
from packages/flutter_tools/gradle

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
