### PR TITLE
windows: allow pwsh.bat wrapper

### DIFF
--- a/bin/dart.bat
+++ b/bin/dart.bat
@@ -18,8 +18,8 @@ FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
 REM Detect which PowerShell executable is available on the host
 REM PowerShell version <= 5: PowerShell.exe
 REM PowerShell version >= 6: pwsh.exe
-WHERE /Q pwsh.exe && (
-    SET powershell_executable=pwsh.exe
+WHERE /Q pwsh && (
+    SET "powershell_executable=call pwsh"
 ) || WHERE /Q PowerShell.exe && (
     SET powershell_executable=PowerShell.exe
 ) || (

--- a/bin/flutter-dev.bat
+++ b/bin/flutter-dev.bat
@@ -37,8 +37,8 @@ IF "%ERRORLEVEL%" NEQ "0" (
 REM Detect which PowerShell executable is available on the host
 REM PowerShell version <= 5: PowerShell.exe
 REM PowerShell version >= 6: pwsh.exe
-WHERE /Q pwsh.exe && (
-    SET powershell_executable=pwsh.exe
+WHERE /Q pwsh && (
+    SET "powershell_executable=call pwsh"
 ) || WHERE /Q PowerShell.exe && (
     SET powershell_executable=PowerShell.exe
 ) || (

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -32,8 +32,8 @@ IF "%ERRORLEVEL%" NEQ "0" (
 REM Detect which PowerShell executable is available on the host
 REM PowerShell version <= 5: PowerShell.exe
 REM PowerShell version >= 6: pwsh.exe
-WHERE /Q pwsh.exe && (
-    SET powershell_executable=pwsh.exe
+WHERE /Q pwsh && (
+    SET "powershell_executable=call pwsh"
 ) || WHERE /Q PowerShell.exe && (
     SET powershell_executable=PowerShell.exe
 ) || (


### PR DESCRIPTION
After git clone flutter/flutter, flutter commands require the use of powershell to run ps1 scripts. On my corporate workstation, I need to use a pwsh.bat wrapper to run ps1 scripts.

This PR uses `pwsh` instead of `pwsh.exe` to find and use a bat wrapper from the path if present. 

Closes https://github.com/flutter/flutter/issues/171777.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.