### PR TITLE
Remove --enable-impeller-3d gn flag

### DIFF
--- a/engine/src/flutter/ci/builders/mac_unopt.json
+++ b/engine/src/flutter/ci/builders/mac_unopt.json
@@ -350,7 +350,6 @@
                 "--prebuilt-dart-sdk",
                 "--mac-cpu",
                 "arm64",
-                "--enable-impeller-3d",
                 "--rbe",
                 "--no-goma",
                 "--xcode-symlinks",

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -1196,14 +1196,6 @@ def parse_args(args):
       help='(dangerous) Disable secure socket support in Dart.',
   )
 
-  # Impeller flags.
-  parser.add_argument(
-      '--enable-impeller-3d',
-      default=False,
-      action='store_true',
-      help='Enables experimental 3d support.'
-  )
-
   parser.add_argument('--malioc-path', type=str, help='The path to the malioc tool.')
 
   parser.add_argument(


### PR DESCRIPTION
This flag is no longer used. Impeller Scene was removed a while back and has been rewritten as [dart package](https://pub.dev/packages/flutter_scene) that runs on Flutter GPU.