### PR TITLE
Add build option to force inclusion of dev_dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_builder.dart
+++ b/packages/flutter_tools/lib/src/android/android_builder.dart
@@ -19,7 +19,12 @@ abstract class AndroidBuilder {
     required FlutterProject project,
     required Set<AndroidBuildInfo> androidBuildInfo,
     required String target,
-    required Future<void> Function(FlutterProject, {required bool releaseMode}) generateTooling,
+    required Future<void> Function(
+      FlutterProject, {
+      required bool releaseMode,
+      required bool forceIncludeDevDependencies,
+    })
+    generateTooling,
     String? outputDirectoryPath,
     required String buildNumber,
   });

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -194,7 +194,12 @@ class AndroidGradleBuilder implements AndroidBuilder {
     required FlutterProject project,
     required Set<AndroidBuildInfo> androidBuildInfo,
     required String target,
-    required Future<void> Function(FlutterProject, {required bool releaseMode}) generateTooling,
+    required Future<void> Function(
+      FlutterProject, {
+      required bool releaseMode,
+      required bool forceIncludeDevDependencies,
+    })
+    generateTooling,
     String? outputDirectoryPath,
     required String buildNumber,
   }) async {
@@ -207,7 +212,11 @@ class AndroidGradleBuilder implements AndroidBuilder {
     }
 
     for (final AndroidBuildInfo androidBuildInfo in androidBuildInfo) {
-      await generateTooling(project, releaseMode: androidBuildInfo.buildInfo.isRelease);
+      await generateTooling(
+        project,
+        releaseMode: androidBuildInfo.buildInfo.isRelease,
+        forceIncludeDevDependencies: androidBuildInfo.buildInfo.forceIncludeDevDependencies,
+      );
       await buildGradleAar(
         project: project,
         androidBuildInfo: androidBuildInfo,

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -54,6 +54,7 @@ class BuildInfo {
     this.buildNativeAssets = true,
     this.useLocalCanvasKit = false,
     this.webEnableHotReload = false,
+    this.forceIncludeDevDependencies = false,
   }) : extraFrontEndOptions = extraFrontEndOptions ?? const <String>[],
        extraGenSnapshotOptions = extraGenSnapshotOptions ?? const <String>[],
        fileSystemRoots = fileSystemRoots ?? const <String>[],
@@ -186,6 +187,10 @@ class BuildInfo {
 
   /// If set, web builds with DDC will run with support for hot reload.
   final bool webEnableHotReload;
+
+  /// If set, dev dependencies will be included in all build modes
+  /// including release builds.
+  final bool forceIncludeDevDependencies;
 
   /// Can be used when the actual information is not needed.
   static const BuildInfo dummy = BuildInfo(

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -20,6 +20,7 @@ class BuildApkCommand extends BuildSubCommand {
     addTreeShakeIconsFlag();
     usesTargetOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
+    addForceIncludeDevDependenciesOption();
     usesFlavorOption();
     usesPubOption();
     usesBuildNumberOption();

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -23,6 +23,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
     addTreeShakeIconsFlag();
     usesTargetOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
+    addForceIncludeDevDependenciesOption();
     usesFlavorOption();
     usesPubOption();
     usesBuildNumberOption();

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -25,6 +25,7 @@ class BuildBundleCommand extends BuildSubCommand {
     usesFilesystemOptions(hide: !verboseHelp);
     usesBuildNumberOption();
     addBuildModeFlags(verboseHelp: verboseHelp, defaultToRelease: false);
+    addForceIncludeDevDependenciesOption();
     usesDartDefineOption();
     usesExtraDartFlagOptions(verboseHelp: verboseHelp);
     argParser

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -666,6 +666,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     addTreeShakeIconsFlag();
     addSplitDebugInfoOption();
     addBuildModeFlags(verboseHelp: verboseHelp);
+    addForceIncludeDevDependenciesOption();
     usesTargetOption();
     usesFlavorOption();
     usesPubOption();

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -267,6 +267,7 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
       await regeneratePlatformSpecificToolingIfApplicable(
         project,
         releaseMode: buildInfo.mode.isRelease,
+        forceIncludeDevDependencies: buildInfo.forceIncludeDevDependencies,
       );
 
       final String? productBundleIdentifier = await project.ios.productBundleIdentifier(buildInfo);

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -85,6 +85,7 @@ class BuildMacOSFrameworkCommand extends BuildFrameworkCommand {
       await regeneratePlatformSpecificToolingIfApplicable(
         project,
         releaseMode: buildInfo.mode.isRelease,
+        forceIncludeDevDependencies: buildInfo.forceIncludeDevDependencies,
       );
 
       final String xcodeBuildConfiguration = buildInfo.mode.uppercaseName;

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -537,6 +537,7 @@ class CreateCommand extends FlutterCommand with CreateBase {
         const bool ignoreReleaseModeSinceItsNotABuildAndHopeItWorks = false;
         await project.ensureReadyForPlatformSpecificTooling(
           releaseMode: ignoreReleaseModeSinceItsNotABuildAndHopeItWorks,
+          forceIncludeDevDependencies: true,
           androidPlatform: includeAndroid,
           iosPlatform: includeIos,
           linuxPlatform: includeLinux,

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -394,11 +394,13 @@ class PackagesGetCommand extends FlutterCommand {
         // itself and example(if present).
         await project.regeneratePlatformSpecificTooling(
           releaseMode: ignoreReleaseModeSinceItsNotABuildAndHopeItWorks,
+          forceIncludeDevDependencies: true,
         );
         if (example && project.hasExampleApp && project.example.pubspecFile.existsSync()) {
           final FlutterProject exampleProject = project.example;
           await exampleProject.regeneratePlatformSpecificTooling(
             releaseMode: ignoreReleaseModeSinceItsNotABuildAndHopeItWorks,
+            forceIncludeDevDependencies: true,
           );
         }
       }

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -337,9 +337,12 @@ class FlutterProject {
   /// If [releaseMode] is `true`, platform-specific tooling and metadata generated
   /// may apply optimizations or changes that are only specific to release builds,
   /// such as not including dev-only dependencies.
+  /// If [forceIncludeDevDependencies] is `true`, dev-only dependencies will be included
+  /// even in release builds.
   Future<void> regeneratePlatformSpecificTooling({
     DeprecationBehavior deprecationBehavior = DeprecationBehavior.none,
     required bool releaseMode,
+    bool forceIncludeDevDependencies = false,
   }) async {
     return ensureReadyForPlatformSpecificTooling(
       androidPlatform: android.existsSync(),
@@ -352,6 +355,7 @@ class FlutterProject {
       webPlatform: featureFlags.isWebEnabled && web.existsSync(),
       deprecationBehavior: deprecationBehavior,
       releaseMode: releaseMode,
+      forceIncludeDevDependencies: forceIncludeDevDependencies,
     );
   }
 
@@ -361,8 +365,11 @@ class FlutterProject {
   /// If [releaseMode] is `true`, platform-specific tooling and metadata generated
   /// may apply optimizations or changes that are only specific to release builds,
   /// such as not including dev-only dependencies.
+  /// If [forceIncludeDevDependencies] is `true`, dev-only dependencies will be included
+  /// even in release builds.
   Future<void> ensureReadyForPlatformSpecificTooling({
     required bool releaseMode,
+    required bool forceIncludeDevDependencies,
     bool androidPlatform = false,
     bool iosPlatform = false,
     bool linuxPlatform = false,
@@ -401,6 +408,7 @@ class FlutterProject {
       macOSPlatform: macOSPlatform,
       windowsPlatform: windowsPlatform,
       releaseMode: releaseMode,
+      forceIncludeDevDependencies: forceIncludeDevDependencies,
     );
   }
 

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -1693,7 +1693,11 @@ Gradle Crashed
         },
         target: '',
         buildNumber: '1.0',
-        generateTooling: (FlutterProject project, {required bool releaseMode}) async {
+        generateTooling: (
+          FlutterProject project, {
+          required bool releaseMode,
+          required bool forceIncludeDevDependencies,
+        }) async {
           generateToolingCalls.add((project, releaseMode));
         },
       );

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -2444,6 +2444,16 @@ flutter:
           expect(generatedPluginRegistrant, exists);
           expect(generatedPluginRegistrant.readAsStringSync(), contains('bar.foo.Foo'));
 
+          // Test release mode including dev dependencies.
+          await injectPlugins(
+            flutterProject,
+            androidPlatform: true,
+            releaseMode: true,
+            forceIncludeDevDependencies: true,
+          );
+          expect(generatedPluginRegistrant, exists);
+          expect(generatedPluginRegistrant.readAsStringSync(), contains('bar.foo.Foo'));
+
           // Test release mode.
           await injectPlugins(flutterProject, androidPlatform: true, releaseMode: true);
           expect(generatedPluginRegistrant, exists);
@@ -2457,7 +2467,7 @@ flutter:
       );
 
       testUsingContext(
-        'includes dev dependencies from iOS plugin registrant',
+        'excludes dev dependencies from iOS plugin registrant',
         () async {
           createPlugin(
             name: testPluginName,
@@ -2483,6 +2493,17 @@ flutter:
           expect(generatedPluginRegistrantImpl, exists);
           expect(generatedPluginRegistrantImpl.readAsStringSync(), contains(devDepImport));
 
+          // Test release mode including dev dependencies.
+          await injectPlugins(
+            flutterProject,
+            iosPlatform: true,
+            darwinDependencyManagement: dependencyManagement,
+            releaseMode: true,
+            forceIncludeDevDependencies: true,
+          );
+          expect(generatedPluginRegistrantImpl, exists);
+          expect(generatedPluginRegistrantImpl.readAsStringSync(), contains(devDepImport));
+
           // Test release mode.
           await injectPlugins(
             flutterProject,
@@ -2491,7 +2512,7 @@ flutter:
             releaseMode: true,
           );
           expect(generatedPluginRegistrantImpl, exists);
-          expect(generatedPluginRegistrantImpl.readAsStringSync(), contains(devDepImport));
+          expect(generatedPluginRegistrantImpl.readAsStringSync(), isNot(contains(devDepImport)));
         },
         overrides: <Type, Generator>{
           FileSystem: () => fs,
@@ -2521,6 +2542,16 @@ flutter:
           expect(generatedPluginRegistrant, exists);
           expect(generatedPluginRegistrant.readAsStringSync(), contains(expectedDevDepImport));
 
+          // Test release mode including dev dependencies.
+          await injectPlugins(
+            flutterProject,
+            linuxPlatform: true,
+            releaseMode: true,
+            forceIncludeDevDependencies: true,
+          );
+          expect(generatedPluginRegistrant, exists);
+          expect(generatedPluginRegistrant.readAsStringSync(), contains(expectedDevDepImport));
+
           // Test release mode.
           await injectPlugins(flutterProject, linuxPlatform: true, releaseMode: true);
           expect(generatedPluginRegistrant, exists);
@@ -2537,7 +2568,7 @@ flutter:
       );
 
       testUsingContext(
-        'includes dev dependencies from MacOS plugin registrant',
+        'excludes dev dependencies from MacOS plugin registrant',
         () async {
           createPlugin(
             name: testPluginName,
@@ -2566,6 +2597,20 @@ flutter:
             contains(expectedDevDepRegistration),
           );
 
+          // Test release mode including dev dependencies.
+          await injectPlugins(
+            flutterProject,
+            macOSPlatform: true,
+            darwinDependencyManagement: dependencyManagement,
+            releaseMode: true,
+            forceIncludeDevDependencies: true,
+          );
+          expect(generatedPluginRegistrant, exists);
+          expect(
+            generatedPluginRegistrant.readAsStringSync(),
+            contains(expectedDevDepRegistration),
+          );
+
           // Test release mode.
           await injectPlugins(
             flutterProject,
@@ -2576,7 +2621,7 @@ flutter:
           expect(generatedPluginRegistrant, exists);
           expect(
             generatedPluginRegistrant.readAsStringSync(),
-            contains(expectedDevDepRegistration),
+            isNot(contains(expectedDevDepRegistration)),
           );
         },
         overrides: <Type, Generator>{
@@ -2609,6 +2654,19 @@ flutter:
           await injectPlugins(flutterProject, windowsPlatform: true, releaseMode: false);
           final File generatedPluginRegistrantImpl = flutterProject.windows.managedDirectory
               .childFile('generated_plugin_registrant.cc');
+          expect(generatedPluginRegistrantImpl, exists);
+          expect(
+            generatedPluginRegistrantImpl.readAsStringSync(),
+            contains(expectedDevDepRegistration),
+          );
+
+          // Test release mode including dev dependencies.
+          await injectPlugins(
+            flutterProject,
+            windowsPlatform: true,
+            releaseMode: true,
+            forceIncludeDevDependencies: true,
+          );
           expect(generatedPluginRegistrantImpl, exists);
           expect(
             generatedPluginRegistrantImpl.readAsStringSync(),

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -20,7 +20,12 @@ class FakeAndroidBuilder implements AndroidBuilder {
     required FlutterProject project,
     required Set<AndroidBuildInfo> androidBuildInfo,
     required String target,
-    required Future<void> Function(FlutterProject, {required bool releaseMode}) generateTooling,
+    required Future<void> Function(
+      FlutterProject, {
+      required bool releaseMode,
+      required bool forceIncludeDevDependencies,
+    })
+    generateTooling,
     String? outputDirectoryPath,
     required String buildNumber,
   }) async {}

--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -241,7 +241,10 @@ instrumentation test for Android, after creating `androidTest` as suggested in t
 ```sh
 pushd android
 # flutter build generates files in android/ for building the app
-flutter build apk
+# Use --force-include-dev-dependencies flag for release build
+# Otherwise integration_test plugin is not included
+flutter build apk --force-include-dev-dependencies
+# Or for debug build: flutter build apk --debug
 ./gradlew app:assembleAndroidTest
 ./gradlew app:assembleDebug -Ptarget=<path_to_test>.dart
 popd
@@ -315,7 +318,7 @@ product="build/ios_integ/Build/Products"
 flutter clean
 
 # Pass --simulator if building for the simulator.
-flutter build ios integration_test/foo_test.dart --release
+flutter build ios integration_test/foo_test.dart --release --force-include-dev-dependencies
 
 pushd ios
 xcodebuild build-for-testing \


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

In the latest stable release version of Flutter _dev_dependencies_ are excluded from release builds. This leads to the issues #170119 and #167377. The PR #171015 fixed this issues only for iOS and macOS build by going a step backward. The PR changed the behavior to always include the _dev_dependencies_ even in release build. This has the downside that the release build gets bigger again and maybe it could lead to other problems as well. So, in general it is desireable to strip out the _dev_dependencies_ in release builds. However, there are scenarios like integration testing in which you want to have a release build including _dev_dependencies_.

So my PR adds the build option _--force-include-dev-dependencies_ that ensures that the _dev_dependencies_ are included in all build modes.

I would prefer this PR over  #171015  because it does not go a step backward and solves the same issues. This PR is not a breaking change.

Example usage:

`flutter build ios integration_test/foo_test.dart --release --force-include-dev-dependencies`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
