### PR TITLE
[skwasm] Decrease reliance on finalizers/GC

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/scene_view.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/scene_view.dart
@@ -97,6 +97,7 @@ class EngineSceneView {
     final List<LayerSlice?> slices = scene.rootLayer.slices;
     final List<ScenePicture> picturesToRender = <ScenePicture>[];
     final List<ScenePicture> originalPicturesToRender = <ScenePicture>[];
+    final List<ScenePicture> picturesToFree = <ScenePicture>[];
     for (final LayerSlice? slice in slices) {
       if (slice == null) {
         continue;
@@ -111,7 +112,9 @@ class EngineSceneView {
         picturesToRender.add(slice.picture);
       } else {
         originalPicturesToRender.add(slice.picture);
-        picturesToRender.add(pictureRenderer.clipPicture(slice.picture, clippedRect));
+        final clippedPicture = pictureRenderer.clipPicture(slice.picture, clippedRect);
+        picturesToRender.add(clippedPicture);
+        picturesToFree.add(clippedPicture);
       }
     }
     final Map<ScenePicture, DomImageBitmap> renderMap;
@@ -129,6 +132,10 @@ class EngineSceneView {
       recorder?.recordRasterFinish();
     }
     recorder?.submitTimings();
+
+    for (final p in picturesToFree) {
+      p.dispose();
+    }
 
     final List<SliceContainer?> reusableContainers = List<SliceContainer?>.from(containers);
     final List<SliceContainer> newContainers = <SliceContainer>[];

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -23,67 +23,66 @@ List<String> _computeEffectiveFontFamilies(List<String> fontFamilies) {
   return filteredFonts.isEmpty ? _testFonts : filteredFonts.toList();
 }
 
-class SkwasmLineMetrics extends SkwasmObjectWrapper<RawLineMetrics> implements ui.LineMetrics {
-  factory SkwasmLineMetrics({
-    required bool hardBreak,
-    required double ascent,
-    required double descent,
-    required double unscaledAscent,
-    required double height,
-    required double width,
-    required double left,
-    required double baseline,
-    required int lineNumber,
-  }) => SkwasmLineMetrics._(
-    lineMetricsCreate(
-      hardBreak,
-      ascent,
-      descent,
-      unscaledAscent,
-      height,
-      width,
-      left,
-      baseline,
-      lineNumber,
-    ),
-  );
+class SkwasmLineMetrics implements ui.LineMetrics {
+  SkwasmLineMetrics({
+    required this.hardBreak,
+    required this.ascent,
+    required this.descent,
+    required this.unscaledAscent,
+    required this.height,
+    required this.width,
+    required this.left,
+    required this.baseline,
+    required this.lineNumber,
+    this.startIndex = 0,
+    this.endIndex = 0,
+  });
 
-  SkwasmLineMetrics._(LineMetricsHandle handle) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawLineMetrics> _registry =
-      SkwasmFinalizationRegistry<RawLineMetrics>(
-        (LineMetricsHandle handle) => lineMetricsDispose(handle),
-      );
-
-  @override
-  bool get hardBreak => lineMetricsGetHardBreak(handle);
+  factory SkwasmLineMetrics._fromHandle(LineMetricsHandle handle) {
+    return SkwasmLineMetrics(
+      hardBreak: lineMetricsGetHardBreak(handle),
+      ascent: lineMetricsGetAscent(handle),
+      descent: lineMetricsGetDescent(handle),
+      unscaledAscent: lineMetricsGetUnscaledAscent(handle),
+      height: lineMetricsGetHeight(handle),
+      width: lineMetricsGetWidth(handle),
+      left: lineMetricsGetLeft(handle),
+      baseline: lineMetricsGetBaseline(handle),
+      lineNumber: lineMetricsGetLineNumber(handle),
+      startIndex: lineMetricsGetStartIndex(handle),
+      endIndex: lineMetricsGetEndIndex(handle),
+    );
+  }
 
   @override
-  double get ascent => lineMetricsGetAscent(handle);
+  final bool hardBreak;
 
   @override
-  double get descent => lineMetricsGetDescent(handle);
+  final double ascent;
 
   @override
-  double get unscaledAscent => lineMetricsGetUnscaledAscent(handle);
+  final double descent;
 
   @override
-  double get height => lineMetricsGetHeight(handle);
+  final double unscaledAscent;
 
   @override
-  double get width => lineMetricsGetWidth(handle);
+  final double height;
 
   @override
-  double get left => lineMetricsGetLeft(handle);
+  final double width;
 
   @override
-  double get baseline => lineMetricsGetBaseline(handle);
+  final double left;
 
   @override
-  int get lineNumber => lineMetricsGetLineNumber(handle);
+  final double baseline;
 
-  int get startIndex => lineMetricsGetStartIndex(handle);
-  int get endIndex => lineMetricsGetEndIndex(handle);
+  @override
+  final int lineNumber;
+
+  final int startIndex;
+  final int endIndex;
 }
 
 class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Paragraph {
@@ -267,16 +266,23 @@ class SkwasmParagraph extends SkwasmObjectWrapper<RawParagraph> implements ui.Pa
   @override
   List<SkwasmLineMetrics> computeLineMetrics() {
     final int lineCount = paragraphGetLineCount(handle);
-    return List<SkwasmLineMetrics>.generate(
-      lineCount,
-      (int index) => SkwasmLineMetrics._(paragraphGetLineMetricsAtIndex(handle, index)),
-    );
+    return List<SkwasmLineMetrics>.generate(lineCount, (int index) {
+      final metricsHandle = paragraphGetLineMetricsAtIndex(handle, index);
+      final metrics = SkwasmLineMetrics._fromHandle(metricsHandle);
+      lineMetricsDispose(metricsHandle);
+      return metrics;
+    });
   }
 
   @override
   ui.LineMetrics? getLineMetricsAt(int index) {
-    final LineMetricsHandle lineMetrics = paragraphGetLineMetricsAtIndex(handle, index);
-    return lineMetrics != nullptr ? SkwasmLineMetrics._(lineMetrics) : null;
+    final LineMetricsHandle metricsHandle = paragraphGetLineMetricsAtIndex(handle, index);
+    if (metricsHandle == nullptr) {
+      return null;
+    }
+    final metrics = SkwasmLineMetrics._fromHandle(metricsHandle);
+    lineMetricsDispose(metricsHandle);
+    return metrics;
   }
 }
 
@@ -579,8 +585,8 @@ class SkwasmTextStyle implements ui.TextStyle {
   }
 }
 
-final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implements ui.StrutStyle {
-  factory SkwasmStrutStyle({
+final class SkwasmStrutStyle implements ui.StrutStyle {
+  SkwasmStrutStyle({
     String? fontFamily,
     List<String>? fontFamilyFallback,
     double? fontSize,
@@ -590,70 +596,15 @@ final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implemen
     ui.FontStyle? fontStyle,
     bool? forceStrutHeight,
     ui.TextLeadingDistribution? leadingDistribution,
-  }) {
-    final StrutStyleHandle handle = strutStyleCreate();
-    final List<String> effectiveFontFamilies = _computeEffectiveFontFamilies(<String>[
-      if (fontFamily != null) fontFamily,
-      if (fontFamilyFallback != null) ...fontFamilyFallback,
-    ]);
-    if (effectiveFontFamilies.isNotEmpty) {
-      withScopedFontList(
-        effectiveFontFamilies,
-        (Pointer<SkStringHandle> families, int count) =>
-            strutStyleSetFontFamilies(handle, families, count),
-      );
-    }
-    if (fontSize != null) {
-      strutStyleSetFontSize(handle, fontSize);
-    }
-    if (height != null && height != ui.kTextHeightNone) {
-      strutStyleSetHeight(handle, height);
-    }
-    if (leadingDistribution != null) {
-      strutStyleSetHalfLeading(handle, leadingDistribution == ui.TextLeadingDistribution.even);
-    }
-    if (leading != null) {
-      strutStyleSetLeading(handle, leading);
-    }
-    if (fontWeight != null || fontStyle != null) {
-      fontWeight ??= ui.FontWeight.normal;
-      fontStyle ??= ui.FontStyle.normal;
-      strutStyleSetFontStyle(handle, fontWeight.value, fontStyle.index);
-    }
-    if (forceStrutHeight != null) {
-      strutStyleSetForceStrutHeight(handle, forceStrutHeight);
-    }
-    return SkwasmStrutStyle._(
-      handle,
-      fontFamily,
-      fontFamilyFallback,
-      fontSize,
-      height,
-      leadingDistribution,
-      leading,
-      fontWeight,
-      fontStyle,
-      forceStrutHeight,
-    );
-  }
-
-  SkwasmStrutStyle._(
-    StrutStyleHandle handle,
-    this._fontFamily,
-    this._fontFamilyFallback,
-    this._fontSize,
-    this._height,
-    this._leadingDistribution,
-    this._leading,
-    this._fontWeight,
-    this._fontStyle,
-    this._forceStrutHeight,
-  ) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawStrutStyle> _registry =
-      SkwasmFinalizationRegistry<RawStrutStyle>(
-        (StrutStyleHandle handle) => strutStyleDispose(handle),
-      );
+  }) : _fontFamily = fontFamily,
+       _fontFamilyFallback = fontFamilyFallback,
+       _fontSize = fontSize,
+       _height = height,
+       _leading = leading,
+       _fontWeight = fontWeight,
+       _fontStyle = fontStyle,
+       _forceStrutHeight = forceStrutHeight,
+       _leadingDistribution = leadingDistribution;
 
   final String? _fontFamily;
   final List<String>? _fontFamilyFallback;
@@ -664,6 +615,44 @@ final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implemen
   final ui.FontStyle? _fontStyle;
   final bool? _forceStrutHeight;
   final ui.TextLeadingDistribution? _leadingDistribution;
+
+  StrutStyleHandle createNativeHandle() {
+    final StrutStyleHandle handle = strutStyleCreate();
+    final List<String> effectiveFontFamilies = _computeEffectiveFontFamilies(<String>[
+      if (_fontFamily != null) _fontFamily,
+      if (_fontFamilyFallback != null) ..._fontFamilyFallback,
+    ]);
+    if (effectiveFontFamilies.isNotEmpty) {
+      withScopedFontList(
+        effectiveFontFamilies,
+        (Pointer<SkStringHandle> families, int count) =>
+            strutStyleSetFontFamilies(handle, families, count),
+      );
+    }
+    if (_fontSize != null) {
+      strutStyleSetFontSize(handle, _fontSize);
+    }
+    if (_height != null && _height != ui.kTextHeightNone) {
+      strutStyleSetHeight(handle, _height);
+    }
+    if (_leadingDistribution != null) {
+      strutStyleSetHalfLeading(handle, _leadingDistribution == ui.TextLeadingDistribution.even);
+    }
+    if (_leading != null) {
+      strutStyleSetLeading(handle, _leading);
+    }
+    if (_fontWeight != null || _fontStyle != null) {
+      strutStyleSetFontStyle(
+        handle,
+        (_fontWeight ?? ui.FontWeight.normal).value,
+        (_fontStyle ?? ui.FontStyle.normal).index,
+      );
+    }
+    if (_forceStrutHeight != null) {
+      strutStyleSetForceStrutHeight(handle, _forceStrutHeight);
+    }
+    return handle;
+  }
 
   @override
   bool operator ==(Object other) {
@@ -722,9 +711,8 @@ final class SkwasmStrutStyle extends SkwasmObjectWrapper<RawStrutStyle> implemen
   }
 }
 
-class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle>
-    implements ui.ParagraphStyle {
-  factory SkwasmParagraphStyle({
+class SkwasmParagraphStyle implements ui.ParagraphStyle {
+  SkwasmParagraphStyle({
     ui.TextAlign? textAlign,
     ui.TextDirection? textDirection,
     int? maxLines,
@@ -737,35 +725,50 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle>
     ui.StrutStyle? strutStyle,
     String? ellipsis,
     ui.Locale? locale,
-  }) {
+  }) : _textAlign = textAlign,
+       _textDirection = textDirection,
+       _maxLines = maxLines,
+       _fontFamily = fontFamily,
+       _fontSize = fontSize,
+       _height = height,
+       _textHeightBehavior = textHeightBehavior,
+       _fontWeight = fontWeight,
+       _fontStyle = fontStyle,
+       _strutStyle = strutStyle,
+       _ellipsis = ellipsis,
+       _locale = locale;
+
+  (ParagraphStyleHandle, SkwasmNativeTextStyle) createNative() {
     final ParagraphStyleHandle handle = paragraphStyleCreate();
-    if (textAlign != null) {
-      paragraphStyleSetTextAlign(handle, textAlign.index);
+    if (_textAlign != null) {
+      paragraphStyleSetTextAlign(handle, _textAlign.index);
     }
-    if (textDirection != null) {
-      paragraphStyleSetTextDirection(handle, textDirection.index);
+    if (_textDirection != null) {
+      paragraphStyleSetTextDirection(handle, _textDirection.index);
     }
-    if (maxLines != null) {
-      paragraphStyleSetMaxLines(handle, maxLines);
+    if (_maxLines != null) {
+      paragraphStyleSetMaxLines(handle, _maxLines);
     }
-    if (height != null && height != ui.kTextHeightNone) {
-      paragraphStyleSetHeight(handle, height);
+    if (_height != null && _height != ui.kTextHeightNone) {
+      paragraphStyleSetHeight(handle, _height);
     }
-    if (textHeightBehavior != null) {
+    if (_textHeightBehavior != null) {
       paragraphStyleSetTextHeightBehavior(
         handle,
-        textHeightBehavior.applyHeightToFirstAscent,
-        textHeightBehavior.applyHeightToLastDescent,
+        _textHeightBehavior.applyHeightToFirstAscent,
+        _textHeightBehavior.applyHeightToLastDescent,
       );
     }
-    if (ellipsis != null) {
-      final SkStringHandle ellipsisHandle = skStringFromDartString(ellipsis);
+    if (_ellipsis != null) {
+      final SkStringHandle ellipsisHandle = skStringFromDartString(_ellipsis);
       paragraphStyleSetEllipsis(handle, ellipsisHandle);
       skStringFree(ellipsisHandle);
     }
-    if (strutStyle != null) {
-      strutStyle as SkwasmStrutStyle;
-      paragraphStyleSetStrutStyle(handle, strutStyle.handle);
+    if (_strutStyle != null) {
+      _strutStyle as SkwasmStrutStyle;
+      final strutStyleHandle = _strutStyle.createNativeHandle();
+      paragraphStyleSetStrutStyle(handle, strutStyleHandle);
+      strutStyleDispose(strutStyleHandle);
     }
     final SkwasmNativeTextStyle textStyle = (renderer.fontCollection as SkwasmFontCollection)
         .defaultTextStyle
@@ -773,7 +776,7 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle>
     final TextStyleHandle textStyleHandle = textStyle.handle;
 
     final List<String> effectiveFontFamilies = _computeEffectiveFontFamilies(<String>[
-      if (fontFamily != null) fontFamily,
+      if (_fontFamily != null) _fontFamily,
     ]);
     if (effectiveFontFamilies.isNotEmpty) {
       withScopedFontList(
@@ -782,75 +785,34 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle>
             textStyleAddFontFamilies(textStyleHandle, families, count),
       );
     }
-    if (fontSize != null) {
-      textStyleSetFontSize(textStyleHandle, fontSize);
+    if (_fontSize != null) {
+      textStyleSetFontSize(textStyleHandle, _fontSize);
     }
-    if (height != null) {
-      textStyleSetHeight(textStyleHandle, height);
+    if (_height != null) {
+      textStyleSetHeight(textStyleHandle, _height);
     }
-    if (fontWeight != null || fontStyle != null) {
-      fontWeight ??= ui.FontWeight.normal;
-      fontStyle ??= ui.FontStyle.normal;
-      textStyleSetFontStyle(textStyleHandle, fontWeight.value, fontStyle.index);
-    }
-    if (textHeightBehavior != null) {
-      textStyleSetHalfLeading(
+    if (_fontWeight != null || _fontStyle != null) {
+      textStyleSetFontStyle(
         textStyleHandle,
-        textHeightBehavior.leadingDistribution == ui.TextLeadingDistribution.even,
+        (_fontWeight ?? ui.FontWeight.normal).value,
+        (_fontStyle ?? ui.FontStyle.normal).index,
       );
     }
-    if (locale != null) {
-      final SkStringHandle localeHandle = skStringFromDartString(locale.toLanguageTag());
+    if (_textHeightBehavior != null) {
+      textStyleSetHalfLeading(
+        textStyleHandle,
+        _textHeightBehavior.leadingDistribution == ui.TextLeadingDistribution.even,
+      );
+    }
+    if (_locale != null) {
+      final SkStringHandle localeHandle = skStringFromDartString(_locale.toLanguageTag());
       textStyleSetLocale(textStyleHandle, localeHandle);
       skStringFree(localeHandle);
     }
     paragraphStyleSetTextStyle(handle, textStyleHandle);
     paragraphStyleSetApplyRoundingHack(handle, false);
-
-    return SkwasmParagraphStyle._(
-      handle,
-      textStyle,
-      fontFamily,
-      textAlign,
-      textDirection,
-      fontWeight,
-      fontStyle,
-      maxLines,
-      fontFamily,
-      fontSize,
-      height,
-      textHeightBehavior,
-      strutStyle,
-      ellipsis,
-      locale,
-    );
+    return (handle, textStyle);
   }
-
-  SkwasmParagraphStyle._(
-    ParagraphStyleHandle handle,
-    this.textStyle,
-    this.defaultFontFamily,
-    this._textAlign,
-    this._textDirection,
-    this._fontWeight,
-    this._fontStyle,
-    this._maxLines,
-    this._fontFamily,
-    this._fontSize,
-    this._height,
-    this._textHeightBehavior,
-    this._strutStyle,
-    this._ellipsis,
-    this._locale,
-  ) : super(handle, _registry);
-
-  static final SkwasmFinalizationRegistry<RawParagraphStyle> _registry =
-      SkwasmFinalizationRegistry<RawParagraphStyle>(
-        (ParagraphStyleHandle handle) => paragraphStyleDispose(handle),
-      );
-
-  final SkwasmNativeTextStyle textStyle;
-  final String? defaultFontFamily;
 
   final ui.TextAlign? _textAlign;
   final ui.TextDirection? _textDirection;
@@ -935,10 +897,16 @@ class SkwasmParagraphStyle extends SkwasmObjectWrapper<RawParagraphStyle>
 
 class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder>
     implements ui.ParagraphBuilder {
-  factory SkwasmParagraphBuilder(SkwasmParagraphStyle style, SkwasmFontCollection collection) =>
-      SkwasmParagraphBuilder._(paragraphBuilderCreate(style.handle, collection.handle), style);
+  factory SkwasmParagraphBuilder(SkwasmParagraphStyle style, SkwasmFontCollection collection) {
+    final (paragraphStyleHandle, nativeTextStyle) = style.createNative();
+    final builder = SkwasmParagraphBuilder._(paragraphBuilderCreate(paragraphStyleHandle, collection.handle), style, nativeTextStyle);
+    paragraphStyleDispose(paragraphStyleHandle);
+    return builder;
+  }
 
-  SkwasmParagraphBuilder._(ParagraphBuilderHandle handle, this.style) : super(handle, _registry);
+  SkwasmParagraphBuilder._(ParagraphBuilderHandle handle, this.style, SkwasmNativeTextStyle baseTextStyle) : super(handle, _registry) {
+    textStyleStack.add(baseTextStyle);
+  }
 
   static final SkwasmFinalizationRegistry<RawParagraphBuilder> _registry =
       SkwasmFinalizationRegistry<RawParagraphBuilder>(
@@ -1086,7 +1054,13 @@ class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder>
     if (!skwasmIsHeavy()) {
       _addSegmenterData();
     }
-    return SkwasmParagraph(paragraphBuilderBuild(handle));
+    final paragraph = SkwasmParagraph(paragraphBuilderBuild(handle));
+    while (textStyleStack.isNotEmpty) {
+      final style = textStyleStack.removeLast();
+      style.dispose();
+    }
+    dispose();
+    return paragraph;
   }
 
   @override
@@ -1102,10 +1076,7 @@ class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder>
   @override
   void pushStyle(ui.TextStyle textStyle) {
     textStyle as SkwasmTextStyle;
-    final SkwasmNativeTextStyle baseStyle = textStyleStack.isNotEmpty
-        ? textStyleStack.last
-        : style.textStyle;
-    final SkwasmNativeTextStyle nativeStyle = baseStyle.copy();
+    final SkwasmNativeTextStyle nativeStyle = textStyleStack.last.copy();
     textStyle.applyToNative(nativeStyle);
     textStyleStack.add(nativeStyle);
     paragraphBuilderPushStyle(handle, nativeStyle.handle);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -899,12 +899,20 @@ class SkwasmParagraphBuilder extends SkwasmObjectWrapper<RawParagraphBuilder>
     implements ui.ParagraphBuilder {
   factory SkwasmParagraphBuilder(SkwasmParagraphStyle style, SkwasmFontCollection collection) {
     final (paragraphStyleHandle, nativeTextStyle) = style.createNative();
-    final builder = SkwasmParagraphBuilder._(paragraphBuilderCreate(paragraphStyleHandle, collection.handle), style, nativeTextStyle);
+    final builder = SkwasmParagraphBuilder._(
+      paragraphBuilderCreate(paragraphStyleHandle, collection.handle),
+      style,
+      nativeTextStyle,
+    );
     paragraphStyleDispose(paragraphStyleHandle);
     return builder;
   }
 
-  SkwasmParagraphBuilder._(ParagraphBuilderHandle handle, this.style, SkwasmNativeTextStyle baseTextStyle) : super(handle, _registry) {
+  SkwasmParagraphBuilder._(
+    ParagraphBuilderHandle handle,
+    this.style,
+    SkwasmNativeTextStyle baseTextStyle,
+  ) : super(handle, _registry) {
     textStyleStack.add(baseTextStyle);
   }
 

--- a/engine/src/flutter/lib/web_ui/test/engine/scene_builder_utils.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/scene_builder_utils.dart
@@ -10,6 +10,8 @@ import 'package:ui/ui.dart' as ui;
 class StubPicture implements ScenePicture {
   StubPicture(this.cullRect);
 
+  bool _isDisposed = false;
+
   @override
   final ui.Rect cullRect;
 
@@ -17,10 +19,13 @@ class StubPicture implements ScenePicture {
   int get approximateBytesUsed => throw UnimplementedError();
 
   @override
-  bool get debugDisposed => throw UnimplementedError();
+  bool get debugDisposed => _isDisposed;
 
   @override
-  void dispose() {}
+  void dispose() {
+    assert(!_isDisposed);
+    _isDisposed = true;
+  }
 
   @override
   Future<ui.Image> toImage(int width, int height) {

--- a/engine/src/flutter/lib/web_ui/test/engine/scene_view_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/scene_view_test.dart
@@ -43,10 +43,13 @@ class StubPictureRenderer implements PictureRenderer {
   @override
   ScenePicture clipPicture(ScenePicture picture, ui.Rect clip) {
     clipRequests[picture] = clip;
-    return picture;
+    final clippedRect = clip.intersect(picture.cullRect);
+    final clippedPicture = StubPicture(clippedRect);
+    return clippedPicture;
   }
 
   List<ScenePicture> renderedPictures = <ScenePicture>[];
+  List<StubPicture> clippedPictures = <StubPicture>[];
   Map<ScenePicture, ui.Rect> clipRequests = <ScenePicture, ui.Rect>{};
 }
 
@@ -277,6 +280,13 @@ void testMain() {
   setUp(() {
     stubPictureRenderer = StubPictureRenderer();
     sceneView = EngineSceneView(stubPictureRenderer, StubFlutterView());
+  });
+
+  tearDown(() {
+    expect(
+      stubPictureRenderer.clippedPictures.every((StubPicture picture) => picture.debugDisposed),
+      true,
+    );
   });
 
   test('SceneView places canvas according to device-pixel ratio', () async {


### PR DESCRIPTION
Some changes which make Skwasm less dependent on GC cycles to free its native resources:
* Explicitly clean up pictures clipped by the scene view
* Free native `ParagraphBuilder` when `build()` is called
* Restructure `TextStyle`, `ParagraphStyle`, `StrutStyle` and `LineMetrics` so that they don't persistently hang on to native objects beyond a paragraph build cycle.

This addresses https://github.com/flutter/flutter/issues/170889