### PR TITLE
Optimize scale translate transforms

### DIFF
--- a/docs/roadmap/Roadmap.md
+++ b/docs/roadmap/Roadmap.md
@@ -7,7 +7,7 @@ _If you are a contributor or team of contributors with long-term plans for [cont
 # 2025
 
 This roadmap is aspirational. It represents primarily content gathered from those of us who work on Flutter as employees of Google. By now non-Google contributors outnumber those employed by Google, so this is not an exhaustive list of all the new and exciting things that we hope will come to Flutter this year!
-As aways in the software business it can be difficult to accurately forecast engineering work — even more so for an open source project. So please be mindful that what we cover here is a statement of intent and not a guarantee.
+As always in the software business it can be difficult to accurately forecast engineering work — even more so for an open source project. So please be mindful that what we cover here is a statement of intent and not a guarantee.
 
 ## Accessibility
 In 2024 we completed validation of several key use cases for accessibility on mobile platforms (iOS and Android). In 2025 we plan to focus on further accessibility support for the web platform.

--- a/engine/src/flutter/impeller/geometry/matrix.h
+++ b/engine/src/flutter/impeller/geometry/matrix.h
@@ -35,6 +35,31 @@ namespace impeller {
 ///                 * This is NOT the same as OpenGL! Be careful.
 ///               * NDC origin is at (0.0f, 0.0f, 0.5f).
 struct Matrix {
+  /// The transform complexity type for the matrix, targeting the primary
+  /// optimizable operations that rectangle transforms can take advantage
+  /// of.
+  ///
+  /// The caller can query the type of the matrix for either 3D or 2D
+  /// operations with the 2D query only considering the entries that
+  /// are involved in transforming 2D coordinates.
+  ///
+  /// @see Classify
+  /// @see Classify2D
+  enum class Type {
+    /// The matrix contains only values that can scale and transform
+    /// coordinates. An Identity matrix also qualifies as kScaleTranslate.
+    kScaleTranslate,
+
+    /// The matrix contains only values that can perform affine operations
+    /// on the coordinates (no perspective).
+    kAffine,
+
+    /// The matrix contains perspective values that require the most general
+    /// type of transform computations. Any NaN values in the matrix will
+    /// also result in this classification.
+    kGeneral,
+  };
+
   union {
     Scalar m[16];
     Scalar e[4][4];
@@ -234,6 +259,35 @@ struct Matrix {
     );
     // clang-format on
   }
+
+  /// Classify the |Type| of matrix for a 3D operation on coordinates of the
+  /// form {x,y,z,1}.
+  constexpr Type Classify() const {
+    if (m[3] == 0.0f && m[7] == 0.0f && m[11] == 0.0f && m[15] == 1.0f) {
+      if (m[1] == 0.0f && m[2] == 0.0f &&  //
+          m[4] == 0.0f && m[6] == 0.0f &&  //
+          m[8] == 0.0f && m[9] == 0.0f) {
+        return Type::kScaleTranslate;
+      }
+      return Type::kAffine;
+    } else {
+      return Type::kGeneral;
+    }
+  };
+
+  /// Classify the |Type| of matrix for a 2D operation on coordinates of the
+  /// form {x,y,0,1}. Matrix entries that only affect incoming or outgoing
+  /// z values are ignored.
+  constexpr inline Type Classify2D() const {
+    if (m[3] == 0.0f && m[7] == 0.0f && m[15] == 1.0f) {
+      if (m[1] == 0.0f && m[4] == 0.0f) {
+        return Type::kScaleTranslate;
+      }
+      return Type::kAffine;
+    } else {
+      return Type::kGeneral;
+    }
+  };
 
   /// The Matrix without its `w` components (without translation).
   constexpr Matrix Basis() const {

--- a/engine/src/flutter/impeller/geometry/rect.h
+++ b/engine/src/flutter/impeller/geometry/rect.h
@@ -441,8 +441,13 @@ struct TRect {
   ///         necessary.
   [[nodiscard]] constexpr TRect TransformAndClipBounds(
       const Matrix& transform) const {
-    if (!transform.HasPerspective2D()) {
-      return TransformBounds(transform);
+    switch (transform.Classify2D()) {
+      case Matrix::Type::kScaleTranslate:
+        return TransformBoundsTranslateScale2D(transform);
+      case Matrix::Type::kAffine:
+        return TransformBounds(transform);
+      case Matrix::Type::kGeneral:
+        break;
     }
 
     if (IsEmpty()) {
@@ -474,6 +479,14 @@ struct TRect {
   /// @brief  Creates a new bounding box that contains this transformed
   ///         rectangle.
   [[nodiscard]] constexpr TRect TransformBounds(const Matrix& transform) const {
+    switch (transform.Classify2D()) {
+      case Matrix::Type::kScaleTranslate:
+        return TransformBoundsTranslateScale2D(transform);
+      case Matrix::Type::kAffine:
+      case Matrix::Type::kGeneral:
+        break;
+    }
+
     if (IsEmpty()) {
       return {};
     }
@@ -483,6 +496,33 @@ struct TRect {
       return bounds.value();
     }
     FML_UNREACHABLE();
+  }
+
+  /// @brief  Creates a new bounding box that contains this transformed
+  ///         rectangle.
+  ///
+  /// [transform] must be a translate-scale only matrix.
+  [[nodiscard]] constexpr TRect TransformBoundsTranslateScale2D(
+      const Matrix& transform) const {
+    if (IsEmpty()) {
+      return {};
+    }
+
+    Scalar tx = transform.m[12];
+    Scalar ty = transform.m[13];
+    Scalar sx = transform.m[0];
+    Scalar sy = transform.m[5];
+
+    Scalar l = GetLeft() * sx + tx;
+    Scalar r = GetRight() * sx + tx;
+    Scalar t = GetTop() * sy + ty;
+    Scalar b = GetBottom() * sy + ty;
+
+    return TRect<float>::MakeLTRB(std::min(l, r),  //
+                                  std::min(t, b),  //
+                                  std::max(l, r),  //
+                                  std::max(t, b)   //
+    );
   }
 
   /// @brief  Constructs a Matrix that will map all points in the coordinate

--- a/engine/src/flutter/impeller/geometry/rect_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/rect_unittests.cc
@@ -3243,5 +3243,25 @@ TEST(RectTest, TransformAndClipBounds) {
   }
 }
 
+TEST(RectTest, TransformBoundsTranslateScale) {
+  std::vector<Matrix> matrices = {
+      Matrix::MakeTranslateScale({2, 2, 1}, {10, 10, 0}),
+      Matrix::MakeTranslateScale({-2, 2, 1}, {10, 10, 0}),
+      Matrix::MakeTranslateScale({2, -2, 1}, {10, 10, 0}),
+      Matrix::MakeTranslateScale({-2, -2, 1}, {10, 10, 0}),
+  };
+  std::vector<Rect> rects = {
+      Rect::MakeLTRB(0, 0, 10, 10), Rect::MakeLTRB(100, 100, 110, 110),
+      Rect::MakeLTRB(0, 0, 0, 0), Rect::MakeLTRB(-10, -10, 10, 10)};
+
+  for (auto i = 0u; i < matrices.size(); i++) {
+    for (auto j = 0u; j < rects.size(); j++) {
+      EXPECT_EQ(rects[j].TransformBounds(matrices[i]),
+                rects[j].TransformBoundsTranslateScale2D(matrices[i]))
+          << rects[j] << " * " << matrices[i];
+    }
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Taken partially from https://github.com/flutter/flutter/pull/170446 with only the changes to add a ScaleTranslate rectangle transform method brought over. Unlike the original PR, this PR will apply that optimized method for any caller who transforms a rectangle rather than just the matrix/clip tracker for the engine layer tree code.

A benchmark for the new methods is also provided to verify their improved performance.