### PR TITLE
Fix use of `Join-Path` in `last_engine_commit.ps1`(poweshell)

### DIFF
--- a/bin/internal/last_engine_commit.ps1
+++ b/bin/internal/last_engine_commit.ps1
@@ -26,7 +26,9 @@ $progName = Split-Path -parent $MyInvocation.MyCommand.Definition
 $flutterRoot = (Get-Item $progName).parent.parent.FullName
 $gitToplevel = (git rev-parse --show-toplevel).Trim()
 
-$RELEASE_CANDIDATE_VERSION_PATH = Join-Path $gitToplevel "bin" "internal" "release-candidate-branch.version"
+$Path1 = Join-Path $gitToplevel "bin"
+$Path2 = Join-Path $Path1 "internal"
+$RELEASE_CANDIDATE_VERSION_PATH = Join-Path $Path2 "release-candidate-branch.version"
 
 # 1. Determine the reference commit: the last commit that changed
 #    'bin/internal/release-candidate-branch.version'.


### PR DESCRIPTION
It worked on the Mac version of Powershell (`pwsh`) but [not on the Windows bots](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8709168939844960513/+/u/run_test.dart_for_framework_tests_shard_and_subshard_misc/stdout):
```txt
00:09 +37 ~2 -3: C:/b/s/w/ir/x/w/flutter/dev/tools/test/last_engine_commit_test.dart: returns the last engine commit [E]
  Failed running "powershell [C:\b\s\w\ir\x\t\last_engine_commit_test.88f44c9f\flutter\bin\internal\last_engine_commit.ps1]" (exit code = 1),
  stdout: 
  stderr: Join-Path : A positional parameter cannot be found that accepts argument 'internal'.
  At C:\b\s\w\ir\x\t\last_engine_commit_test.88f44c9f\flutter\bin\internal\last_engine_commit.ps1:29 char:35
  + ... SION_PATH = Join-Path $gitToplevel "bin" "internal" "release-candidat ...
  +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      + CategoryInfo          : InvalidArgument: (:) [Join-Path], ParentContainsErrorRecordException
      + FullyQualifiedErrorId : PositionalParameterNotFound,Microsoft.PowerShell.Commands.JoinPathCommand
```

... this looks safer, I'll make sure it passes pre-subs this time.