### PR TITLE
Fix InputDecorationThemeData.activeIndicatorBorder is not applied

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2243,9 +2243,10 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
 
     if (themeData.useMaterial3) {
       if (decoration.filled!) {
+        final InputDecorationThemeData decorationTheme = InputDecorationTheme.of(context);
         return border.copyWith(
           borderSide: MaterialStateProperty.resolveAs(
-            defaults.activeIndicatorBorder,
+            decorationTheme.activeIndicatorBorder ?? defaults.activeIndicatorBorder,
             materialState,
           ),
         );

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -914,6 +914,22 @@ void main() {
 
         expect(getContainerRect(tester).height, 52.0);
       });
+
+      testWidgets('Ambient activeIndicatorBorder is used', (WidgetTester tester) async {
+        const BorderSide activeIndicatorBorder = BorderSide(color: Colors.amber, width: 2.0);
+        await tester.pumpWidget(
+          buildInputDecorator(
+            inputDecorationTheme: const InputDecorationThemeData(
+              filled: true,
+              activeIndicatorBorder: activeIndicatorBorder,
+            ),
+            decoration: const InputDecoration(labelText: labelText),
+          ),
+        );
+
+        expect(getBorderColor(tester), activeIndicatorBorder.color);
+        expect(getBorderWeight(tester), activeIndicatorBorder.width);
+      });
     });
 
     group('for outlined text field', () {
@@ -9822,6 +9838,22 @@ void main() {
       );
 
       expect(findBorderPainter(), paints..path(style: PaintingStyle.fill, color: fillColor));
+    });
+
+    testWidgets('activeIndicatorBorder', (WidgetTester tester) async {
+      const BorderSide activeIndicatorBorder = BorderSide(color: Colors.amber, width: 2.0);
+      await tester.pumpWidget(
+        buildInputDecorator(
+          localInputDecorationTheme: const InputDecorationThemeData(
+            filled: true,
+            activeIndicatorBorder: activeIndicatorBorder,
+          ),
+          decoration: const InputDecoration(labelText: labelText),
+        ),
+      );
+
+      expect(getBorderColor(tester), activeIndicatorBorder.color);
+      expect(getBorderWeight(tester), activeIndicatorBorder.width);
     });
 
     testWidgets('hoverColor', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR fixes input decorator logic related to `InputDecorationThemeData.activeIndicatorBorder`.
Before this PR, this property was ignored.

| Before | After |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/7108d760-fe7a-48c4-8ef5-df5709a3573a) | ![Image](https://github.com/user-attachments/assets/7c07c702-ed81-4ae9-ba07-b471330d5e09) |

## Related Issue

Fixes [InputDecorationTheme.activeIndicatorBorder is not used](https://github.com/flutter/flutter/issues/171522) 

## Tests

Adds 2 tests