### PR TITLE
Remove redundant ThemeData(useMaterial3: true) from tests

### DIFF
--- a/packages/flutter/test/material/calendar_date_picker_test.dart
+++ b/packages/flutter/test/material/calendar_date_picker_test.dart
@@ -1527,7 +1527,6 @@ void main() {
     testWidgets('Defaults to Gregorian calendar system', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: CalendarDatePicker(
               initialDate: DateTime(2025, DateTime.february, 26),
@@ -1556,7 +1555,6 @@ void main() {
     testWidgets('Using custom calendar delegate implementation', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: CalendarDatePicker(
               initialDate: DateTime(2025, DateTime.february, 26),

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -2680,7 +2680,6 @@ void main() {
     testWidgets('Defaults to Gregorian calendar system', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: DatePickerDialog(
               initialDate: initialDate,
@@ -2698,7 +2697,6 @@ void main() {
     testWidgets('Using custom calendar delegate implementation', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: DatePickerDialog(
               initialDate: initialDate,
@@ -2722,7 +2720,6 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: DatePickerDialog(
               initialDate: initialDate,

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1836,7 +1836,6 @@ void main() {
     testWidgets('Defaults to Gregorian calendar system', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: DateRangePickerDialog(
               initialDateRange: initialDateRange,
@@ -1854,7 +1853,6 @@ void main() {
     testWidgets('Using custom calendar delegate implementation', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: DateRangePickerDialog(
               initialDateRange: initialDateRange,
@@ -1946,7 +1944,6 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: DateRangePickerDialog(
               initialDateRange: initialDateRange,

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -420,7 +420,6 @@ void main() {
     testWidgets('Defaults to Gregorian calendar system', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: InputDatePickerFormField(
               initialDate: DateTime(2025, DateTime.february, 26),
@@ -440,7 +439,6 @@ void main() {
     testWidgets('Using custom calendar delegate implementation', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: InputDatePickerFormField(
               initialDate: DateTime(2025, DateTime.february, 26),
@@ -463,7 +461,6 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(useMaterial3: true),
           home: Material(
             child: InputDatePickerFormField(
               initialDate: DateTime(2025, DateTime.february, 26),


### PR DESCRIPTION
Reference Link https://github.com/flutter/flutter/pull/168441#discussion_r2178859272

This PR removes explicit ThemeData(useMaterial3: true) assignments from test files. Since useMaterial3 now defaults to true in Flutter, these lines are no longer necessary and can be safely omitted.

**Why?**  

- Keeps test code clean and up-to-date with current Flutter defaults.
- Prevents confusion for contributors who may think this setting is still required.



