### PR TITLE
[tool] Make google3 have to override feature flags

### DIFF
--- a/docs/contributing/Feature-flags.md
+++ b/docs/contributing/Feature-flags.md
@@ -142,8 +142,8 @@ The following steps are required:
 
 1. Create a [G3Fix][] to update google3's [`Google3Features`][]:
 
-   [G3Fix]: https://g3doc.corp.google.com/company/teams/core/developer/acx/flutter/process/life_of_a_pr/index.md?cl=head#g3fix
-   [`Google3Features`]: http://google3/mobile/flutter/cli/context/lib/context.dart?q=symbol%3A%5CbGoogle3Features%5Cb%20case%3Ayes
+   [G3Fix]: http://go/g3fix
+   [`Google3Features`]: http://go/flutter-google3features
 
     1. Add a new field to `Google3Features` :
 

--- a/docs/contributing/Feature-flags.md
+++ b/docs/contributing/Feature-flags.md
@@ -116,7 +116,7 @@ The following steps are required:
    ```dart
    abstract class FeatureFlags {
      /// Whether to add unicorm emojis in lots of fun places.
-     bool get isUnicornEmojisEnabled => false;
+     bool get isUnicornEmojisEnabled;
    }
    ```
 
@@ -130,6 +130,38 @@ The following steps are required:
    ```
 
    [`FlutterFeatureFlagsIsEnabled`]: ../../packages/flutter_tools/lib/src/flutter_features.dart
+
+1. Add a new entry in `FeatureFlags.allFeatures`:
+
+   ```dart
+   List<Feature> get allFeatures => const <Feature>[
+     // ...
+     unicornEmojis,
+   ];
+   ```
+
+1. Create a [G3Fix][] to update google3's [`Google3Features`][]:
+
+   [G3Fix]: https://g3doc.corp.google.com/company/teams/core/developer/acx/flutter/process/life_of_a_pr/index.md?cl=head#g3fix
+   [`Google3Features`]: http://google3/mobile/flutter/cli/context/lib/context.dart?q=symbol%3A%5CbGoogle3Features%5Cb%20case%3Ayes
+
+    1. Add a new field to `Google3Features` :
+
+       ```dart
+       class Google3Features extends FeatureFlags {
+         @override
+         bool get isUnicornEmojisEnabled => true;
+       }
+       ```
+
+    2. Add a new entry to `Google3Features.allFeatures`:
+
+       ```dart
+       List<Feature> get allFeatures => const <Feature>[
+         // ...
+         unicornEmojis,
+       ];
+       ```
 
 ### Allowing flags to be enabled
 

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'flutter_features.dart';
+library;
+
 import 'package:meta/meta.dart';
 
 import 'base/context.dart';
@@ -11,52 +14,55 @@ FeatureFlags get featureFlags => context.get<FeatureFlags>()!;
 
 /// The interface used to determine if a particular [Feature] is enabled.
 ///
-/// The rest of the tools code should use this class instead of looking up
-/// features directly. To facilitate rolls to google3 and other clients, all
-/// flags should be provided with a default implementation here. Clients that
-/// use this class should extend instead of implement, so that new flags are
-/// picked up automatically.
+/// This class is extended in google3. Whenever a new flag is added,
+/// google3 must also be updated using a g3fix.
+///
+/// See also:
+///
+/// * [FlutterFeatureFlags], Flutter's implementation of this class.
+/// * https://github.com/flutter/flutter/blob/master/docs/contributing/Feature-flags.md,
+///   docs on feature flags and how to add or use them.
 abstract class FeatureFlags {
   /// const constructor so that subclasses can be const.
   const FeatureFlags();
 
   /// Whether flutter desktop for linux is enabled.
-  bool get isLinuxEnabled => false;
+  bool get isLinuxEnabled;
 
   /// Whether flutter desktop for macOS is enabled.
-  bool get isMacOSEnabled => false;
+  bool get isMacOSEnabled;
 
   /// Whether flutter web is enabled.
-  bool get isWebEnabled => false;
+  bool get isWebEnabled;
 
   /// Whether flutter desktop for Windows is enabled.
-  bool get isWindowsEnabled => false;
+  bool get isWindowsEnabled;
 
   /// Whether android is enabled.
-  bool get isAndroidEnabled => true;
+  bool get isAndroidEnabled;
 
   /// Whether iOS is enabled.
-  bool get isIOSEnabled => true;
+  bool get isIOSEnabled;
 
   /// Whether fuchsia is enabled.
-  bool get isFuchsiaEnabled => true;
+  bool get isFuchsiaEnabled;
 
   /// Whether custom devices are enabled.
-  bool get areCustomDevicesEnabled => false;
+  bool get areCustomDevicesEnabled;
 
   /// Whether animations are used in the command line interface.
-  bool get isCliAnimationEnabled => true;
+  bool get isCliAnimationEnabled;
 
   /// Whether native assets compilation and bundling is enabled.
-  bool get isNativeAssetsEnabled => true;
+  bool get isNativeAssetsEnabled;
 
   /// Whether Swift Package Manager dependency management is enabled.
-  bool get isSwiftPackageManagerEnabled => false;
+  bool get isSwiftPackageManagerEnabled;
 
   /// Whether to stop writing the `{FLUTTER_ROOT}/version` file.
   ///
   /// Tracking removal: <https://github.com/flutter/flutter/issues/171900>.
-  bool get isOmitLegacyVersionFileEnabled => false;
+  bool get isOmitLegacyVersionFileEnabled;
 
   /// Whether a particular feature is enabled for the current channel.
   ///

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -20,7 +20,7 @@ FeatureFlags get featureFlags => context.get<FeatureFlags>()!;
 /// See also:
 ///
 /// * [FlutterFeatureFlags], Flutter's implementation of this class.
-/// * https://github.com/flutter/flutter/blob/master/docs/contributing/Feature-flags.md,
+/// * https://github.com/flutter/flutter/blob/main/docs/contributing/Feature-flags.md,
 ///   docs on feature flags and how to add or use them.
 abstract class FeatureFlags {
   /// const constructor so that subclasses can be const.

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -792,6 +792,42 @@ class FakeFlutterFeatures extends FeatureFlags {
   final bool _enabled;
 
   @override
+  bool get isLinuxEnabled => _enabled;
+
+  @override
+  bool get isMacOSEnabled => _enabled;
+
+  @override
+  bool get isWebEnabled => _enabled;
+
+  @override
+  bool get isWindowsEnabled => _enabled;
+
+  @override
+  bool get isAndroidEnabled => _enabled;
+
+  @override
+  bool get isIOSEnabled => _enabled;
+
+  @override
+  bool get isFuchsiaEnabled => _enabled;
+
+  @override
+  bool get areCustomDevicesEnabled => _enabled;
+
+  @override
+  bool get isCliAnimationEnabled => _enabled;
+
+  @override
+  bool get isNativeAssetsEnabled => _enabled;
+
+  @override
+  bool get isSwiftPackageManagerEnabled => _enabled;
+
+  @override
+  bool get isOmitLegacyVersionFileEnabled => _enabled;
+
+  @override
   final List<Feature> allFeatures;
 
   @override


### PR DESCRIPTION
_⚠️ Landing this is blocked until: 1) https://critique.corp.google.com/cl/781275353 lands and 2) google3 is updated to add the new feature flag introduced in https://github.com/flutter/flutter/pull/171903._ 

Currently, google3's `Google3Features` extends `FeatureFlags`. As a result, google3 automatically gets the same feature flag values as in Flutter.

This makes Flutter's feature flag values abstract, thereby requiring that google3's `Google3Features` must explicitly set each feature flag's value.

Discussion that motivated this change:  https://github.com/flutter/flutter/pull/171797
Internal CL: https://critique.corp.google.com/cl/781275353
Part of: https://github.com/flutter/flutter/issues/167668

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
