### PR TITLE
Create `release-candidate-branch.version`

### DIFF
--- a/bin/internal/release-candidate-branch.version
+++ b/bin/internal/release-candidate-branch.version
@@ -1,0 +1,1 @@
+flutter-3.35-candidate.0


### PR DESCRIPTION
Starts the `flutter-3.35-candidate.0` release branch.

Towards https://github.com/flutter/flutter/issues/172014.