### PR TITLE
Update dart_action to dartvm_action to account for the recent change in Dart

### DIFF
--- a/engine/src/flutter/build/dart/internal/application_snapshot.gni
+++ b/engine/src/flutter/build/dart/internal/application_snapshot.gni
@@ -128,7 +128,7 @@ template("application_snapshot") {
       args += training_args
     }
   } else {
-    dart_action(target_name) {
+    dartvm_action(target_name) {
       forward_variables_from(invoker,
                              [
                                "testonly",


### PR DESCRIPTION
Update dart_action to dartvm_action to account for the recent change in Dart, this should account for the
breakage in the internal HH bots.

This needs to land after a Dart roll into Flutter that includes https://dart-review.googlesource.com/c/sdk/+/364202 has landed