### PR TITLE
feat: Tag Fuchsia artifacts by content hash

### DIFF
--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -263,7 +263,7 @@ def ProcessCIPDPackage(upload, engine_version, content_hash):
     print('CIPD package flutter/fuchsia tag %s already exists!' % gitTag)
     return
 
-  contentTag = 'cah_revision:%s' % content_hash
+  contentTag = 'content_aware_hash:%s' % content_hash
   already_exists = CheckCIPDPackageExists('flutter/fuchsia', contentTag)
   if already_exists:
     print('CIPD package flutter/fuchsia tag %s already exists!' % contentTag)

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -413,7 +413,9 @@ def main():
         ci_config = json.load(f)
         upload_content_hash = ci_config.get('luci_flags', {}).get('upload_content_hash', False)
     if upload_content_hash:
-      script_path = os.path.join(_src_root_dir, '..', 'bin', 'internal', 'content_aware_hash.sh')
+      script_path = os.path.join(
+          _src_root_dir, '..', '..', 'bin', 'internal', 'content_aware_hash.sh'
+      )
       if os.path.exists(script_path):
         command = [script_path]
         try:

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -241,7 +241,7 @@ def RunCIPDCommandWithRetries(command):
         raise
 
 
-def ProcessCIPDPackage(upload, engine_version):
+def ProcessCIPDPackage(upload, engine_version, content_hash):
   if not upload or not IsLinux():
     RunCIPDCommandWithRetries([
         'cipd', 'pkg-build', '-pkg-def', 'fuchsia.cipd.yaml', '-out',
@@ -261,16 +261,19 @@ def ProcessCIPDPackage(upload, engine_version):
     print('CIPD package flutter/fuchsia tag %s already exists!' % tag)
     return
 
-  RunCIPDCommandWithRetries([
-      'cipd',
-      'create',
-      '-pkg-def',
-      'fuchsia.cipd.yaml',
-      '-ref',
-      'latest',
-      '-tag',
-      tag,
-  ])
+  print('codefu: tag:%s' % tag)
+
+  if false:
+    RunCIPDCommandWithRetries([
+        'cipd',
+        'create',
+        '-pkg-def',
+        'fuchsia.cipd.yaml',
+        '-ref',
+        'latest',
+        '-tag',
+        tag,
+    ])
 
 
 def main():
@@ -428,7 +431,7 @@ def main():
 
   # Create and optionally upload CIPD package
   if args.cipd_dry_run or args.upload:
-    ProcessCIPDPackage(should_upload, engine_version)
+    ProcessCIPDPackage(should_upload, engine_version, content_hash)
 
   return 0
 

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -263,13 +263,7 @@ def ProcessCIPDPackage(upload, engine_version, content_hash):
     print('CIPD package flutter/fuchsia tag %s already exists!' % gitTag)
     return
 
-  contentTag = 'content_aware_hash:%s' % content_hash
-  already_exists = CheckCIPDPackageExists('flutter/fuchsia', contentTag)
-  if already_exists:
-    print('CIPD package flutter/fuchsia tag %s already exists!' % contentTag)
-    return
-
-  RunCIPDCommandWithRetries([
+  command = [
       'cipd',
       'create',
       '-pkg-def',
@@ -278,9 +272,17 @@ def ProcessCIPDPackage(upload, engine_version, content_hash):
       'latest',
       '-tag',
       gitTag,
-      '-tag',
-      contentTag,
-  ])
+  ]
+
+  contentTag = 'content_aware_hash:%s' % content_hash
+  already_exists = CheckCIPDPackageExists('flutter/fuchsia', contentTag)
+  if already_exists:
+    print('CIPD package flutter/fuchsia tag %s already exists!' % contentTag)
+    # do not return; content hash can match multiple PRs (reverts, framework only)
+  else:
+    command.extend(['-tag', contentTag])
+
+  RunCIPDCommandWithRetries(command)
 
 
 def main():

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -257,10 +257,10 @@ def ProcessCIPDPackage(upload, engine_version, content_hash):
     print('--upload requires --engine-version to be specified.')
     return
 
-  gitTag = 'git_revision:%s' % engine_version
-  already_exists = CheckCIPDPackageExists('flutter/fuchsia', gitTag)
+  git_tag = 'git_revision:%s' % engine_version
+  already_exists = CheckCIPDPackageExists('flutter/fuchsia', git_tag)
   if already_exists:
-    print('CIPD package flutter/fuchsia tag %s already exists!' % gitTag)
+    print('CIPD package flutter/fuchsia tag %s already exists!' % git_tag)
     return
 
   command = [
@@ -271,16 +271,16 @@ def ProcessCIPDPackage(upload, engine_version, content_hash):
       '-ref',
       'latest',
       '-tag',
-      gitTag,
+      git_tag,
   ]
 
-  contentTag = 'content_aware_hash:%s' % content_hash
-  already_exists = CheckCIPDPackageExists('flutter/fuchsia', contentTag)
+  content_tag = 'content_aware_hash:%s' % content_hash
+  already_exists = CheckCIPDPackageExists('flutter/fuchsia', content_tag)
   if already_exists:
-    print('CIPD package flutter/fuchsia tag %s already exists!' % contentTag)
+    print('CIPD package flutter/fuchsia tag %s already exists!' % content_tag)
     # do not return; content hash can match multiple PRs (reverts, framework only)
   else:
-    command.extend(['-tag', contentTag])
+    command.extend(['-tag', content_tag])
 
   RunCIPDCommandWithRetries(command)
 
@@ -412,13 +412,13 @@ def main():
   should_upload = args.upload
   engine_version = args.engine_version
   content_hash = ''
-  if not engine_version:
-    engine_version = 'HEAD'
-    should_upload = False
-  else:
+  if engine_version:
     # When content hashing is enabled, the engine version will be a content
     # hash instead of a git revision.
     content_hash = get_content_hash()
+  else:
+    engine_version = 'HEAD'
+    should_upload = False
 
   # Create and optionally upload CIPD package
   if args.cipd_dry_run or args.upload:

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -257,23 +257,30 @@ def ProcessCIPDPackage(upload, engine_version, content_hash):
     print('--upload requires --engine-version to be specified.')
     return
 
+  gitTag = 'git_revision:%s' % engine_version
+  already_exists = CheckCIPDPackageExists('flutter/fuchsia', gitTag)
   if already_exists:
-    print('CIPD package flutter/fuchsia tag %s already exists!' % tag)
+    print('CIPD package flutter/fuchsia tag %s already exists!' % gitTag)
     return
 
-  print('codefu: tag:%s' % tag)
+  contentTag = 'cah_revision:%s' % content_hash
+  already_exists = CheckCIPDPackageExists('flutter/fuchsia', contentTag)
+  if already_exists:
+    print('CIPD package flutter/fuchsia tag %s already exists!' % contentTag)
+    return
 
-  if false:
-    RunCIPDCommandWithRetries([
-        'cipd',
-        'create',
-        '-pkg-def',
-        'fuchsia.cipd.yaml',
-        '-ref',
-        'latest',
-        '-tag',
-        tag,
-    ])
+  RunCIPDCommandWithRetries([
+      'cipd',
+      'create',
+      '-pkg-def',
+      'fuchsia.cipd.yaml',
+      '-ref',
+      'latest',
+      '-tag',
+      gitTag,
+      '-tag',
+      contentTag,
+  ])
 
 
 def main():

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -9,7 +9,6 @@
 
 import argparse
 import errno
-import json
 import os
 import platform
 import re
@@ -17,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from get_content_hash import get_content_hash
 
 _script_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..'))
 _src_root_dir = os.path.join(_script_dir, '..', '..', '..')
@@ -416,25 +416,7 @@ def main():
   else:
     # When content hashing is enabled, the engine version will be a content
     # hash instead of a git revision.
-    ci_config_path = os.path.join(_src_root_dir, 'flutter', 'ci', 'builders', 'linux_fuchsia.json')
-    upload_content_hash = False
-    if os.path.exists(ci_config_path):
-      with open(ci_config_path, 'r') as f:
-        ci_config = json.load(f)
-        upload_content_hash = ci_config.get('luci_flags', {}).get('upload_content_hash', False)
-    if upload_content_hash:
-      script_path = os.path.join(
-          _src_root_dir, '..', '..', 'bin', 'internal', 'content_aware_hash.sh'
-      )
-      if os.path.exists(script_path):
-        command = [script_path]
-        try:
-          content_hash = subprocess.check_output(command, text=True).strip()
-          print('Using content hash %s for engine version' % content_hash)
-        except subprocess.CalledProcessError as e:
-          print('Error getting content hash, falling back to git hash: %s' % e)
-      else:
-        print('Could not find content_aware_hash.sh at %s' % script_path)
+    content_hash = get_content_hash()
 
   # Create and optionally upload CIPD package
   if args.cipd_dry_run or args.upload:

--- a/engine/src/flutter/tools/fuchsia/get_content_hash.py
+++ b/engine/src/flutter/tools/fuchsia/get_content_hash.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+""" Shared code for handling content_aware_hashing for fuchsia.
+"""
+import json
+import os
+import subprocess
+
+_script_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..'))
+_src_root_dir = os.path.join(_script_dir, '..', '..', '..')
+
+
+def get_content_hash():
+  ci_config_path = os.path.join(_src_root_dir, 'flutter', 'ci', 'builders', 'linux_fuchsia.json')
+  upload_content_hash = False
+  if os.path.exists(ci_config_path):
+    with open(ci_config_path, 'r') as f:
+      ci_config = json.load(f)
+      upload_content_hash = ci_config.get('luci_flags', {}).get('upload_content_hash', False)
+  if upload_content_hash:
+    script_path = os.path.join(
+        _src_root_dir, '..', '..', 'bin', 'internal', 'content_aware_hash.sh'
+    )
+    if os.path.exists(script_path):
+      command = [script_path]
+      try:
+        content_hash = subprocess.check_output(command, text=True).strip()
+        print('Using content hash %s for engine version' % content_hash)
+        return content_hash
+      except subprocess.CalledProcessError as e:
+        print('Error getting content hash, falling back to git hash: %s' % e)
+    else:
+      print('Could not find content_aware_hash.sh at %s' % script_path)
+  return ''

--- a/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -82,18 +82,18 @@ def ProcessCIPDPackage(upload, cipd_yaml, engine_version, content_hash, out_dir,
   _packaging_dir = GetPackagingDir(out_dir)
   package_name = 'flutter/fuchsia-debug-symbols-%s' % target_arch
 
-  gitTag = 'git_revision:%s' % engine_version
-  already_exists = CheckCIPDPackageExists(package_name, gitTag)
+  git_tag = 'git_revision:%s' % engine_version
+  already_exists = CheckCIPDPackageExists(package_name, git_tag)
   if already_exists:
-    print('CIPD package %s tag %s already exists!' % (package_name, gitTag))
+    print('CIPD package %s tag %s already exists!' % (package_name, git_tag))
 
-  contentTag = ''
+  content_tag = ''
   if content_hash:
-    contentTag = 'content_aware_hash:%s' % content_hash
-    content_already_exists = CheckCIPDPackageExists(package_name, contentTag)
+    content_tag = 'content_aware_hash:%s' % content_hash
+    content_already_exists = CheckCIPDPackageExists(package_name, content_tag)
     if content_already_exists:
-      print('CIPD package %s tag %s already exists!' % (package_name, contentTag))
-      contentTag = ''
+      print('CIPD package %s tag %s already exists!' % (package_name, content_tag))
+      content_tag = ''
       # do not return; content hash can match multiple PRs (reverts, framework only)
 
   if upload and IsLinux() and not already_exists:
@@ -105,12 +105,12 @@ def ProcessCIPDPackage(upload, cipd_yaml, engine_version, content_hash, out_dir,
         '-ref',
         'latest',
         '-tag',
-        gitTag,
+        git_tag,
         '-verification-timeout',
         '10m0s',
     ]
-    if contentTag:
-      command.extend(['-tag', contentTag])
+    if content_tag:
+      command.extend(['-tag', content_tag])
   else:
     command = [
         'cipd', 'pkg-build', '-pkg-def', cipd_yaml, '-out',
@@ -224,13 +224,13 @@ def main():
   should_upload = args.upload
   engine_version = args.engine_version
   content_hash = ''
-  if not engine_version:
-    engine_version = 'HEAD'
-    should_upload = False
-  else:
+  if engine_version:
     # When content hashing is enabled, the engine version will be a content
     # hash instead of a git revision.
     content_hash = get_content_hash()
+  else:
+    engine_version = 'HEAD'
+    should_upload = False
 
   ProcessCIPDPackage(should_upload, cipd_def, engine_version, content_hash, out_dir, arch)
   return 0

--- a/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -91,9 +91,10 @@ def ProcessCIPDPackage(upload, cipd_yaml, engine_version, content_hash, out_dir,
   contentTag = ''
   if content_hash:
     contentTag = 'content_aware_hash:%s' % content_hash
-    already_exists = CheckCIPDPackageExists(package_name, contentTag) or already_exists
-    if already_exists:
+    content_already_exists = CheckCIPDPackageExists(package_name, contentTag)
+    if content_already_exists:
       print('CIPD package %s tag %s already exists!' % (package_name, contentTag))
+      already_exists = True
 
   if upload and IsLinux() and not already_exists:
     command = [

--- a/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -90,7 +90,7 @@ def ProcessCIPDPackage(upload, cipd_yaml, engine_version, content_hash, out_dir,
 
   contentTag = ''
   if content_hash:
-    contentTag = 'cah_revision:%s' % content_hash
+    contentTag = 'content_aware_hash:%s' % content_hash
     already_exists = CheckCIPDPackageExists(package_name, contentTag) or already_exists
     if already_exists:
       print('CIPD package %s tag %s already exists!' % (package_name, contentTag))

--- a/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -18,12 +18,11 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from get_content_hash import get_content_hash
 
 # Path to the engine root checkout. This is used to calculate absolute
 # paths if relative ones are passed to the script.
 BUILD_ROOT_DIR = os.path.abspath(os.path.join(os.path.realpath(__file__), '..', '..', '..', '..'))
-_script_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..'))
-_src_root_dir = os.path.join(_script_dir, '..', '..', '..')
 
 
 def IsLinux():
@@ -230,25 +229,7 @@ def main():
   else:
     # When content hashing is enabled, the engine version will be a content
     # hash instead of a git revision.
-    ci_config_path = os.path.join(_src_root_dir, 'flutter', 'ci', 'builders', 'linux_fuchsia.json')
-    upload_content_hash = False
-    if os.path.exists(ci_config_path):
-      with open(ci_config_path, 'r') as f:
-        ci_config = json.load(f)
-        upload_content_hash = ci_config.get('luci_flags', {}).get('upload_content_hash', False)
-    if upload_content_hash:
-      script_path = os.path.join(
-          _src_root_dir, '..', '..', 'bin', 'internal', 'content_aware_hash.sh'
-      )
-      if os.path.exists(script_path):
-        command = [script_path]
-        try:
-          content_hash = subprocess.check_output(command, text=True).strip()
-          print('Using content hash %s for engine version' % content_hash)
-        except subprocess.CalledProcessError as e:
-          print('Error getting content hash, falling back to git hash: %s' % e)
-      else:
-        print('Could not find content_aware_hash.sh at %s' % script_path)
+    content_hash = get_content_hash()
 
   ProcessCIPDPackage(should_upload, cipd_def, engine_version, content_hash, out_dir, arch)
   return 0

--- a/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/engine/src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -93,7 +93,8 @@ def ProcessCIPDPackage(upload, cipd_yaml, engine_version, content_hash, out_dir,
     content_already_exists = CheckCIPDPackageExists(package_name, contentTag)
     if content_already_exists:
       print('CIPD package %s tag %s already exists!' % (package_name, contentTag))
-      already_exists = True
+      contentTag = ''
+      # do not return; content hash can match multiple PRs (reverts, framework only)
 
   if upload and IsLinux() and not already_exists:
     command = [


### PR DESCRIPTION
After the fuchsia build process, be sure to tag uploaded artifacts with `content_aware_hash:` if configured.

fixes #171985

This was a bit of a rabbit hole, with some "magic parameters" that control uploading / tagging. I'm not sure cipd supports two tags with the say keys; but I wouldn't want the content hash having the key "git_revision".

Pre-submits:  Not affected since --engine-version is always '' which is read as "do not upload"
Post-submits: Reads the `linux_fuchsia.json` builder to look for flags.

> Note: This needs to land before the tool can be updated to download the content_aware_hash tag.

Tested: locally, on linux, after building all the x64 targets. With and without engine-version, with and without linux_fuchsia.json flags.

```shell
$ src/flutter/tools/fuchsia/merge_and_upload_debug_symbols.py --target-arch x64 --engine 'abcd' --upload --out-dir tmp  --symbol-dirs out/ci/fuchsia_debug_x64/.build-id out/ci/fuchsia_release_x64/.build-id out/ci/fuchsia_profile_x64/.build-id

Using content hash 2201006225127f112f6576fcf73dd00671b2012e for engine version
['cipd', 'create', '-pkg-def', '/usr/local/google/home/codefu/src/flutter/engine/tmp/debug_symbols.cipd.yaml', '-ref', 'latest', '-tag', 'git_revision:abcd', '-verification-timeout', '10m0s', '-tag', 'content_aware_hash:2201006225127f112f6576fcf73dd00671b2012e']
```

```
$ python3 src/flutter/tools/fuchsia/build_fuchsia_artifacts.py --archs x64 --engine 'abc' --cipd-dry-run --upload

Using content hash 2201006225127f112f6576fcf73dd00671b2012e for engine version
codefu: ['cipd', 'create', '-pkg-def', 'fuchsia.cipd.yaml', '-ref', 'latest', '-tag', 'git_revision:abc', '-tag', 'content_aware_hash:2201006225127f112f6576fcf73dd00671b2012e']
```