### PR TITLE
fix: focus traversal into nested scrollable

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -815,7 +815,6 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     TraversalDirection direction, {
     bool forward = true,
   }) {
-    final ScrollableState? focusedScrollable = Scrollable.maybeOf(focusedChild.context!);
     switch (direction) {
       case TraversalDirection.down:
       case TraversalDirection.up:
@@ -827,14 +826,6 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         );
         if (eligibleNodes.isEmpty) {
           break;
-        }
-        if (focusedScrollable != null && !focusedScrollable.position.atEdge) {
-          final Iterable<FocusNode> filteredEligibleNodes = eligibleNodes.where(
-            (FocusNode node) => Scrollable.maybeOf(node.context!) == focusedScrollable,
-          );
-          if (filteredEligibleNodes.isNotEmpty) {
-            eligibleNodes = filteredEligibleNodes;
-          }
         }
         if (direction == TraversalDirection.up) {
           eligibleNodes = eligibleNodes.toList().reversed;
@@ -878,14 +869,6 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         );
         if (eligibleNodes.isEmpty) {
           break;
-        }
-        if (focusedScrollable != null && !focusedScrollable.position.atEdge) {
-          final Iterable<FocusNode> filteredEligibleNodes = eligibleNodes.where(
-            (FocusNode node) => Scrollable.maybeOf(node.context!) == focusedScrollable,
-          );
-          if (filteredEligibleNodes.isNotEmpty) {
-            eligibleNodes = filteredEligibleNodes;
-          }
         }
         if (direction == TraversalDirection.left) {
           eligibleNodes = eligibleNodes.toList().reversed;


### PR DESCRIPTION
- Fix for https://github.com/flutter/flutter/issues/160431.
- Checking of eligible node `Scrollable` is equals to `focusedScrollable` prevent this node of receive a focus. This logic makes focus navigation on TV devices complicated in a case of a combination of vertical scroll and horizontal lists.