### PR TITLE
[Android] remove obsolete gradle api in FGP

### DIFF
--- a/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
+++ b/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
@@ -21,7 +21,7 @@ List<VersionTuple> versionTuples = <VersionTuple>[
   // Template
   VersionTuple(agpVersion: '8.9.1', gradleVersion: '8.12', kotlinVersion: '2.1.0'),
   // Max known
-  VersionTuple(agpVersion: '8.10.0', gradleVersion: '8.12', kotlinVersion: '2.2.0'),
+  VersionTuple(agpVersion: '8.10.0', gradleVersion: '9.0.0-rc-2', kotlinVersion: '2.2.0'),
   /* Others */
   VersionTuple(agpVersion: '8.4.0', gradleVersion: '8.6', kotlinVersion: '1.8.22'),
   VersionTuple(agpVersion: '8.6.0', gradleVersion: '8.7', kotlinVersion: '1.8.22'),

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -755,10 +755,12 @@ class FlutterPlugin : Plugin<Project> {
                 ) {
                     dependsOn(compileTask)
                     with(compileTask.assets)
-                    // TODO(gmackall): Replace with filePermissions.user.read/write = true once
-                    //   minimum supported Gradle version is 8.3.
-                    @Suppress("DEPRECATION")
-                    fileMode = 420 // corresponds to unix 0644 in base 8
+                    filePermissions {
+                        user {
+                            read = true
+                            write = true
+                        }
+                    }
                     if (isUsedAsSubproject) {
                         // TODO(gmackall): above is always false, can delete
                         dependsOn(packageAssets)

--- a/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/FlutterPluginTest.kt
@@ -4,13 +4,25 @@ import com.android.build.api.dsl.ApplicationDefaultConfig
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.gradle.AbstractAppExtension
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.AndroidSourceDirectorySet
+import com.android.build.gradle.internal.core.InternalBaseVariant
+import com.android.build.gradle.tasks.MergeSourceSetFolders
+import com.android.build.gradle.tasks.ProcessAndroidResources
+import com.flutter.gradle.tasks.FlutterTask
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.verify
+import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.file.Directory
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.io.path.writeText
@@ -55,6 +67,8 @@ class FlutterPluginTest {
         val mockDirectory = mockk<Directory>(relaxed = true)
         every { project.layout.buildDirectory.get() } returns mockDirectory
         val mockAndroidSourceSet = mockk<com.android.build.gradle.api.AndroidSourceSet>(relaxed = true)
+        val mockAndroidSourceDirectorySet = mockk<AndroidSourceDirectorySet>(relaxed = true)
+        every { mockAndroidSourceSet.jniLibs.srcDir(any()) } returns mockAndroidSourceDirectorySet
         every { mockAbstractAppExtension.sourceSets.getByName("main") } returns mockAndroidSourceSet
         // mock return of NativePluginLoaderReflectionBridge.getPlugins
         mockkObject(NativePluginLoaderReflectionBridge)
@@ -69,6 +83,173 @@ class FlutterPluginTest {
         verify { project.tasks.register("generateLockfiles", any()) }
         verify { project.tasks.register("javaVersion", any()) }
         verify { project.tasks.register("printBuildVariants", any()) }
+    }
+
+    @Test
+    fun `copyFlutterAssets task sets filePermissions correctly`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("project-dir").resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+        val settingsFile = projectDir.parent.resolve("settings.gradle")
+        settingsFile.writeText("empty for now")
+        val fakeFlutterSdkDir = tempDir.resolve("fake-flutter-sdk")
+        fakeFlutterSdkDir.toFile().mkdirs()
+        val fakeCacheDir = fakeFlutterSdkDir.resolve("bin").resolve("cache")
+        fakeCacheDir.toFile().mkdirs()
+        val fakeEngineStampFile = fakeCacheDir.resolve("engine.stamp")
+        fakeEngineStampFile.writeText(FAKE_ENGINE_STAMP)
+        val fakeEngineRealmFile = fakeCacheDir.resolve("engine.realm")
+        fakeEngineRealmFile.writeText(FAKE_ENGINE_REALM)
+        val project = mockk<Project>(relaxed = true)
+        val mockAbstractAppExtension = mockk<AbstractAppExtension>(relaxed = true)
+        every { project.extensions.findByType(AbstractAppExtension::class.java) } returns mockAbstractAppExtension
+        every { project.extensions.getByType(AbstractAppExtension::class.java) } returns mockAbstractAppExtension
+        every { project.extensions.findByName("android") } returns mockAbstractAppExtension
+        every { project.projectDir } returns projectDir.toFile()
+        every { project.findProperty("flutter.sdk") } returns fakeFlutterSdkDir.toString()
+        every { project.file(fakeFlutterSdkDir.toString()) } returns fakeFlutterSdkDir.toFile()
+        val flutterExtension = FlutterExtension()
+        every { project.extensions.create("flutter", any<Class<*>>()) } returns flutterExtension
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns flutterExtension
+        val mockBaseExtension = mockk<BaseExtension>(relaxed = true)
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
+        val mockApplicationExtension = mockk<ApplicationExtension>(relaxed = true)
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockApplicationExtension
+        val mockApplicationDefaultConfig = mockk<ApplicationDefaultConfig>(relaxed = true)
+        every { mockApplicationExtension.defaultConfig } returns mockApplicationDefaultConfig
+        every { project.rootProject } returns project
+        every { project.state.failure } returns null
+        val mockDirectory = mockk<Directory>(relaxed = true)
+        every { project.layout.buildDirectory.get() } returns mockDirectory
+        val mockAndroidSourceSet = mockk<com.android.build.gradle.api.AndroidSourceSet>(relaxed = true)
+        val mockAndroidSourceDirectorySet = mockk<AndroidSourceDirectorySet>(relaxed = true)
+        every { mockAndroidSourceSet.jniLibs.srcDir(any()) } returns mockAndroidSourceDirectorySet
+        every { mockAbstractAppExtension.sourceSets.getByName("main") } returns mockAndroidSourceSet
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        mockkObject(NativePluginLoaderReflectionBridge)
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns
+            listOf()
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.file(flutterExtension.source!!) } returns mockk()
+        // Set up the task container and our task capture
+        val taskContainer = mockk<TaskContainer>(relaxed = true)
+        every { project.tasks } returns taskContainer
+        val copyTaskActionCaptor = slot<Action<Copy>>()
+        val copyTask = mockk<Copy>(relaxed = true)
+        val mockVariant = mockk<com.android.build.gradle.api.ApplicationVariant>(relaxed = true)
+        every { mockVariant.name } returns "debug"
+        every { mockVariant.buildType.name } returns "debug"
+        every { mockVariant.flavorName } returns ""
+        val mergedFlavor = mockk<InternalBaseVariant.MergedFlavor>(relaxed = true)
+        every { mockVariant.mergedFlavor } returns mergedFlavor
+        val apiLevel = mockk<com.android.builder.model.ApiVersion>(relaxed = true)
+        every { apiLevel.apiLevel } returns 21
+        every { mergedFlavor.minSdkVersion } returns apiLevel
+        val variantOutput = mockk<com.android.build.gradle.api.BaseVariantOutput>(relaxed = true)
+        val outputsIterator = mockk<MutableIterator<com.android.build.gradle.api.BaseVariantOutput>>()
+        every { outputsIterator.hasNext() } returns true andThen false
+        every { outputsIterator.next() } returns variantOutput
+        val variantOutputCollection = mockk<org.gradle.api.DomainObjectCollection<com.android.build.gradle.api.BaseVariantOutput>>()
+        every { variantOutputCollection.iterator() } returns outputsIterator
+        every { mockVariant.outputs } returns variantOutputCollection
+        val processResourcesProvider = mockk<TaskProvider<ProcessAndroidResources>>(relaxed = true)
+        every { processResourcesProvider.hint(ProcessAndroidResources::class).get() } returns mockk<ProcessAndroidResources>(relaxed = true)
+        every { variantOutput.processResourcesProvider } returns processResourcesProvider
+        val assembleTask = mockk<Task>(relaxed = true)
+        val assembleTaskProvider = mockk<TaskProvider<Task>>(relaxed = true)
+        every { assembleTaskProvider.get() } returns assembleTask
+        every { mockVariant.assembleProvider } returns assembleTaskProvider
+        val variants = listOf(mockVariant)
+        val variantsIterator = mockk<MutableIterator<com.android.build.gradle.api.ApplicationVariant>>()
+        every { variantsIterator.hasNext() } returns true andThen false
+        every { variantsIterator.next() } returns mockVariant
+        val variantCollection = mockk<org.gradle.api.DomainObjectSet<com.android.build.gradle.api.ApplicationVariant>>()
+        every { mockAbstractAppExtension.applicationVariants } returns variantCollection
+        every { variantCollection.iterator() } returns variantsIterator
+        every {
+            variantCollection.configureEach(any<Action<com.android.build.gradle.api.ApplicationVariant>>())
+        } answers {
+            variants.forEach { firstArg<Action<com.android.build.gradle.api.ApplicationVariant>>().execute(it) }
+        }
+        every { mockVariant.mergeAssetsProvider.hint(MergeSourceSetFolders::class).get() } returns
+            mockk<MergeSourceSetFolders>(relaxed = true)
+        val flutterTask = mockk<FlutterTask>(relaxed = true)
+        val copySpec = mockk<org.gradle.api.file.CopySpec>(relaxed = true)
+        every {
+            (flutterTask).assets
+        } returns copySpec
+        val flutterTaskProvider = mockk<TaskProvider<FlutterTask>>(relaxed = true)
+        every {
+            flutterTaskProvider.hint(FlutterTask::class).get()
+        } returns flutterTask
+        every {
+            taskContainer.register(
+                match { it.contains("compileFlutterBuild") },
+                any<Class<FlutterTask>>(),
+                any()
+            )
+        } answers {
+            flutterTaskProvider
+        }
+        // Actual task that should be captured to test if permissions have been set
+        val mockCopyTaskProvider = mockk<TaskProvider<Copy>>(relaxed = true)
+        every { mockCopyTaskProvider.hint(Copy::class).get() } returns copyTask
+        every {
+            taskContainer.register(
+                match { it.startsWith("copyFlutterAssets") },
+                eq(Copy::class.java),
+                capture(copyTaskActionCaptor)
+            )
+        } answers {
+            mockCopyTaskProvider
+        }
+        val mockJarTaskProvider = mockk<TaskProvider<org.gradle.api.tasks.bundling.Jar>>(relaxed = true)
+        every { mockJarTaskProvider.hint(org.gradle.api.tasks.bundling.Jar::class).get() } returns
+            mockk<org.gradle.api.tasks.bundling.Jar>(relaxed = true)
+        every {
+            taskContainer.register(
+                match { it.contains("packJniLibs") },
+                eq(org.gradle.api.tasks.bundling.Jar::class.java),
+                any()
+            )
+        } answers {
+            mockJarTaskProvider
+        }
+        val mockTaskProvider = mockk<TaskProvider<Task>>(relaxed = true)
+        every { mockTaskProvider.hint(Task::class).get() } returns mockk<Task>(relaxed = true)
+        every {
+            taskContainer.named(any<String>())
+        } returns mockTaskProvider
+        val flutterPlugin = FlutterPlugin()
+        flutterPlugin.apply(project)
+
+        copyTaskActionCaptor.captured.execute(copyTask)
+        val filePermissionsActionCaptor = slot<Action<org.gradle.api.file.ConfigurableFilePermissions>>()
+        verify {
+            copyTask.filePermissions(capture(filePermissionsActionCaptor))
+        }
+        if (filePermissionsActionCaptor.isCaptured) {
+            val mockFilePermissionSet = mockk<org.gradle.api.file.ConfigurableFilePermissions>(relaxed = true)
+            filePermissionsActionCaptor.captured.execute(mockFilePermissionSet)
+            val userPermissionsActionCaptor = slot<Action<org.gradle.api.file.ConfigurableUserClassFilePermissions>>()
+            verify {
+                mockFilePermissionSet.user(capture(userPermissionsActionCaptor))
+            }
+            if (userPermissionsActionCaptor.isCaptured) {
+                val mockUserPermission = mockk<org.gradle.api.file.ConfigurableUserClassFilePermissions>(relaxed = true)
+                userPermissionsActionCaptor.captured.execute(mockUserPermission)
+                verify {
+                    mockUserPermission.read = true
+                    mockUserPermission.write = true
+                }
+            } else {
+                fail("User permissions configuration action was not captured")
+            }
+        } else {
+            fail("FilePermissions configuration action was not captured")
+        }
     }
 
     companion object {


### PR DESCRIPTION
fixes #170791 

This PR replaces the deprecated (and removed in 9.0) Gradle fileMode API in favor of filePermissions. 
This change finally unlocks builds with gradle 9 (confirmed in smoke tests, 9.0.0-rc.2 is the latest prerelease version to the date).

**Testing strategy**

There's an attempt to add a Kotlin unit test that confirms that `filePermissions` were called during plugin application. I failed to find a more precise way to check if the new code works as intended (such as testing that permissions were really changed or something like that), but on the other hand, it should not be required since it will transform the test in a way that it will start to test Gradle APIs and their behavior, and I believe it's a bit out of scope: Gradle APIs are tested in Gradle tests :)

Anyway, this new test is a bit cumbersome because it's required to mock all the behaviours related to variants configuration and capturing calls – If it is not desired im not hesitant to remove it.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
