### PR TITLE
Upgrade flutter_lints in project template pubspec.yaml files

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4668,7 +4668,6 @@ targets:
       - DEPS
 
   - name: Mac_x64 tool_tests_commands
-    bringup: true # https://github.com/flutter/flutter/issues/172375
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -4684,7 +4683,6 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
 
   - name: Mac_arm64 tool_tests_commands
-    bringup: true # https://github.com/flutter/flutter/issues/172375
     recipe: flutter/flutter_drone
     timeout: 60
     properties:

--- a/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/app/pubspec.yaml.tmpl
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 flutter:
   uses-material-design: true
@@ -80,7 +80,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/module/common/pubspec.yaml.tmpl
@@ -31,7 +31,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package/pubspec.yaml.tmpl
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -14,5 +14,5 @@ dependencies:
 dev_dependencies:
   ffi: ^2.1.3
   ffigen: ^13.0.0
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   test: ^1.25.8

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -24,7 +24,7 @@ dev_dependencies:
 {{/withFfi}}
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
The version of flutter_lints used by newly created projects should match the version used by flutter_tools.  This ensures that "pub get --offline" will work on a project that was generated by "flutter create".

Also restore the Mac tool_tests_commands that were temporarily disabled in https://github.com/flutter/flutter/pull/172388

Fixes https://github.com/flutter/flutter/issues/172375