### PR TITLE
[Web] Implement disabling interactive selection

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1532,6 +1532,8 @@ abstract class DefaultTextEditingStrategy
       return editingState;
     }
 
+    // If interactive selection is disabled, collapse the selection to the newly
+    // selected offset.
     var currentOffset = lastEditingState?.baseOffset ?? 0;
     if (activeDomElement.isA<DomHTMLInputElement>()) {
       final element = domElement as DomHTMLInputElement;
@@ -1542,7 +1544,6 @@ abstract class DefaultTextEditingStrategy
         'forward' => selectionEnd,
         _ => currentOffset == selectionStart ? selectionEnd : selectionStart,
       };
-      // TODO: Is this necessary? Or will Flutter framework send this back? Does that cause flicker?
       element.setSelectionRange(collapsedOffset, collapsedOffset);
       return editingState.copyWith(baseOffset: collapsedOffset, extentOffset: collapsedOffset);
     } else if (domElement.isA<DomHTMLTextAreaElement>()) {
@@ -1554,7 +1555,6 @@ abstract class DefaultTextEditingStrategy
         'forward' => selectionEnd,
         _ => currentOffset == selectionStart ? selectionEnd : selectionStart,
       };
-      // TODO: Is this necessary? Or will Flutter framework send this back? Does that cause flicker?
       element.setSelectionRange(collapsedOffset, collapsedOffset);
       return editingState.copyWith(baseOffset: collapsedOffset, extentOffset: collapsedOffset);
     } else {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1411,6 +1411,14 @@ abstract class DefaultTextEditingStrategy
       );
     }
 
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'copy', createDomEventListener(handleClipboardEvent)),
+    );
+
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'paste', createDomEventListener(handleClipboardEvent)),
+    );
+
     addCompositionEventHandlers(activeDomElement);
 
     preventDefaultForMouseEvents();
@@ -1516,7 +1524,6 @@ abstract class DefaultTextEditingStrategy
   }
 
   EditingState suppressInteractiveSelectionIfNeeded(EditingState editingState) {
-    // TODO: Flutter Web's click to move cursor seems to be broken with enableInteractiveSelection: false.
     if (inputConfiguration.enableInteractiveSelection) {
       return editingState;
     }
@@ -1535,6 +1542,7 @@ abstract class DefaultTextEditingStrategy
         'forward' => selectionEnd,
         _ => currentOffset == selectionStart ? selectionEnd : selectionStart,
       };
+      // TODO: Is this necessary? Or will Flutter framework send this back? Does that cause flicker?
       element.setSelectionRange(collapsedOffset, collapsedOffset);
       return editingState.copyWith(baseOffset: collapsedOffset, extentOffset: collapsedOffset);
     } else if (domElement.isA<DomHTMLTextAreaElement>()) {
@@ -1546,6 +1554,7 @@ abstract class DefaultTextEditingStrategy
         'forward' => selectionEnd,
         _ => currentOffset == selectionStart ? selectionEnd : selectionStart,
       };
+      // TODO: Is this necessary? Or will Flutter framework send this back? Does that cause flicker?
       element.setSelectionRange(collapsedOffset, collapsedOffset);
       return editingState.copyWith(baseOffset: collapsedOffset, extentOffset: collapsedOffset);
     } else {
@@ -1620,6 +1629,13 @@ abstract class DefaultTextEditingStrategy
     }
   }
 
+  void handleClipboardEvent(DomEvent event) {
+    // Prevent clipboard copy/paste if interactive selection is disabled.
+    if (!inputConfiguration.enableInteractiveSelection) {
+      event.preventDefault();
+    }
+  }
+
   void maybeSendAction(DomEvent e) {
     if (e.isA<DomKeyboardEvent>()) {
       final DomKeyboardEvent event = e as DomKeyboardEvent;
@@ -1634,15 +1650,15 @@ abstract class DefaultTextEditingStrategy
       }
 
       // Suppress shortcuts if interactive selection is disabled.
-      if (!inputConfiguration.enableInteractiveSelection) {
-        const shortcuts = <String>{'a', 'c', 'v'};
-        final isMacOs = ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs;
-        if (isMacOs && event.metaKey && shortcuts.contains(event.key)) {
-          event.preventDefault();
-        } else if (!isMacOs && event.ctrlKey && shortcuts.contains(event.key)) {
-          event.preventDefault();
-        }
-      }
+      // if (!inputConfiguration.enableInteractiveSelection) {
+      //   const shortcuts = <String>{'a', 'c', 'v'};
+      //   final isMacOs = ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs;
+      //   if (isMacOs && event.metaKey && shortcuts.contains(event.key)) {
+      //     event.preventDefault();
+      //   } else if (!isMacOs && event.ctrlKey && shortcuts.contains(event.key)) {
+      //     event.preventDefault();
+      //   }
+      // }
     }
   }
 
@@ -1814,6 +1830,14 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
       DomSubscription(activeDomElement, 'blur', createDomEventListener(handleBlur)),
     );
 
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'copy', createDomEventListener(handleClipboardEvent)),
+    );
+
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'paste', createDomEventListener(handleClipboardEvent)),
+    );
+
     addCompositionEventHandlers(activeDomElement);
 
     // Position the DOM element after it is focused.
@@ -1952,6 +1976,14 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
       DomSubscription(activeDomElement, 'blur', createDomEventListener(handleBlur)),
     );
 
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'copy', createDomEventListener(handleClipboardEvent)),
+    );
+
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'paste', createDomEventListener(handleClipboardEvent)),
+    );
+
     addCompositionEventHandlers(activeDomElement);
 
     preventDefaultForMouseEvents();
@@ -2036,6 +2068,14 @@ class FirefoxTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
     subscriptions.add(
       DomSubscription(activeDomElement, 'blur', createDomEventListener(handleBlur)),
+    );
+
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'copy', createDomEventListener(handleClipboardEvent)),
+    );
+
+    subscriptions.add(
+      DomSubscription(activeDomElement, 'paste', createDomEventListener(handleClipboardEvent)),
     );
 
     preventDefaultForMouseEvents();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1648,17 +1648,6 @@ abstract class DefaultTextEditingStrategy
         // Prevent the browser from inserting a new line.
         event.preventDefault();
       }
-
-      // Suppress shortcuts if interactive selection is disabled.
-      // if (!inputConfiguration.enableInteractiveSelection) {
-      //   const shortcuts = <String>{'a', 'c', 'v'};
-      //   final isMacOs = ui_web.browser.operatingSystem == ui_web.OperatingSystem.macOs;
-      //   if (isMacOs && event.metaKey && shortcuts.contains(event.key)) {
-      //     event.preventDefault();
-      //   } else if (!isMacOs && event.ctrlKey && shortcuts.contains(event.key)) {
-      //     event.preventDefault();
-      //   }
-      // }
     }
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1091,7 +1091,7 @@ class InputConfiguration {
 
   final TextCapitalizationConfig textCapitalization;
 
-  /// Whether the user can change the text seelction.
+  /// Whether the user can change the text selection.
   ///
   /// When this is false, the text selection cannot be adjusted by
   /// the user, text cannot be copied, and the user cannot paste into

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1532,34 +1532,13 @@ abstract class DefaultTextEditingStrategy
       return editingState;
     }
 
-    // If interactive selection is disabled, collapse the selection to the newly
-    // selected offset.
-    var currentOffset = lastEditingState?.baseOffset ?? 0;
-    if (activeDomElement.isA<DomHTMLInputElement>()) {
-      final element = domElement as DomHTMLInputElement;
-      final selectionStart = element.selectionStart?.toInt() ?? 0;
-      final selectionEnd = element.selectionEnd?.toInt() ?? 0;
-      final collapsedOffset = switch (element.selectionDirection) {
-        'backward' => selectionStart,
-        'forward' => selectionEnd,
-        _ => currentOffset == selectionStart ? selectionEnd : selectionStart,
-      };
-      element.setSelectionRange(collapsedOffset, collapsedOffset);
-      return editingState.copyWith(baseOffset: collapsedOffset, extentOffset: collapsedOffset);
-    } else if (domElement.isA<DomHTMLTextAreaElement>()) {
-      final element = domElement as DomHTMLTextAreaElement;
-      final selectionStart = element.selectionStart?.toInt() ?? 0;
-      final selectionEnd = element.selectionEnd?.toInt() ?? 0;
-      final collapsedOffset = switch (element.selectionDirection) {
-        'backward' => selectionStart,
-        'forward' => selectionEnd,
-        _ => currentOffset == selectionStart ? selectionEnd : selectionStart,
-      };
-      element.setSelectionRange(collapsedOffset, collapsedOffset);
-      return editingState.copyWith(baseOffset: collapsedOffset, extentOffset: collapsedOffset);
-    } else {
-      return editingState;
-    }
+    // If interactive selection is disabled, collapse the selection to the end.
+    final newEditingState = editingState.copyWith(
+      baseOffset: editingState.extentOffset,
+      extentOffset: editingState.extentOffset,
+    );
+    newEditingState.applyToDomElement(activeDomElement);
+    return newEditingState;
   }
 
   void handleBeforeInput(DomEvent event) {

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -726,6 +726,7 @@ Future<void> testMain() async {
       bool decimal = false,
       bool isMultiline = false,
       bool autofillEnabled = true,
+      bool enableInteractiveSelection = true,
     }) {
       final MethodCall setClient = MethodCall('TextInput.setClient', <dynamic>[
         ++clientId,
@@ -736,6 +737,7 @@ Future<void> testMain() async {
           decimal: decimal,
           isMultiline: isMultiline,
           autofillEnabled: autofillEnabled,
+          enableInteractiveSelection: enableInteractiveSelection,
         ),
       ]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
@@ -2948,14 +2950,8 @@ Future<void> testMain() async {
     }, skip: true);
 
     test('Collapses selections if interactive selection disabled', () {
-      final MethodCall setClient = MethodCall('TextInput.setClient', <dynamic>[
-        123,
-        createFlutterConfig('text', enableInteractiveSelection: false),
-      ]);
-      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+      final int clientId = showKeyboard(inputType: 'text', enableInteractiveSelection: false);
 
-      const MethodCall show = MethodCall('TextInput.show');
-      sendFrameworkMessage(codec.encodeMethodCall(show));
       // The Safari strategy doesn't insert the input element into the DOM until
       // it has received the geometry information.
       final List<double> transform = Matrix4.identity().storage.toList();
@@ -2985,7 +2981,7 @@ Future<void> testMain() async {
       expect(spy.messages[0].channel, 'flutter/textinput');
       expect(spy.messages[0].methodName, 'TextInputClient.updateEditingState');
       expect(spy.messages[0].methodArguments, <dynamic>[
-        123, // Client ID
+        clientId,
         <String, dynamic>{
           'text': 'something',
           'selectionBase': 5,

--- a/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/text_editing_test.dart
@@ -2969,6 +2969,7 @@ Future<void> testMain() async {
 
       spy.messages.clear();
 
+      // Forward selection collapses at the end.
       input.setSelectionRange(2, 5, 'forward');
       if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
         final DomEvent keyup = createDomEvent('Event', 'keyup');
@@ -2986,6 +2987,30 @@ Future<void> testMain() async {
           'text': 'something',
           'selectionBase': 5,
           'selectionExtent': 5,
+          'composingBase': -1,
+          'composingExtent': -1,
+        },
+      ]);
+      spy.messages.clear();
+
+      // Backward selection collapses at the start.
+      input.setSelectionRange(2, 5, 'backward');
+      if (ui_web.browser.browserEngine == ui_web.BrowserEngine.firefox) {
+        final DomEvent keyup = createDomEvent('Event', 'keyup');
+        textEditing!.strategy.domElement!.dispatchEvent(keyup);
+      } else {
+        domDocument.dispatchEvent(createDomEvent('Event', 'selectionchange'));
+      }
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingState');
+      expect(spy.messages[0].methodArguments, <dynamic>[
+        clientId,
+        <String, dynamic>{
+          'text': 'something',
+          'selectionBase': 2,
+          'selectionExtent': 2,
           'composingBase': -1,
           'composingExtent': -1,
         },


### PR DESCRIPTION
This updates Flutter Web to ignore copy/paste/selections if `enableInteractiveSelection` is `false` in a text field.

Part of https://github.com/flutter/flutter/issues/157611

## Scenarios tested

1. Click/tap on text: cursor should not move.
2. Double click/tap on text: text should not be selected
3. Triple click/tap on text: text should not be selected
4. Move cursor back (`Left arrow`): cursor should move back
5. Move cursor forward (`Right arrow`): cursor should move forward
8. Select previous word (`Shift+Left arrow`): text should not be selected, cursor moves to previous word
9. Select previous word (`Shift+Right arrow`): text should not be selected, cursor moves the next word
7. Select all shortcut (`Ctrl+A` or `Apple+A`): text should not be selected. ⚠️ With this fix, Flutter Web moves the cursor to the end of the text field.
8. Copy shortcut (`Ctrl+C` or `Apple+C`): clipboard should not be updated
9. Paste shortcut (`Ctrl+V` or `Apple+V`): clipboard should not be pasted
10. Right-click > Copy: clipboard should not be updated
11. Right-click > Paste: clipboard should not be pasted

## Browsers tested

macOS: Chrome, Firefox, Safari

## Example app

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(
    MaterialApp(
      home: Scaffold(
        body: SafeArea(
          child: TextField(
            enableInteractiveSelection: false,
          ),
        ),
      ),
    ),
  );
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
