### PR TITLE
[ Tool ] Support upgrading to a new Flutter version pointing to the same revision as a previous version

### DIFF
--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -123,7 +123,10 @@ class UpgradeCommandRunner {
     required bool verifyOnly,
   }) async {
     final FlutterVersion upstreamVersion = await fetchLatestVersion(localVersion: flutterVersion);
-    if (flutterVersion.frameworkRevision == upstreamVersion.frameworkRevision) {
+    // It's possible for a given framework revision to have multiple tags (i.e., due to a release
+    // rollback). Verify the upstream version tag isn't newer than the current tag.
+    if (flutterVersion.frameworkRevision == upstreamVersion.frameworkRevision &&
+        flutterVersion.gitTagVersion.gitTag.compareTo(upstreamVersion.gitTagVersion.gitTag) >= 0) {
       globals.printStatus('Flutter is already up to date on channel ${flutterVersion.channel}');
       globals.printStatus('$flutterVersion');
       return;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -963,15 +963,15 @@ String _shortGitRevision(String? revision) {
 /// Version of Flutter SDK parsed from Git.
 class GitTagVersion {
   const GitTagVersion({
-    this.x,
-    this.y,
-    this.z,
+    required this.x,
+    required this.y,
+    required this.z,
+    required this.hash,
+    required this.gitTag,
     this.hotfix,
     this.devVersion,
     this.devPatch,
     this.commits,
-    this.hash,
-    this.gitTag,
   });
   const GitTagVersion.unknown()
     : x = null,
@@ -1000,7 +1000,7 @@ class GitTagVersion {
   final int? commits;
 
   /// The git hash (or an abbreviation thereof) for this commit.
-  final String? hash;
+  final String hash;
 
   /// The N in X.Y.Z-dev.N.M.
   final int? devVersion;
@@ -1009,7 +1009,7 @@ class GitTagVersion {
   final int? devPatch;
 
   /// The git tag that is this version's closest ancestor.
-  final String? gitTag;
+  final String gitTag;
 
   static GitTagVersion determine(
     ProcessUtils processUtils,
@@ -1032,12 +1032,13 @@ class GitTagVersion {
         _runGit('git fetch $flutterGit --tags -f', processUtils, workingDirectory);
       }
     }
-    // find all tags attached to the given [gitRef]
+    // find all tags attached to the given [gitRef]. These are returned in alphabetical order, so
+    // we reverse the set of tags to examine the most recent tag versions first.
     final List<String> tags = _runGit(
       'git tag --points-at $gitRef',
       processUtils,
       workingDirectory,
-    ).trim().split('\n');
+    ).trim().split('\n').reversed.toList();
 
     // Check first for a stable tag
     final RegExp stableTagPattern = RegExp(r'^\d+\.\d+\.\d+$');
@@ -1116,11 +1117,11 @@ class GitTagVersion {
   }
 
   String frameworkVersionFor(String revision) {
-    if (x == null || y == null || z == null || (hash != null && !revision.startsWith(hash!))) {
+    if (x == null || y == null || z == null || !revision.startsWith(hash)) {
       return kUnknownFrameworkVersion;
     }
-    if (commits == 0 && gitTag != null) {
-      return gitTag!;
+    if (commits == 0) {
+      return gitTag;
     }
     if (hotfix != null) {
       // This is an unexpected state where untagged commits exist past a hotfix

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -102,6 +102,8 @@ void main() {
             z: 10,
             hotfix: 13,
             commits: 2,
+            hash: '',
+            gitTag: frameworkVersion,
           );
           final FakeFlutterVersion fakeFlutterVersion = FakeFlutterVersion(
             gitTagVersion: gitTagVersion,
@@ -135,7 +137,15 @@ void main() {
         'throws when license not found',
         () async {
           final FakeFlutterVersion fakeFlutterVersion = FakeFlutterVersion(
-            gitTagVersion: const GitTagVersion(x: 1, y: 13, z: 10, hotfix: 13, commits: 0),
+            gitTagVersion: const GitTagVersion(
+              x: 1,
+              y: 13,
+              z: 10,
+              hotfix: 13,
+              commits: 0,
+              hash: '',
+              gitTag: '1.13.10+hotfix.14.0',
+            ),
           );
 
           final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
@@ -159,7 +169,7 @@ void main() {
       );
 
       group('is created', () {
-        const String frameworkVersion = 'v1.13.11+hotfix.13';
+        const String frameworkVersion = 'v1.13.11+hotfix.14';
         const String licenseText = 'This is the license!';
 
         setUp(() {
@@ -174,16 +184,19 @@ void main() {
           testUsingContext(
             'created when forced',
             () async {
+              const String frameworkVersionWithCommits = '$frameworkVersion.pre.100';
               const GitTagVersion gitTagVersion = GitTagVersion(
                 x: 1,
                 y: 13,
                 z: 11,
                 hotfix: 13,
                 commits: 100,
+                hash: '',
+                gitTag: frameworkVersionWithCommits,
               );
               final FakeFlutterVersion fakeFlutterVersion = FakeFlutterVersion(
                 gitTagVersion: gitTagVersion,
-                frameworkVersion: frameworkVersion,
+                frameworkVersion: frameworkVersionWithCommits,
               );
 
               final BuildIOSFrameworkCommand command = BuildIOSFrameworkCommand(
@@ -209,16 +222,19 @@ void main() {
         group('not on master channel', () {
           late FakeFlutterVersion fakeFlutterVersion;
           setUp(() {
+            const String frameworkVersionWithCommits = '$frameworkVersion.pre.0';
             const GitTagVersion gitTagVersion = GitTagVersion(
               x: 1,
               y: 13,
               z: 11,
               hotfix: 13,
               commits: 0,
+              hash: '',
+              gitTag: frameworkVersionWithCommits,
             );
             fakeFlutterVersion = FakeFlutterVersion(
               gitTagVersion: gitTagVersion,
-              frameworkVersion: frameworkVersion,
+              frameworkVersion: frameworkVersionWithCommits,
             );
           });
 
@@ -387,13 +403,15 @@ void main() {
       testUsingContext(
         'throws when not on a released version',
         () async {
-          const String frameworkVersion = 'v1.13.10+hotfix-pre.2';
+          const String frameworkVersion = 'v1.13.10+hotfix.14.pre.2';
           const GitTagVersion gitTagVersion = GitTagVersion(
             x: 1,
             y: 13,
             z: 10,
             hotfix: 13,
             commits: 2,
+            hash: '',
+            gitTag: frameworkVersion,
           );
           final FakeFlutterVersion fakeFlutterVersion = FakeFlutterVersion(
             gitTagVersion: gitTagVersion,
@@ -427,7 +445,15 @@ void main() {
         'throws when license not found',
         () async {
           final FakeFlutterVersion fakeFlutterVersion = FakeFlutterVersion(
-            gitTagVersion: const GitTagVersion(x: 1, y: 13, z: 10, hotfix: 13, commits: 0),
+            gitTagVersion: const GitTagVersion(
+              x: 1,
+              y: 13,
+              z: 10,
+              hotfix: 13,
+              commits: 0,
+              hash: '',
+              gitTag: '1.13.10+hotfix.14.pre.0',
+            ),
           );
 
           final BuildMacOSFrameworkCommand command = BuildMacOSFrameworkCommand(
@@ -472,6 +498,8 @@ void main() {
                 z: 11,
                 hotfix: 13,
                 commits: 100,
+                hash: '',
+                gitTag: '$frameworkVersion.pre.100',
               );
               final FakeFlutterVersion fakeFlutterVersion = FakeFlutterVersion(
                 gitTagVersion: gitTagVersion,
@@ -507,6 +535,8 @@ void main() {
               z: 11,
               hotfix: 13,
               commits: 0,
+              hash: '',
+              gitTag: '$frameworkVersion.pre.0',
             );
             fakeFlutterVersion = FakeFlutterVersion(
               gitTagVersion: gitTagVersion,


### PR DESCRIPTION
In the case of a bad release, we should be able to release a new version of Flutter that points to the revision of the last good release.

This change updates the tool to not only compare framework revisions when determining if the current installation is up to date, and also updates the tag selection logic to pick the most recent version tag first.

Fixes https://github.com/flutter/flutter/issues/170679