### PR TITLE
[Impeller] libImpeller: Correctly release mappings created using the C++ API wrapper.

### DIFF
--- a/engine/src/flutter/impeller/toolkit/interop/impeller.hpp
+++ b/engine/src/flutter/impeller/toolkit/interop/impeller.hpp
@@ -345,6 +345,12 @@ class Mapping {
         size_(size),
         release_callback_(std::move(release_callback)) {}
 
+  ~Mapping() {
+    if (release_callback_) {
+      release_callback_();
+    }
+  }
+
   const uint8_t* GetMapping() const { return mapping_; }
 
   size_t GetSize() const { return size_; }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/170388

Converted `InteropPlaygroundTest::CanDrawImage` to use the C++ API too.