### PR TITLE
[tool] Support FeatureFlags.isEnabled in google3

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'flutter_features.dart';
+library;
+
 import 'package:meta/meta.dart';
 
 import 'base/context.dart';
@@ -56,7 +59,25 @@ abstract class FeatureFlags {
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
-  bool isEnabled(Feature feature);
+  ///
+  /// This default implementation is used by google3 to facilitate rolls.
+  /// In Flutter, this is overriden by [FlutterFeatureFlags.isEnabled].
+  bool isEnabled(Feature feature) {
+    return switch (feature) {
+      flutterWebFeature => isWebEnabled,
+      flutterLinuxDesktopFeature => isLinuxEnabled,
+      flutterMacOSDesktopFeature => isMacOSEnabled,
+      flutterWindowsDesktopFeature => isWindowsEnabled,
+      flutterAndroidFeature => isAndroidEnabled,
+      flutterIOSFeature => isIOSEnabled,
+      flutterFuchsiaFeature => isFuchsiaEnabled,
+      flutterCustomDevicesFeature => areCustomDevicesEnabled,
+      cliAnimation => isCliAnimationEnabled,
+      nativeAssets => isNativeAssetsEnabled,
+      swiftPackageManager => isSwiftPackageManagerEnabled,
+      _ => throw UnsupportedError('Unknown feature "${feature.name}"'),
+    };
+  }
 
   /// All current Flutter feature flags.
   List<Feature> get allFeatures => const <Feature>[
@@ -81,7 +102,6 @@ abstract class FeatureFlags {
   }
 
   /// All Flutter feature flags that are enabled.
-  // This member is overriden in google3.
   Iterable<Feature> get allEnabledFeatures {
     return allFeatures.where(isEnabled);
   }

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -139,6 +139,13 @@ void main() {
 
       expect(featureNames, unorderedEquals(testFeatureNames));
     });
+
+    testUsingContext('FeatureFlags.isEnabled does not throw UnsupportedError', () {
+      final FeatureFlags testFeatureFlags = _DefaultFeatureFlags();
+      for (final Feature feature in featureFlags.allFeatures) {
+        expect(() => testFeatureFlags.isEnabled(feature), returnsNormally);
+      }
+    });
   });
 
   group('Linux Destkop', () {
@@ -473,3 +480,5 @@ final class _TestIsGetterForwarding with FlutterFeatureFlagsIsEnabled {
   @override
   Iterable<Feature> get allEnabledFeatures => throw UnimplementedError();
 }
+
+class _DefaultFeatureFlags extends FeatureFlags {}


### PR DESCRIPTION
Currently, google3's implementation of `FeatureFlags.isEnabled` throws. Instead, you have to call `FeatureFlags.isFooEnabled`, which in google3 returns hardcoded values (google3 does not allow for features to be enabled through configs).

This provides an implementation of `FeatureFlags.isEnabled` that returns the hardcoded values.

Part of https://github.com/flutter/flutter/issues/167668

### Alternatives considered

Since this implementation is used by google3, I considered downstreaming this logic to google3. However, this would be brittle: whenever we add a new feature flag, we would need to remember to update google3's `FeatureFlags.isEnabled` implementation. And since we need to roll the new flag to google3 before we can update google3's `FeatureFlags.isEnabled` implementation, we can't write a google3 test that verifies that all flags are supported by google3's `FeatureFlags.isEnabled`. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
