### PR TITLE
fix: adjust scrollable size assertion with tolerance

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable_helpers.dart
+++ b/packages/flutter/lib/src/widgets/scrollable_helpers.dart
@@ -227,13 +227,19 @@ class EdgeDraggingAutoScroller {
 
   Future<void> _scroll() async {
     final RenderBox scrollRenderBox = scrollable.context.findRenderObject()! as RenderBox;
+    final Matrix4 transform = scrollRenderBox.getTransformTo(null);
     final Rect globalRect = MatrixUtils.transformRect(
-      scrollRenderBox.getTransformTo(null),
+      transform,
       Rect.fromLTWH(0, 0, scrollRenderBox.size.width, scrollRenderBox.size.height),
     );
+    final Rect transformedDragTarget = MatrixUtils.transformRect(
+      transform,
+      _dragTargetRelatedToScrollOrigin,
+    );
+
     assert(
-      globalRect.size.width >= _dragTargetRelatedToScrollOrigin.size.width &&
-          globalRect.size.height >= _dragTargetRelatedToScrollOrigin.size.height,
+      (globalRect.size.width + precisionErrorTolerance) >= transformedDragTarget.size.width &&
+          (globalRect.size.height + precisionErrorTolerance) >= transformedDragTarget.size.height,
       'Drag target size is larger than scrollable size, which may cause bouncing',
     );
     _scrolling = true;

--- a/packages/flutter/test/widgets/scrollable_helpers_test.dart
+++ b/packages/flutter/test/widgets/scrollable_helpers_test.dart
@@ -667,4 +667,106 @@ void main() {
     },
     variant: KeySimulatorTransitModeVariant.all(),
   );
+
+  testWidgets('EdgeDraggingAutoScroller handles drag target size correctly with Transform.scale', (
+    WidgetTester tester,
+  ) async {
+    final ScrollController controller = ScrollController();
+    addTearDown(controller.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Transform.scale(
+              scale: 0.5,
+              child: SizedBox(
+                width: 400,
+                height: 400,
+                child: ListView.builder(
+                  controller: controller,
+                  itemCount: 20,
+                  itemBuilder: (BuildContext context, int index) {
+                    return SizedBox(height: 100, child: Center(child: Text('Item $index')));
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final ScrollableState scrollableState = tester.state(find.byType(Scrollable));
+    final EdgeDraggingAutoScroller scroller = EdgeDraggingAutoScroller(
+      scrollableState,
+      velocityScalar: 1.0,
+    );
+    final RenderBox scrollRenderBox = scrollableState.context.findRenderObject()! as RenderBox;
+    final Rect dragTarget = Rect.fromLTWH(
+      0,
+      0,
+      scrollRenderBox.size.width,
+      scrollRenderBox.size.height,
+    );
+
+    scroller.startAutoScrollIfNecessary(dragTarget);
+    await tester.pump();
+
+    expect(tester.takeException(), isNull);
+
+    scroller.stopAutoScroll();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+    'ReorderableListView in Flexible with one item does not assert when dragged to edge',
+    (WidgetTester tester) async {
+      final List<String> items = <String>['Item 1'];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: <Widget>[
+                Flexible(
+                  child: StatefulBuilder(
+                    builder: (BuildContext context, StateSetter setState) {
+                      return ReorderableListView(
+                        onReorder: (int oldIndex, int newIndex) {
+                          setState(() {
+                            if (newIndex > oldIndex) {
+                              newIndex -= 1;
+                            }
+                            final String item = items.removeAt(oldIndex);
+                            items.insert(newIndex, item);
+                          });
+                        },
+                        children: <Widget>[
+                          ListTile(key: const ValueKey<String>('Item 1'), title: Text(items.first)),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final Offset startLocation = tester.getCenter(find.byKey(const ValueKey<String>('Item 1')));
+      final TestGesture gesture = await tester.startGesture(startLocation);
+      await tester.pump();
+      await gesture.moveTo(tester.getBottomRight(find.byType(Scaffold)) - const Offset(10, 10));
+      await tester.pump(const Duration(seconds: 1));
+
+      expect(tester.takeException(), isNull);
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+    },
+  );
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fixes: https://github.com/flutter/flutter/issues/136331

The original issue highlights two separate bugs:
1. When Flutter calculates Widgets, there might be floating-point precision issues. For example, the calculation result may show _dragTargetRelatedToScrollOrigin.size.height as 64.00000000000003. Therefore, I introduced a very small tolerance to address this.
2. When there's a size scaling effect on the ReorderableListView, such as an influence from Transform.scale, the method for calculating the drag target becomes incorrect.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
