### PR TITLE
[skwasm] Port to `DisplayList` objects

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -716,6 +716,8 @@ if (is_win) {
       # freetype2 needs these two
       "-Wno-unused-function",
       "-Wno-unused-variable",
+
+      "-Wno-sign-conversion",
     ]
   }
 
@@ -1110,10 +1112,15 @@ config("prevent_unsafe_narrowing") {
       "-Wshorten-64-to-32",
       "-Wimplicit-int-conversion",
       "-Wsign-compare",
-      "-Wsign-conversion",
       # Avoid bugs of the form `if (size_t i = size; i >= 0; --i)` while
       # fixing types to be sign-correct.
       "-Wtautological-unsigned-zero-compare",
     ]
+
+    if (!is_wasm) {
+      # emscripten's headers themselves trigger this warning, so we can't
+      # keep this enabled on the wasm target.
+      cflags += [ "-Wsign-conversion" ]
+    }
   }
 }

--- a/engine/src/flutter/display_list/BUILD.gn
+++ b/engine/src/flutter/display_list/BUILD.gn
@@ -298,7 +298,6 @@ if (enable_unittests) {
     deps = [
       ":display_list",
       ":display_list_fixtures",
-      "$dart_src/runtime:libdart_jit",  # for tracing
       "//flutter/benchmarking",
       "//flutter/common/graphics",
       "//flutter/display_list/testing:display_list_surface_provider",
@@ -308,6 +307,12 @@ if (enable_unittests) {
       "//flutter/testing:skia",
       "//flutter/testing:testing_lib",
     ]
+
+    if (!is_wasm) {
+      deps += [
+        "$dart_src/runtime:libdart_jit",  # for tracing
+      ]
+    }
   }
 
   executable("display_list_benchmarks") {

--- a/engine/src/flutter/fml/BUILD.gn
+++ b/engine/src/flutter/fml/BUILD.gn
@@ -33,8 +33,6 @@ source_set("fml") {
     "hash_combine.h",
     "hex_codec.cc",
     "hex_codec.h",
-    "icu_util.cc",
-    "icu_util.h",
     "log_level.h",
     "log_settings.cc",
     "log_settings.h",
@@ -101,7 +99,7 @@ source_set("fml") {
     "wakeable.h",
   ]
 
-  if (enable_backtrace) {
+  if (enable_backtrace && !is_wasm) {
     sources += [ "backtrace.cc" ]
   } else {
     sources += [ "backtrace_stub.cc" ]
@@ -113,15 +111,24 @@ source_set("fml") {
     ":string_conversion",
   ]
 
-  deps = [ "//flutter/third_party/icu" ]
+  deps = []
+  if (target_os != "wasm") {
+    deps += [ "//flutter/third_party/icu" ]
+
+    sources += [
+      "icu_util.cc",
+      "icu_util.h",
+    ]
+  }
 
   if (enable_backtrace) {
     # This abseil dependency is only used by backtrace.cc.
     deps += [ "//flutter/third_party/abseil-cpp/absl/debugging:symbolize" ]
   }
 
-  configs += [ "//flutter/third_party/icu:icu_config" ]
-
+  if (target_os != "wasm") {
+    configs += [ "//flutter/third_party/icu:icu_config" ]
+  }
   public_configs = [
     "//flutter:config",
     "//flutter/common:flutter_config",

--- a/engine/src/flutter/fml/build_config.h
+++ b/engine/src/flutter/fml/build_config.h
@@ -50,6 +50,8 @@
 #define FML_OS_SOLARIS 1
 #elif defined(__QNXNTO__)
 #define FML_OS_QNX 1
+#elif defined(__EMSCRIPTEN__)
+#define FML_OS_EMSCRIPTEN
 #else
 #error Please add support for your platform in flutter/fml/build_config.h
 #endif
@@ -105,6 +107,9 @@
 #define FML_ARCH_CPU_LITTLE_ENDIAN 1
 #elif defined(__pnacl__)
 #define FML_ARCH_CPU_32_BITS 1
+#define FML_ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__EMSCRIPTEN__)
+#define FML_ARGH_CPU_32_BITS 1
 #define FML_ARCH_CPU_LITTLE_ENDIAN 1
 #else
 #error Please add support for your architecture in flutter/fml/build_config.h

--- a/engine/src/flutter/impeller/display_list/aiks_context.h
+++ b/engine/src/flutter/impeller/display_list/aiks_context.h
@@ -9,6 +9,7 @@
 
 #include "impeller/entity/contents/content_context.h"
 #include "impeller/renderer/context.h"
+
 #include "impeller/renderer/render_target.h"
 #include "impeller/typographer/typographer_context.h"
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/layers.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/layers.dart
@@ -418,7 +418,7 @@ class ImageFilterOperation implements LayerOperation {
   final ui.Offset offset;
 
   @override
-  ui.Rect mapRect(ui.Rect contentRect) => filter.filterBounds(contentRect);
+  ui.Rect mapRect(ui.Rect contentRect) => filter.filterBounds(contentRect).shift(offset);
 
   @override
   void pre(SceneCanvas canvas) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/canvas.dart
@@ -34,16 +34,10 @@ class SkwasmCanvas implements SceneCanvas {
     final paintHandle = (paint as SkwasmPaint).toRawPaint();
     if (bounds != null) {
       withStackScope((StackScope s) {
-        canvasSaveLayer(
-          _handle,
-          s.convertRectToNative(bounds),
-          paintHandle,
-          nullptr,
-          ui.TileMode.clamp.index,
-        );
+        canvasSaveLayer(_handle, s.convertRectToNative(bounds), paintHandle, nullptr);
       });
     } else {
-      canvasSaveLayer(_handle, nullptr, paintHandle, nullptr, ui.TileMode.clamp.index);
+      canvasSaveLayer(_handle, nullptr, paintHandle, nullptr);
     }
     paintDispose(paintHandle);
   }
@@ -60,29 +54,16 @@ class SkwasmCanvas implements SceneCanvas {
     // and instead needs it supplied to the saveLayer call itself as a
     // separate argument.
     final SkwasmImageFilter nativeFilter = SkwasmImageFilter.fromUiFilter(imageFilter);
-    final ui.TileMode? backdropTileMode = nativeFilter.backdropTileMode;
     final paintHandle = (paint as SkwasmPaint).toRawPaint(/*ui.TileMode.decal*/);
     if (bounds != null) {
       withStackScope((StackScope s) {
         nativeFilter.withRawImageFilter((nativeFilterHandle) {
-          canvasSaveLayer(
-            _handle,
-            s.convertRectToNative(bounds),
-            paintHandle,
-            nativeFilterHandle,
-            (backdropTileMode ?? ui.TileMode.mirror).index,
-          );
+          canvasSaveLayer(_handle, s.convertRectToNative(bounds), paintHandle, nativeFilterHandle);
         }, defaultBlurTileMode: ui.TileMode.mirror);
       });
     } else {
       nativeFilter.withRawImageFilter((nativeFilterHandle) {
-        canvasSaveLayer(
-          _handle,
-          nullptr,
-          paintHandle,
-          nativeFilterHandle,
-          (backdropTileMode ?? ui.TileMode.mirror).index,
-        );
+        canvasSaveLayer(_handle, nullptr, paintHandle, nativeFilterHandle);
       }, defaultBlurTileMode: ui.TileMode.mirror);
     }
     paintDispose(paintHandle);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paint.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ffi';
-
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
@@ -26,16 +24,21 @@ class SkwasmPaint implements ui.Paint {
       strokeCap.index,
       strokeJoin.index,
       strokeMiterLimit,
+      invertColors,
     );
 
-    _maybeSetEffectiveColorFilter(rawPaint);
+    final localColorFilter = _colorFilter;
+    if (localColorFilter != null) {
+      SkwasmColorFilter.fromEngineColorFilter(localColorFilter).withRawColorFilter((
+        nativeFilterHandle,
+      ) {
+        paintSetColorFilter(rawPaint, nativeFilterHandle);
+      });
+    }
 
     final shaderHandle = _shader?.handle;
     if (shaderHandle != null) {
       paintSetShader(rawPaint, shaderHandle);
-      if (_shader!.isGradient) {
-        paintSetDither(rawPaint, true);
-      }
     }
 
     final localMaskFilter = maskFilter;
@@ -55,39 +58,6 @@ class SkwasmPaint implements ui.Paint {
 
     return rawPaint;
   }
-
-  /// If `invertColors` is true or `colorFilter` is not null, sets the
-  /// appropriate Skia color filter. Otherwise, does nothing.
-  void _maybeSetEffectiveColorFilter(Pointer<RawPaint> handle) {
-    final nativeFilter = _colorFilter != null
-        ? SkwasmColorFilter.fromEngineColorFilter(_colorFilter!)
-        : null;
-    if (invertColors) {
-      if (nativeFilter != null) {
-        final composedFilter = SkwasmColorFilter.composed(_invertColorFilter, nativeFilter);
-        composedFilter.withRawColorFilter((composedFilterHandle) {
-          paintSetColorFilter(handle, composedFilterHandle);
-        });
-      } else {
-        _invertColorFilter.withRawColorFilter((invertFilterHandle) {
-          paintSetColorFilter(handle, invertFilterHandle);
-        });
-      }
-    } else if (nativeFilter != null) {
-      nativeFilter.withRawColorFilter((nativeFilterHandle) {
-        paintSetColorFilter(handle, nativeFilterHandle);
-      });
-    }
-  }
-
-  static final SkwasmColorFilter _invertColorFilter = SkwasmColorFilter.fromEngineColorFilter(
-    const EngineColorFilter.matrix(<double>[
-      -1.0, 0, 0, 1.0, 0, // row
-      0, -1.0, 0, 1.0, 0, // row
-      0, 0, -1.0, 1.0, 0, // row
-      1.0, 1.0, 1.0, 1.0, 0,
-    ]),
-  );
 
   @override
   ui.BlendMode blendMode = _kBlendModeDefault;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_canvas.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_canvas.dart
@@ -16,7 +16,7 @@ typedef CanvasHandle = Pointer<RawCanvas>;
 @Native<Void Function(CanvasHandle)>(symbol: 'canvas_save', isLeaf: true)
 external void canvasSave(CanvasHandle canvas);
 
-@Native<Void Function(CanvasHandle, RawRect, PaintHandle, ImageFilterHandle, Int)>(
+@Native<Void Function(CanvasHandle, RawRect, PaintHandle, ImageFilterHandle)>(
   symbol: 'canvas_saveLayer',
   isLeaf: true,
 )
@@ -25,7 +25,6 @@ external void canvasSaveLayer(
   RawRect rect,
   PaintHandle paint,
   ImageFilterHandle handle,
-  int backdropTileMode,
 );
 
 @Native<Void Function(CanvasHandle)>(symbol: 'canvas_restore', isLeaf: true)

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_filters.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_filters.dart
@@ -75,12 +75,6 @@ external ColorFilterHandle colorFilterCreateSRGBToLinearGamma();
 @Native<ColorFilterHandle Function()>(symbol: 'colorFilter_createLinearToSRGBGamma', isLeaf: true)
 external ColorFilterHandle colorFilterCreateLinearToSRGBGamma();
 
-@Native<ColorFilterHandle Function(ColorFilterHandle, ColorFilterHandle)>(
-  symbol: 'colorFilter_compose',
-  isLeaf: true,
-)
-external ColorFilterHandle colorFilterCompose(ColorFilterHandle outer, ColorFilterHandle inner);
-
 @Native<Void Function(ColorFilterHandle)>(symbol: 'colorFilter_dispose', isLeaf: true)
 external void colorFilterDispose(ColorFilterHandle handle);
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_paint.dart
@@ -14,7 +14,7 @@ final class RawPaint extends Opaque {}
 typedef PaintHandle = Pointer<RawPaint>;
 
 typedef _PaintCreateInitSignature =
-    PaintHandle Function(Bool, Int, Int, Int, Float, Int, Int, Float);
+    PaintHandle Function(Bool, Int, Int, Int, Float, Int, Int, Float, Bool);
 
 @Native<_PaintCreateInitSignature>(symbol: 'paint_create', isLeaf: true)
 external PaintHandle paintCreate(
@@ -26,6 +26,7 @@ external PaintHandle paintCreate(
   int strokeCap,
   int strokeJoin,
   double strokeMiterLimit,
+  bool invertColors,
 );
 
 @Native<Void Function(PaintHandle)>(symbol: 'paint_dispose', isLeaf: true)
@@ -33,9 +34,6 @@ external void paintDispose(PaintHandle paint);
 
 @Native<Void Function(PaintHandle, ShaderHandle)>(symbol: 'paint_setShader', isLeaf: true)
 external void paintSetShader(PaintHandle handle, ShaderHandle shader);
-
-@Native<Void Function(PaintHandle, Bool)>(symbol: 'paint_setDither', isLeaf: true)
-external void paintSetDither(PaintHandle handle, bool isDither);
 
 @Native<Void Function(PaintHandle, ImageFilterHandle)>(symbol: 'paint_setImageFilter', isLeaf: true)
 external void paintSetImageFilter(PaintHandle handle, ImageFilterHandle filter);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/raw/raw_shaders.dart
@@ -17,6 +17,10 @@ final class RawRuntimeEffect extends Opaque {}
 
 typedef RuntimeEffectHandle = Pointer<RawRuntimeEffect>;
 
+final class RawUniformData extends Opaque {}
+
+typedef UniformDataHandle = Pointer<RawUniformData>;
+
 @Native<ShaderHandle Function(RawPointArray, RawColorArray, Pointer<Float>, Int, Int, RawMatrix33)>(
   symbol: 'shader_createLinearGradient',
   isLeaf: true,
@@ -104,13 +108,13 @@ external void runtimeEffectDispose(RuntimeEffectHandle handle);
 @Native<Size Function(RuntimeEffectHandle)>(symbol: 'runtimeEffect_getUniformSize', isLeaf: true)
 external int runtimeEffectGetUniformSize(RuntimeEffectHandle handle);
 
-@Native<ShaderHandle Function(RuntimeEffectHandle, SkDataHandle, Pointer<ShaderHandle>, Size)>(
+@Native<ShaderHandle Function(RuntimeEffectHandle, UniformDataHandle, Pointer<ShaderHandle>, Size)>(
   symbol: 'shader_createRuntimeEffectShader',
   isLeaf: true,
 )
 external ShaderHandle shaderCreateRuntimeEffectShader(
   RuntimeEffectHandle runtimeEffect,
-  SkDataHandle uniforms,
+  UniformDataHandle uniforms,
   Pointer<ShaderHandle> childShaders,
   int childCount,
 );
@@ -126,3 +130,12 @@ external ShaderHandle shaderCreateFromImage(
   int quality,
   RawMatrix33 localMatrix,
 );
+
+@Native<UniformDataHandle Function(Int)>(symbol: 'uniformData_create')
+external UniformDataHandle uniformDataCreate(int size);
+
+@Native<Void Function(UniformDataHandle)>(symbol: 'uniformData_dispose')
+external void uniformDataDispose(UniformDataHandle handle);
+
+@Native<Pointer<Void> Function(UniformDataHandle)>(symbol: 'uniformData_getPointer')
+external Pointer<Void> uniformDataGetPointer(UniformDataHandle handle);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -254,11 +254,15 @@ class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
   int get uniformSize => runtimeEffectGetUniformSize(handle);
 }
 
-class SkwasmShaderData extends SkwasmObjectWrapper<RawSkData> {
-  SkwasmShaderData(int size) : super(skDataCreate(size), _registry);
+class SkwasmShaderData extends SkwasmObjectWrapper<RawUniformData> {
+  SkwasmShaderData(int size) : super(uniformDataCreate(size), _registry);
 
-  static final SkwasmFinalizationRegistry<RawSkData> _registry =
-      SkwasmFinalizationRegistry<RawSkData>((SkDataHandle handle) => skDataDispose(handle));
+  static final SkwasmFinalizationRegistry<RawUniformData> _registry =
+      SkwasmFinalizationRegistry<RawUniformData>(
+        (UniformDataHandle handle) => uniformDataDispose(handle),
+      );
+
+  Pointer<Void> get pointer => uniformDataGetPointer(handle);
 }
 
 // This class does not inherit from SkwasmNativeShader, as its handle might
@@ -326,7 +330,7 @@ class SkwasmFragmentShader implements SkwasmShader, ui.FragmentShader {
       _nativeShader!.dispose();
       _nativeShader = null;
     }
-    final Pointer<Float> dataPointer = skDataGetPointer(_uniformData.handle).cast<Float>();
+    final Pointer<Float> dataPointer = _uniformData.pointer.cast<Float>();
     dataPointer[index] = value;
   }
 
@@ -350,7 +354,7 @@ class SkwasmFragmentShader implements SkwasmShader, ui.FragmentShader {
     _childShaders[index] = shader;
     oldShader?.dispose();
 
-    final Pointer<Float> dataPointer = skDataGetPointer(_uniformData.handle).cast<Float>();
+    final Pointer<Float> dataPointer = _uniformData.pointer.cast<Float>();
     dataPointer[_floatUniformCount + index * 2] = image.width.toDouble();
     dataPointer[_floatUniformCount + index * 2 + 1] = image.height.toDouble();
   }

--- a/engine/src/flutter/lib/web_ui/skwasm/BUILD.gn
+++ b/engine/src/flutter/lib/web_ui/skwasm/BUILD.gn
@@ -32,6 +32,7 @@ template("skwasm_variant") {
       "text/paragraph_style.cpp",
       "text/strut_style.cpp",
       "text/text_style.cpp",
+      "text/text_types.h",
       "vertices.cpp",
       "wrappers.h",
     ]
@@ -70,7 +71,6 @@ template("skwasm_variant") {
 
     if (is_debug) {
       ldflags += [
-        "-sDEMANGLE_SUPPORT=1",
         "-sASSERTIONS=1",
         "-sGL_ASSERTIONS=1",
       ]
@@ -79,6 +79,7 @@ template("skwasm_variant") {
     }
 
     deps = [
+      "//flutter/display_list",
       "//flutter/skia",
       "//flutter/skia/modules/skparagraph",
       "//flutter/skia/modules/skunicode",

--- a/engine/src/flutter/lib/web_ui/skwasm/canvas.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/canvas.cpp
@@ -4,272 +4,364 @@
 
 #include "export.h"
 #include "helpers.h"
+#include "text/text_types.h"
 #include "wrappers.h"
 
-#include "third_party/skia/include/core/SkPoint3.h"
-#include "third_party/skia/include/core/SkVertices.h"
-#include "third_party/skia/include/utils/SkShadowUtils.h"
 #include "third_party/skia/modules/skparagraph/include/Paragraph.h"
 
-using namespace skia::textlayout;
+#include "flutter/display_list/dl_builder.h"
+#include "flutter/display_list/dl_text_skia.h"
 
 using namespace Skwasm;
+using namespace flutter;
 
 namespace {
-// These numbers have been chosen empirically to give a result closest to the
-// material spec.
-// These values are also used by the CanvasKit renderer and the native engine.
-// See:
-//   flutter/display_list/skia/dl_sk_dispatcher.cc
-//   flutter/lib/web_ui/lib/src/engine/canvaskit/util.dart
-constexpr SkScalar kShadowAmbientAlpha = 0.039;
-constexpr SkScalar kShadowSpotAlpha = 0.25;
-constexpr SkScalar kShadowLightRadius = 1.1;
-constexpr SkScalar kShadowLightHeight = 600.0;
-constexpr SkScalar kShadowLightXOffset = 0;
-constexpr SkScalar kShadowLightYOffset = -450;
+class SkwasmParagraphPainter : public skia::textlayout::ParagraphPainter {
+ public:
+  SkwasmParagraphPainter(DisplayListBuilder& builder,
+                         const std::vector<DlPaint>& paints)
+      : _builder(builder), _paints(paints) {}
+
+  virtual void drawTextBlob(const sk_sp<SkTextBlob>& blob,
+                            SkScalar x,
+                            SkScalar y,
+                            const SkPaintOrID& paint) override {
+    if (!blob) {
+      return;
+    }
+
+    const int* paintID = std::get_if<PaintID>(&paint);
+    auto dlPaint = paintID ? _paints[*paintID] : DlPaint();
+    _builder.DrawText(DlTextSkia::Make(blob), x, y, dlPaint);
+  }
+
+  virtual void drawTextShadow(const sk_sp<SkTextBlob>& blob,
+                              SkScalar x,
+                              SkScalar y,
+                              SkColor color,
+                              SkScalar blurSigma) override {
+    if (!blob) {
+      return;
+    }
+
+    DlPaint paint;
+    paint.setColor(DlColor(color));
+    if (blurSigma > 0.0) {
+      DlBlurMaskFilter filter(DlBlurStyle::kNormal, blurSigma, false);
+      paint.setMaskFilter(&filter);
+    }
+    _builder.DrawText(DlTextSkia::Make(blob), x, y, paint);
+  }
+
+  virtual void drawRect(const SkRect& rect, const SkPaintOrID& paint) override {
+    const int* paintID = std::get_if<PaintID>(&paint);
+    auto dlPaint = paintID ? _paints[*paintID] : DlPaint();
+    _builder.DrawRect(ToDlRect(rect), dlPaint);
+  }
+
+  virtual void drawFilledRect(const SkRect& rect,
+                              const DecorationStyle& decorStyle) override {
+    DlPaint paint = toDlPaint(decorStyle, DlDrawStyle::kFill);
+    _builder.DrawRect(ToDlRect(rect), paint);
+  }
+
+  virtual void drawPath(const SkPath& path,
+                        const DecorationStyle& decorStyle) override {
+    _builder.DrawPath(DlPath(path), toDlPaint(decorStyle));
+  }
+
+  virtual void drawLine(SkScalar x0,
+                        SkScalar y0,
+                        SkScalar x1,
+                        SkScalar y1,
+                        const DecorationStyle& decorStyle) override {
+    auto paint = toDlPaint(decorStyle);
+    auto dashPathEffect = decorStyle.getDashPathEffect();
+
+    if (dashPathEffect) {
+      _builder.DrawDashedLine(DlPoint(x0, y0), DlPoint(x1, y1),
+                              dashPathEffect->fOnLength,
+                              dashPathEffect->fOffLength, paint);
+    } else {
+      _builder.DrawLine(DlPoint(x0, y0), DlPoint(x1, y1), paint);
+    }
+  }
+
+  virtual void clipRect(const SkRect& rect) override {
+    _builder.ClipRect(ToDlRect(rect));
+  }
+
+  virtual void translate(SkScalar dx, SkScalar dy) override {
+    _builder.Translate(dx, dy);
+  }
+
+  virtual void save() override { _builder.Save(); }
+
+  virtual void restore() override { _builder.Restore(); }
+
+ private:
+  DisplayListBuilder& _builder;
+  const std::vector<DlPaint>& _paints;
+
+  DlPaint toDlPaint(const DecorationStyle& decor_style,
+                    DlDrawStyle draw_style = DlDrawStyle::kStroke) {
+    DlPaint paint;
+    paint.setDrawStyle(draw_style);
+    paint.setAntiAlias(true);
+    paint.setColor(DlColor(decor_style.getColor()));
+    paint.setStrokeWidth(decor_style.getStrokeWidth());
+    return paint;
+  }
+};
 }  // namespace
 
-SKWASM_EXPORT void canvas_saveLayer(SkCanvas* canvas,
-                                    SkRect* rect,
-                                    SkPaint* paint,
-                                    SkImageFilter* backdrop,
-                                    SkTileMode backdropTileMode) {
-  canvas->saveLayer(SkCanvas::SaveLayerRec(rect, paint, backdrop,
-                                           backdropTileMode, nullptr, 0));
+SKWASM_EXPORT void canvas_saveLayer(DisplayListBuilder* canvas,
+                                    DlRect* rect,
+                                    DlPaint* paint,
+                                    sp_wrapper<DlImageFilter>* backdrop) {
+  canvas->SaveLayer(rect ? std::optional(*rect) : std::nullopt, paint,
+                    backdrop ? backdrop->raw() : nullptr);
 }
 
-SKWASM_EXPORT void canvas_save(SkCanvas* canvas) {
-  canvas->save();
+SKWASM_EXPORT void canvas_save(DisplayListBuilder* canvas) {
+  canvas->Save();
 }
 
-SKWASM_EXPORT void canvas_restore(SkCanvas* canvas) {
-  canvas->restore();
+SKWASM_EXPORT void canvas_restore(DisplayListBuilder* canvas) {
+  canvas->Restore();
 }
 
-SKWASM_EXPORT void canvas_restoreToCount(SkCanvas* canvas, int count) {
-  canvas->restoreToCount(count);
+SKWASM_EXPORT void canvas_restoreToCount(DisplayListBuilder* canvas,
+                                         int count) {
+  if (count > canvas->GetSaveCount()) {
+    // According to the docs:
+    // "If count is greater than the current getSaveCount then nothing happens."
+    return;
+  }
+  canvas->RestoreToCount(count);
 }
 
-SKWASM_EXPORT int canvas_getSaveCount(SkCanvas* canvas) {
-  return canvas->getSaveCount();
+SKWASM_EXPORT int canvas_getSaveCount(DisplayListBuilder* canvas) {
+  return canvas->GetSaveCount();
 }
 
-SKWASM_EXPORT void canvas_translate(SkCanvas* canvas,
-                                    SkScalar dx,
-                                    SkScalar dy) {
-  canvas->translate(dx, dy);
+SKWASM_EXPORT void canvas_translate(DisplayListBuilder* canvas,
+                                    float dx,
+                                    float dy) {
+  canvas->Translate(dx, dy);
 }
 
-SKWASM_EXPORT void canvas_scale(SkCanvas* canvas, SkScalar sx, SkScalar sy) {
-  canvas->scale(sx, sy);
+SKWASM_EXPORT void canvas_scale(DisplayListBuilder* canvas,
+                                float sx,
+                                float sy) {
+  canvas->Scale(sx, sy);
 }
 
-SKWASM_EXPORT void canvas_rotate(SkCanvas* canvas, SkScalar degrees) {
-  canvas->rotate(degrees);
+SKWASM_EXPORT void canvas_rotate(DisplayListBuilder* canvas, DlScalar degrees) {
+  canvas->Rotate(degrees);
 }
 
-SKWASM_EXPORT void canvas_skew(SkCanvas* canvas, SkScalar sx, SkScalar sy) {
-  canvas->skew(sx, sy);
+SKWASM_EXPORT void canvas_skew(DisplayListBuilder* canvas,
+                               DlScalar sx,
+                               DlScalar sy) {
+  canvas->Skew(sx, sy);
 }
 
-SKWASM_EXPORT void canvas_transform(SkCanvas* canvas, const SkM44* matrix44) {
-  canvas->concat(*matrix44);
+SKWASM_EXPORT void canvas_transform(DisplayListBuilder* canvas,
+                                    const DlMatrix* matrix44) {
+  canvas->Transform(*matrix44);
 }
 
-SKWASM_EXPORT void canvas_clipRect(SkCanvas* canvas,
-                                   const SkRect* rect,
-                                   SkClipOp op,
+SKWASM_EXPORT void canvas_clipRect(DisplayListBuilder* canvas,
+                                   const DlRect* rect,
+                                   DlClipOp op,
                                    bool antialias) {
-  canvas->clipRect(*rect, op, antialias);
+  canvas->ClipRect(*rect, op);
 }
 
-SKWASM_EXPORT void canvas_clipRRect(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_clipRRect(DisplayListBuilder* canvas,
                                     const SkScalar* rrectValues,
                                     bool antialias) {
-  canvas->clipRRect(createRRect(rrectValues), antialias);
+  canvas->ClipRoundRect(createDlRRect(rrectValues), DlClipOp::kIntersect,
+                        antialias);
 }
 
-SKWASM_EXPORT void canvas_clipPath(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_clipPath(DisplayListBuilder* canvas,
                                    SkPath* path,
                                    bool antialias) {
-  canvas->clipPath(*path, antialias);
+  canvas->ClipPath(DlPath(*path), DlClipOp::kIntersect, antialias);
 }
 
-SKWASM_EXPORT void canvas_drawColor(SkCanvas* canvas,
-                                    SkColor color,
-                                    SkBlendMode blendMode) {
-  canvas->drawColor(color, blendMode);
+SKWASM_EXPORT void canvas_drawColor(DisplayListBuilder* canvas,
+                                    uint32_t color,
+                                    DlBlendMode blendMode) {
+  canvas->DrawColor(DlColor(color), blendMode);
 }
 
-SKWASM_EXPORT void canvas_drawLine(SkCanvas* canvas,
-                                   SkScalar x1,
-                                   SkScalar y1,
-                                   SkScalar x2,
-                                   SkScalar y2,
-                                   SkPaint* paint) {
-  canvas->drawLine(x1, y1, x2, y2, *paint);
+SKWASM_EXPORT void canvas_drawLine(DisplayListBuilder* canvas,
+                                   DlScalar x1,
+                                   DlScalar y1,
+                                   DlScalar x2,
+                                   DlScalar y2,
+                                   DlPaint* paint) {
+  canvas->DrawLine(DlPoint{x1, y1}, DlPoint{x2, y2},
+                   paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawPaint(SkCanvas* canvas, SkPaint* paint) {
-  canvas->drawPaint(*paint);
+SKWASM_EXPORT void canvas_drawPaint(DisplayListBuilder* canvas,
+                                    DlPaint* paint) {
+  canvas->DrawPaint(paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawRect(SkCanvas* canvas,
-                                   SkRect* rect,
-                                   SkPaint* paint) {
-  canvas->drawRect(*rect, *paint);
+SKWASM_EXPORT void canvas_drawRect(DisplayListBuilder* canvas,
+                                   DlRect* rect,
+                                   DlPaint* paint) {
+  canvas->DrawRect(*rect, paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawRRect(SkCanvas* canvas,
-                                    const SkScalar* rrectValues,
-                                    SkPaint* paint) {
-  canvas->drawRRect(createRRect(rrectValues), *paint);
+SKWASM_EXPORT void canvas_drawRRect(DisplayListBuilder* canvas,
+                                    const DlScalar* rrectValues,
+                                    DlPaint* paint) {
+  canvas->DrawRoundRect(createDlRRect(rrectValues), paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawDRRect(SkCanvas* canvas,
-                                     const SkScalar* outerRrectValues,
-                                     const SkScalar* innerRrectValues,
-                                     SkPaint* paint) {
-  canvas->drawDRRect(createRRect(outerRrectValues),
-                     createRRect(innerRrectValues), *paint);
+SKWASM_EXPORT void canvas_drawDRRect(DisplayListBuilder* canvas,
+                                     const DlScalar* outerRrectValues,
+                                     const DlScalar* innerRrectValues,
+                                     DlPaint* paint) {
+  canvas->DrawDiffRoundRect(createDlRRect(outerRrectValues),
+                            createDlRRect(innerRrectValues),
+                            paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawOval(SkCanvas* canvas,
-                                   const SkRect* rect,
-                                   SkPaint* paint) {
-  canvas->drawOval(*rect, *paint);
+SKWASM_EXPORT void canvas_drawOval(DisplayListBuilder* canvas,
+                                   const DlRect* rect,
+                                   DlPaint* paint) {
+  canvas->DrawOval(*rect, paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawCircle(SkCanvas* canvas,
-                                     SkScalar x,
-                                     SkScalar y,
-                                     SkScalar radius,
-                                     SkPaint* paint) {
-  canvas->drawCircle(x, y, radius, *paint);
+SKWASM_EXPORT void canvas_drawCircle(DisplayListBuilder* canvas,
+                                     DlScalar x,
+                                     DlScalar y,
+                                     DlScalar radius,
+                                     DlPaint* paint) {
+  canvas->DrawCircle(DlPoint{x, y}, radius, paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawArc(SkCanvas* canvas,
-                                  const SkRect* rect,
-                                  SkScalar startAngleDegrees,
-                                  SkScalar sweepAngleDegrees,
+SKWASM_EXPORT void canvas_drawArc(DisplayListBuilder* canvas,
+                                  const DlRect* rect,
+                                  DlScalar startAngleDegrees,
+                                  DlScalar sweepAngleDegrees,
                                   bool useCenter,
-                                  SkPaint* paint) {
-  canvas->drawArc(*rect, startAngleDegrees, sweepAngleDegrees, useCenter,
-                  *paint);
+                                  DlPaint* paint) {
+  canvas->DrawArc(*rect, startAngleDegrees, sweepAngleDegrees, useCenter,
+                  paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawPath(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawPath(DisplayListBuilder* canvas,
                                    SkPath* path,
-                                   SkPaint* paint) {
-  canvas->drawPath(*path, *paint);
+                                   DlPaint* paint) {
+  canvas->DrawPath(DlPath(*path), paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawShadow(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawShadow(DisplayListBuilder* canvas,
                                      SkPath* path,
-                                     SkScalar elevation,
-                                     SkScalar devicePixelRatio,
-                                     SkColor color,
+                                     DlScalar elevation,
+                                     DlScalar devicePixelRatio,
+                                     uint32_t color,
                                      bool transparentOccluder) {
-  SkColor inAmbient =
-      SkColorSetA(color, kShadowAmbientAlpha * SkColorGetA(color));
-  SkColor inSpot = SkColorSetA(color, kShadowSpotAlpha * SkColorGetA(color));
-  SkColor outAmbient;
-  SkColor outSpot;
-  SkShadowUtils::ComputeTonalColors(inAmbient, inSpot, &outAmbient, &outSpot);
-  uint32_t flags = transparentOccluder
-                       ? SkShadowFlags::kTransparentOccluder_ShadowFlag
-                       : SkShadowFlags::kNone_ShadowFlag;
-  flags |= SkShadowFlags::kDirectionalLight_ShadowFlag;
-  SkShadowUtils::DrawShadow(
-      canvas, *path, SkPoint3::Make(0.0f, 0.0f, elevation * devicePixelRatio),
-      SkPoint3::Make(kShadowLightXOffset, kShadowLightYOffset,
-                     kShadowLightHeight * devicePixelRatio),
-      devicePixelRatio * kShadowLightRadius, outAmbient, outSpot, flags);
+  canvas->DrawShadow(DlPath(*path), DlColor(color), elevation,
+                     transparentOccluder, devicePixelRatio);
 }
 
-SKWASM_EXPORT void canvas_drawParagraph(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawParagraph(DisplayListBuilder* canvas,
                                         Paragraph* paragraph,
-                                        SkScalar x,
-                                        SkScalar y) {
-  paragraph->paint(canvas, x, y);
+                                        DlScalar x,
+                                        DlScalar y) {
+  auto painter = SkwasmParagraphPainter(*canvas, paragraph->paints);
+  paragraph->skiaParagraph->paint(&painter, x, y);
 }
 
-SKWASM_EXPORT void canvas_drawPicture(SkCanvas* canvas, SkPicture* picture) {
-  canvas->drawPicture(picture);
+SKWASM_EXPORT void canvas_drawPicture(DisplayListBuilder* canvas,
+                                      DisplayList* picture) {
+  canvas->DrawDisplayList(sk_ref_sp(picture));
 }
 
-SKWASM_EXPORT void canvas_drawImage(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawImage(DisplayListBuilder* canvas,
                                     SkImage* image,
-                                    SkScalar offsetX,
-                                    SkScalar offsetY,
-                                    SkPaint* paint,
+                                    DlScalar offsetX,
+                                    DlScalar offsetY,
+                                    DlPaint* paint,
                                     FilterQuality quality) {
-  canvas->drawImage(image, offsetX, offsetY, samplingOptionsForQuality(quality),
-                    paint);
+  canvas->DrawImage(DlImage::Make(image), DlPoint{offsetX, offsetY},
+                    samplingOptionsForQuality(quality), paint);
 }
 
-SKWASM_EXPORT void canvas_drawImageRect(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawImageRect(DisplayListBuilder* canvas,
                                         SkImage* image,
-                                        SkRect* sourceRect,
-                                        SkRect* destRect,
-                                        SkPaint* paint,
+                                        DlRect* sourceRect,
+                                        DlRect* destRect,
+                                        DlPaint* paint,
                                         FilterQuality quality) {
-  canvas->drawImageRect(image, *sourceRect, *destRect,
+  canvas->DrawImageRect(DlImage::Make(image), *sourceRect, *destRect,
                         samplingOptionsForQuality(quality), paint,
-                        SkCanvas::kStrict_SrcRectConstraint);
+                        DlSrcRectConstraint::kStrict);
 }
 
-SKWASM_EXPORT void canvas_drawImageNine(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawImageNine(DisplayListBuilder* canvas,
                                         SkImage* image,
-                                        SkIRect* centerRect,
-                                        SkRect* destinationRect,
-                                        SkPaint* paint,
+                                        DlIRect* centerRect,
+                                        DlRect* destinationRect,
+                                        DlPaint* paint,
                                         FilterQuality quality) {
-  canvas->drawImageNine(image, *centerRect, *destinationRect,
+  canvas->DrawImageNine(DlImage::Make(image), *centerRect, *destinationRect,
                         filterModeForQuality(quality), paint);
 }
 
-SKWASM_EXPORT void canvas_drawVertices(SkCanvas* canvas,
-                                       SkVertices* vertices,
-                                       SkBlendMode mode,
-                                       SkPaint* paint) {
-  canvas->drawVertices(sk_ref_sp<SkVertices>(vertices), mode, *paint);
+SKWASM_EXPORT void canvas_drawVertices(DisplayListBuilder* canvas,
+                                       sp_wrapper<DlVertices>* vertices,
+                                       DlBlendMode mode,
+                                       DlPaint* paint) {
+  canvas->DrawVertices(vertices->shared(), mode, paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawPoints(SkCanvas* canvas,
-                                     SkCanvas::PointMode mode,
-                                     SkPoint* points,
+SKWASM_EXPORT void canvas_drawPoints(DisplayListBuilder* canvas,
+                                     DlPointMode mode,
+                                     DlPoint* points,
                                      int pointCount,
-                                     SkPaint* paint) {
-  canvas->drawPoints(mode, pointCount, points, *paint);
+                                     DlPaint* paint) {
+  canvas->DrawPoints(mode, pointCount, points, paint ? *paint : DlPaint());
 }
 
-SKWASM_EXPORT void canvas_drawAtlas(SkCanvas* canvas,
+SKWASM_EXPORT void canvas_drawAtlas(DisplayListBuilder* canvas,
                                     SkImage* atlas,
-                                    SkRSXform* transforms,
-                                    SkRect* rects,
-                                    SkColor* colors,
+                                    DlRSTransform* transforms,
+                                    DlRect* rects,
+                                    uint32_t* colors,
                                     int spriteCount,
-                                    SkBlendMode mode,
-                                    SkRect* cullRect,
-                                    SkPaint* paint) {
-  canvas->drawAtlas(
-      atlas, transforms, rects, colors, spriteCount, mode,
-      SkSamplingOptions{SkFilterMode::kLinear, SkMipmapMode::kNone}, cullRect,
-      paint);
+                                    DlBlendMode mode,
+                                    DlRect* cullRect,
+                                    DlPaint* paint) {
+  std::vector<DlColor> dlColors(spriteCount);
+  for (int i = 0; i < spriteCount; i++) {
+    dlColors[i] = DlColor(colors[i]);
+  }
+  canvas->DrawAtlas(
+      DlImage::Make(atlas), transforms, rects, dlColors.data(), spriteCount,
+      mode, samplingOptionsForQuality(FilterQuality::medium), cullRect, paint);
 }
 
-SKWASM_EXPORT void canvas_getTransform(SkCanvas* canvas, SkM44* outTransform) {
-  *outTransform = canvas->getLocalToDevice();
+SKWASM_EXPORT void canvas_getTransform(DisplayListBuilder* canvas,
+                                       DlMatrix* outTransform) {
+  *outTransform = canvas->GetMatrix();
 }
 
-SKWASM_EXPORT void canvas_getLocalClipBounds(SkCanvas* canvas,
-                                             SkRect* outRect) {
-  *outRect = canvas->getLocalClipBounds();
+SKWASM_EXPORT void canvas_getLocalClipBounds(DisplayListBuilder* canvas,
+                                             DlRect* outRect) {
+  *outRect = canvas->GetLocalClipCoverage();
 }
 
-SKWASM_EXPORT void canvas_getDeviceClipBounds(SkCanvas* canvas,
-                                              SkIRect* outRect) {
-  *outRect = canvas->getDeviceClipBounds();
+SKWASM_EXPORT void canvas_getDeviceClipBounds(DisplayListBuilder* canvas,
+                                              DlIRect* outRect) {
+  *outRect = DlIRect::RoundOut(canvas->GetDestinationClipCoverage());
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/filters.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/filters.cpp
@@ -6,112 +6,116 @@
 #include "helpers.h"
 #include "live_objects.h"
 
-#include "third_party/skia/include/core/SkColorFilter.h"
-#include "third_party/skia/include/core/SkMaskFilter.h"
-#include "third_party/skia/include/effects/SkImageFilters.h"
+#include "flutter/display_list/effects/dl_color_filter.h"
+#include "flutter/display_list/effects/dl_image_filter.h"
+#include "flutter/display_list/effects/dl_mask_filter.h"
 
 using namespace Skwasm;
+using namespace flutter;
 
-SKWASM_EXPORT SkImageFilter* imageFilter_createBlur(SkScalar sigmaX,
-                                                    SkScalar sigmaY,
-                                                    SkTileMode tileMode) {
+SKWASM_EXPORT sp_wrapper<DlImageFilter>*
+imageFilter_createBlur(DlScalar sigmaX, DlScalar sigmaY, DlTileMode tileMode) {
   liveImageFilterCount++;
-  return SkImageFilters::Blur(sigmaX, sigmaY, tileMode, nullptr).release();
+  return new sp_wrapper<DlImageFilter>(
+      DlImageFilter::MakeBlur(sigmaX, sigmaY, tileMode));
 }
 
-SKWASM_EXPORT SkImageFilter* imageFilter_createDilate(SkScalar radiusX,
-                                                      SkScalar radiusY) {
+SKWASM_EXPORT sp_wrapper<DlImageFilter>* imageFilter_createDilate(
+    DlScalar radiusX,
+    DlScalar radiusY) {
   liveImageFilterCount++;
-  return SkImageFilters::Dilate(radiusX, radiusY, nullptr).release();
+  return new sp_wrapper<DlImageFilter>(
+      DlImageFilter::MakeDilate(radiusX, radiusY));
 }
 
-SKWASM_EXPORT SkImageFilter* imageFilter_createErode(SkScalar radiusX,
-                                                     SkScalar radiusY) {
+SKWASM_EXPORT sp_wrapper<DlImageFilter>* imageFilter_createErode(
+    DlScalar radiusX,
+    DlScalar radiusY) {
   liveImageFilterCount++;
-  return SkImageFilters::Erode(radiusX, radiusY, nullptr).release();
+  return new sp_wrapper<DlImageFilter>(
+      DlImageFilter::MakeErode(radiusX, radiusY));
 }
 
-SKWASM_EXPORT SkImageFilter* imageFilter_createMatrix(SkScalar* matrix33,
-                                                      FilterQuality quality) {
+SKWASM_EXPORT sp_wrapper<DlImageFilter>* imageFilter_createMatrix(
+    DlScalar* matrix33,
+    FilterQuality quality) {
   liveImageFilterCount++;
-  return SkImageFilters::MatrixTransform(createMatrix(matrix33),
-                                         samplingOptionsForQuality(quality),
-                                         nullptr)
-      .release();
+  auto dlFilter = DlImageFilter::MakeMatrix(createDlMatrixFrom3x3(matrix33),
+                                            samplingOptionsForQuality(quality));
+  return dlFilter ? new sp_wrapper<DlImageFilter>(dlFilter) : nullptr;
 }
 
-SKWASM_EXPORT SkImageFilter* imageFilter_createFromColorFilter(
-    SkColorFilter* filter) {
+SKWASM_EXPORT sp_wrapper<DlImageFilter>* imageFilter_createFromColorFilter(
+    sp_wrapper<DlColorFilter>* filter) {
   liveImageFilterCount++;
-  return SkImageFilters::ColorFilter(sk_ref_sp<SkColorFilter>(filter), nullptr)
-      .release();
+  return new sp_wrapper<DlImageFilter>(
+      DlImageFilter::MakeColorFilter(filter->shared()));
 }
 
-SKWASM_EXPORT SkImageFilter* imageFilter_compose(SkImageFilter* outer,
-                                                 SkImageFilter* inner) {
+SKWASM_EXPORT sp_wrapper<DlImageFilter>* imageFilter_compose(
+    sp_wrapper<DlImageFilter>* outer,
+    sp_wrapper<DlImageFilter>* inner) {
   liveImageFilterCount++;
-
-  return SkImageFilters::Compose(sk_ref_sp<SkImageFilter>(outer),
-                                 sk_ref_sp<SkImageFilter>(inner))
-      .release();
+  return new sp_wrapper<DlImageFilter>(
+      DlImageFilter::MakeCompose(outer->shared(), inner->shared()));
 }
 
-SKWASM_EXPORT void imageFilter_dispose(SkImageFilter* filter) {
+SKWASM_EXPORT void imageFilter_dispose(sp_wrapper<DlImageFilter>* filter) {
   liveImageFilterCount--;
-  filter->unref();
+  delete filter;
 }
 
-SKWASM_EXPORT void imageFilter_getFilterBounds(SkImageFilter* filter,
-                                               SkIRect* inOutBounds) {
-  SkIRect outputRect =
-      filter->filterBounds(*inOutBounds, SkMatrix(),
-                           SkImageFilter::MapDirection::kForward_MapDirection);
-  *inOutBounds = outputRect;
+SKWASM_EXPORT void imageFilter_getFilterBounds(
+    sp_wrapper<DlImageFilter>* filter,
+    DlIRect* inOutBounds) {
+  DlIRect inRect = *inOutBounds;
+  filter->shared()->map_device_bounds(inRect, DlMatrix(), *inOutBounds);
 }
 
-SKWASM_EXPORT SkColorFilter* colorFilter_createMode(SkColor color,
-                                                    SkBlendMode mode) {
+SKWASM_EXPORT sp_wrapper<const DlColorFilter>* colorFilter_createMode(
+    uint32_t color,
+    DlBlendMode mode) {
   liveColorFilterCount++;
-  return SkColorFilters::Blend(color, mode).release();
+  return new sp_wrapper<const DlColorFilter>(
+      DlColorFilter::MakeBlend(DlColor(color), mode));
 }
 
-SKWASM_EXPORT SkColorFilter* colorFilter_createMatrix(
+SKWASM_EXPORT sp_wrapper<const DlColorFilter>* colorFilter_createMatrix(
     float* matrixData  // 20 values
 ) {
   liveColorFilterCount++;
-  return SkColorFilters::Matrix(matrixData).release();
+  return new sp_wrapper<const DlColorFilter>(
+      DlColorFilter::MakeMatrix(matrixData));
 }
 
-SKWASM_EXPORT SkColorFilter* colorFilter_createSRGBToLinearGamma() {
+SKWASM_EXPORT sp_wrapper<const DlColorFilter>*
+colorFilter_createSRGBToLinearGamma() {
   liveColorFilterCount++;
-  return SkColorFilters::SRGBToLinearGamma().release();
+  return new sp_wrapper<const DlColorFilter>(
+      DlColorFilter::MakeSrgbToLinearGamma());
 }
 
-SKWASM_EXPORT SkColorFilter* colorFilter_createLinearToSRGBGamma() {
+SKWASM_EXPORT sp_wrapper<const DlColorFilter>*
+colorFilter_createLinearToSRGBGamma() {
   liveColorFilterCount++;
-  return SkColorFilters::LinearToSRGBGamma().release();
+  return new sp_wrapper<const DlColorFilter>(
+      DlColorFilter::MakeLinearToSrgbGamma());
 }
 
-SKWASM_EXPORT SkColorFilter* colorFilter_compose(SkColorFilter* outer,
-                                                 SkColorFilter* inner) {
-  liveColorFilterCount++;
-  return SkColorFilters::Compose(sk_ref_sp<SkColorFilter>(outer),
-                                 sk_ref_sp<SkColorFilter>(inner))
-      .release();
-}
-
-SKWASM_EXPORT void colorFilter_dispose(SkColorFilter* filter) {
+SKWASM_EXPORT void colorFilter_dispose(
+    sp_wrapper<const DlColorFilter>* filter) {
   liveColorFilterCount--;
-  filter->unref();
+  delete filter;
 }
 
-SKWASM_EXPORT SkMaskFilter* maskFilter_createBlur(SkBlurStyle blurStyle,
-                                                  SkScalar sigma) {
+SKWASM_EXPORT sp_wrapper<DlMaskFilter>* maskFilter_createBlur(
+    DlBlurStyle blurStyle,
+    DlScalar sigma) {
   liveMaskFilterCount++;
-  return SkMaskFilter::MakeBlur(blurStyle, sigma).release();
+  return new sp_wrapper<DlMaskFilter>(DlBlurMaskFilter::Make(blurStyle, sigma));
 }
 
-SKWASM_EXPORT void maskFilter_dispose(SkMaskFilter* filter) {
+SKWASM_EXPORT void maskFilter_dispose(sp_wrapper<DlMaskFilter>* filter) {
   liveMaskFilterCount--;
-  filter->unref();
+  delete filter;
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/helpers.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/helpers.h
@@ -5,21 +5,68 @@
 #ifndef FLUTTER_LIB_WEB_UI_SKWASM_HELPERS_H_
 #define FLUTTER_LIB_WEB_UI_SKWASM_HELPERS_H_
 
+#include "flutter/display_list/dl_sampling_options.h"
+#include "flutter/display_list/geometry/dl_geometry_types.h"
+
 #include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkSamplingOptions.h"
 
 namespace Skwasm {
 
-inline SkMatrix createMatrix(const SkScalar* f) {
+template <typename T>
+class sp_wrapper {
+ public:
+  sp_wrapper(std::shared_ptr<T> ptr) : _ptr(std::move(ptr)) {}
+
+  const std::shared_ptr<T>& shared() { return _ptr; }
+
+  T* raw() { return _ptr.get(); }
+
+ private:
+  std::shared_ptr<T> _ptr;
+};
+
+inline flutter::DlMatrix createDlMatrixFrom3x3(const flutter::DlScalar* f) {
+  // clang-format off
+  return flutter::DlMatrix(
+    f[0], f[3], 0, f[6],
+    f[1], f[4], 0, f[7],
+    0, 0, 1, 0,
+    f[2], f[5], 0, f[8]
+  );
+  // clang-format on
+}
+
+inline SkMatrix createSkMatrix(const SkScalar* f) {
   return SkMatrix::MakeAll(f[0], f[1], f[2], f[3], f[4], f[5], f[6], f[7],
                            f[8]);
 }
 
-inline SkRRect createRRect(const SkScalar* f) {
+inline flutter::DlRect createDlRect(const float* f) {
+  return flutter::DlRect::MakeLTRB(f[0], f[1], f[2], f[3]);
+}
+
+inline flutter::DlRoundingRadii createDlRadii(const float* f) {
+  // Flutter has radii in TL,TR,BR,BL (clockwise) order,
+  // but Impeller uses TL,TR,BL,BR (zig-zag) order
+  impeller::RoundingRadii radii = {
+      .top_left = flutter::DlSize(f[0], f[1]),
+      .top_right = flutter::DlSize(f[2], f[3]),
+      .bottom_left = flutter::DlSize(f[6], f[7]),
+      .bottom_right = flutter::DlSize(f[4], f[5]),
+  };
+  return radii;
+}
+
+inline flutter::DlRoundRect createDlRRect(const float* f) {
+  return flutter::DlRoundRect::MakeRectRadii(createDlRect(f),
+                                             createDlRadii(f + 4));
+}
+
+inline SkRRect createSkRRect(const SkScalar* f) {
   const SkRect* rect = reinterpret_cast<const SkRect*>(f);
   const SkVector* radiiValues = reinterpret_cast<const SkVector*>(f + 4);
-
   SkRRect rr;
   rr.setRectRadii(*rect, radiiValues);
   return rr;
@@ -33,29 +80,28 @@ enum class FilterQuality {
   high,
 };
 
-inline SkFilterMode filterModeForQuality(FilterQuality quality) {
+inline flutter::DlFilterMode filterModeForQuality(FilterQuality quality) {
   switch (quality) {
     case FilterQuality::none:
+      return flutter::DlFilterMode::kNearest;
     case FilterQuality::low:
-      return SkFilterMode::kNearest;
     case FilterQuality::medium:
     case FilterQuality::high:
-      return SkFilterMode::kLinear;
+      return flutter::DlFilterMode::kLinear;
   }
 }
 
-inline SkSamplingOptions samplingOptionsForQuality(FilterQuality quality) {
+inline flutter::DlImageSampling samplingOptionsForQuality(
+    FilterQuality quality) {
   switch (quality) {
     case FilterQuality::none:
-      return SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone);
+      return flutter::DlImageSampling::kNearestNeighbor;
     case FilterQuality::low:
-      return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone);
+      return flutter::DlImageSampling::kLinear;
     case FilterQuality::medium:
-      return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear);
+      return flutter::DlImageSampling::kMipmapLinear;
     case FilterQuality::high:
-      // Cubic equation coefficients recommended by Mitchell & Netravali
-      // in their paper on cubic interpolation.
-      return SkSamplingOptions(SkCubicResampler::Mitchell());
+      return flutter::DlImageSampling::kCubic;
   }
 }
 }  // namespace Skwasm

--- a/engine/src/flutter/lib/web_ui/skwasm/paint.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/paint.cpp
@@ -5,56 +5,58 @@
 #include "export.h"
 #include "helpers.h"
 #include "live_objects.h"
-#include "third_party/skia/include/core/SkColorFilter.h"
-#include "third_party/skia/include/core/SkImageFilter.h"
-#include "third_party/skia/include/core/SkMaskFilter.h"
-#include "third_party/skia/include/core/SkPaint.h"
-#include "third_party/skia/include/core/SkShader.h"
+
+#include "flutter/display_list/dl_paint.h"
+#include "flutter/display_list/geometry/dl_geometry_types.h"
 
 using namespace Skwasm;
+using namespace flutter;
 
-SKWASM_EXPORT SkPaint* paint_create(bool isAntiAlias,
-                                    SkBlendMode blendMode,
-                                    SkColor color,
-                                    SkPaint::Style style,
-                                    SkScalar strokeWidth,
-                                    SkPaint::Cap strokeCap,
-                                    SkPaint::Join strokeJoin,
-                                    SkScalar strokeMiterLimit) {
+SKWASM_EXPORT DlPaint* paint_create(bool isAntiAlias,
+                                    DlBlendMode blendMode,
+                                    uint32_t color,
+                                    DlDrawStyle style,
+                                    DlScalar strokeWidth,
+                                    DlStrokeCap strokeCap,
+                                    DlStrokeJoin strokeJoin,
+                                    DlScalar strokeMiterLimit,
+                                    bool invertColors) {
   livePaintCount++;
-  auto paint = new SkPaint();
+  auto paint = new DlPaint();
   paint->setAntiAlias(isAntiAlias);
   paint->setBlendMode(blendMode);
-  paint->setStyle(style);
+  paint->setDrawStyle(style);
   paint->setStrokeWidth(strokeWidth);
   paint->setStrokeCap(strokeCap);
   paint->setStrokeJoin(strokeJoin);
-  paint->setColor(color);
+  paint->setColor(DlColor(color));
   paint->setStrokeMiter(strokeMiterLimit);
+  paint->setInvertColors(invertColors);
   return paint;
 }
 
-SKWASM_EXPORT void paint_dispose(SkPaint* paint) {
+SKWASM_EXPORT void paint_dispose(DlPaint* paint) {
   livePaintCount--;
   delete paint;
 }
 
-SKWASM_EXPORT void paint_setShader(SkPaint* paint, SkShader* shader) {
-  paint->setShader(sk_ref_sp<SkShader>(shader));
+SKWASM_EXPORT void paint_setShader(DlPaint* paint,
+                                   sp_wrapper<DlColorSource>* shader) {
+  paint->setColorSource(shader->shared());
 }
 
-SKWASM_EXPORT void paint_setDither(SkPaint* paint, bool isDither) {
-  paint->setDither(isDither);
+SKWASM_EXPORT void paint_setImageFilter(DlPaint* paint,
+                                        sp_wrapper<DlImageFilter>* filter) {
+  paint->setImageFilter(filter->shared());
 }
 
-SKWASM_EXPORT void paint_setImageFilter(SkPaint* paint, SkImageFilter* filter) {
-  paint->setImageFilter(sk_ref_sp<SkImageFilter>(filter));
+SKWASM_EXPORT void paint_setColorFilter(
+    DlPaint* paint,
+    sp_wrapper<const DlColorFilter>* filter) {
+  paint->setColorFilter(filter->shared());
 }
 
-SKWASM_EXPORT void paint_setColorFilter(SkPaint* paint, SkColorFilter* filter) {
-  paint->setColorFilter(sk_ref_sp<SkColorFilter>(filter));
-}
-
-SKWASM_EXPORT void paint_setMaskFilter(SkPaint* paint, SkMaskFilter* filter) {
-  paint->setMaskFilter(sk_ref_sp<SkMaskFilter>(filter));
+SKWASM_EXPORT void paint_setMaskFilter(DlPaint* paint,
+                                       sp_wrapper<DlMaskFilter>* filter) {
+  paint->setMaskFilter(filter->shared());
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/path.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/path.cpp
@@ -158,14 +158,14 @@ SKWASM_EXPORT void path_addPolygon(SkPath* path,
 }
 
 SKWASM_EXPORT void path_addRRect(SkPath* path, const SkScalar* rrectValues) {
-  path->addRRect(createRRect(rrectValues), SkPathDirection::kCW);
+  path->addRRect(createSkRRect(rrectValues), SkPathDirection::kCW);
 }
 
 SKWASM_EXPORT void path_addPath(SkPath* path,
                                 const SkPath* other,
                                 const SkScalar* matrix33,
                                 SkPath::AddPathMode extendPath) {
-  path->addPath(*other, createMatrix(matrix33), extendPath);
+  path->addPath(*other, createSkMatrix(matrix33), extendPath);
 }
 
 SKWASM_EXPORT void path_close(SkPath* path) {
@@ -181,7 +181,7 @@ SKWASM_EXPORT bool path_contains(SkPath* path, SkScalar x, SkScalar y) {
 }
 
 SKWASM_EXPORT void path_transform(SkPath* path, const SkScalar* matrix33) {
-  path->transform(createMatrix(matrix33));
+  path->transform(createSkMatrix(matrix33));
 }
 
 SKWASM_EXPORT void path_getBounds(SkPath* path, SkRect* rect) {

--- a/engine/src/flutter/lib/web_ui/skwasm/picture.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/picture.cpp
@@ -5,46 +5,62 @@
 #include "export.h"
 #include "helpers.h"
 #include "live_objects.h"
-#include "third_party/skia/include/core/SkBBHFactory.h"
-#include "third_party/skia/include/core/SkPicture.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "wrappers.h"
 
+#include "flutter/display_list/dl_builder.h"
+
+#include <cassert>
+
 using namespace Skwasm;
+using namespace flutter;
 
-SkRTreeFactory bbhFactory;
+class PictureRecorder {
+ public:
+  PictureRecorder() {};
 
-SKWASM_EXPORT SkPictureRecorder* pictureRecorder_create() {
+  DisplayListBuilder* beginRecording(const DlRect& cullRect) {
+    assert(!_builder);
+    _builder = std::make_unique<DisplayListBuilder>(cullRect);
+    return _builder.get();
+  }
+
+  sk_sp<DisplayList> finishRecordingAsPicture() { return _builder->Build(); }
+
+ private:
+  std::unique_ptr<DisplayListBuilder> _builder;
+};
+
+SKWASM_EXPORT PictureRecorder* pictureRecorder_create() {
   livePictureRecorderCount++;
-  return new SkPictureRecorder();
+  return new PictureRecorder();
 }
 
-SKWASM_EXPORT void pictureRecorder_dispose(SkPictureRecorder* recorder) {
+SKWASM_EXPORT void pictureRecorder_dispose(PictureRecorder* recorder) {
   livePictureRecorderCount--;
   delete recorder;
 }
 
-SKWASM_EXPORT SkCanvas* pictureRecorder_beginRecording(
-    SkPictureRecorder* recorder,
-    const SkRect* cullRect) {
-  return recorder->beginRecording(*cullRect, &bbhFactory);
+SKWASM_EXPORT DisplayListBuilder* pictureRecorder_beginRecording(
+    PictureRecorder* recorder,
+    const DlRect* cullRect) {
+  return recorder->beginRecording(*cullRect);
 }
 
-SKWASM_EXPORT SkPicture* pictureRecorder_endRecording(
-    SkPictureRecorder* recorder) {
+SKWASM_EXPORT DisplayList* pictureRecorder_endRecording(
+    PictureRecorder* recorder) {
   livePictureCount++;
   return recorder->finishRecordingAsPicture().release();
 }
 
-SKWASM_EXPORT void picture_getCullRect(SkPicture* picture, SkRect* outRect) {
-  *outRect = picture->cullRect();
+SKWASM_EXPORT void picture_getCullRect(DisplayList* picture, DlRect* outRect) {
+  *outRect = picture->GetBounds();
 }
 
-SKWASM_EXPORT void picture_dispose(SkPicture* picture) {
+SKWASM_EXPORT void picture_dispose(DisplayList* picture) {
   livePictureCount--;
   picture->unref();
 }
 
-SKWASM_EXPORT uint32_t picture_approximateBytesUsed(SkPicture* picture) {
-  return static_cast<uint32_t>(picture->approximateBytesUsed());
+SKWASM_EXPORT uint32_t picture_approximateBytesUsed(DisplayList* picture) {
+  return static_cast<uint32_t>(picture->bytes());
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/shaders.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/shaders.cpp
@@ -5,107 +5,132 @@
 #include "export.h"
 #include "helpers.h"
 #include "live_objects.h"
-#include "third_party/skia/include/core/SkImage.h"
-#include "third_party/skia/include/effects/SkGradientShader.h"
-#include "third_party/skia/include/effects/SkRuntimeEffect.h"
 #include "wrappers.h"
 
-using namespace Skwasm;
+#include "flutter/display_list/effects/dl_color_source.h"
+#include "flutter/display_list/effects/dl_runtime_effect_skia.h"
+#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/effects/SkRuntimeEffect.h"
 
-SKWASM_EXPORT SkShader* shader_createLinearGradient(
-    SkPoint* endPoints,  // Two points
-    SkColor* colors,
-    SkScalar* stops,
+using namespace Skwasm;
+using namespace flutter;
+
+namespace Skwasm {
+struct UniformData {
+  std::shared_ptr<std::vector<uint8_t>> data;
+};
+}  // namespace Skwasm
+
+SKWASM_EXPORT sp_wrapper<DlColorSource>* shader_createLinearGradient(
+    DlPoint* endPoints,  // Two points
+    uint32_t* colors,
+    DlScalar* stops,
     int count,  // Number of stops/colors
-    SkTileMode tileMode,
-    SkScalar* matrix33  // Can be nullptr
+    DlTileMode tileMode,
+    DlScalar* matrix33  // Can be nullptr
 ) {
   liveShaderCount++;
+  std::vector<DlColor> dlColors;
+  dlColors.resize(count);
+  for (int i = 0; i < count; i++) {
+    dlColors[i] = DlColor(colors[i]);
+  }
   if (matrix33) {
-    SkMatrix localMatrix = createMatrix(matrix33);
-    return SkGradientShader::MakeLinear(endPoints, colors, stops, count,
-                                        tileMode, 0, &localMatrix)
-        .release();
+    auto matrix = createDlMatrixFrom3x3(matrix33);
+    return new sp_wrapper<DlColorSource>(
+        DlColorSource::MakeLinear(endPoints[0], endPoints[1], count,
+                                  dlColors.data(), stops, tileMode, &matrix));
   } else {
-    return SkGradientShader::MakeLinear(endPoints, colors, stops, count,
-                                        tileMode)
-        .release();
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeLinear(
+        endPoints[0], endPoints[1], count, dlColors.data(), stops, tileMode));
   }
 }
 
-SKWASM_EXPORT SkShader* shader_createRadialGradient(SkScalar centerX,
-                                                    SkScalar centerY,
-                                                    SkScalar radius,
-                                                    SkColor* colors,
-                                                    SkScalar* stops,
-                                                    int count,
-                                                    SkTileMode tileMode,
-                                                    SkScalar* matrix33) {
-  liveShaderCount++;
-  if (matrix33) {
-    SkMatrix localMatrix = createMatrix(matrix33);
-    return SkGradientShader::MakeRadial({centerX, centerY}, radius, colors,
-                                        stops, count, tileMode, 0, &localMatrix)
-        .release();
-  } else {
-    return SkGradientShader::MakeRadial({centerX, centerY}, radius, colors,
-                                        stops, count, tileMode)
-        .release();
-  }
-}
-
-SKWASM_EXPORT SkShader* shader_createConicalGradient(
-    SkPoint* endPoints,  // Two points
-    SkScalar startRadius,
-    SkScalar endRadius,
-    SkColor* colors,
-    SkScalar* stops,
+SKWASM_EXPORT sp_wrapper<DlColorSource>* shader_createRadialGradient(
+    DlScalar centerX,
+    DlScalar centerY,
+    DlScalar radius,
+    uint32_t* colors,
+    DlScalar* stops,
     int count,
-    SkTileMode tileMode,
-    SkScalar* matrix33) {
+    DlTileMode tileMode,
+    DlScalar* matrix33) {
   liveShaderCount++;
+  std::vector<DlColor> dlColors;
+  dlColors.resize(count);
+  for (int i = 0; i < count; i++) {
+    dlColors[i] = DlColor(colors[i]);
+  }
   if (matrix33) {
-    SkMatrix localMatrix = createMatrix(matrix33);
-    return SkGradientShader::MakeTwoPointConical(
-               endPoints[0], startRadius, endPoints[1], endRadius, colors,
-               stops, count, tileMode, 0, &localMatrix)
-        .release();
-
+    auto localMatrix = createDlMatrixFrom3x3(matrix33);
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeRadial(
+        DlPoint{centerX, centerY}, radius, count, dlColors.data(), stops,
+        tileMode, &localMatrix));
   } else {
-    return SkGradientShader::MakeTwoPointConical(endPoints[0], startRadius,
-                                                 endPoints[1], endRadius,
-                                                 colors, stops, count, tileMode)
-        .release();
+    return new sp_wrapper<DlColorSource>(
+        DlColorSource::MakeRadial(DlPoint{centerX, centerY}, radius, count,
+                                  dlColors.data(), stops, tileMode));
   }
 }
 
-SKWASM_EXPORT SkShader* shader_createSweepGradient(SkScalar centerX,
-                                                   SkScalar centerY,
-                                                   SkColor* colors,
-                                                   SkScalar* stops,
-                                                   int count,
-                                                   SkTileMode tileMode,
-                                                   SkScalar startAngle,
-                                                   SkScalar endAngle,
-                                                   SkScalar* matrix33) {
+SKWASM_EXPORT sp_wrapper<DlColorSource>* shader_createConicalGradient(
+    DlPoint* endPoints,  // Two points
+    DlScalar startRadius,
+    DlScalar endRadius,
+    uint32_t* colors,
+    DlScalar* stops,
+    int count,
+    DlTileMode tileMode,
+    DlScalar* matrix33) {
   liveShaderCount++;
+  std::vector<DlColor> dlColors;
+  dlColors.resize(count);
+  for (int i = 0; i < count; i++) {
+    dlColors[i] = DlColor(colors[i]);
+  }
   if (matrix33) {
-    SkMatrix localMatrix = createMatrix(matrix33);
-    return SkGradientShader::MakeSweep(centerX, centerY, colors, stops, count,
-                                       tileMode, startAngle, endAngle, 0,
-                                       &localMatrix)
-        .release();
+    auto localMatrix = createDlMatrixFrom3x3(matrix33);
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeConical(
+        endPoints[0], startRadius, endPoints[1], endRadius, count,
+        dlColors.data(), stops, tileMode, &localMatrix));
   } else {
-    return SkGradientShader::MakeSweep(centerX, centerY, colors, stops, count,
-                                       tileMode, startAngle, endAngle, 0,
-                                       nullptr)
-        .release();
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeConical(
+        endPoints[0], startRadius, endPoints[1], endRadius, count,
+        dlColors.data(), stops, tileMode));
   }
 }
 
-SKWASM_EXPORT void shader_dispose(SkShader* shader) {
+SKWASM_EXPORT sp_wrapper<DlColorSource>* shader_createSweepGradient(
+    DlScalar centerX,
+    DlScalar centerY,
+    uint32_t* colors,
+    DlScalar* stops,
+    int count,
+    DlTileMode tileMode,
+    DlScalar startAngle,
+    DlScalar endAngle,
+    DlScalar* matrix33) {
+  liveShaderCount++;
+  std::vector<DlColor> dlColors;
+  dlColors.resize(count);
+  for (int i = 0; i < count; i++) {
+    dlColors[i] = DlColor(colors[i]);
+  }
+  if (matrix33) {
+    auto localMatrix = createDlMatrixFrom3x3(matrix33);
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeSweep(
+        DlPoint{centerX, centerY}, startAngle, endAngle, count, dlColors.data(),
+        stops, tileMode, &localMatrix));
+  } else {
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeSweep(
+        DlPoint{centerX, centerY}, startAngle, endAngle, count, dlColors.data(),
+        stops, tileMode));
+  }
+}
+
+SKWASM_EXPORT void shader_dispose(sp_wrapper<DlColorSource>* shader) {
   liveShaderCount--;
-  shader->unref();
+  delete shader;
 }
 
 SKWASM_EXPORT SkRuntimeEffect* runtimeEffect_create(SkString* source) {
@@ -129,38 +154,50 @@ SKWASM_EXPORT size_t runtimeEffect_getUniformSize(SkRuntimeEffect* effect) {
   return effect->uniformSize();
 }
 
-SKWASM_EXPORT SkShader* shader_createRuntimeEffectShader(
+SKWASM_EXPORT sp_wrapper<DlColorSource>* shader_createRuntimeEffectShader(
     SkRuntimeEffect* runtimeEffect,
-    SkData* uniforms,
-    SkShader** children,
+    UniformData* uniforms,
+    sp_wrapper<DlColorSource>** children,
     size_t childCount) {
   liveShaderCount++;
-  std::vector<sk_sp<SkShader>> childPointers;
+  std::vector<std::shared_ptr<DlColorSource>> childPointers;
+  childPointers.resize(childCount);
   for (size_t i = 0; i < childCount; i++) {
-    childPointers.emplace_back(sk_ref_sp<SkShader>(children[i]));
+    childPointers[i] = children[i]->shared();
   }
 
-  return runtimeEffect
-      ->makeShader(sk_ref_sp<SkData>(uniforms), childPointers.data(),
-                   childCount, nullptr)
-      .release();
+  return new sp_wrapper<DlColorSource>(DlColorSource::MakeRuntimeEffect(
+      DlRuntimeEffectSkia::Make(sk_ref_sp(runtimeEffect)),
+      std::move(childPointers), uniforms->data));
 }
 
-SKWASM_EXPORT SkShader* shader_createFromImage(SkImage* image,
-                                               SkTileMode tileModeX,
-                                               SkTileMode tileModeY,
-                                               FilterQuality quality,
-                                               SkScalar* matrix33) {
+SKWASM_EXPORT sp_wrapper<DlColorSource>* shader_createFromImage(
+    SkImage* image,
+    DlTileMode tileModeX,
+    DlTileMode tileModeY,
+    FilterQuality quality,
+    DlScalar* matrix33) {
   liveShaderCount++;
   if (matrix33) {
-    SkMatrix localMatrix = createMatrix(matrix33);
-    return image
-        ->makeShader(tileModeX, tileModeY, samplingOptionsForQuality(quality),
-                     &localMatrix)
-        .release();
+    auto localMatrix = createDlMatrixFrom3x3(matrix33);
+    return new sp_wrapper<DlColorSource>(DlColorSource::MakeImage(
+        DlImage::Make(image), tileModeX, tileModeY,
+        samplingOptionsForQuality(quality), &localMatrix));
   } else {
-    return image
-        ->makeShader(tileModeX, tileModeY, samplingOptionsForQuality(quality))
-        .release();
+    return new sp_wrapper<DlColorSource>(
+        DlColorSource::MakeImage(DlImage::Make(image), tileModeX, tileModeY,
+                                 samplingOptionsForQuality(quality)));
   }
+}
+
+SKWASM_EXPORT UniformData* uniformData_create(int size) {
+  return new UniformData{std::make_shared<std::vector<uint8_t>>(size)};
+}
+
+SKWASM_EXPORT void uniformData_dispose(UniformData* data) {
+  delete data;
+}
+
+SKWASM_EXPORT void* uniformData_getPointer(UniformData* data) {
+  return data->data->data();
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/skwasm_support.h
@@ -12,6 +12,10 @@
 
 using SkwasmObject = __externref_t;
 
+namespace flutter {
+class DisplayList;
+}
+
 extern "C" {
 extern bool skwasm_isSingleThreaded();
 extern void skwasm_setAssociatedObjectOnThread(unsigned long threadId,
@@ -23,7 +27,7 @@ extern void skwasm_disposeAssociatedObjectOnThread(unsigned long threadId,
 extern void skwasm_connectThread(pthread_t threadId);
 extern void skwasm_dispatchRenderPictures(unsigned long threadId,
                                           Skwasm::Surface* surface,
-                                          sk_sp<SkPicture>* pictures,
+                                          sk_sp<flutter::DisplayList>* pictures,
                                           int count,
                                           uint32_t callbackId);
 extern uint32_t skwasm_createOffscreenCanvas(int width, int height);

--- a/engine/src/flutter/lib/web_ui/skwasm/surface.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/surface.cpp
@@ -3,18 +3,22 @@
 // found in the LICENSE file.
 
 #include "surface.h"
-#include <emscripten/wasm_worker.h>
-#include <algorithm>
 #include "live_objects.h"
-
 #include "skwasm_support.h"
+
+#include "flutter/display_list/display_list.h"
+#include "flutter/display_list/skia/dl_sk_dispatcher.h"
 #include "third_party/skia/include/gpu/ganesh/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLBackendSurface.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLDirectContext.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLMakeWebGLInterface.h"
 
+#include <emscripten/wasm_worker.h>
+#include <algorithm>
+
 using namespace Skwasm;
+using namespace flutter;
 
 Surface::Surface() {
   if (skwasm_isSingleThreaded()) {
@@ -39,11 +43,11 @@ void Surface::dispose() {
 }
 
 // Main thread only
-uint32_t Surface::renderPictures(SkPicture** pictures, int count) {
+uint32_t Surface::renderPictures(DisplayList** pictures, int count) {
   assert(emscripten_is_main_browser_thread());
   uint32_t callbackId = ++_currentCallbackId;
-  std::unique_ptr<sk_sp<SkPicture>[]> picturePointers =
-      std::make_unique<sk_sp<SkPicture>[]>(count);
+  std::unique_ptr<sk_sp<DisplayList>[]> picturePointers =
+      std::make_unique<sk_sp<DisplayList>[]>(count);
   for (int i = 0; i < count; i++) {
     picturePointers[i] = sk_ref_sp(pictures[i]);
   }
@@ -131,7 +135,7 @@ void Surface::_recreateSurface() {
 }
 
 // Worker thread only
-void Surface::renderPicturesOnWorker(sk_sp<SkPicture>* pictures,
+void Surface::renderPicturesOnWorker(sk_sp<DisplayList>* pictures,
                                      int pictureCount,
                                      uint32_t callbackId,
                                      double rasterStart) {
@@ -143,21 +147,23 @@ void Surface::renderPicturesOnWorker(sk_sp<SkPicture>* pictures,
   // passed in.
   SkwasmObject imagePromiseArray = __builtin_wasm_ref_null_extern();
   for (int i = 0; i < pictureCount; i++) {
-    sk_sp<SkPicture> picture = pictures[i];
-    SkRect pictureRect = picture->cullRect();
-    SkIRect roundedOutRect;
-    pictureRect.roundOut(&roundedOutRect);
-    _resizeCanvasToFit(roundedOutRect.width(), roundedOutRect.height());
-    SkMatrix matrix =
-        SkMatrix::Translate(-roundedOutRect.fLeft, -roundedOutRect.fTop);
+    sk_sp<DisplayList> picture = pictures[i];
+    DlRect pictureRect = picture->GetBounds();
+    DlIRect roundedOutRect = DlIRect::RoundOut(pictureRect);
+    _resizeCanvasToFit(roundedOutRect.GetWidth(), roundedOutRect.GetHeight());
     makeCurrent(_glContext);
     auto canvas = _surface->getCanvas();
     canvas->drawColor(SK_ColorTRANSPARENT, SkBlendMode::kSrc);
-    canvas->drawPicture(picture, &matrix, nullptr);
+    auto dispatcher = DlSkCanvasDispatcher(canvas);
+    dispatcher.save();
+    dispatcher.translate(-roundedOutRect.GetLeft(), -roundedOutRect.GetTop());
+    dispatcher.drawDisplayList(picture, 1.0f);
+    dispatcher.restore();
+
     _grContext->flush(_surface.get());
-    imagePromiseArray =
-        skwasm_captureImageBitmap(_glContext, roundedOutRect.width(),
-                                  roundedOutRect.height(), imagePromiseArray);
+    imagePromiseArray = skwasm_captureImageBitmap(
+        _glContext, roundedOutRect.GetWidth(), roundedOutRect.GetHeight(),
+        imagePromiseArray);
   }
   skwasm_resolveAndPostImages(this, imagePromiseArray, rasterStart, callbackId);
 }
@@ -263,19 +269,19 @@ SKWASM_EXPORT void surface_dispose(Surface* surface) {
 }
 
 SKWASM_EXPORT uint32_t surface_renderPictures(Surface* surface,
-                                              SkPicture** pictures,
+                                              DisplayList** pictures,
                                               int count) {
   return surface->renderPictures(pictures, count);
 }
 
 SKWASM_EXPORT void surface_renderPicturesOnWorker(Surface* surface,
-                                                  sk_sp<SkPicture>* pictures,
+                                                  sk_sp<DisplayList>* pictures,
                                                   int pictureCount,
                                                   uint32_t callbackId,
                                                   double rasterStart) {
   // This will release the pictures when they leave scope.
-  std::unique_ptr<sk_sp<SkPicture>[]> picturesPointer =
-      std::unique_ptr<sk_sp<SkPicture>[]>(pictures);
+  std::unique_ptr<sk_sp<DisplayList>[]> picturesPointer =
+      std::unique_ptr<sk_sp<DisplayList>[]>(pictures);
   surface->renderPicturesOnWorker(pictures, pictureCount, callbackId,
                                   rasterStart);
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/surface.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/surface.h
@@ -15,7 +15,6 @@
 #include "export.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColorSpace.h"
-#include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/encode/SkPngEncoder.h"
 #include "third_party/skia/include/gpu/ganesh/GrDirectContext.h"
@@ -23,6 +22,10 @@
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLInterface.h"
 #include "third_party/skia/include/gpu/ganesh/gl/GrGLTypes.h"
 #include "wrappers.h"
+
+namespace flutter {
+class DisplayList;
+}
 
 namespace Skwasm {
 // This must be kept in sync with the `ImageByteFormat` enum in dart:ui.
@@ -55,7 +58,7 @@ class Surface {
 
   // Main thread only
   void dispose();
-  uint32_t renderPictures(SkPicture** picture, int count);
+  uint32_t renderPictures(flutter::DisplayList** picture, int count);
   uint32_t rasterizeImage(SkImage* image, ImageByteFormat format);
   void setCallbackHandler(CallbackHandler* callbackHandler);
   void onRenderComplete(uint32_t callbackId, SkwasmObject imageBitmap);
@@ -66,7 +69,7 @@ class Surface {
       SkwasmObject textureSource);
 
   // Worker thread
-  void renderPicturesOnWorker(sk_sp<SkPicture>* picture,
+  void renderPicturesOnWorker(sk_sp<flutter::DisplayList>* picture,
                               int pictureCount,
                               uint32_t callbackId,
                               double rasterStart);

--- a/engine/src/flutter/lib/web_ui/skwasm/text/paragraph.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/text/paragraph.cpp
@@ -8,8 +8,9 @@
 #include "DartTypes.h"
 #include "TextStyle.h"
 #include "include/core/SkScalar.h"
+#include "text_types.h"
 
-using namespace skia::textlayout;
+using namespace Skwasm;
 
 SKWASM_EXPORT void paragraph_dispose(Paragraph* paragraph) {
   liveParagraphCount--;
@@ -17,46 +18,48 @@ SKWASM_EXPORT void paragraph_dispose(Paragraph* paragraph) {
 }
 
 SKWASM_EXPORT SkScalar paragraph_getWidth(Paragraph* paragraph) {
-  return paragraph->getMaxWidth();
+  return paragraph->skiaParagraph->getMaxWidth();
 }
 
 SKWASM_EXPORT SkScalar paragraph_getHeight(Paragraph* paragraph) {
-  return paragraph->getHeight();
+  return paragraph->skiaParagraph->getHeight();
 }
 
 SKWASM_EXPORT SkScalar paragraph_getLongestLine(Paragraph* paragraph) {
-  return paragraph->getLongestLine();
+  return paragraph->skiaParagraph->getLongestLine();
 }
 
 SKWASM_EXPORT SkScalar paragraph_getMinIntrinsicWidth(Paragraph* paragraph) {
-  return paragraph->getMinIntrinsicWidth();
+  return paragraph->skiaParagraph->getMinIntrinsicWidth();
 }
 
 SKWASM_EXPORT SkScalar paragraph_getMaxIntrinsicWidth(Paragraph* paragraph) {
-  return paragraph->getMaxIntrinsicWidth();
+  return paragraph->skiaParagraph->getMaxIntrinsicWidth();
 }
 
 SKWASM_EXPORT SkScalar paragraph_getAlphabeticBaseline(Paragraph* paragraph) {
-  return paragraph->getAlphabeticBaseline();
+  return paragraph->skiaParagraph->getAlphabeticBaseline();
 }
 
 SKWASM_EXPORT SkScalar paragraph_getIdeographicBaseline(Paragraph* paragraph) {
-  return paragraph->getIdeographicBaseline();
+  return paragraph->skiaParagraph->getIdeographicBaseline();
 }
 
 SKWASM_EXPORT bool paragraph_getDidExceedMaxLines(Paragraph* paragraph) {
-  return paragraph->didExceedMaxLines();
+  return paragraph->skiaParagraph->didExceedMaxLines();
 }
 
 SKWASM_EXPORT void paragraph_layout(Paragraph* paragraph, SkScalar width) {
-  paragraph->layout(width);
+  paragraph->skiaParagraph->layout(width);
 }
 
-SKWASM_EXPORT int32_t paragraph_getPositionForOffset(Paragraph* paragraph,
-                                                     SkScalar offsetX,
-                                                     SkScalar offsetY,
-                                                     Affinity* outAffinity) {
-  auto position = paragraph->getGlyphPositionAtCoordinate(offsetX, offsetY);
+SKWASM_EXPORT int32_t
+paragraph_getPositionForOffset(Paragraph* paragraph,
+                               SkScalar offsetX,
+                               SkScalar offsetY,
+                               skia::textlayout::Affinity* outAffinity) {
+  auto position =
+      paragraph->skiaParagraph->getGlyphPositionAtCoordinate(offsetX, offsetY);
   if (outAffinity) {
     *outAffinity = position.affinity;
   }
@@ -71,8 +74,9 @@ SKWASM_EXPORT bool paragraph_getClosestGlyphInfoAtCoordinate(
     SkRect* graphemeLayoutBounds,   // 1 SkRect
     size_t* graphemeCodeUnitRange,  // 2 size_ts: [start, end]
     bool* booleanFlags) {           // 1 boolean: isLTR
-  Paragraph::GlyphInfo glyphInfo;
-  if (!paragraph->getClosestUTF16GlyphInfoAt(offsetX, offsetY, &glyphInfo)) {
+  skia::textlayout::Paragraph::GlyphInfo glyphInfo;
+  if (!paragraph->skiaParagraph->getClosestUTF16GlyphInfoAt(offsetX, offsetY,
+                                                            &glyphInfo)) {
     return false;
   }
   // This is more verbose than memcpying the whole struct but ideally we don't
@@ -93,8 +97,8 @@ SKWASM_EXPORT bool paragraph_getGlyphInfoAt(
     SkRect* graphemeLayoutBounds,   // 1 SkRect
     size_t* graphemeCodeUnitRange,  // 2 size_ts: [start, end]
     bool* booleanFlags) {           // 1 boolean: isLTR
-  Paragraph::GlyphInfo glyphInfo;
-  if (!paragraph->getGlyphInfoAtUTF16Offset(index, &glyphInfo)) {
+  skia::textlayout::Paragraph::GlyphInfo glyphInfo;
+  if (!paragraph->skiaParagraph->getGlyphInfoAtUTF16Offset(index, &glyphInfo)) {
     return false;
   }
   std::memcpy(graphemeLayoutBounds, &glyphInfo.fGraphemeLayoutBounds,
@@ -111,25 +115,26 @@ SKWASM_EXPORT void paragraph_getWordBoundary(
     unsigned int position,
     int32_t* outRange  // Two `int32_t`s, start and end
 ) {
-  auto range = paragraph->getWordBoundary(position);
+  auto range = paragraph->skiaParagraph->getWordBoundary(position);
   outRange[0] = range.start;
   outRange[1] = range.end;
 }
 
 SKWASM_EXPORT size_t paragraph_getLineCount(Paragraph* paragraph) {
-  return paragraph->lineNumber();
+  return paragraph->skiaParagraph->lineNumber();
 }
 
 SKWASM_EXPORT int paragraph_getLineNumberAt(Paragraph* paragraph,
                                             size_t characterIndex) {
-  return paragraph->getLineNumberAtUTF16Offset(characterIndex);
+  return paragraph->skiaParagraph->getLineNumberAtUTF16Offset(characterIndex);
 }
 
-SKWASM_EXPORT LineMetrics* paragraph_getLineMetricsAtIndex(Paragraph* paragraph,
-                                                           size_t lineNumber) {
+SKWASM_EXPORT skia::textlayout::LineMetrics* paragraph_getLineMetricsAtIndex(
+    Paragraph* paragraph,
+    size_t lineNumber) {
   liveLineMetricsCount++;
-  auto metrics = new LineMetrics();
-  if (paragraph->getLineMetricsAt(lineNumber, metrics)) {
+  auto metrics = new skia::textlayout::LineMetrics();
+  if (paragraph->skiaParagraph->getLineMetricsAt(lineNumber, metrics)) {
     return metrics;
   } else {
     delete metrics;
@@ -138,7 +143,7 @@ SKWASM_EXPORT LineMetrics* paragraph_getLineMetricsAtIndex(Paragraph* paragraph,
 }
 
 struct TextBoxList {
-  std::vector<TextBox> boxes;
+  std::vector<skia::textlayout::TextBox> boxes;
 };
 
 SKWASM_EXPORT void textBoxList_dispose(TextBoxList* list) {
@@ -150,9 +155,8 @@ SKWASM_EXPORT size_t textBoxList_getLength(TextBoxList* list) {
   return list->boxes.size();
 }
 
-SKWASM_EXPORT TextDirection textBoxList_getBoxAtIndex(TextBoxList* list,
-                                                      size_t index,
-                                                      SkRect* outRect) {
+SKWASM_EXPORT skia::textlayout::TextDirection
+textBoxList_getBoxAtIndex(TextBoxList* list, size_t index, SkRect* outRect) {
   const auto& box = list->boxes[index];
   *outRect = box.rect;
   return box.direction;
@@ -162,17 +166,17 @@ SKWASM_EXPORT TextBoxList* paragraph_getBoxesForRange(
     Paragraph* paragraph,
     int start,
     int end,
-    RectHeightStyle heightStyle,
-    RectWidthStyle widthStyle) {
+    skia::textlayout::RectHeightStyle heightStyle,
+    skia::textlayout::RectWidthStyle widthStyle) {
   liveTextBoxListCount++;
-  return new TextBoxList{
-      paragraph->getRectsForRange(start, end, heightStyle, widthStyle)};
+  return new TextBoxList{paragraph->skiaParagraph->getRectsForRange(
+      start, end, heightStyle, widthStyle)};
 }
 
 SKWASM_EXPORT TextBoxList* paragraph_getBoxesForPlaceholders(
     Paragraph* paragraph) {
   liveTextBoxListCount++;
-  return new TextBoxList{paragraph->getRectsForPlaceholders()};
+  return new TextBoxList{paragraph->skiaParagraph->getRectsForPlaceholders()};
 }
 
 // Returns a list of the code points that were unable to be rendered with the
@@ -186,10 +190,10 @@ SKWASM_EXPORT int paragraph_getUnresolvedCodePoints(Paragraph* paragraph,
                                                     SkUnichar* outCodePoints,
                                                     int outLength) {
   if (!outCodePoints) {
-    return paragraph->unresolvedCodepoints().size();
+    return paragraph->skiaParagraph->unresolvedCodepoints().size();
   }
   int outIndex = 0;
-  for (SkUnichar character : paragraph->unresolvedCodepoints()) {
+  for (SkUnichar character : paragraph->skiaParagraph->unresolvedCodepoints()) {
     if (outIndex < outLength) {
       outCodePoints[outIndex] = character;
       outIndex++;

--- a/engine/src/flutter/lib/web_ui/skwasm/text/paragraph_builder.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/text/paragraph_builder.cpp
@@ -5,10 +5,10 @@
 #include "../export.h"
 #include "../live_objects.h"
 #include "../wrappers.h"
+#include "text_types.h"
 #include "third_party/skia/modules/skparagraph/include/ParagraphBuilder.h"
 #include "third_party/skia/modules/skunicode/include/SkUnicode_client.h"
 
-using namespace skia::textlayout;
 using namespace Skwasm;
 
 SKWASM_EXPORT void paragraphBuilder_dispose(ParagraphBuilder* builder) {
@@ -20,32 +20,34 @@ SKWASM_EXPORT void paragraphBuilder_addPlaceholder(
     ParagraphBuilder* builder,
     SkScalar width,
     SkScalar height,
-    PlaceholderAlignment alignment,
+    skia::textlayout::PlaceholderAlignment alignment,
     SkScalar baselineOffset,
-    TextBaseline baseline) {
-  builder->addPlaceholder(
-      PlaceholderStyle(width, height, alignment, baseline, baselineOffset));
+    skia::textlayout::TextBaseline baseline) {
+  builder->skiaParagraphBuilder->addPlaceholder(
+      skia::textlayout::PlaceholderStyle(width, height, alignment, baseline,
+                                         baselineOffset));
 }
 
 SKWASM_EXPORT void paragraphBuilder_addText(ParagraphBuilder* builder,
                                             std::u16string* text) {
-  builder->addText(*text);
+  builder->skiaParagraphBuilder->addText(*text);
 }
 
 SKWASM_EXPORT char* paragraphBuilder_getUtf8Text(ParagraphBuilder* builder,
                                                  uint32_t* outLength) {
-  auto span = builder->getText();
+  auto span = builder->skiaParagraphBuilder->getText();
   *outLength = span.size();
   return span.data();
 }
 
 SKWASM_EXPORT void paragraphBuilder_pushStyle(ParagraphBuilder* builder,
                                               TextStyle* style) {
-  builder->pushStyle(*style);
+  style->populatePaintIds(builder->paints);
+  builder->skiaParagraphBuilder->pushStyle(style->skiaStyle);
 }
 
 SKWASM_EXPORT void paragraphBuilder_pop(ParagraphBuilder* builder) {
-  builder->pop();
+  builder->skiaParagraphBuilder->pop();
 }
 
 SKWASM_EXPORT std::vector<SkUnicode::Position>* unicodePositionBuffer_create(

--- a/engine/src/flutter/lib/web_ui/skwasm/text/paragraph_builder_builtin_icu.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/text/paragraph_builder_builtin_icu.cpp
@@ -6,9 +6,9 @@
 #include "../live_objects.h"
 #include "../wrappers.h"
 #include "modules/skunicode/include/SkUnicode_icu.h"
+#include "text_types.h"
 #include "third_party/skia/modules/skparagraph/include/ParagraphBuilder.h"
 
-using namespace skia::textlayout;
 using namespace Skwasm;
 
 SKWASM_EXPORT bool skwasm_isHeavy() {
@@ -19,14 +19,20 @@ SKWASM_EXPORT ParagraphBuilder* paragraphBuilder_create(
     ParagraphStyle* style,
     FlutterFontCollection* collection) {
   liveParagraphBuilderCount++;
-  return ParagraphBuilder::make(*style, collection->collection,
-                                SkUnicodes::ICU::Make())
-      .release();
+  std::vector<flutter::DlPaint> paints;
+  style->textStyle.populatePaintIds(paints);
+  style->skiaParagraphStyle.setTextStyle(style->textStyle.skiaStyle);
+  return new ParagraphBuilder{
+      skia::textlayout::ParagraphBuilder::make(style->skiaParagraphStyle,
+                                               collection->collection,
+                                               SkUnicodes::ICU::Make()),
+      std::move(paints)};
 }
 
 SKWASM_EXPORT Paragraph* paragraphBuilder_build(ParagraphBuilder* builder) {
   liveParagraphCount++;
-  return builder->Build().release();
+  return new Paragraph{builder->skiaParagraphBuilder->Build(),
+                       std::move(builder->paints)};
 }
 
 SKWASM_EXPORT void paragraphBuilder_setGraphemeBreaksUtf16(

--- a/engine/src/flutter/lib/web_ui/skwasm/text/paragraph_style.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/text/paragraph_style.cpp
@@ -4,21 +4,19 @@
 
 #include "../export.h"
 #include "../wrappers.h"
+#include "text_types.h"
 #include "third_party/skia/modules/skparagraph/include/Paragraph.h"
 
-using namespace skia::textlayout;
 using namespace Skwasm;
 
 SKWASM_EXPORT ParagraphStyle* paragraphStyle_create() {
   auto style = new ParagraphStyle();
 
   // This is the default behavior in Flutter
-  style->setReplaceTabCharacters(true);
+  style->skiaParagraphStyle.setReplaceTabCharacters(true);
 
   // Default text style has a black color
-  TextStyle textStyle;
-  textStyle.setColor(SK_ColorBLACK);
-  style->setTextStyle(textStyle);
+  style->textStyle.skiaStyle.setColor(SK_ColorBLACK);
 
   return style;
 }
@@ -27,59 +25,62 @@ SKWASM_EXPORT void paragraphStyle_dispose(ParagraphStyle* style) {
   delete style;
 }
 
-SKWASM_EXPORT void paragraphStyle_setTextAlign(ParagraphStyle* style,
-                                               TextAlign align) {
-  style->setTextAlign(align);
+SKWASM_EXPORT void paragraphStyle_setTextAlign(
+    ParagraphStyle* style,
+    skia::textlayout::TextAlign align) {
+  style->skiaParagraphStyle.setTextAlign(align);
 }
 
-SKWASM_EXPORT void paragraphStyle_setTextDirection(ParagraphStyle* style,
-                                                   TextDirection direction) {
-  style->setTextDirection(direction);
+SKWASM_EXPORT void paragraphStyle_setTextDirection(
+    ParagraphStyle* style,
+    skia::textlayout::TextDirection direction) {
+  style->skiaParagraphStyle.setTextDirection(direction);
 }
 
 SKWASM_EXPORT void paragraphStyle_setMaxLines(ParagraphStyle* style,
                                               size_t maxLines) {
-  style->setMaxLines(maxLines);
+  style->skiaParagraphStyle.setMaxLines(maxLines);
 }
 
 SKWASM_EXPORT void paragraphStyle_setHeight(ParagraphStyle* style,
                                             SkScalar height) {
-  style->setHeight(height);
+  style->skiaParagraphStyle.setHeight(height);
 }
 
 SKWASM_EXPORT void paragraphStyle_setTextHeightBehavior(
     ParagraphStyle* style,
     bool applyHeightToFirstAscent,
     bool applyHeightToLastDescent) {
-  TextHeightBehavior behavior;
+  skia::textlayout::TextHeightBehavior behavior;
   if (!applyHeightToFirstAscent && !applyHeightToLastDescent) {
-    behavior = kDisableAll;
+    behavior = skia::textlayout::kDisableAll;
   } else if (!applyHeightToLastDescent) {
-    behavior = kDisableLastDescent;
+    behavior = skia::textlayout::kDisableLastDescent;
   } else if (!applyHeightToFirstAscent) {
-    behavior = kDisableFirstAscent;
+    behavior = skia::textlayout::kDisableFirstAscent;
   } else {
-    behavior = kAll;
+    behavior = skia::textlayout::kAll;
   }
-  style->setTextHeightBehavior(behavior);
+  style->skiaParagraphStyle.setTextHeightBehavior(behavior);
 }
 
 SKWASM_EXPORT void paragraphStyle_setEllipsis(ParagraphStyle* style,
                                               SkString* ellipsis) {
-  style->setEllipsis(*ellipsis);
+  style->skiaParagraphStyle.setEllipsis(*ellipsis);
 }
 
-SKWASM_EXPORT void paragraphStyle_setStrutStyle(ParagraphStyle* style,
-                                                StrutStyle* strutStyle) {
-  style->setStrutStyle(*strutStyle);
+SKWASM_EXPORT void paragraphStyle_setStrutStyle(
+    ParagraphStyle* style,
+    skia::textlayout::StrutStyle* strutStyle) {
+  style->skiaParagraphStyle.setStrutStyle(*strutStyle);
 }
 
 SKWASM_EXPORT void paragraphStyle_setTextStyle(ParagraphStyle* style,
                                                TextStyle* textStyle) {
-  style->setTextStyle(*textStyle);
+  style->textStyle = *textStyle;
 }
 
 SKWASM_EXPORT void paragraphStyle_setApplyRoundingHack(ParagraphStyle* style,
                                                        bool applyRoundingHack) {
-  style->setApplyRoundingHack(applyRoundingHack);
+  style->skiaParagraphStyle.setApplyRoundingHack(applyRoundingHack);
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/text/text_style.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/text/text_style.cpp
@@ -5,11 +5,11 @@
 #include "../export.h"
 #include "../live_objects.h"
 #include "../wrappers.h"
+#include "text_types.h"
 #include "third_party/skia/modules/skparagraph/include/Paragraph.h"
 
 const double kTextHeightNone = 0.0;
 
-using namespace skia::textlayout;
 using namespace Skwasm;
 
 SKWASM_EXPORT TextStyle* textStyle_create() {
@@ -17,7 +17,7 @@ SKWASM_EXPORT TextStyle* textStyle_create() {
   auto style = new TextStyle();
 
   // Default color in flutter is black.
-  style->setColor(SK_ColorBLACK);
+  style->skiaStyle.setColor(SK_ColorBLACK);
   return style;
 }
 
@@ -32,49 +32,53 @@ SKWASM_EXPORT void textStyle_dispose(TextStyle* style) {
 }
 
 SKWASM_EXPORT void textStyle_setColor(TextStyle* style, SkColor color) {
-  style->setColor(color);
+  style->skiaStyle.setColor(color);
 }
 
-SKWASM_EXPORT void textStyle_setDecoration(TextStyle* style,
-                                           TextDecoration decoration) {
-  style->setDecoration(decoration);
+SKWASM_EXPORT void textStyle_setDecoration(
+    TextStyle* style,
+    skia::textlayout::TextDecoration decoration) {
+  style->skiaStyle.setDecoration(decoration);
 }
 
 SKWASM_EXPORT void textStyle_setDecorationColor(TextStyle* style,
                                                 SkColor color) {
-  style->setDecorationColor(color);
+  style->skiaStyle.setDecorationColor(color);
 }
 
 SKWASM_EXPORT void textStyle_setDecorationStyle(
     TextStyle* style,
-    TextDecorationStyle decorationStyle) {
-  style->setDecorationStyle(decorationStyle);
+    skia::textlayout::TextDecorationStyle decorationStyle) {
+  style->skiaStyle.setDecorationStyle(decorationStyle);
 }
 
 SKWASM_EXPORT void textStyle_setDecorationThickness(TextStyle* style,
                                                     SkScalar thickness) {
-  style->setDecorationThicknessMultiplier(thickness);
+  style->skiaStyle.setDecorationThicknessMultiplier(thickness);
 }
 
 SKWASM_EXPORT void textStyle_setFontStyle(TextStyle* style,
                                           int weight,
                                           SkFontStyle::Slant slant) {
-  style->setFontStyle(SkFontStyle(weight, SkFontStyle::kNormal_Width, slant));
+  style->skiaStyle.setFontStyle(
+      SkFontStyle(weight, SkFontStyle::kNormal_Width, slant));
 }
 
-SKWASM_EXPORT void textStyle_setTextBaseline(TextStyle* style,
-                                             TextBaseline baseline) {
-  style->setTextBaseline(baseline);
+SKWASM_EXPORT void textStyle_setTextBaseline(
+    TextStyle* style,
+    skia::textlayout::TextBaseline baseline) {
+  style->skiaStyle.setTextBaseline(baseline);
 }
 
 SKWASM_EXPORT void textStyle_clearFontFamilies(TextStyle* style) {
-  style->setFontFamilies({});
+  style->skiaStyle.setFontFamilies({});
 }
 
 SKWASM_EXPORT void textStyle_addFontFamilies(TextStyle* style,
                                              SkString** fontFamilies,
                                              int count) {
-  const std::vector<SkString>& currentFamilies = style->getFontFamilies();
+  const std::vector<SkString>& currentFamilies =
+      style->skiaStyle.getFontFamilies();
   std::vector<SkString> newFamilies;
   newFamilies.reserve(currentFamilies.size() + count);
   for (int i = 0; i < count; i++) {
@@ -83,43 +87,45 @@ SKWASM_EXPORT void textStyle_addFontFamilies(TextStyle* style,
   for (const auto& family : currentFamilies) {
     newFamilies.push_back(family);
   }
-  style->setFontFamilies(std::move(newFamilies));
+  style->skiaStyle.setFontFamilies(std::move(newFamilies));
 }
 
 SKWASM_EXPORT void textStyle_setFontSize(TextStyle* style, SkScalar size) {
-  style->setFontSize(size);
+  style->skiaStyle.setFontSize(size);
 }
 
 SKWASM_EXPORT void textStyle_setLetterSpacing(TextStyle* style,
                                               SkScalar letterSpacing) {
-  style->setLetterSpacing(letterSpacing);
+  style->skiaStyle.setLetterSpacing(letterSpacing);
 }
 
 SKWASM_EXPORT void textStyle_setWordSpacing(TextStyle* style,
                                             SkScalar wordSpacing) {
-  style->setWordSpacing(wordSpacing);
+  style->skiaStyle.setWordSpacing(wordSpacing);
 }
 
 SKWASM_EXPORT void textStyle_setHeight(TextStyle* style, SkScalar height) {
-  style->setHeight(height);
-  style->setHeightOverride(height != kTextHeightNone);
+  style->skiaStyle.setHeight(height);
+  style->skiaStyle.setHeightOverride(height != kTextHeightNone);
 }
 
 SKWASM_EXPORT void textStyle_setHalfLeading(TextStyle* style,
                                             bool halfLeading) {
-  style->setHalfLeading(halfLeading);
+  style->skiaStyle.setHalfLeading(halfLeading);
 }
 
 SKWASM_EXPORT void textStyle_setLocale(TextStyle* style, SkString* locale) {
-  style->setLocale(*locale);
+  style->skiaStyle.setLocale(*locale);
 }
 
-SKWASM_EXPORT void textStyle_setBackground(TextStyle* style, SkPaint* paint) {
-  style->setBackgroundColor(*paint);
+SKWASM_EXPORT void textStyle_setBackground(TextStyle* style,
+                                           flutter::DlPaint* paint) {
+  style->background = *paint;
 }
 
-SKWASM_EXPORT void textStyle_setForeground(TextStyle* style, SkPaint* paint) {
-  style->setForegroundColor(*paint);
+SKWASM_EXPORT void textStyle_setForeground(TextStyle* style,
+                                           flutter::DlPaint* paint) {
+  style->foreground = *paint;
 }
 
 SKWASM_EXPORT void textStyle_addShadow(TextStyle* style,
@@ -127,13 +133,14 @@ SKWASM_EXPORT void textStyle_addShadow(TextStyle* style,
                                        SkScalar offsetX,
                                        SkScalar offsetY,
                                        SkScalar blurSigma) {
-  style->addShadow(TextShadow(color, {offsetX, offsetY}, blurSigma));
+  style->skiaStyle.addShadow(
+      skia::textlayout::TextShadow(color, {offsetX, offsetY}, blurSigma));
 }
 
 SKWASM_EXPORT void textStyle_addFontFeature(TextStyle* style,
                                             SkString* featureName,
                                             int value) {
-  style->addFontFeature(*featureName, value);
+  style->skiaStyle.addFontFeature(*featureName, value);
 }
 
 SKWASM_EXPORT void textStyle_setFontVariations(TextStyle* style,
@@ -146,6 +153,6 @@ SKWASM_EXPORT void textStyle_setFontVariations(TextStyle* style,
   }
   SkFontArguments::VariationPosition position = {
       coordinates.data(), static_cast<int>(coordinates.size())};
-  style->setFontArguments(
+  style->skiaStyle.setFontArguments(
       SkFontArguments().setVariationDesignPosition(position));
 }

--- a/engine/src/flutter/lib/web_ui/skwasm/text/text_types.h
+++ b/engine/src/flutter/lib/web_ui/skwasm/text/text_types.h
@@ -1,0 +1,54 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_WEB_UI_SKWASM_TEXT_TEXT_TYPES_H_
+#define FLUTTER_LIB_WEB_UI_SKWASM_TEXT_TEXT_TYPES_H_
+
+#include "flutter/display_list/dl_paint.h"
+#include "third_party/skia/modules/skparagraph/include/Paragraph.h"
+#include "third_party/skia/modules/skparagraph/include/ParagraphBuilder.h"
+
+#include <optional>
+#include <vector>
+
+namespace Skwasm {
+struct TextStyle {
+  skia::textlayout::TextStyle skiaStyle;
+  std::optional<flutter::DlPaint> foreground;
+  std::optional<flutter::DlPaint> background;
+
+  void populatePaintIds(std::vector<flutter::DlPaint>& paints) {
+    if (background) {
+      skiaStyle.setBackgroundPaintID(paints.size());
+      paints.push_back(*background);
+    }
+    if (foreground) {
+      skiaStyle.setForegroundPaintID(paints.size());
+      paints.push_back(*foreground);
+    } else {
+      flutter::DlPaint paint;
+      paint.setColor(flutter::DlColor(skiaStyle.getColor()));
+      skiaStyle.setForegroundPaintID(paints.size());
+      paints.push_back(std::move(paint));
+    }
+  }
+};
+
+struct ParagraphStyle {
+  skia::textlayout::ParagraphStyle skiaParagraphStyle;
+  TextStyle textStyle;
+};
+
+struct ParagraphBuilder {
+  std::unique_ptr<skia::textlayout::ParagraphBuilder> skiaParagraphBuilder;
+  std::vector<flutter::DlPaint> paints;
+};
+
+struct Paragraph {
+  std::unique_ptr<skia::textlayout::Paragraph> skiaParagraph;
+  std::vector<flutter::DlPaint> paints;
+};
+}  // namespace Skwasm
+
+#endif  // FLUTTER_LIB_WEB_UI_SKWASM_TEXT_TEXT_TYPES_H_

--- a/engine/src/flutter/lib/web_ui/skwasm/vertices.cpp
+++ b/engine/src/flutter/lib/web_ui/skwasm/vertices.cpp
@@ -3,24 +3,38 @@
 // found in the LICENSE file.
 
 #include "export.h"
+#include "helpers.h"
 #include "live_objects.h"
 
-#include "third_party/skia/include/core/SkVertices.h"
+#include "flutter/display_list/dl_vertices.h"
 
-SKWASM_EXPORT SkVertices* vertices_create(SkVertices::VertexMode vertexMode,
-                                          int vertexCount,
-                                          SkPoint* positions,
-                                          SkPoint* textureCoordinates,
-                                          SkColor* colors,
-                                          int indexCount,
-                                          uint16_t* indices) {
+using namespace flutter;
+using namespace Skwasm;
+
+SKWASM_EXPORT sp_wrapper<DlVertices>* vertices_create(
+    DlVertexMode vertexMode,
+    int vertexCount,
+    DlPoint* positions,
+    DlPoint* textureCoordinates,
+    uint32_t* colors,
+    int indexCount,
+    uint16_t* indices) {
   liveVerticesCount++;
-  return SkVertices::MakeCopy(vertexMode, vertexCount, positions,
-                              textureCoordinates, colors, indexCount, indices)
-      .release();
+  std::vector<DlColor> dlColors;
+  DlColor* dlColorPointer = nullptr;
+  if (colors != nullptr) {
+    dlColors.resize(vertexCount);
+    for (int i = 0; i < vertexCount; i++) {
+      dlColors[i] = DlColor(colors[i]);
+    }
+    dlColorPointer = dlColors.data();
+  }
+  return new sp_wrapper<DlVertices>(
+      DlVertices::Make(vertexMode, vertexCount, positions, textureCoordinates,
+                       dlColorPointer, indexCount, indices));
 }
 
-SKWASM_EXPORT void vertices_dispose(SkVertices* vertices) {
+SKWASM_EXPORT void vertices_dispose(sp_wrapper<DlVertices>* vertices) {
   liveVerticesCount--;
-  vertices->unref();
+  delete vertices;
 }


### PR DESCRIPTION
This PR refactors the skwasm renderer to use `DisplayList` objects as its main model objects instead of using Skia objects directly. Then, at render time, we dispatch the display list commands to the skia surface. This is a preparatory step for impeller on web.
* Some build rules were reworked in order to allow `DisplayList` to compile via emscripten
* Some pieces of the display list library were further refactored to allow us to compile it without actually building and linking the impeller shaders. The two major classes that needed to be separated out were `DlRuntimeEffect` and the text drawing system.
* `SkPath` and `SkImage` are still used as the main model objects in skwasm. As of right now, `DisplayList` just thinly wraps these objects, so this is the minimal possible change for now. I will have to refactor this somewhat further when preparing for actual impeller adoption.
* Several special cased code paths in skwasm were removed, as they are taken care of by `DisplayList` itself. This includes shadow drawing, determining when to enable dithering, and determining the right clamp value for filters.