### PR TITLE
Use `$dartSdkVersion` when creating "dummy" pubspec for `create_api_docs`

### DIFF
--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -284,7 +284,7 @@ class Configurator {
       'homepage: https://flutter.dev',
       'version: 0.0.0',
       'environment:',
-      "  sdk: '>=3.2.0-0 <4.0.0'",
+      "  sdk: '^${FlutterInformation.instance.getDartSdkVersion()}",
       'dependencies:',
       for (final String package in findPackageNames(filesystem)) '  $package:\n    sdk: flutter',
       '  $kPlatformIntegrationPackageName: 0.0.1',
@@ -1193,6 +1193,9 @@ class FlutterInformation {
 
   /// Gets the name of the current branch in the Flutter framework in the repo.
   String getBranchName() => getFlutterInformation()['branchName']! as String;
+
+  /// Gets the current Dart SDK version.
+  Version getDartSdkVersion() => getFlutterInformation()['dartSdkVersion']! as Version;
 
   Map<String, Object>? _cachedFlutterInformation;
 

--- a/dev/tools/create_api_docs.dart
+++ b/dev/tools/create_api_docs.dart
@@ -284,7 +284,7 @@ class Configurator {
       'homepage: https://flutter.dev',
       'version: 0.0.0',
       'environment:',
-      "  sdk: '^${FlutterInformation.instance.getDartSdkVersion()}",
+      "  sdk: '^${FlutterInformation.instance.getDartSdkVersion()}'",
       'dependencies:',
       for (final String package in findPackageNames(filesystem)) '  $package:\n    sdk: flutter',
       '  $kPlatformIntegrationPackageName: 0.0.1',

--- a/dev/tools/test/create_api_docs_test.dart
+++ b/dev/tools/test/create_api_docs_test.dart
@@ -338,15 +338,13 @@ void main() {
     test('.generateConfiguration generates pubspec.yaml', () async {
       configurator.generateConfiguration();
       expect(packageRoot.childFile('pubspec.yaml').existsSync(), isTrue);
-      expect(packageRoot.childFile('pubspec.yaml').readAsStringSync(), contains('flutter_gpu:'));
-      expect(
-        packageRoot.childFile('pubspec.yaml').readAsStringSync(),
-        contains('dependency_overrides:'),
-      );
-      expect(
-        packageRoot.childFile('pubspec.yaml').readAsStringSync(),
-        contains('platform_integration:'),
-      );
+
+      final String pubspecContents = packageRoot.childFile('pubspec.yaml').readAsStringSync();
+
+      expect(pubspecContents, contains('flutter_gpu:'));
+      expect(pubspecContents, contains("sdk: '^2.14.0-360.0.dev'"));
+      expect(pubspecContents, contains('dependency_overrides:'));
+      expect(pubspecContents, contains('platform_integration:'));
     });
 
     test('.generateConfiguration generates fake lib', () async {


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/70239.

/cc @ievdokdm 