### PR TITLE
Apply normalization to TimePickerThemeData.inputDecorationTheme

### DIFF
--- a/dev/tools/gen_defaults/lib/time_picker_template.dart
+++ b/dev/tools/gen_defaults/lib/time_picker_template.dart
@@ -299,7 +299,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
   }
 
   @override
-  InputDecorationTheme get inputDecorationTheme {
+  InputDecorationThemeData get inputDecorationTheme {
     // This is NOT correct, but there's no token for
     // 'time-input.container.shape', so this is using the radius from the shape
     // for the hour/minute selector. It's a BorderRadiusGeometry, so we have to
@@ -307,7 +307,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
     final BorderRadius selectorRadius = ${shape('$hourMinuteComponent.container')}
       .borderRadius
       .resolve(Directionality.of(context));
-    return InputDecorationTheme(
+    return InputDecorationThemeData(
       contentPadding: EdgeInsets.zero,
       filled: true,
       // This should be derived from a token, but there isn't one for 'time-input'.

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -2101,7 +2101,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
         : _TimePickerDefaultsM2(context);
     final bool alwaysUse24HourFormat = MediaQuery.alwaysUse24HourFormatOf(context);
 
-    final InputDecorationTheme inputDecorationTheme =
+    final InputDecorationThemeData inputDecorationTheme =
         timePickerTheme.inputDecorationTheme ?? defaultTheme.inputDecorationTheme;
     InputDecoration inputDecoration = InputDecoration(
       // Prevent the error text from appearing when
@@ -2110,7 +2110,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
       // https://github.com/flutter/flutter/issues/54104
       // is fixed.
       errorStyle: defaultTheme.inputDecorationTheme.errorStyle,
-    ).applyDefaults(inputDecorationTheme.data);
+    ).applyDefaults(inputDecorationTheme);
     // Remove the hint text when focused because the centered cursor
     // appears odd above the hint text.
     final String? hintText = focusNode.hasFocus ? null : _formattedValue;
@@ -3256,7 +3256,7 @@ abstract class _TimePickerDefaults extends TimePickerThemeData {
   TextStyle get hourMinuteTextStyle;
 
   @override
-  InputDecorationTheme get inputDecorationTheme;
+  InputDecorationThemeData get inputDecorationTheme;
 
   @override
   EdgeInsetsGeometry get padding;
@@ -3462,8 +3462,8 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
   }
 
   @override
-  InputDecorationTheme get inputDecorationTheme {
-    return InputDecorationTheme(
+  InputDecorationThemeData get inputDecorationTheme {
+    return InputDecorationThemeData(
       contentPadding: EdgeInsets.zero,
       filled: true,
       fillColor: _hourMinuteInputColor,
@@ -3779,7 +3779,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
   }
 
   @override
-  InputDecorationTheme get inputDecorationTheme {
+  InputDecorationThemeData get inputDecorationTheme {
     // This is NOT correct, but there's no token for
     // 'time-input.container.shape', so this is using the radius from the shape
     // for the hour/minute selector. It's a BorderRadiusGeometry, so we have to
@@ -3787,7 +3787,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
     final BorderRadius selectorRadius = const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0)))
       .borderRadius
       .resolve(Directionality.of(context));
-    return InputDecorationTheme(
+    return InputDecorationThemeData(
       contentPadding: EdgeInsets.zero,
       filled: true,
       // This should be derived from a token, but there isn't one for 'time-input'.

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -66,12 +66,19 @@ class TimePickerThemeData with Diagnosticable {
     this.hourMinuteShape,
     this.hourMinuteTextColor,
     this.hourMinuteTextStyle,
-    this.inputDecorationTheme,
+    // TODO(bleroux): Clean this up once `InputDecorationTheme` is fully normalized.
+    Object? inputDecorationTheme,
     this.padding,
     this.shape,
     this.timeSelectorSeparatorColor,
     this.timeSelectorSeparatorTextStyle,
-  }) : _dayPeriodColor = dayPeriodColor;
+  }) : assert(
+         inputDecorationTheme == null ||
+             (inputDecorationTheme is InputDecorationTheme ||
+                 inputDecorationTheme is InputDecorationThemeData),
+       ),
+       _inputDecorationTheme = inputDecorationTheme,
+       _dayPeriodColor = dayPeriodColor;
 
   /// The background color of a time picker.
   ///
@@ -267,7 +274,17 @@ class TimePickerThemeData with Diagnosticable {
   /// The input decoration theme for the [TextField]s in the time picker.
   ///
   /// If this is null, the time picker provides its own defaults.
-  final InputDecorationTheme? inputDecorationTheme;
+  // TODO(bleroux): Clean this up once `InputDecorationTheme` is fully normalized.
+  InputDecorationThemeData? get inputDecorationTheme {
+    if (_inputDecorationTheme == null) {
+      return null;
+    }
+    return _inputDecorationTheme is InputDecorationTheme
+        ? _inputDecorationTheme.data
+        : _inputDecorationTheme as InputDecorationThemeData;
+  }
+
+  final Object? _inputDecorationTheme;
 
   /// The padding around the time picker dialog when the entry mode is
   /// [TimePickerEntryMode.dial] or [TimePickerEntryMode.dialOnly].
@@ -529,8 +546,8 @@ class TimePickerThemeData with Diagnosticable {
     );
     properties.add(
       DiagnosticsProperty<InputDecorationThemeData>(
-        'inputDecorationTheme.data',
-        inputDecorationTheme?.data,
+        'inputDecorationTheme',
+        inputDecorationTheme,
         defaultValue: null,
       ),
     );

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -120,7 +120,7 @@ void main() {
         'hourMinuteShape: RoundedRectangleBorder(BorderSide(color: ${const Color(0xffffffff)}), BorderRadius.zero)',
         'hourMinuteTextColor: ${const Color(0xfffffff0)}',
         'hourMinuteTextStyle: TextStyle(inherit: true, color: ${const Color(0xfffffff1)})',
-        'inputDecorationTheme.data: InputDecorationThemeData#ff861(labelStyle: TextStyle(inherit: true, color: ${const Color(0xfffffff2)}))',
+        'inputDecorationTheme: InputDecorationThemeData#ff861(labelStyle: TextStyle(inherit: true, color: ${const Color(0xfffffff2)}))',
         'padding: EdgeInsets.all(1.0)',
         'shape: RoundedRectangleBorder(BorderSide(color: ${const Color(0xfffffff3)}), BorderRadius.zero)',
         'timeSelectorSeparatorColor: WidgetStatePropertyAll(${const Color(0xfffffff4)})',
@@ -128,6 +128,25 @@ void main() {
       ]),
     );
   });
+
+  test(
+    'TimePickerThemeData.inputDecorationTheme accepts only InputDecorationTheme or InputDecorationThemeData instances',
+    () {
+      const InputDecorationTheme decorationTheme = InputDecorationTheme();
+      TimePickerThemeData timePickerTheme = const TimePickerThemeData(
+        inputDecorationTheme: decorationTheme,
+      );
+      expect(timePickerTheme.inputDecorationTheme, decorationTheme.data);
+
+      timePickerTheme = TimePickerThemeData(inputDecorationTheme: decorationTheme.data);
+      expect(timePickerTheme.inputDecorationTheme, decorationTheme.data);
+
+      // Wrong type throws.
+      expect(() {
+        TimePickerThemeData(inputDecorationTheme: Object());
+      }, throwsA(isA<AssertionError>()));
+    },
+  );
 
   testWidgets('Material2 - Passing no TimePickerThemeData uses defaults', (
     WidgetTester tester,


### PR DESCRIPTION
## Description

This PR is similar to what was done for `DatePickerThemeData` in https://github.com/flutter/flutter/pull/168981.
It changes `TimePickerThemeData.inputDecorationTheme` type to `InputDecorationThemeData` (instead of `InputDecorationTheme`) and uses Object? for the corresponding constructor parameter.

## Tests

Adds 1 test