### PR TITLE
#171817

### DIFF
--- a/packages/flutter/lib/src/painting/debug.dart
+++ b/packages/flutter/lib/src/painting/debug.dart
@@ -18,6 +18,7 @@ library;
 import 'dart:io';
 import 'dart:ui' show Image, Picture, Size, TextDirection;
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 
 /// Whether to replace all shadows with solid color blocks.
@@ -236,7 +237,7 @@ bool _defaultImageCapture(Image image) => true;
 /// Asserts that a given [TextDirection] is not null.
 ///
 /// Used by painting library classes that require a [TextDirection] to resolve
-/// their properties, such as [BorderRadiusDirectional].
+/// their properties, such as [BorderRadiusDirectional], [EdgeInsetsDirectional].
 ///
 /// Does nothing if asserts are disabled. Always returns true.
 ///

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -12,6 +12,7 @@ import 'dart:ui' as ui show ViewPadding, lerpDouble;
 import 'package:flutter/foundation.dart';
 
 import 'basic_types.dart';
+import 'debug.dart';
 
 /// Base class for [EdgeInsets] that allows for text-direction aware
 /// resolution.
@@ -1005,7 +1006,7 @@ class _MixedEdgeInsets extends EdgeInsetsGeometry {
 
   @override
   EdgeInsets resolve(TextDirection? direction) {
-    assert(direction != null);
+    assert(debugCheckCanResolveTextDirection(direction, '$EdgeInsetsDirectional'));
     return switch (direction!) {
       TextDirection.rtl => EdgeInsets.fromLTRB(_end + _left, _top, _start + _right, _bottom),
       TextDirection.ltr => EdgeInsets.fromLTRB(_start + _left, _top, _end + _right, _bottom),

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -473,4 +474,23 @@ void main() {
     );
     expect(EdgeInsetsGeometry.zero, EdgeInsets.zero);
   });
+
+  test('EdgeInsetsDirectional.resolve with null throws detailed error', () {
+    const EdgeInsetsDirectional insets = EdgeInsetsDirectional.only(start: 8.0);
+    expect(
+          () => insets.resolve(null),
+      throwsA(
+        isFlutterError.having(
+              (FlutterError e) => e.message,
+          'message',
+          allOf(
+            contains('No TextDirection found.'),
+            contains('EdgeInsetsDirectional.resolve'),
+            contains('without a Directionality ancestor'),
+          ),
+        ),
+      ),
+    );
+  });
+
 }

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -779,6 +779,32 @@ void main() {
       matchesGoldenFile('container.clipBehaviour.with.shadow.png'),
     );
   });
+
+  testWidgets(
+    'Container with EdgeInsetsDirectional and no Directionality throws a detailed error',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const Padding(
+          padding: EdgeInsetsDirectional.only(start: 16.0),
+          child: Placeholder(),
+        ),
+      );
+
+      expect(
+        tester.takeException(),
+        isFlutterError.having(
+              (FlutterError e) => e.message,
+          'message',
+          allOf(
+            contains('No TextDirection found.'),
+            contains('EdgeInsetsDirectional.resolve'),
+            contains('without a Directionality ancestor'),
+          ),
+        ),
+      );
+    },
+  );
+
 }
 
 class _MockPaintingContext extends Fake implements PaintingContext {

--- a/packages/flutter_tools/test/data/vscode/application/Resources/app/package.json
+++ b/packages/flutter_tools/test/data/vscode/application/Resources/app/package.json
@@ -1,4 +1,0 @@
-{
-	"name": "fake-vs-code-install-for-tests",
-	"version": "1.2.3"
-}


### PR DESCRIPTION
This PR adds a debug assertion to EdgeInsetsDirectional.resolve to throw a detailed error when called with a null TextDirection, matching the pattern in #171805. Also included a unit test to verify the error message.

Fixes #171817

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
