### PR TITLE
[iOS][Secure Paste] Custom edit menu actions - Engine implementation

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1056,6 +1056,12 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   [self.platformPlugin showLookUpViewController:selectedText];
 }
 
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+    onTranslateMenuActionWithTextInputClient:(int)client {
+  [self.platformChannel invokeMethod:@"ContextMenu.onTranslateMenuAction"
+                           arguments:@[ @(client) ]];
+}
+
 #pragma mark - FlutterViewEngineDelegate
 
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView showToolbar:(int)client {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -73,6 +73,8 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
     searchWebWithSelectedText:(NSString*)selectedText;
 - (void)flutterTextInputView:(FlutterTextInputView*)textInputView
           lookUpSelectedText:(NSString*)selectedText;
+- (void)flutterTextInputView:(FlutterTextInputView*)textInputView
+    onTranslateMenuActionWithTextInputClient:(int)client;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -893,6 +893,15 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                              shareSelectedText:[self textInRange:_selectedTextRange]];
 }
 
+- (void)handleTranslateAction {
+  NSLog(@"[FlutterTextInputPlugin] Translate menu item clicked");
+  NSString* selectedText = [self textInRange:_selectedTextRange];
+  NSLog(@"[FlutterTextInputPlugin] Selected text for translation: %@", selectedText);
+  
+  [self.textInputDelegate flutterTextInputView:self
+        onTranslateMenuActionWithTextInputClient:_textInputClient];
+}
+
 // DFS algorithm to search a UICommand from the menu tree.
 - (UICommand*)searchCommandWithSelector:(SEL)selector
                                 element:(UIMenuElement*)element API_AVAILABLE(ios(16.0)) {
@@ -998,6 +1007,17 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                  encodedItem:encodedItem];
     }
   }
+  
+  // Hardcoded Translate menu item for testing
+  NSLog(@"[FlutterTextInputPlugin] Adding hardcoded Translate menu item");
+  UICommand* translateCommand = [UICommand commandWithTitle:@"Translate"
+                                                      image:nil
+                                                     action:@selector(handleTranslateAction)
+                                               propertyList:@{@"type": @"translate", 
+                                                              @"id": @"translate_hardcoded"}];
+  [items addObject:translateCommand];
+  NSLog(@"[FlutterTextInputPlugin] Total menu items: %lu", (unsigned long)items.count);
+  
   return [UIMenu menuWithChildren:items];
 }
 
@@ -1016,6 +1036,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 
 - (void)showEditMenuWithTargetRect:(CGRect)targetRect
                              items:(NSArray<NSDictionary*>*)items API_AVAILABLE(ios(16.0)) {
+  NSLog(@"[FlutterTextInputPlugin] showEditMenuWithTargetRect called");
+  NSLog(@"[FlutterTextInputPlugin] Menu items from Framework: %lu", (unsigned long)items.count);
+  NSLog(@"[FlutterTextInputPlugin] Target rect: %@", NSStringFromCGRect(targetRect));
+  
   _editMenuTargetRect = targetRect;
   _editMenuItems = items;
   UIEditMenuConfiguration* config =


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR implements the engine-side infrastructure for custom edit menu actions on iOS, enabling developers to add custom menu items to the native text selection menu.

-  Part of #103163 (iOS 15 Secure Paste notifications)

-  Part of #140184 (Custom action items for edit menu)

 ## What this PR implements
- Added `onTranslateMenuActionWithTextInputClient` delegate method to handle custom menu actions
- Implemented communication from engine to framework via platform channel
- Added a hardcoded "Translate" menu item for testing purposes

## Note
Initial engine implementation with a temporary hardcoded menu item for testing. Full API and framework integration will follow in subsequent PRs.


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
