### PR TITLE
Use baseUri always when doing a hot reload or hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -202,7 +202,7 @@ class WebDevFS implements DevFS {
   Set<String> get assetPathsToEvict => const <String>{};
 
   @override
-  Uri? get baseUri => webAssetServer.baseUri;
+  Uri get baseUri => webAssetServer.baseUri;
 
   @override
   Future<Uri> create() async {
@@ -234,7 +234,7 @@ class WebDevFS implements DevFS {
       platform: platform,
       shouldEnableMiddleware: shouldEnableMiddleware,
     );
-    return baseUri!;
+    return baseUri;
   }
 
   @override

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -177,7 +177,7 @@ class WebAssetServer implements AssetReader {
   }
 
   Uri get baseUri => _baseUri;
-  late final Uri _baseUri;
+  late Uri _baseUri;
 
   /// Start the web asset server on a [hostname] and [port].
   ///

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -122,7 +122,7 @@ class WebAssetServer implements AssetReader {
     }
     if (writeRestartScripts) {
       final srcIdsList = <Map<String, String>>[
-        for (final String src in modules) <String, String>{'src': src, 'id': src},
+        for (final String src in modules) <String, String>{'src': '$baseUri/$src', 'id': src},
       ];
       writeFile('restart_scripts.json', json.encode(srcIdsList));
     }
@@ -161,7 +161,7 @@ class WebAssetServer implements AssetReader {
             as Map<String, dynamic>,
       );
       final List<String> libraries = metadata.libraries.keys.toList();
-      final moduleUri = baseUri != null ? '$baseUri/$module' : module;
+      final moduleUri = '$baseUri/$module';
       moduleToLibrary.add(<String, Object>{
         'src': moduleUri,
         'module': metadata.name,
@@ -176,8 +176,8 @@ class WebAssetServer implements AssetReader {
     return _webMemoryFS.write(codeFile, manifestFile, sourcemapFile, metadataFile);
   }
 
-  Uri? get baseUri => _baseUri;
-  Uri? _baseUri;
+  Uri get baseUri => _baseUri;
+  late final Uri _baseUri;
 
   /// Start the web asset server on a [hostname] and [port].
   ///
@@ -351,8 +351,8 @@ class WebAssetServer implements AssetReader {
                   ),
                 ),
                 packageConfigPath: buildInfo.packageConfigPath,
-                hotReloadSourcesUri: server._baseUri!.replace(
-                  pathSegments: List<String>.from(server._baseUri!.pathSegments)
+                hotReloadSourcesUri: server._baseUri.replace(
+                  pathSegments: List<String>.from(server._baseUri.pathSegments)
                     ..add(_reloadScriptsFileName),
                 ),
               ).strategy

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -268,6 +268,14 @@ $_simpleLoaderScript
               var script = scripts[i];
               if (script.id == null) continue;
               var src = script.src.toString();
+              var oldSrc = window.\$dartLoader.moduleIdToUrl.get(script.id);
+
+              // We might actually load from a different uri, delete the old one
+              // just to be sure.
+              window.\$dartLoader.urlToModuleId.delete(oldSrc);
+
+              window.\$dartLoader.moduleIdToUrl.set(script.id, src);
+              window.\$dartLoader.urlToModuleId.set(src, script.id);
 
               numToLoad++;
 

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -267,15 +267,7 @@ $_simpleLoaderScript
             for (var i = 0; i < scripts.length; i++) {
               var script = scripts[i];
               if (script.id == null) continue;
-              var src = _currentDirectory + script.src.toString();
-              var oldSrc = window.\$dartLoader.moduleIdToUrl.get(script.id);
-
-              // We might actually load from a different uri, delete the old one
-              // just to be sure.
-              window.\$dartLoader.urlToModuleId.delete(oldSrc);
-
-              window.\$dartLoader.moduleIdToUrl.set(script.id, src);
-              window.\$dartLoader.urlToModuleId.set(src, script.id);
+              var src = script.src.toString();
 
               numToLoad++;
 


### PR DESCRIPTION
We already use the baseUri when computing hot reload sources metadata as it can never be null. The member is changed to be non-nullable to reflect that.

To be consistent, we also use the baseUri (full url) for a hot restart when running with the DDC library bundle format.

Related PR: https://github.com/dart-lang/webdev/pull/2650

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
