### PR TITLE
Revert "Mark web_long_running_tests_2_5 as bringup"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1782,7 +1782,6 @@ targets:
 
   - name: Linux web_long_running_tests_2_5
     recipe: flutter/flutter_drone
-    bringup: true # brittle line numbers https://github.com/flutter/flutter/issues/171725
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Reverts flutter/flutter#171726

The failure is fixed in https://github.com/flutter/flutter/pull/171801 and the task has been green ever since.

<img width="275" alt="image" src="https://github.com/user-attachments/assets/f2fc18e6-7dcd-4017-a5c5-ade6988b0692" />

Follow up for https://github.com/flutter/flutter/issues/171725