### PR TITLE
Fix time picker period selector a11y touch targets

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -3049,8 +3049,20 @@ class _TimePickerState extends State<_TimePicker> with RestorationMixin {
                 ? localizations.timePickerDialHelpText
                 : localizations.timePickerDialHelpText.toUpperCase());
 
+        // The vertical adjustment used to make both AM/PM buttons accessible.
+        // Because the period selector height is increased based on this value,
+        // the dial padding has to be decreased of the same amount.
+        final double portraitMinInteractiveVerticalAdjustment = math.max(
+          0,
+          2 * kMinInteractiveDimension - defaultTheme.dayPeriodPortraitSize.height,
+        );
+
         final EdgeInsetsGeometry dialPadding = switch (orientation) {
-          Orientation.portrait => const EdgeInsets.only(left: 12, right: 12, top: 36),
+          Orientation.portrait => EdgeInsets.only(
+            left: 12,
+            right: 12,
+            top: 36 - portraitMinInteractiveVerticalAdjustment / 2,
+          ),
           Orientation.landscape => const EdgeInsetsDirectional.only(start: 64),
         };
         final Widget dial = Padding(

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -684,7 +684,6 @@ class _DayPeriodControl extends StatelessWidget {
           child: SizedBox.fromSize(
             size: dayPeriodSize,
             child: Material(
-              clipBehavior: Clip.antiAlias,
               color: Colors.transparent,
               shape: resolvedShape,
               child: Column(
@@ -725,7 +724,6 @@ class _DayPeriodControl extends StatelessWidget {
           child: SizedBox(
             height: dayPeriodSize.height,
             child: Material(
-              clipBehavior: Clip.antiAlias,
               color: Colors.transparent,
               shape: resolvedShape,
               child: Row(
@@ -874,9 +872,6 @@ class _RenderAmPmSemantics extends RenderProxyBox {
       height: minSemanticHeight,
     );
   }
-
-  @override
-  bool get semanticsBoundsClippedByParent => false;
 }
 
 /// A widget to pad the area around the [_DayPeriodControl]'s inner [Material].

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -684,6 +684,7 @@ class _DayPeriodControl extends StatelessWidget {
           child: SizedBox.fromSize(
             size: dayPeriodSize,
             child: Material(
+              clipBehavior: Clip.antiAlias,
               color: Colors.transparent,
               shape: resolvedShape,
               child: Column(
@@ -724,6 +725,7 @@ class _DayPeriodControl extends StatelessWidget {
           child: SizedBox(
             height: dayPeriodSize.height,
             child: Material(
+              clipBehavior: Clip.antiAlias,
               color: Colors.transparent,
               shape: resolvedShape,
               child: Row(
@@ -872,6 +874,9 @@ class _RenderAmPmSemantics extends RenderProxyBox {
       height: minSemanticHeight,
     );
   }
+
+  @override
+  bool get semanticsBoundsClippedByParent => false;
 }
 
 /// A widget to pad the area around the [_DayPeriodControl]'s inner [Material].

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3727,6 +3727,11 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// object, for accessibility purposes.
   Rect get semanticBounds;
 
+  /// Wether the semantic bounding box will be clipped by [parent].
+  ///
+  /// Defaults to true,
+  bool get semanticsBoundsClippedByParent => true;
+
   /// Whether the semantics of this render object is dirty and await the update.
   ///
   /// Always returns false in release mode.
@@ -6429,15 +6434,21 @@ final class _SemanticsGeometry {
       }
     }
 
-    Rect rect =
-        semanticsClipRect?.intersect(child.renderObject.semanticBounds) ??
-        child.renderObject.semanticBounds;
+    final bool shouldClip = child.renderObject.semanticsBoundsClippedByParent;
+
+    Rect rect = child.renderObject.semanticBounds;
     bool isRectHidden = false;
-    if (paintClipRect != null) {
-      final Rect paintRect = paintClipRect.intersect(rect);
-      isRectHidden = paintRect.isEmpty && !rect.isEmpty;
-      if (!isRectHidden) {
-        rect = paintRect;
+
+    if (shouldClip) {
+      rect =
+          semanticsClipRect?.intersect(child.renderObject.semanticBounds) ??
+          child.renderObject.semanticBounds;
+      if (paintClipRect != null) {
+        final Rect paintRect = paintClipRect.intersect(rect);
+        isRectHidden = paintRect.isEmpty && !rect.isEmpty;
+        if (!isRectHidden) {
+          rect = paintRect;
+        }
       }
     }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3729,7 +3729,7 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
 
   /// Wether the semantic bounding box will be clipped by [parent].
   ///
-  /// Defaults to true,
+  /// Defaults to true.
   bool get semanticsBoundsClippedByParent => true;
 
   /// Whether the semantics of this render object is dirty and await the update.

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3727,11 +3727,6 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// object, for accessibility purposes.
   Rect get semanticBounds;
 
-  /// Wether the semantic bounding box will be clipped by [parent].
-  ///
-  /// Defaults to true.
-  bool get semanticsBoundsClippedByParent => true;
-
   /// Whether the semantics of this render object is dirty and await the update.
   ///
   /// Always returns false in release mode.
@@ -6434,21 +6429,15 @@ final class _SemanticsGeometry {
       }
     }
 
-    final bool shouldClip = child.renderObject.semanticsBoundsClippedByParent;
-
-    Rect rect = child.renderObject.semanticBounds;
+    Rect rect =
+        semanticsClipRect?.intersect(child.renderObject.semanticBounds) ??
+        child.renderObject.semanticBounds;
     bool isRectHidden = false;
-
-    if (shouldClip) {
-      rect =
-          semanticsClipRect?.intersect(child.renderObject.semanticBounds) ??
-          child.renderObject.semanticBounds;
-      if (paintClipRect != null) {
-        final Rect paintRect = paintClipRect.intersect(rect);
-        isRectHidden = paintRect.isEmpty && !rect.isEmpty;
-        if (!isRectHidden) {
-          rect = paintRect;
-        }
+    if (paintClipRect != null) {
+      final Rect paintRect = paintClipRect.intersect(rect);
+      isRectHidden = paintRect.isEmpty && !rect.isEmpty;
+      if (!isRectHidden) {
+        rect = paintRect;
       }
     }
 

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3727,6 +3727,11 @@ abstract class RenderObject with DiagnosticableTreeMixin implements HitTestTarge
   /// object, for accessibility purposes.
   Rect get semanticBounds;
 
+  /// Wether the semantic bounding box will be clipped by [parent].
+  ///
+  /// Defaults to true.
+  bool get semanticsBoundsClippedByParent => true;
+
   /// Whether the semantics of this render object is dirty and await the update.
   ///
   /// Always returns false in release mode.
@@ -6429,15 +6434,21 @@ final class _SemanticsGeometry {
       }
     }
 
-    Rect rect =
-        semanticsClipRect?.intersect(child.renderObject.semanticBounds) ??
-        child.renderObject.semanticBounds;
+    final bool shouldClip = child.renderObject.semanticsBoundsClippedByParent;
+
+    Rect rect = child.renderObject.semanticBounds;
     bool isRectHidden = false;
-    if (paintClipRect != null) {
-      final Rect paintRect = paintClipRect.intersect(rect);
-      isRectHidden = paintRect.isEmpty && !rect.isEmpty;
-      if (!isRectHidden) {
-        rect = paintRect;
+
+    if (shouldClip) {
+      rect =
+          semanticsClipRect?.intersect(child.renderObject.semanticBounds) ??
+          child.renderObject.semanticBounds;
+      if (paintClipRect != null) {
+        final Rect paintRect = paintClipRect.intersect(rect);
+        isRectHidden = paintRect.isEmpty && !rect.isEmpty;
+        if (!isRectHidden) {
+          rect = paintRect;
+        }
       }
     }
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -1697,6 +1697,46 @@ void main() {
         expect(minuteSize.width, greaterThanOrEqualTo(48));
         expect(minuteSize.height, greaterThanOrEqualTo(48));
       });
+
+      testWidgets(
+        'Period selector touch target respects accessibility guidelines - Portrait mode',
+        (WidgetTester tester) async {
+          final SemanticsTester semantics = SemanticsTester(tester);
+          const Size minInteractiveSize = Size(kMinInteractiveDimension, kMinInteractiveDimension);
+
+          // Ensure picker is displayed in portrait mode.
+          tester.view.physicalSize = const Size(600, 1000);
+          addTearDown(tester.view.reset);
+
+          await mediaQueryBoilerplate(tester, materialType: materialType);
+
+          final SemanticsNode amButton = semantics.nodesWith(label: amString).single;
+          expect(amButton.rect.size >= minInteractiveSize, isTrue);
+
+          final SemanticsNode pmButton = semantics.nodesWith(label: pmString).single;
+          expect(pmButton.rect.size >= minInteractiveSize, isTrue);
+
+          semantics.dispose();
+        },
+      );
+
+      testWidgets(
+        'Period selector touch target respects accessibility guidelines - Landscape mode',
+        (WidgetTester tester) async {
+          final SemanticsTester semantics = SemanticsTester(tester);
+          const Size minInteractiveSize = Size(kMinInteractiveDimension, kMinInteractiveDimension);
+
+          await mediaQueryBoilerplate(tester, materialType: materialType);
+
+          final SemanticsNode amButton = semantics.nodesWith(label: amString).single;
+          expect(amButton.rect.size >= minInteractiveSize, isTrue);
+
+          final SemanticsNode pmButton = semantics.nodesWith(label: pmString).single;
+          expect(pmButton.rect.size >= minInteractiveSize, isTrue);
+
+          semantics.dispose();
+        },
+      );
     });
 
     group('Time picker - Input (${materialType.name})', () {
@@ -2405,9 +2445,9 @@ void main() {
     (WidgetTester tester) async {
       addTearDown(tester.view.reset);
 
-      final Finder dayPeriodControlFinder = find.byWidgetPredicate(
-        (Widget w) => '${w.runtimeType}' == '_DayPeriodControl',
-      );
+      final Finder amButtonFinder = find
+          .byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_AmPmButton')
+          .first;
       final Finder timeControlFinder = find
           .ancestor(of: find.text('7'), matching: find.byType(Row))
           .first;
@@ -2421,10 +2461,10 @@ void main() {
         locale: const Locale('ko', 'KR'),
       );
 
+      const double dayPeriodPortraitGap = 12.0; // From Material spec.
       expect(
-        tester.getBottomLeft(timeControlFinder).dx -
-            tester.getBottomRight(dayPeriodControlFinder).dx,
-        12,
+        tester.getBottomLeft(timeControlFinder).dx - tester.getBottomRight(amButtonFinder).dx,
+        dayPeriodPortraitGap,
       );
 
       // Dismiss the dialog.
@@ -2443,9 +2483,10 @@ void main() {
         locale: const Locale('ko', 'KR'),
       );
 
+      const double dayPeriodLandscapeGap = 16.0; // From Material spec.
       expect(
-        tester.getTopLeft(timeControlFinder).dy - tester.getBottomLeft(dayPeriodControlFinder).dy,
-        12,
+        tester.getTopLeft(timeControlFinder).dy - tester.getBottomLeft(amButtonFinder).dy,
+        dayPeriodLandscapeGap,
       );
     },
   );


### PR DESCRIPTION
## Description

This PR fixes the TimePicker day period selector touch targets and semantics bounds.

|  | Before | After |
|--------|--------|--------|
| dial mode portrait | ![image](https://github.com/user-attachments/assets/13911951-c387-4980-abdc-0b4addd541f7) | ![image](https://github.com/user-attachments/assets/90ef4969-5643-48a9-8073-dc11a20c1f4f) |
| dial mode landscape | ![image](https://github.com/user-attachments/assets/454ae506-6158-4558-b65d-3a40eab90371) | ![image](https://github.com/user-attachments/assets/e094b330-4124-4d22-8b84-67d672b35a84) |
| input mode | ![image](https://github.com/user-attachments/assets/f61e7c3a-d9d4-45b7-8f4c-ea4a4893790c) | ![image](https://github.com/user-attachments/assets/f89c5d3c-9a7f-4183-9950-8f12a53c1f86) | 

## Implementation choice

This PR implements two main changes:
- it expands the `_DayPeriodControl` bounds by reducing some existing spacing. Doing so the touch area of the AM/PM buttons can grow outside the day period container and respect the minimum interactive height.
- it expands the bounds of the AM/PM buttons semantics. In order to do it introduces a new public getter `semanticsBoundsClippedByParent` to `RenderObject`. This getter returns true by default and can be overriden to return false which allows a RenderObject.semanticsBounds to expand outside of parents clip bounds.

Side not, If `semanticsBoundsClippedByParent` is accepted, I will file a separate PR for it, with proper testing.

## Related Issue

Fixes [touch target size not up to a11y standards for DatePicker day period selector.](https://github.com/flutter/flutter/issues/168245)

## Tests

Adds 2 tests.
