### PR TITLE
Make sure that a MaterialBanner doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/banner_test.dart
+++ b/packages/flutter/test/material/banner_test.dart
@@ -1207,6 +1207,20 @@ void main() {
     final Size materialBarSize = tester.getSize(find.byType(MaterialBanner));
     expect(materialBarSize.height, equals(minActionBarHeight));
   });
+
+  testWidgets('MaterialBanner renders at zero size', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: MaterialBanner(content: Text('X'), actions: <Widget>[SizedBox.shrink()]),
+          ),
+        ),
+      ),
+    );
+    final Finder content = find.text('X');
+    expect(tester.getSize(content).isEmpty, isTrue);
+  });
 }
 
 Material _getMaterialFromBanner(WidgetTester tester) {


### PR DESCRIPTION
This is my attempt to handle #6537 for the MaterialBanner UI control.