### PR TITLE
Re-pin package:intl

### DIFF
--- a/packages/flutter_localizations/pubspec.yaml
+++ b/packages/flutter_localizations/pubspec.yaml
@@ -13,11 +13,11 @@ dependencies:
 
   flutter:
     sdk: flutter
-  intl: ^0.20.2
+  intl: 0.20.2
   path: 1.9.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-# PUBSPEC CHECKSUM: pmbisj
+# PUBSPEC CHECKSUM: c2j4ng

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,7 +120,7 @@ dependencies:
   http: 1.4.0
   http_multi_server: 3.2.2
   http_parser: 4.1.2
-  intl: ^0.20.2
+  intl: 0.20.2
   io: 1.0.5
   isolate: 2.1.1
   js: 0.7.2
@@ -213,4 +213,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.2
-# PUBSPEC CHECKSUM: omd6r4
+# PUBSPEC CHECKSUM: j61vfe


### PR DESCRIPTION
Reverts https://github.com/flutter/flutter/pull/169286.

I am in agreement with the goal of unpinning packages dependencies, but a change of this significance should have a fleshed out design doc and plan, and be presented at the Dash forum so that the whole team is aware of the changes. 