### PR TITLE
Add detailed error message for BorderRadiusDirectional

### DIFF
--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -11,6 +11,7 @@ library;
 import 'package:flutter/foundation.dart';
 
 import 'basic_types.dart';
+import 'debug.dart';
 
 /// Base class for [BorderRadius] that allows for text-direction aware resolution.
 ///
@@ -785,7 +786,7 @@ class BorderRadiusDirectional extends BorderRadiusGeometry {
 
   @override
   BorderRadius resolve(TextDirection? direction) {
-    assert(direction != null);
+    assert(debugCheckCanResolveTextDirection(direction, '$BorderRadiusDirectional'));
     switch (direction!) {
       case TextDirection.rtl:
         return BorderRadius.only(

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -16,7 +16,7 @@
 library;
 
 import 'dart:io';
-import 'dart:ui' show Image, Picture, Size;
+import 'dart:ui' show Image, Picture, Size, TextDirection;
 
 import 'package:flutter/foundation.dart';
 
@@ -232,3 +232,38 @@ bool _defaultPictureCapture(Picture picture) => true;
 /// Tests may use this to capture the picture and run assertions on it.
 ShaderWarmUpImageCallback debugCaptureShaderWarmUpImage = _defaultImageCapture;
 bool _defaultImageCapture(Image image) => true;
+
+/// Asserts that a given [TextDirection] is not null.
+///
+/// Used by painting library classes that require a [TextDirection] to resolve
+/// their properties, such as [BorderRadiusDirectional].
+///
+/// See also:
+///
+///  * [debugCheckHasDirectionality], which is a similar widgets-library level function.
+bool debugCheckCanResolveTextDirection(TextDirection? direction, String target) {
+  assert(() {
+    if (direction == null) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('No TextDirection found.'),
+        ErrorDescription(
+          'To resolve $target properties, it must be provided with a TextDirection.',
+        ),
+        ErrorHint(
+          'This error usually occurs when $target is used in a widget without '
+          'a Directionality ancestor.',
+        ),
+        ErrorHint(
+          'Typically, the Directionality widget is introduced by the MaterialApp '
+          'or WidgetsApp widget at the top of your application widget tree. It '
+          'determines the ambient reading direction and is used, for example, to '
+          'determine how to lay out text, how to interpret "start" and "end" '
+          'values, and to resolve EdgeInsetsDirectional, '
+          'AlignmentDirectional, and other *Directional objects.',
+        ),
+      ]);
+    }
+    return true;
+  }());
+  return true;
+}

--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -238,6 +238,8 @@ bool _defaultImageCapture(Image image) => true;
 /// Used by painting library classes that require a [TextDirection] to resolve
 /// their properties, such as [BorderRadiusDirectional].
 ///
+/// Does nothing if asserts are disabled. Always returns true.
+///
 /// See also:
 ///
 ///  * [debugCheckHasDirectionality], which is a similar widgets-library level function.

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -357,6 +357,11 @@ bool debugCheckHasMediaQuery(BuildContext context) {
 /// hit.
 ///
 /// Does nothing if asserts are disabled. Always returns true.
+///
+/// See also:
+///
+///  * [debugCheckHasDirectionality], which is a similar, but more general
+///    painting-library level function.
 bool debugCheckHasDirectionality(
   BuildContext context, {
   String? why,

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -339,11 +339,7 @@ void main() {
         isFlutterError.having(
           (FlutterError e) => e.message,
           'message',
-          '''
-No TextDirection found.
-To resolve BorderRadiusDirectional properties, it must be provided with a TextDirection.
-This error usually occurs when BorderRadiusDirectional is used in a widget without a Directionality ancestor.
-Typically, the Directionality widget is introduced by the MaterialApp or WidgetsApp widget at the top of your application widget tree. It determines the ambient reading direction and is used, for example, to determine how to lay out text, how to interpret "start" and "end" values, and to resolve EdgeInsetsDirectional, AlignmentDirectional, and other *Directional objects.''',
+          allOf(contains('No TextDirection found.'), contains('without a Directionality ancestor')),
         ),
       ),
     );

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -328,6 +329,24 @@ void main() {
     expect(BorderRadiusDirectional.circular(15.0) ~/ 10.0, BorderRadiusDirectional.circular(1.0));
 
     expect(BorderRadiusDirectional.circular(15.0) % 10.0, BorderRadiusDirectional.circular(5.0));
+  });
+
+  test('BorderRadiusDirectional.resolve with null throws detailed error', () {
+    const BorderRadiusDirectional borderRadius = BorderRadiusDirectional.all(Radius.circular(1.0));
+    expect(
+      () => borderRadius.resolve(null),
+      throwsA(
+        isFlutterError.having(
+          (FlutterError e) => e.message,
+          'message',
+          '''
+No TextDirection found.
+To resolve BorderRadiusDirectional properties, it must be provided with a TextDirection.
+This error usually occurs when BorderRadiusDirectional is used in a widget without a Directionality ancestor.
+Typically, the Directionality widget is introduced by the MaterialApp or WidgetsApp widget at the top of your application widget tree. It determines the ambient reading direction and is used, for example, to determine how to lay out text, how to interpret "start" and "end" values, and to resolve EdgeInsetsDirectional, AlignmentDirectional, and other *Directional objects.''',
+        ),
+      ),
+    );
   });
 
   test('BorderRadiusDirectional.lerp() invariants', () {

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -743,7 +743,6 @@ void main() {
           ),
         ),
       );
-      await tester.pump();
 
       expect(
         tester.takeException(),

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -732,6 +732,33 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Container with BorderRadiusDirectional and no Directionality throws a detailed error',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Container(
+          decoration: const BoxDecoration(
+            borderRadius: BorderRadiusDirectional.all(Radius.circular(1.0)),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        tester.takeException(),
+        isFlutterError.having(
+          (FlutterError e) => e.message,
+          'message',
+          '''
+No TextDirection found.
+To resolve BorderRadiusDirectional properties, it must be provided with a TextDirection.
+This error usually occurs when BorderRadiusDirectional is used in a widget without a Directionality ancestor.
+Typically, the Directionality widget is introduced by the MaterialApp or WidgetsApp widget at the top of your application widget tree. It determines the ambient reading direction and is used, for example, to determine how to lay out text, how to interpret "start" and "end" values, and to resolve EdgeInsetsDirectional, AlignmentDirectional, and other *Directional objects.''',
+        ),
+      );
+    },
+  );
+
   testWidgets('using clipBehaviour and shadow, should not clip the shadow', (
     WidgetTester tester,
   ) async {
@@ -746,9 +773,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      RepaintBoundary(
-        child: Padding(padding: const EdgeInsets.all(30.0), child: container),
-      ),
+      RepaintBoundary(child: Padding(padding: const EdgeInsets.all(30.0), child: container)),
     );
 
     await expectLater(

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -737,8 +737,9 @@ void main() {
     (WidgetTester tester) async {
       await tester.pumpWidget(
         Container(
-          decoration: const BoxDecoration(
-            borderRadius: BorderRadiusDirectional.all(Radius.circular(1.0)),
+          decoration: BoxDecoration(
+            border: Border.all(),
+            borderRadius: const BorderRadiusDirectional.all(Radius.circular(1.0)),
           ),
         ),
       );
@@ -749,11 +750,7 @@ void main() {
         isFlutterError.having(
           (FlutterError e) => e.message,
           'message',
-          '''
-No TextDirection found.
-To resolve BorderRadiusDirectional properties, it must be provided with a TextDirection.
-This error usually occurs when BorderRadiusDirectional is used in a widget without a Directionality ancestor.
-Typically, the Directionality widget is introduced by the MaterialApp or WidgetsApp widget at the top of your application widget tree. It determines the ambient reading direction and is used, for example, to determine how to lay out text, how to interpret "start" and "end" values, and to resolve EdgeInsetsDirectional, AlignmentDirectional, and other *Directional objects.''',
+          allOf(contains('No TextDirection found.'), contains('without a Directionality ancestor')),
         ),
       );
     },
@@ -773,7 +770,9 @@ Typically, the Directionality widget is introduced by the MaterialApp or Widgets
     );
 
     await tester.pumpWidget(
-      RepaintBoundary(child: Padding(padding: const EdgeInsets.all(30.0), child: container)),
+      RepaintBoundary(
+        child: Padding(padding: const EdgeInsets.all(30.0), child: container),
+      ),
     );
 
     await expectLater(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds a more descriptive error message for cases when BorderRadiusDirectional is used in widgets whose ancestors aren't wrapped into Directionality.

Fixes https://github.com/flutter/flutter/issues/88644

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
