### PR TITLE
Make sure that a BottomAppBar doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -733,6 +733,18 @@ void main() {
     expect(iconButton.center.dy, barCenter);
     expect(fab.center.dy, barCenter);
   });
+
+  testWidgets('BottomAppBar renders at zero size', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: SizedBox.shrink(child: BottomAppBar(child: Text('X'))),
+        ),
+      ),
+    );
+    final Finder bottomAppBarChild = find.text('X');
+    expect(tester.getSize(bottomAppBarChild).isEmpty, isTrue);
+  });
 }
 
 // The bottom app bar clip path computation is only available at paint time.


### PR DESCRIPTION
This is my attempt to handle #6537 for the BottomAppBar UI control.