### PR TITLE
Remove emoji from ci.yaml, because we still live with CP1252 for some silly reason

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -555,11 +555,11 @@ targets:
     properties:
       config_name: windows_unopt
 
-  #          _____________________⚠️__________________________
+  #          _________________[WARNING]_______________________
   #
   #      This is a size experiment for reducing engine binary sizes.
   #     It is highly volatile and will not be supported if you use it.
-  #          _____________________⚠️__________________________
+  #          _________________[WARNING]_______________________
   #
   - name: Linux linux_android_aot_engine_size_exp
     recipe: engine_v2/engine_v2


### PR DESCRIPTION
WARNING: codefu's snark level is approaching maximums.
