### PR TITLE
Fix grammar: Change 'A' to 'An' before IOSSystemContextMenuItemData

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2888,7 +2888,7 @@ sealed class IOSSystemContextMenuItemData {
   }
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in copy button.
+/// An [IOSSystemContextMenuItemData] for the system's built-in copy button.
 ///
 /// The title and action are both handled by the platform.
 ///
@@ -2906,7 +2906,7 @@ final class IOSSystemContextMenuItemDataCopy extends IOSSystemContextMenuItemDat
   String get _jsonType => 'copy';
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in cut button.
+/// An [IOSSystemContextMenuItemData] for the system's built-in cut button.
 ///
 /// The title and action are both handled by the platform.
 ///
@@ -2924,7 +2924,7 @@ final class IOSSystemContextMenuItemDataCut extends IOSSystemContextMenuItemData
   String get _jsonType => 'cut';
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in paste button.
+/// An [IOSSystemContextMenuItemData] for the system's built-in paste button.
 ///
 /// The title and action are both handled by the platform.
 ///
@@ -2942,7 +2942,7 @@ final class IOSSystemContextMenuItemDataPaste extends IOSSystemContextMenuItemDa
   String get _jsonType => 'paste';
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in select all
+/// An [IOSSystemContextMenuItemData] for the system's built-in select all
 /// button.
 ///
 /// The title and action are both handled by the platform.
@@ -2961,7 +2961,7 @@ final class IOSSystemContextMenuItemDataSelectAll extends IOSSystemContextMenuIt
   String get _jsonType => 'selectAll';
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in look up
+/// An [IOSSystemContextMenuItemData] for the system's built-in look up
 /// button.
 ///
 /// Must specify a [title], typically [WidgetsLocalizations.lookUpButtonLabel].
@@ -2993,7 +2993,7 @@ final class IOSSystemContextMenuItemDataLookUp extends IOSSystemContextMenuItemD
   }
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in search web
+/// An [IOSSystemContextMenuItemData] for the system's built-in search web
 /// button.
 ///
 /// Must specify a [title], typically
@@ -3026,7 +3026,7 @@ final class IOSSystemContextMenuItemDataSearchWeb extends IOSSystemContextMenuIt
   }
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in share button.
+/// An [IOSSystemContextMenuItemData] for the system's built-in share button.
 ///
 /// Must specify a [title], typically
 /// [WidgetsLocalizations.shareButtonLabel].
@@ -3058,7 +3058,7 @@ final class IOSSystemContextMenuItemDataShare extends IOSSystemContextMenuItemDa
   }
 }
 
-/// A [IOSSystemContextMenuItemData] for the system's built-in Live Text
+/// An [IOSSystemContextMenuItemData] for the system's built-in Live Text
 /// (OCR) button.
 ///
 /// This button is only available on iOS 15.0+ devices with camera support.


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR fixes a grammar issue in the documentation comments for `IOSSystemContextMenuItemData` subclasses in `text_input.dart`.

Follow-up to #170969.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
