### PR TITLE
Use `release-*.version` to simplify `last_engine_commit.sh` (no branch operations)

### DIFF
--- a/bin/internal/last_engine_commit.ps1
+++ b/bin/internal/last_engine_commit.ps1
@@ -5,7 +5,7 @@
 # Based on the current repository state, writes on stdout the last commit in the
 # git tree that edited either `DEPS` or any file in the `engine/` sub-folder,
 # which is used to ensure `bin/internal/engine.version` is set correctly.
-
+#
 # ---------------------------------- NOTE ---------------------------------- #
 #
 # Please keep the logic in this file consistent with the logic in the
@@ -20,52 +20,46 @@
 #
 # -------------------------------------------------------------------------- #
 
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = "Stop" # Equivalent to 'set -e' in bash
 
 $progName = Split-Path -parent $MyInvocation.MyCommand.Definition
 $flutterRoot = (Get-Item $progName).parent.parent.FullName
 $gitToplevel = (git rev-parse --show-toplevel).Trim()
-# 1. Determine when we diverged from master.
-$MERGE_BASE_COMMIT = ""
+
+$RELEASE_CANDIDATE_VERSION_PATH = Join-Path $gitToplevel "bin" "internal" "release-candidate-branch.version"
+
+# 1. Determine the reference commit: the last commit that changed
+#    'bin/internal/release-candidate-branch.version'.
+#    This serves as the starting point for evaluating changes on the current branch.
+$REFERENCE_COMMIT = ""
 try {
-    $MERGE_BASE_COMMIT = (git merge-base HEAD master).Trim()
+    $REFERENCE_COMMIT = (git log -1 --pretty=format:%H -- "$RELEASE_CANDIDATE_VERSION_PATH" -ErrorAction Stop).Trim()
 }
 catch {
-    # If git merge-base fails (e.g., master not found, no common history),
-    # $MERGE_BASE_COMMIT will remain empty.
+    # If git log fails (e.g., file not found or no history), $REFERENCE_COMMIT will remain empty.
 }
 
-# If we did not find a merge-base, fail
-if ([string]::IsNullOrEmpty($MERGE_BASE_COMMIT)) {
+# If we did not find this reference commit, fail.
+if ([string]::IsNullOrEmpty($REFERENCE_COMMIT)) {
     Write-Error "Error: Could not determine a suitable engine commit." -ErrorAction Stop
-    Write-Error "Current branch: $(git rev-parse --abbrev-ref HEAD).Trim()" -ErrorAction Stop
-    Write-Error "Expected a different branch, from 'master', or a 'master' branch that exists and has history." -ErrorAction Stop
+    Write-Error "Current branch: $((git rev-parse --abbrev-ref HEAD).Trim())" -ErrorAction Stop
+    Write-Error "No file $RELEASE_CANDIDATE_VERSION_PATH found, or it has no history." -ErrorAction Stop
     exit 1
 }
 
-# 2. Define and search history range to search within (unique to changes on this branch).
-$HISTORY_RANGE = "$MERGE_BASE_COMMIT..HEAD"
+# 2. Define the history range to search within: commits reachable from HEAD
+#    but not from the REFERENCE_COMMIT. This focuses the search on commits
+#    *unique to the current branch* since that file was last changed.
+$HISTORY_RANGE = "$REFERENCE_COMMIT..HEAD"
 $DEPS_PATH = Join-Path $gitToplevel "DEPS"
 $ENGINE_PATH = Join-Path $gitToplevel "engine"
 
 $ENGINE_COMMIT = (git log -1 --pretty=format:%H --ancestry-path $HISTORY_RANGE -- "$DEPS_PATH" "$ENGINE_PATH")
 
-# 3. If no engine-related commit was found within the current branch's history, fallback to the first commit on this branch.
+# 3. If no engine-related commit was found within the current branch's history,
+#    fallback to the REFERENCE_COMMIT itself.
 if ([string]::IsNullOrEmpty($ENGINE_COMMIT)) {
-    # Find the oldest commit on HEAD that is *not* reachable from MERGE_BASE_COMMIT.
-    # This is the first commit *on this branch* after it diverged from 'master'.
-    $ENGINE_COMMIT = (git log --pretty=format:%H --reverse --ancestry-path "$MERGE_BASE_COMMIT..HEAD" | Select-Object -First 1).Trim()
-
-    # Final check: If even this fallback fails (which would be highly unusual if MERGE_BASE_COMMIT was found),
-    # then something is truly wrong.
-    if ([string]::IsNullOrEmpty($ENGINE_COMMIT)) {
-        Write-Error "Error: Unexpected state. MERGE_BASE_COMMIT was found ($MERGE_BASE_COMMIT), but no commits found on current branch after it." -ErrorAction Stop
-        Write-Error "Current branch: $((git rev-parse --abbrev-ref HEAD).Trim())" -ErrorAction Stop
-        Write-Error "History range searched for fallback: $HISTORY_RANGE" -ErrorAction Stop
-        Write-Error "All commits on current branch (for debug):" -ErrorAction Stop
-        (git log --pretty=format:%H) | Write-Error -ErrorAction Stop
-        exit 1
-    }
+    $ENGINE_COMMIT = $REFERENCE_COMMIT
 }
 
 Write-Output $ENGINE_COMMIT

--- a/bin/internal/last_engine_commit.sh
+++ b/bin/internal/last_engine_commit.sh
@@ -7,7 +7,7 @@
 # git tree that edited either `DEPS` or any file in the `engine/` sub-folder,
 # which is used to ensure `bin/internal/engine.version` is set correctly.
 #
-
+#
 # ---------------------------------- NOTE ---------------------------------- #
 #
 # Please keep the logic in this file consistent with the logic in the
@@ -26,37 +26,27 @@ set -e
 
 FLUTTER_ROOT="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
 
-# 1. Determine when we diverged from master, and prevent set -e from exiting.
-MERGE_BASE_COMMIT="$(git merge-base HEAD master || echo "")"
+# 1. Determine when the release branch was started, and prevent set -e from exiting.
+RELEASE_CANDIDATE_VERSION_PATH="$(git rev-parse --show-toplevel)/bin/internal/release-candidate-branch.version"
+REFERENCE_COMMIT="$(git log -1 --pretty=format:%H -- "$RELEASE_CANDIDATE_VERSION_PATH")"
 
 # If we did not find a merge-base, fail
-if [[ -z "$MERGE_BASE_COMMIT" ]]; then
+if [[ -z "$REFERENCE_COMMIT" ]]; then
   echo >&2 "Error: Could not determine a suitable engine commit."
   echo >&2 "Current branch: $(git rev-parse --abbrev-ref HEAD)"
-  echo >&2 "Expected a different branch, from master"
+  echo >&2 "No file $RELEASE_CANDIDATE_VERSION_PATH found"
   exit 1
 fi
 
 # 2. Define and search history range to searhc within (unique to changes on this branch).
-HISTORY_RANGE="$MERGE_BASE_COMMIT..HEAD"
+HISTORY_RANGE="$REFERENCE_COMMIT..HEAD"
 ENGINE_COMMIT="$(git log -1 --pretty=format:%H --ancestry-path "$HISTORY_RANGE" -- "$(git rev-parse --show-toplevel)/DEPS" "$(git rev-parse --show-toplevel)/engine")"
 
 # 3. If no engine-related commit was found within the current branch's history, fallback to the first commit on this branch.
 if [[ -z "$ENGINE_COMMIT" ]]; then
   # Find the oldest commit on HEAD that is *not* reachable from MERGE_BASE_COMMIT.
   # This is the first commit *on this branch* after it diverged from 'master'.
-  ENGINE_COMMIT="$(git log --pretty=format:%H --reverse --ancestry-path "$MERGE_BASE_COMMIT"..HEAD | head -n 1)"
-
-  # Final check: If even this fallback fails (which would be highly unusual if MERGE_BASE_COMMIT was found),
-  # then something is truly wrong.
-  if [[ -z "$ENGINE_COMMIT" ]]; then
-    echo >&2 "Error: Unexpected state. MERGE_BASE_COMMIT was found ($MERGE_BASE_COMMIT), but no commits found on current branch after it."
-    echo >&2 "Current branch: $(git rev-parse --abbrev-ref HEAD)"
-    echo >&2 "History range searched for fallback: $HISTORY_RANGE"
-    echo >&2 "All commits on current branch (for debug):"
-    git log --pretty=format:%H
-    exit 1
-  fi
+  ENGINE_COMMIT="$REFERENCE_COMMIT"
 fi
 
 echo "$ENGINE_COMMIT"

--- a/dev/tools/test/last_engine_commit_test.dart
+++ b/dev/tools/test/last_engine_commit_test.dart
@@ -163,12 +163,8 @@ void main() {
     run('git', <String>['commit', '-m', 'Wrote ${files.length} files']);
   }
 
-  void changeBranch({required String newBranchName}) {
-    run('git', <String>['checkout', '-b', newBranchName]);
-  }
-
   test('returns the last engine commit', () {
-    changeBranch(newBranchName: 'flutter-1.2.3-candidate.0');
+    writeCommit(<String>['bin/internal/release-candidate-branch.version']);
     writeCommit(<String>['DEPS', 'engine/README.md']);
 
     final String lastEngine = getLastEngineCommit();
@@ -179,7 +175,7 @@ void main() {
   });
 
   test('considers DEPS an engine change', () {
-    changeBranch(newBranchName: 'flutter-1.2.3-candidate.0');
+    writeCommit(<String>['bin/internal/release-candidate-branch.version']);
     writeCommit(<String>['DEPS', 'engine/README.md']);
 
     final String lastEngineA = getLastEngineCommit();
@@ -196,9 +192,8 @@ void main() {
     // Make an engine change *before* the branch.
     writeCommit(<String>['engine/README.md']);
     final String engineCommitPreBranch = getLastCommit();
-    changeBranch(newBranchName: 'flutter-1.2.3-candidate.0');
 
-    // Make a non-engine change, but no engine changes, after branching.
+    // Write the branch file.
     writeCommit(<String>['bin/internal/release-candidate-branch.version']);
     final String initialBranchCommit = getLastCommit();
 
@@ -213,10 +208,10 @@ void main() {
       initialBranchCommit,
       reason:
           'The git history for this simulation looks like this:\n'
-          'master (intial commit)    | $initialStartingCommit\n'
-          'master (touches engine)   | $engineCommitPreBranch\n'
-          'flutter-1.2.3-candidate.0 | $initialBranchCommit\n'
-          'flutter-1.2.3-candidate.0 | $latestCommitIgnore\n'
+          'master                    | $initialStartingCommit\n'
+          'master                    | $engineCommitPreBranch\n'
+          'release                   | $initialBranchCommit\n'
+          'release                   | $latestCommitIgnore\n'
           '\n'
           'We expected our script to select HEAD~2, $initialBranchCommit, but '
           'instead it selected $lastCommitToEngine, which is incorrect. See '


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/pull/172184 by considering the last commit to `release-candidate-branch.version` as the significant commit. 

Otherwise, operationally, it works the same. I tested this on 3.35 and it works as expected (where the current does not).