### PR TITLE
[ Tool ] Fix `flutter upgrade` stating that an upgrade is available on `main` when up to date

### DIFF
--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -740,7 +740,7 @@ Future<void> _runFromList(
 /// Returns null if the contents are good. Returns a string if they are bad.
 /// The string is an error message.
 Future<String?> verifyVersion(File file) async {
-  final RegExp pattern = RegExp(r'^(\d+)\.(\d+)\.(\d+)((-\d+\.\d+)?\.pre(\.\d+)?)?$');
+  final RegExp pattern = RegExp(r'^(\d+)\.(\d+)\.(\d+)((-\d+\.\d+)?\.pre([-\.]\d+)?)?$');
   if (!file.existsSync()) {
     return 'The version logic failed to create the Flutter version file.';
   }

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -1073,7 +1073,7 @@ class GitTagVersion {
   /// return '1.2.3-4.5.pre-6-gabc123').
   static GitTagVersion parseVersion(String version) {
     final versionPattern = RegExp(
-      r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?(?:-(\d+)-g([a-f0-9]+))?$',
+      r'^(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?(?:[-\.](\d+)(?:-g([a-f0-9]+))?)?$',
     );
     final Match? match = versionPattern.firstMatch(version.trim());
     if (match == null) {
@@ -1128,14 +1128,14 @@ class GitTagVersion {
     }
     if (hotfix != null) {
       // This is an unexpected state where untagged commits exist past a hotfix
-      return '$x.$y.$z+hotfix.${hotfix! + 1}.pre.$commits';
+      return '$x.$y.$z+hotfix.${hotfix! + 1}.pre-$commits';
     }
     if (devPatch != null && devVersion != null) {
       // The next tag that will contain this commit will be the next candidate
       // branch, which will increment the devVersion.
-      return '$x.$y.0-${devVersion! + 1}.0.pre.$commits';
+      return '$x.$y.0-${devVersion! + 1}.0.pre-$commits';
     }
-    return '$x.$y.${z! + 1}-0.0.pre.$commits';
+    return '$x.$y.${z! + 1}-0.0.pre-$commits';
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -1403,7 +1403,7 @@ void main() {
       workingDirectory: '.',
     );
     // reported version should increment the m
-    expect(gitTagVersion.frameworkVersionFor(headRevision), '1.2.0-3.0.pre.12');
+    expect(gitTagVersion.frameworkVersionFor(headRevision), '1.2.0-3.0.pre-12');
   });
 
   testUsingContext('determine does not call fetch --tags', () {

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -1242,7 +1242,16 @@ void main() {
 
     // Master channel
     gitTagVersion = GitTagVersion.parse('1.2.0-4.5.pre-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.0-5.0.pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.0-5.0.pre-13');
+    expect(gitTagVersion.gitTag, '1.2.0-4.5.pre');
+    expect(gitTagVersion.devVersion, 4);
+    expect(gitTagVersion.devPatch, 5);
+
+    // Master channel
+    // Format from old version files used '.' instead of '-' for the commit count.
+    // See https://github.com/flutter/flutter/issues/172091#issuecomment-3071202443
+    gitTagVersion = GitTagVersion.parse('1.2.0-4.5.pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.0-5.0.pre-13');
     expect(gitTagVersion.gitTag, '1.2.0-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
@@ -1264,7 +1273,7 @@ void main() {
     expect(gitTagVersion.devPatch, 5);
 
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-0.0.pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-0.0.pre-13');
     expect(gitTagVersion.gitTag, '1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
@@ -1278,14 +1287,29 @@ void main() {
 
     // new tag release format, stable channel
     gitTagVersion = GitTagVersion.parse('1.2.3-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-0.0.pre.13');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.4-0.0.pre-13');
     expect(gitTagVersion.gitTag, '1.2.3');
     expect(gitTagVersion.devVersion, null);
     expect(gitTagVersion.devPatch, null);
 
+    // new tag release format, beta channel, old version file format
+    // Format from old version files used '.' instead of '-' for the commit count.
+    // See https://github.com/flutter/flutter/issues/172091#issuecomment-3071202443
+    gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre.0');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.3-4.5.pre');
+    expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
+    expect(gitTagVersion.devVersion, 4);
+    expect(gitTagVersion.devPatch, 5);
+
     expect(
       GitTagVersion.parse('98.76.54-32-g$hash').frameworkVersionFor(hash),
-      '98.76.55-0.0.pre.32',
+      '98.76.55-0.0.pre-32',
+    );
+    // Format from old version files used '.' instead of '-' for the commit count.
+    // See https://github.com/flutter/flutter/issues/172091#issuecomment-3071202443
+    expect(
+      GitTagVersion.parse('98.76.54.32-g$hash').frameworkVersionFor(hash),
+      '98.76.55-0.0.pre-32',
     );
     expect(GitTagVersion.parse('10.20.30-0-g$hash').frameworkVersionFor(hash), '10.20.30');
     expect(testLogger.traceText, '');


### PR DESCRIPTION
The `frameworkVersion` string written to the version files wasn't actually parsable by `GitTagVersion` as it didn't match the format output by `git`.

This change updates the `frameworkVersion` format to use a `-` instead of a `.` before the commit count and adds support to the version parsing regex to handle both `.` and `-` separators before the commit count.

Fixes https://github.com/flutter/flutter/issues/172091
