### PR TITLE
fix: produce pom/jar files with content_hash

### DIFF
--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -93,6 +93,9 @@ void PrintUsage(const std::string& executable_name) {
 
   std::cerr << "Flutter Engine Version: " << GetFlutterEngineVersion()
             << std::endl;
+
+  std::cerr << "Flutter Content Hash: " << GetFlutterContentHash() << std::endl;
+
   std::cerr << "Skia Version: " << GetSkiaVersion() << std::endl;
 
   std::cerr << "Dart Version: " << GetDartVersion() << std::endl << std::endl;

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -533,6 +533,8 @@ action("android_jar") {
   deps = [
     ":flutter_shell_java",
     ":flutter_shell_native",
+    ":pom_content_hash_embedding",
+    ":pom_content_hash_libflutter",
     ":pom_embedding",
     ":pom_libflutter",
   ]
@@ -603,6 +605,30 @@ action("pom_libflutter") {
   ]
 }
 
+action("pom_content_hash_libflutter") {
+  script = "//flutter/tools/androidx/generate_pom_file.py"
+
+  inputs = [ "//flutter/tools/androidx/files.json" ]
+
+  artifact_id =
+      string_replace(android_app_abi, "-", "_") + "_" + flutter_runtime_mode
+
+  hash_dir = "$root_build_dir/content_hash"
+  outputs = [
+    "$hash_dir/$artifact_id.pom",
+    "$hash_dir/$artifact_id.maven-metadata.xml",
+  ]
+
+  args = [
+    "--destination",
+    rebase_path(hash_dir),
+    "--engine-version",
+    content_hash,
+    "--engine-artifact-id",
+    artifact_id,
+  ]
+}
+
 action("pom_embedding") {
   script = "//flutter/tools/androidx/generate_pom_file.py"
 
@@ -620,6 +646,31 @@ action("pom_embedding") {
     rebase_path(root_build_dir),
     "--engine-version",
     engine_version,
+    "--engine-artifact-id",
+    artifact_id,
+    "--include-embedding-dependencies",
+    "true",
+  ]
+}
+
+action("pom_content_hash_embedding") {
+  script = "//flutter/tools/androidx/generate_pom_file.py"
+
+  inputs = [ "//flutter/tools/androidx/files.json" ]
+
+  artifact_id = "flutter_embedding_$flutter_runtime_mode"
+
+  hash_dir = "$root_build_dir/content_hash"
+  outputs = [
+    "$hash_dir/$artifact_id.pom",
+    "$hash_dir/$artifact_id.maven-metadata.xml",
+  ]
+
+  args = [
+    "--destination",
+    rebase_path(hash_dir),
+    "--engine-version",
+    content_hash,
     "--engine-artifact-id",
     artifact_id,
     "--include-embedding-dependencies",
@@ -792,18 +843,26 @@ action("embedding_jars") {
 
   deps = [
     ":flutter_shell_java",
+    ":pom_content_hash_embedding",
     ":pom_embedding",
   ]
-  sources = [
+  base_sources = [
     "$root_out_dir/flutter_embedding_$flutter_runtime_mode.jar",
     "$root_out_dir/flutter_embedding_$flutter_runtime_mode.pom",
   ]
+  hash_dir = "$root_build_dir/content_hash"
+  hash_sources = [
+    "$hash_dir/flutter_embedding_$flutter_runtime_mode.pom",
+    "$root_out_dir/flutter_embedding_$flutter_runtime_mode.jar",
+  ]
+  sources = base_sources + hash_sources
+
   outputs = []
   args = []
   base_name = "$root_out_dir/zip_archives/download.flutter.io/io/flutter/" +
               "flutter_embedding_$flutter_runtime_mode/1.0.0-$engine_version/" +
               "flutter_embedding_$flutter_runtime_mode-1.0.0-${engine_version}"
-  foreach(source, sources) {
+  foreach(source, base_sources) {
     extension = get_path_info(source, "extension")
     name = get_path_info(source, "name")
     if (extension == "jar") {
@@ -828,6 +887,40 @@ action("embedding_jars") {
       ]
     }
   }
+
+  # NOTE(codefu): the URL having /*-$engine_version/ is expected; we want these
+  # files in one URL. The flutter-recipes duplicate them to content_hash as
+  # part of its upload step.
+  # More info here: https://github.com/flutter/flutter/issues/172259
+  hash_base_name =
+      "$root_out_dir/zip_archives/download.flutter.io/io/flutter/" +
+      "flutter_embedding_$flutter_runtime_mode/1.0.0-$engine_version/" +
+      "flutter_embedding_$flutter_runtime_mode-1.0.0-${content_hash}"
+  foreach(source, hash_sources) {
+    extension = get_path_info(source, "extension")
+    name = get_path_info(source, "name")
+    if (extension == "jar") {
+      outputs += [
+        "${hash_base_name}.jar",
+        "${hash_base_name}-sources.jar",
+      ]
+      args += [
+        "-i",
+        "${name}.jar",
+        rebase_path("${hash_base_name}.jar"),
+        "-i",
+        "${name}-sources.jar",
+        rebase_path("${hash_base_name}-sources.jar"),
+      ]
+    } else {
+      outputs += [ "${hash_base_name}.${extension}" ]
+      args += [
+        "-i",
+        rebase_path(source),
+        rebase_path("${hash_base_name}.${extension}"),
+      ]
+    }
+  }
 }
 
 # Renames android artifacts and places them in the final
@@ -836,21 +929,28 @@ action("abi_jars") {
   script = "//flutter/build/android_artifacts.py"
   deps = [
     ":android_jar",
+    ":pom_content_hash_libflutter",
     ":pom_libflutter",
   ]
 
   artifact_id =
       string_replace(android_app_abi, "-", "_") + "_" + flutter_runtime_mode
-  sources = [
+  base_sources = [
     "$root_out_dir/${artifact_id}.jar",
     "$root_out_dir/${artifact_id}.pom",
   ]
+  hash_dir = "$root_build_dir/content_hash"
+  hash_sources = [
+    "$hash_dir/${artifact_id}.pom",
+    "$root_out_dir/${artifact_id}.jar",
+  ]
+  sources = base_sources + hash_sources
   outputs = []
   args = []
   base_name = "$root_out_dir/zip_archives/download.flutter.io/io/flutter/" +
               "${artifact_id}/1.0.0-$engine_version/" +
               "${artifact_id}-1.0.0-${engine_version}"
-  foreach(source, sources) {
+  foreach(source, base_sources) {
     extension = get_path_info(source, "extension")
     name = get_path_info(source, "name")
     outputs += [ "${base_name}.${extension}" ]
@@ -858,6 +958,25 @@ action("abi_jars") {
       "-i",
       rebase_path(source),
       rebase_path("${base_name}.${extension}"),
+    ]
+  }
+
+  # NOTE(codefu): the URL having /*-$engine_version/ is expected; we want these
+  # files in one URL. The flutter-recipes duplicate them to content_hash as
+  # part of its upload step.
+  # More info here: https://github.com/flutter/flutter/issues/172259
+  hash_base_name =
+      "$root_out_dir/zip_archives/download.flutter.io/io/flutter/" +
+      "${artifact_id}/1.0.0-$engine_version/" +
+      "${artifact_id}-1.0.0-${content_hash}"
+  foreach(source, hash_sources) {
+    extension = get_path_info(source, "extension")
+    name = get_path_info(source, "name")
+    outputs += [ "${hash_base_name}.${extension}" ]
+    args += [
+      "-i",
+      rebase_path(source),
+      rebase_path("${hash_base_name}.${extension}"),
     ]
   }
 }

--- a/engine/src/flutter/shell/version/BUILD.gn
+++ b/engine/src/flutter/shell/version/BUILD.gn
@@ -12,6 +12,7 @@ source_set("version") {
 
   defines = [
     "FLUTTER_ENGINE_VERSION=\"$engine_version\"",
+    "FLUTTER_CONTENT_HASH=\"$content_hash\"",
     "SKIA_VERSION=\"$skia_version\"",
     "DART_VERSION=\"$dart_version\"",
   ]

--- a/engine/src/flutter/shell/version/version.cc
+++ b/engine/src/flutter/shell/version/version.cc
@@ -12,6 +12,10 @@ const char* GetFlutterEngineVersion() {
   return FLUTTER_ENGINE_VERSION;
 }
 
+const char* GetFlutterContentHash() {
+  return FLUTTER_CONTENT_HASH;
+}
+
 const char* GetSkiaVersion() {
   return SKIA_VERSION;
 }

--- a/engine/src/flutter/shell/version/version.gni
+++ b/engine/src/flutter/shell/version/version.gni
@@ -7,6 +7,8 @@ import("//flutter/build/dart/dart.gni")
 declare_args() {
   engine_version = ""
 
+  content_hash = ""
+
   skia_version = ""
 
   dart_version = ""
@@ -15,5 +17,6 @@ declare_args() {
 _flutter_root = "//flutter"
 
 assert(engine_version != "", "The engine_version argument must be supplied")
+assert(content_hash != "", "The content_hash argument must be supplied")
 assert(skia_version != "", "The skia_version argument must be supplied")
 assert(dart_version != "", "The dart_version argument must be supplied")

--- a/engine/src/flutter/shell/version/version.h
+++ b/engine/src/flutter/shell/version/version.h
@@ -9,6 +9,8 @@ namespace flutter {
 
 const char* GetFlutterEngineVersion();
 
+const char* GetFlutterContentHash();
+
 const char* GetSkiaVersion();
 
 const char* GetDartVersion();

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -328,12 +328,26 @@ def get_repository_version(repository):
   return str(version.strip(), 'utf-8')
 
 
+def get_content_hash():
+  'Returns the content hash for the engine.'
+  hash_command = os.path.join(SRC_ROOT, '..', '..', 'bin', 'internal', 'content_aware_hash')
+
+  if sys.platform.startswith(('cygwin', 'win')):
+    hash_command = f'{hash_command}.ps1'
+  else:
+    hash_command = f'{hash_command}.sh'
+
+  version = subprocess.check_output([hash_command])
+
+  return str(version.strip(), 'utf-8')
+
+
 def setup_git_versions():
   revision_args = {}
 
   engine_path = os.path.join(SRC_ROOT, 'flutter')
   revision_args['engine_version'] = get_repository_version(engine_path)
-
+  revision_args['content_hash'] = get_content_hash()
   skia_path = os.path.join(SRC_ROOT, 'flutter', 'third_party', 'skia')
   revision_args['skia_version'] = get_repository_version(skia_path)
 

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -330,14 +330,19 @@ def get_repository_version(repository):
 
 def get_content_hash():
   'Returns the content hash for the engine.'
-  hash_command = os.path.join(SRC_ROOT, '..', '..', 'bin', 'internal', 'content_aware_hash')
-
+  hash_method = os.path.join(SRC_ROOT, '..', '..', 'bin', 'internal', 'content_aware_hash')
   if sys.platform.startswith(('cygwin', 'win')):
-    hash_command = f'{hash_command}.ps1'
+    hash_method = f'{hash_method}.ps1'
+    # hash_command.insert(0, 'cmd.exe /c powershell.exe')
   else:
-    hash_command = f'{hash_command}.sh'
+    hash_method = f'{hash_method}.sh'
 
-  version = subprocess.check_output([hash_command])
+  hash_command = []
+  if sys.platform.startswith(('cygwin', 'win')):
+    hash_command = hash_command + ['cmd.exe', '/c', 'powershell.exe']
+  hash_command = hash_command + [hash_method]
+
+  version = subprocess.check_output(hash_command)
 
   return str(version.strip(), 'utf-8')
 


### PR DESCRIPTION
fixes: #172259

The contents of the files (pom, .jar) produced by android also reference the artifacts version number (which includes the git-hash). The flutter recipies are just dumb re-uploaders for the content hash at the moment. In order to change the contents, we can just update some GN files. This has some local duplication of files, but is acceptible for now.

I've also added the content-hash as a string in the .so file and its printed out next to the hash.

"Why is the folder name the git-hash?"

The recipies have a quirk - the logs will have you believe they upload individual files such that "gsutil cp a.jar b.jar" would produce "b.jar"; but that's not what's going on. The recipies recurisively upload from the root of the temporary folder the files are copied to. At the moment, the "Ensure" step of builder.py updates the URL path, so it will handling uploading to the correct path, but not the file or its contents (hence this change).

Plan for the future: at some point we can stop producing git-ref hashes.

E.g.
git-hash: dfd7318efc71019bce1665bc41c0e8c21d1344f9 content-hash: 3bfa6013b7be2b0bbadc22a9c3495d4efa46aba7

```shell
zip_archives
└── download.flutter.io
    └── io
        └── flutter
            ├── arm64_v8a_debug
            │   └── 1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9
            │       ├── arm64_v8a_debug-1.0.0-3bfa6013b7be2b0bbadc22a9c3495d4efa46aba7.jar
            │       ├── arm64_v8a_debug-1.0.0-3bfa6013b7be2b0bbadc22a9c3495d4efa46aba7.pom
            │       ├── arm64_v8a_debug-1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9.jar
            │       └── arm64_v8a_debug-1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9.pom
            └── flutter_embedding_debug
                └── 1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9
                    ├── flutter_embedding_debug-1.0.0-3bfa6013b7be2b0bbadc22a9c3495d4efa46aba7-sources.jar
                    ├── flutter_embedding_debug-1.0.0-3bfa6013b7be2b0bbadc22a9c3495d4efa46aba7.jar
                    ├── flutter_embedding_debug-1.0.0-3bfa6013b7be2b0bbadc22a9c3495d4efa46aba7.pom
                    ├── flutter_embedding_debug-1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9-sources.jar
                    ├── flutter_embedding_debug-1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9.jar
                    └── flutter_embedding_debug-1.0.0-dfd7318efc71019bce1665bc41c0e8c21d1344f9.pom
```