### PR TITLE
[web] Wasm minification default matches JS minification default

### DIFF
--- a/packages/flutter_tools/lib/src/web/compiler_config.dart
+++ b/packages/flutter_tools/lib/src/web/compiler_config.dart
@@ -146,7 +146,7 @@ class WasmCompilerConfig extends WebCompilerConfig {
   const WasmCompilerConfig({
     super.optimizationLevel,
     this.stripWasm = true,
-    this.minify = true,
+    this.minify,
     super.sourceMaps = true,
     super.renderer = WebRendererMode.defaultForWasm,
   });

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -1283,6 +1283,76 @@ name: foo
     expect(buildKeys.toSet().length, buildKeys.length);
   });
 
+  test('JsCompilerConfig minification based on release mode', () {
+    // Explicit `minify: true` should always result in `--minify` in all modes.
+    expect(
+      const JsCompilerConfig(minify: true).toCommandOptions(BuildMode.debug),
+      contains('--minify'),
+    );
+    expect(
+      const JsCompilerConfig(minify: true).toCommandOptions(BuildMode.profile),
+      contains('--minify'),
+    );
+    expect(
+      const JsCompilerConfig(minify: true).toCommandOptions(BuildMode.release),
+      contains('--minify'),
+    );
+
+    // Explicit `minify: false` should always result in `--no-minify` in all modes.
+    expect(
+      const JsCompilerConfig(minify: false).toCommandOptions(BuildMode.debug),
+      contains('--no-minify'),
+    );
+    expect(
+      const JsCompilerConfig(minify: false).toCommandOptions(BuildMode.profile),
+      contains('--no-minify'),
+    );
+    expect(
+      const JsCompilerConfig(minify: false).toCommandOptions(BuildMode.release),
+      contains('--no-minify'),
+    );
+
+    // Default `minify` should result in `--minify` only in release mode.
+    expect(const JsCompilerConfig().toCommandOptions(BuildMode.debug), contains('--no-minify'));
+    expect(const JsCompilerConfig().toCommandOptions(BuildMode.profile), contains('--no-minify'));
+    expect(const JsCompilerConfig().toCommandOptions(BuildMode.release), contains('--minify'));
+  });
+
+  test('WasmCompilerConfig minification based on release mode', () {
+    // Explicit `minify: true` should always result in `--minify` in all modes.
+    expect(
+      const WasmCompilerConfig(minify: true).toCommandOptions(BuildMode.debug),
+      contains('--minify'),
+    );
+    expect(
+      const WasmCompilerConfig(minify: true).toCommandOptions(BuildMode.profile),
+      contains('--minify'),
+    );
+    expect(
+      const WasmCompilerConfig(minify: true).toCommandOptions(BuildMode.release),
+      contains('--minify'),
+    );
+
+    // Explicit `minify: false` should always result in `--no-minify` in all modes.
+    expect(
+      const WasmCompilerConfig(minify: false).toCommandOptions(BuildMode.debug),
+      contains('--no-minify'),
+    );
+    expect(
+      const WasmCompilerConfig(minify: false).toCommandOptions(BuildMode.profile),
+      contains('--no-minify'),
+    );
+    expect(
+      const WasmCompilerConfig(minify: false).toCommandOptions(BuildMode.release),
+      contains('--no-minify'),
+    );
+
+    // Default `minify` should result in `--minify` only in release mode.
+    expect(const WasmCompilerConfig().toCommandOptions(BuildMode.debug), contains('--no-minify'));
+    expect(const WasmCompilerConfig().toCommandOptions(BuildMode.profile), contains('--no-minify'));
+    expect(const WasmCompilerConfig().toCommandOptions(BuildMode.release), contains('--minify'));
+  });
+
   test(
     'Generated service worker is empty with none-strategy',
     () => testbed.run(() {


### PR DESCRIPTION
The default minification behavior should be based on build mode.

Fixes https://github.com/flutter/flutter/issues/171702