### PR TITLE
[web] Disable auto-formatting for the stack_trace.dart test file

### DIFF
--- a/dev/bots/suite_runners/run_web_tests.dart
+++ b/dev/bots/suite_runners/run_web_tests.dart
@@ -336,7 +336,6 @@ class WebTestsSuite {
     required String webRenderer,
     required String testAppDirectory,
     String? driver,
-    bool expectFailure = false,
     bool silenceBrowserOutput = false,
     bool expectWriteResponseFile = false,
     String expectResponseFileContent = '',
@@ -373,7 +372,6 @@ class WebTestsSuite {
         ],
         '--no-web-resources-cdn',
       ],
-      expectNonZeroExit: expectFailure,
       workingDirectory: testAppDirectory,
       environment: <String, String>{'FLUTTER_WEB': 'true'},
       removeLine: (String line) {

--- a/dev/integration_tests/web/lib/stack_trace.dart
+++ b/dev/integration_tests/web/lib/stack_trace.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// Auto-format is disabled for this file to keep stack trace lines and columns stable.
+
+// dart format off
+
 import 'dart:js_interop';
 
 import 'package:collection/collection.dart';
@@ -26,14 +30,13 @@ final List<StackFrame> expectedProfileStackFrames = callChain.map<StackFrame>((S
   );
 }).toList();
 
-// TODO(yjbanov): fix these stack traces when https://github.com/flutter/flutter/issues/50753 is fixed.
 const List<StackFrame> expectedDebugStackFrames = <StackFrame>[
   StackFrame(
     number: -1,
     packageScheme: 'package',
     package: 'web_integration',
     packagePath: 'stack_trace.dart',
-    line: 117,
+    line: 121,
     column: 3,
     className: '<unknown>',
     method: 'baz',
@@ -44,7 +47,7 @@ const List<StackFrame> expectedDebugStackFrames = <StackFrame>[
     packageScheme: 'package',
     package: 'web_integration',
     packagePath: 'stack_trace.dart',
-    line: 112,
+    line: 116,
     column: 3,
     className: '<unknown>',
     method: 'bar',
@@ -55,7 +58,7 @@ const List<StackFrame> expectedDebugStackFrames = <StackFrame>[
     packageScheme: 'package',
     package: 'web_integration',
     packagePath: 'stack_trace.dart',
-    line: 107,
+    line: 111,
     column: 3,
     className: '<unknown>',
     method: 'foo',

--- a/packages/integration_test/example/.gitignore
+++ b/packages/integration_test/example/.gitignore
@@ -31,7 +31,6 @@
 /build/
 
 # Web related
-lib/generated_plugin_registrant.dart
 
 # Symbolication related
 app.*.symbols


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/171725