### PR TITLE
Fix a race in FlutterEngineTest.CanLogToStdout

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTestUtils.swift
+++ b/engine/src/flutter/shell/platform/darwin/common/framework/Source/LoggerTestUtils.swift
@@ -11,16 +11,23 @@ public final class StringOutputWriter: NSObject, OutputWriter {
   @objc public var didLog = false
   public var lastLevel: LogLevel!
   @objc public var lastLine: String!
+  @objc public var expectedOutput: String?
+  @objc public var gotExpectedOutput = false
 
   public func writeLine(level: LogLevel, _ message: String) {
     didLog = true
     lastLevel = level
     lastLine = message
+    if let expectedOutput, message.contains(expectedOutput) {
+      gotExpectedOutput = true
+    }
   }
 
   @objc public func reset() {
     didLog = false
     lastLevel = nil
     lastLine = nil
+    expectedOutput = nil
+    gotExpectedOutput = false
   }
 }

--- a/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -212,6 +212,7 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
 
   // Replace stdout stream buffer with our own.
   FlutterStringOutputWriter* writer = [[FlutterStringOutputWriter alloc] init];
+  writer.expectedOutput = @"Hello logging";
   FlutterLogger.outputWriter = writer;
 
   // Launch the test entrypoint.
@@ -224,7 +225,7 @@ TEST_F(FlutterEngineTest, CanLogToStdout) {
   }
 
   // Verify hello world was written to stdout.
-  EXPECT_TRUE([writer.lastLine containsString:@"Hello logging"]);
+  EXPECT_TRUE(writer.gotExpectedOutput);
 }
 
 TEST_F(FlutterEngineTest, DISABLED_BackgroundIsBlack) {


### PR DESCRIPTION
FlutterEngineTest.CanLogToStdout has been flaking on CI.  This fixes a potential cause of the flakes that could happen if other strings are logged by the Dart VM after the print statement run by the test.