### PR TITLE
[Impeller] Add missing SetPipeline call for the vertices uber pipeline in AtlasContents

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_atlas_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_atlas_unittests.cc
@@ -317,5 +317,20 @@ TEST_P(AiksTest, DrawImageRectWithMatrixColorFilter) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, DrawAtlasWithColorBurn) {
+  DisplayListBuilder builder;
+  auto [texture_coordinates, transforms, atlas] = CreateTestData(this);
+
+  std::vector<DlColor> colors = {DlColor::kDarkGrey(), DlColor::kBlack(),
+                                 DlColor::kLightGrey(), DlColor::kWhite()};
+
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  builder.DrawAtlas(atlas, transforms.data(), texture_coordinates.data(),
+                    colors.data(), /*count=*/4, DlBlendMode::kColorBurn,
+                    DlImageSampling::kNearestNeighbor, /*cullRect=*/nullptr);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/atlas_contents.cc
@@ -255,8 +255,8 @@ bool AtlasContents::Render(const ContentContext& renderer,
 #endif  // IMPELLER_DEBUG
   pass.SetVertexBuffer(geometry_->CreateBlendVertexBuffer(host_buffer));
 
-  renderer.GetDrawVerticesUberPipeline(blend_mode,
-                                       OptionsFromPassAndEntity(pass, entity));
+  pass.SetPipeline(renderer.GetDrawVerticesUberPipeline(
+      blend_mode, OptionsFromPassAndEntity(pass, entity)));
   FS::BindTextureSampler(pass, geometry_->GetAtlas(), dst_sampler);
 
   VUS::FrameInfo frame_info;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/171719