### PR TITLE
[skia] Fix flag fiddling for Fuchsia, FreeType, & friends

### DIFF
--- a/engine/src/flutter/skia/BUILD.gn
+++ b/engine/src/flutter/skia/BUILD.gn
@@ -12,6 +12,11 @@ import("flutter_defines.gni")
 
 if (is_fuchsia) {
   import("//flutter/tools/fuchsia/gn-sdk/src/gn_configs.gni")
+
+  skia_use_gl = false
+  skia_use_icu = false
+  skia_use_freetype = true
+  skia_use_vulkan = true
 }
 
 # Skia public API, generally provided by :skia.
@@ -299,12 +304,12 @@ optional("fontmgr_fuchsia") {
   enabled = is_fuchsia
   public_defines = [ "SK_FONTMGR_FUCHSIA_AVAILABLE" ]
 
-  deps = []
+  deps = [ ":typeface_freetype" ]
 
   if (is_fuchsia) {
     deps += [ "${fuchsia_sdk}/fidl/fuchsia.fonts" ]
   } else {
-    deps = [ "//sdk/fidl/fuchsia.fonts" ]
+    deps += [ "//sdk/fidl/fuchsia.fonts" ]
   }
   public = skia_ports_fontmgr_fuchsia_public
   sources = skia_ports_fontmgr_fuchsia_sources


### PR DESCRIPTION
In https://review.skia.org/1017296, Skia deleted some logic in skia.gni that dealt with Fuchsia. Flutter had been unintentionally depending on that to set FreeType integration, as well as Ganesh GL/Vulkan and ICU. This moves those flags into Flutter's BUILD.gn file for Skia, making the explicit and keeping the old behavior the same as the new behavior.

I had to add an explicit dependency between the Fuchsia SkFontMgr and Freetype, which has been "just working" by accident before.

See https://g-issues.skia.org/issues/427681157 for more.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
