### PR TITLE
[ Tool ] Downgrade and pin DDS to 5.0.3

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -23,6 +23,8 @@ const kManuallyPinnedDependencies = <String, String>{
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
   'code_assets':
       '0.19.4', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
+  'dds':
+      '5.0.3', // 5.0.4 contains bugs described in https://github.com/Dart-Code/Dart-Code/issues/4678.
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   # https://github.com/flutter/flutter/blob/main/docs/infra/Updating-dependencies-in-Flutter.md
   archive: 3.6.1
   args: 2.7.0
-  dds: 5.0.4
+  dds: 5.0.3
   dwds: 24.4.0
   code_builder: 4.10.1
   collection: 1.19.1
@@ -126,4 +126,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: kr614i
+# PUBSPEC CHECKSUM: 2b0aoj


### PR DESCRIPTION
The sole change in 5.0.4 can cause memory leaks in the VM. Pinning to 5.0.3 for the release cut.

See https://github.com/Dart-Code/Dart-Code/issues/4678 for details.