### PR TITLE
Set width and height when creating <img> platform view for NetworkImage

### DIFF
--- a/packages/flutter/lib/src/widgets/_web_image_web.dart
+++ b/packages/flutter/lib/src/widgets/_web_image_web.dart
@@ -33,29 +33,7 @@ class ImgElementPlatformView extends StatelessWidget {
   static void _register() {
     assert(!_registered);
     _registered = true;
-    //registerFactory(registry: ui_web.platformViewRegistry);
-    print('CALLING REGISTERVIEWFACTORY with ${ui_web.platformViewRegistry}');
     ui_web.platformViewRegistry.registerViewFactory(_viewType, (int viewId, {Object? params}) {
-      final Map<Object?, Object?> paramsMap = params! as Map<Object?, Object?>;
-      // Create a new <img> element. The browser is able to display the image
-      // without fetching it over the network again.
-      final web.HTMLImageElement img = web.document.createElement('img') as web.HTMLImageElement;
-      img.src = paramsMap['src']! as String;
-      // Set `width` and `height`, otherwise the engine will issue a warning.
-      img.style
-        ..width = '100%'
-        ..height = '100%';
-      return img;
-    });
-  }
-
-  /// Registers the `<img>` element factory with the given [registry].
-  ///
-  /// This is visible for testing only, it should not be called outside of this
-  /// class.
-  @visibleForTesting
-  static void registerFactory({required ui_web.PlatformViewRegistry registry}) {
-    registry.registerViewFactory(_viewType, (int viewId, {Object? params}) {
       final Map<Object?, Object?> paramsMap = params! as Map<Object?, Object?>;
       // Create a new <img> element. The browser is able to display the image
       // without fetching it over the network again.
@@ -79,7 +57,7 @@ class ImgElementPlatformView extends StatelessWidget {
     }
     return HtmlElementView(
       viewType: _viewType,
-      creationParams: <String, Object?>{'src': src},
+      creationParams: <String, String?>{'src': src},
       hitTestBehavior: PlatformViewHitTestBehavior.transparent,
     );
   }

--- a/packages/flutter/lib/src/widgets/_web_image_web.dart
+++ b/packages/flutter/lib/src/widgets/_web_image_web.dart
@@ -33,12 +33,38 @@ class ImgElementPlatformView extends StatelessWidget {
   static void _register() {
     assert(!_registered);
     _registered = true;
+    //registerFactory(registry: ui_web.platformViewRegistry);
+    print('CALLING REGISTERVIEWFACTORY with ${ui_web.platformViewRegistry}');
     ui_web.platformViewRegistry.registerViewFactory(_viewType, (int viewId, {Object? params}) {
       final Map<Object?, Object?> paramsMap = params! as Map<Object?, Object?>;
       // Create a new <img> element. The browser is able to display the image
       // without fetching it over the network again.
       final web.HTMLImageElement img = web.document.createElement('img') as web.HTMLImageElement;
       img.src = paramsMap['src']! as String;
+      // Set `width` and `height`, otherwise the engine will issue a warning.
+      img.style
+        ..width = '100%'
+        ..height = '100%';
+      return img;
+    });
+  }
+
+  /// Registers the `<img>` element factory with the given [registry].
+  ///
+  /// This is visible for testing only, it should not be called outside of this
+  /// class.
+  @visibleForTesting
+  static void registerFactory({required ui_web.PlatformViewRegistry registry}) {
+    registry.registerViewFactory(_viewType, (int viewId, {Object? params}) {
+      final Map<Object?, Object?> paramsMap = params! as Map<Object?, Object?>;
+      // Create a new <img> element. The browser is able to display the image
+      // without fetching it over the network again.
+      final web.HTMLImageElement img = web.document.createElement('img') as web.HTMLImageElement;
+      img.src = paramsMap['src']! as String;
+      // Set `width` and `height`, otherwise the engine will issue a warning.
+      img.style
+        ..width = '100%'
+        ..height = '100%';
       return img;
     });
   }
@@ -53,7 +79,7 @@ class ImgElementPlatformView extends StatelessWidget {
     }
     return HtmlElementView(
       viewType: _viewType,
-      creationParams: <String, String?>{'src': src},
+      creationParams: <String, Object?>{'src': src},
       hitTestBehavior: PlatformViewHitTestBehavior.transparent,
     );
   }


### PR DESCRIPTION
Fixes a console warning from Flutter Web engine when creating a platform view without setting `width` and `height`.

Fixes https://github.com/flutter/flutter/issues/170567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
