### PR TITLE
Add a warning on usage of `dartPluginClass: 'none'`.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1659,7 +1659,19 @@ bool _hasPluginInlineImpl(
 /// Determine if the plugin provides an inline Dart implementation.
 bool _hasPluginInlineDartImpl(Plugin plugin, String platformKey) {
   final DartPluginClassAndFilePair? platformInfo = plugin.pluginDartClassPlatforms[platformKey];
-  return platformInfo != null && platformInfo.dartClass != 'none';
+  if (platformInfo == null) {
+    return false;
+  }
+  if (platformInfo.dartClass == 'none') {
+    // TODO(matanlurey): Remove as part of https://github.com/flutter/flutter/issues/57497.
+    globals.printWarning(
+      'Use of `dartPluginClass: none` (${plugin.name}) is deprecated, and will '
+      'be removed in the next stable version. See '
+      'https://github.com/flutter/flutter/issues/57497 for details.',
+    );
+    return false;
+  }
+  return true;
 }
 
 /// Get the resolved [Plugin] `resolution` from the [candidates] serving as

--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -6,6 +6,7 @@ import 'package:yaml/yaml.dart';
 
 import 'base/common.dart';
 import 'base/file_system.dart';
+import 'globals.dart' as globals;
 
 /// Constant for 'pluginClass' key in plugin maps.
 const kPluginClass = 'pluginClass';
@@ -367,8 +368,18 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
       );
     }
 
-    // Treat 'none' as not present. See https://github.com/flutter/flutter/issues/57497.
-    final String? pluginClass = yaml[kPluginClass] == 'none' ? null : yaml[kPluginClass] as String?;
+    final String? pluginClass;
+    if (yaml[kPluginClass] == 'none') {
+      // TODO(matanlurey): Remove as part of https://github.com/flutter/flutter/issues/57497.
+      globals.printWarning(
+        'Use of `dartPluginClass: none` ($name) is deprecated, and will be '
+        'removed in the next stable version. See '
+        'https://github.com/flutter/flutter/issues/57497 for details.',
+      );
+      pluginClass = null;
+    } else {
+      pluginClass = yaml[kPluginClass] as String?;
+    }
 
     return MacOSPlugin(
       name: name,
@@ -446,9 +457,14 @@ class WindowsPlugin extends PluginPlatform implements NativeOrDartPlugin, Varian
 
   factory WindowsPlugin.fromYaml(String name, YamlMap yaml) {
     assert(validate(yaml));
-    // Treat 'none' as not present. See https://github.com/flutter/flutter/issues/57497.
     var pluginClass = yaml[kPluginClass] as String?;
     if (pluginClass == 'none') {
+      // TODO(matanlurey): Remove as part of https://github.com/flutter/flutter/issues/57497.
+      globals.printWarning(
+        'Use of `dartPluginClass: none` ($name) is deprecated, and will be '
+        'removed in the next stable version. See '
+        'https://github.com/flutter/flutter/issues/57497 for details.',
+      );
       pluginClass = null;
     }
     final variants = <PluginPlatformVariant>{};
@@ -564,10 +580,22 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
       );
     }
 
+    final String? pluginClass;
+    if (yaml[kPluginClass] == 'none') {
+      // TODO(matanlurey): Remove as part of https://github.com/flutter/flutter/issues/57497.
+      globals.printWarning(
+        'Use of `dartPluginClass: none` ($name) is deprecated, and will be '
+        'removed in the next stable version. See '
+        'https://github.com/flutter/flutter/issues/57497 for details.',
+      );
+      pluginClass = null;
+    } else {
+      pluginClass = yaml[kPluginClass] as String?;
+    }
+
     return LinuxPlugin(
       name: name,
-      // Treat 'none' as not present. See https://github.com/flutter/flutter/issues/57497.
-      pluginClass: yaml[kPluginClass] == 'none' ? null : yaml[kPluginClass] as String?,
+      pluginClass: pluginClass,
       dartPluginClass: dartPluginClass,
       dartFileName: dartFileName,
       ffiPlugin: yaml[kFfiPlugin] as bool? ?? false,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -54,12 +55,33 @@ environment:
   flutter: ">=1.20.0"
 ''';
 
+/// Returns a `pubspec.yaml` where `$platform` uses `dartPluginClass: 'none'`.
+String samplePluginPubspecWithDartPluginClassNone({required String platform}) =>
+    '''
+name: path_provider_$platform
+description: $platform implementation of the path_provider plugin
+// version: 2.0.1
+// homepage: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_$platform
+flutter:
+  plugin:
+    implements: path_provider
+    platforms:
+      $platform:
+        dartPluginClass: none
+        pluginClass: none
+environment:
+  sdk: ^3.7.0-0
+  flutter: ">=1.20.0"
+''';
+
 void main() {
   group('Dart plugin registrant', () {
     late FileSystem fileSystem;
+    late BufferLogger logger;
 
     setUp(() {
       fileSystem = MemoryFileSystem.test();
+      logger = BufferLogger.test();
     });
 
     testWithoutContext('skipped based on environment.generateDartPluginRegistry', () async {
@@ -157,6 +179,59 @@ name: path_provider_example
         Pub: ThrowingPub.new,
       },
     );
+
+    for (final platform in ['linux', 'macos', 'windows']) {
+      testUsingContext(
+        '$platform treats dartPluginClass: "none" as omitted',
+        () async {
+          final Directory projectDir = fileSystem.directory('project')..createSync();
+          final environment = Environment.test(
+            fileSystem.currentDirectory,
+            projectDir: projectDir,
+            artifacts: Artifacts.test(),
+            fileSystem: fileSystem,
+            logger: BufferLogger.test(),
+            processManager: FakeProcessManager.any(),
+            defines: <String, String>{
+              kTargetFile: projectDir.childDirectory('lib').childFile('main.dart').absolute.path,
+            },
+            generateDartPluginRegistry: true,
+          );
+
+          writePackageConfigFiles(
+            directory: projectDir,
+            mainLibName: 'path_provider_example',
+            packages: <String, String>{'path_provider_$platform': '/path_provider_$platform'},
+            languageVersions: <String, String>{'path_provider_example': '2.12'},
+          );
+
+          projectDir.childFile('pubspec.yaml').writeAsStringSync(_kSamplePubspecFile);
+
+          projectDir.childDirectory('lib').childFile('main.dart').createSync(recursive: true);
+
+          environment.fileSystem.currentDirectory
+              .childDirectory('path_provider_$platform')
+              .childFile('pubspec.yaml')
+            ..createSync(recursive: true)
+            ..writeAsStringSync(samplePluginPubspecWithDartPluginClassNone(platform: platform));
+
+          final FlutterProject testProject = FlutterProject.fromDirectoryTest(projectDir);
+          await DartPluginRegistrantTarget.test(testProject).build(environment);
+
+          final File generatedMain = projectDir
+              .childDirectory('.dart_tool')
+              .childDirectory('flutter_build')
+              .childFile('dart_plugin_registrant.dart');
+          expect(generatedMain, isNot(exists));
+          expect(logger.warningText, contains('Use of `dartPluginClass: none`'));
+        },
+        overrides: {
+          Logger: () => logger,
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: ThrowingPub.new,
+        },
+      );
+    }
 
     testUsingContext(
       'regenerates dart_plugin_registrant.dart',


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/57497.

Supersedes https://github.com/flutter/flutter/pull/171922 based on @stuartmorgan-g's advice for a warning release.

I'll CP this into `3.35` (beta) so that we can clean it up on `master` anytime.