### PR TITLE
Platform views shouldn't receive pointer events when not laid out

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -344,6 +344,13 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
 
   // This is registered as a global PointerRoute while the render object is attached.
   void _handleGlobalPointerEvent(PointerEvent event) {
+    // Don't receive pointer events if not laid out. For example, a RenderBox
+    // that is offscreen could be attached but not laid out, and in that case it
+    // should not be interactive with a pointer.
+    // See https://github.com/flutter/flutter/issues/83481.
+    if (!hasSize) {
+      return;
+    }
     if (event is! PointerDownEvent) {
       return;
     }

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -11,11 +11,19 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../services/fake_platform_views.dart';
 import 'rendering_tester.dart';
 
 void main() {
   final TestRenderingFlutterBinding binding = TestRenderingFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    // Lay out a dummy RenderBox to make sure that anything that was laid out
+    // during the test gets detached.
+    final RenderBox emptyRenderBox = RenderCustomPaint(painter: _EmptyPainter());
+    layout(emptyRenderBox);
+  });
 
   group('PlatformViewRenderBox', () {
     late FakePlatformViewController fakePlatformViewController;
@@ -379,6 +387,177 @@ void main() {
       expect(futureCallbackRan, true);
     });
   });
+
+  group('RenderDarwinPlatformView', () {
+    const MethodChannel channel = MethodChannel('flutter/platform_views');
+    late int gestureRejections;
+    late Completer<void> viewCreation;
+
+    setUp(() {
+      gestureRejections = 0;
+      viewCreation = Completer<void>();
+
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+        MethodCall methodCall,
+      ) async {
+        switch (methodCall.method) {
+          case 'create':
+            await viewCreation.future;
+          case 'rejectGesture':
+            gestureRejections++;
+          default:
+            throw UnsupportedError('Unexpected method call ${methodCall.method}.');
+        }
+        return /*textureId=*/ 0;
+      });
+    });
+
+    tearDown(() {
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/83481.
+    test('RenderUiKitView does not handle pointer events when not laid out', () async {
+      await FakeAsync().run((FakeAsync async) {
+        PlatformViewsService.initUiKitView(
+          id: 0,
+          viewType: 'webview',
+          layoutDirection: TextDirection.ltr,
+        ).then((UiKitViewController viewController) {
+          final RenderUiKitView renderBox = RenderUiKitView(
+            viewController: viewController,
+            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+          );
+          renderBox.attach(TestRenderingFlutterBinding.instance.pipelineOwner);
+
+          expect(renderBox.debugNeedsLayout, isTrue);
+          expect(gestureRejections, 0);
+
+          const PointerDownEvent event = PointerDownEvent(position: Offset(10, 10));
+          GestureBinding.instance.pointerRouter.route(event);
+
+          // Didn't receive the gesture because the RenderBox is not laid out,
+          // even though it's attached.
+          expect(gestureRejections, 0);
+
+          renderBox.detach();
+        });
+
+        viewCreation.complete();
+        async.flushMicrotasks();
+      });
+    });
+
+    test('RenderUiKitView handles pointer events when laid out', () async {
+      await FakeAsync().run((FakeAsync async) {
+        PlatformViewsService.initUiKitView(
+          id: 0,
+          viewType: 'webview',
+          layoutDirection: TextDirection.ltr,
+        ).then((UiKitViewController viewController) {
+          final RenderUiKitView renderBox = RenderUiKitView(
+            viewController: viewController,
+            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+          );
+
+          expect(renderBox.debugNeedsLayout, isTrue);
+          expect(gestureRejections, 0);
+
+          const PointerDownEvent event = PointerDownEvent(position: Offset(10, 10));
+          GestureBinding.instance.pointerRouter.route(event);
+
+          // Didn't receive the gesture because the RenderBox is not laid out.
+          expect(gestureRejections, 0);
+
+          layout(renderBox);
+          pumpFrame(phase: EnginePhase.flushSemantics);
+          expect(renderBox.debugNeedsLayout, isFalse);
+
+          const PointerDownEvent event2 = PointerDownEvent(position: Offset(10, 10));
+          GestureBinding.instance.pointerRouter.route(event2);
+
+          // Now that the RenderBox is laid out, received the gesture.
+          expect(gestureRejections, 1);
+        });
+
+        viewCreation.complete();
+        async.flushMicrotasks();
+      });
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/83481.
+    test('RenderAppKitView does not handle pointer events when not laid out', () async {
+      await FakeAsync().run((FakeAsync async) {
+        PlatformViewsService.initAppKitView(
+          id: 0,
+          viewType: 'webview',
+          layoutDirection: TextDirection.ltr,
+        ).then((AppKitViewController viewController) {
+          final RenderAppKitView renderBox = RenderAppKitView(
+            viewController: viewController,
+            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+          );
+          renderBox.attach(TestRenderingFlutterBinding.instance.pipelineOwner);
+
+          expect(renderBox.debugNeedsLayout, isTrue);
+          expect(gestureRejections, 0);
+
+          const PointerDownEvent event = PointerDownEvent(position: Offset(10, 10));
+          GestureBinding.instance.pointerRouter.route(event);
+
+          // Didn't receive the gesture because the RenderBox is not laid out.
+          expect(gestureRejections, 0);
+
+          renderBox.detach();
+        });
+
+        viewCreation.complete();
+        async.flushMicrotasks();
+      });
+    });
+
+    // Regression test for https://github.com/flutter/flutter/issues/83481.
+    test('RenderAppKitView handles pointer events when laid out', () async {
+      await FakeAsync().run((FakeAsync async) {
+        PlatformViewsService.initAppKitView(
+          id: 0,
+          viewType: 'webview',
+          layoutDirection: TextDirection.ltr,
+        ).then((AppKitViewController viewController) {
+          final RenderAppKitView renderBox = RenderAppKitView(
+            viewController: viewController,
+            hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+          );
+
+          expect(renderBox.debugNeedsLayout, isTrue);
+          expect(gestureRejections, 0);
+
+          const PointerDownEvent event = PointerDownEvent(position: Offset(10, 10));
+          GestureBinding.instance.pointerRouter.route(event);
+
+          // Didn't receive the gesture because the RenderBox is not laid out.
+          expect(gestureRejections, 0);
+
+          layout(renderBox);
+          pumpFrame(phase: EnginePhase.flushSemantics);
+          expect(renderBox.debugNeedsLayout, isFalse);
+
+          const PointerDownEvent event2 = PointerDownEvent(position: Offset(10, 10));
+          GestureBinding.instance.pointerRouter.route(event2);
+
+          // Now that the RenderBox is laid out, received the gesture.
+          expect(gestureRejections, 1);
+        });
+
+        viewCreation.complete();
+        async.flushMicrotasks();
+      });
+    });
+  });
 }
 
 ui.PointerData _pointerData(
@@ -399,4 +578,15 @@ ui.PointerData _pointerData(
     kind: kind,
     device: device,
   );
+}
+
+class _EmptyPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()..color = const Color(0x00000000);
+    canvas.drawRect(Offset.zero & size, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
 }


### PR DESCRIPTION
This PR makes platform views ignore pointer events when they're not laid out.

Platform views register themselves for global pointer events when their RenderBox attaches:

https://github.com/flutter/flutter/blob/9c626d9f9afa6da96433e3bfc4895492f87e0009/packages/flutter/lib/src/rendering/platform_view.dart#L370-L380

But a RenderBox that is attached is not necessarily laid out. The problem in the issue seemed to be that a page was created offscreen (attached and not laid out), but it still received pointer events, and this caused errors with using `size` before layout.

This PR simply ignores pointer events when not laid out.

Fixes https://github.com/flutter/flutter/issues/83481