### PR TITLE
Migrate to null aware elements - Part 5

### DIFF
--- a/dev/bots/run_command.dart
+++ b/dev/bots/run_command.dart
@@ -212,7 +212,7 @@ Future<CommandResult> runCommand(
     }
     final String allOutput = '${result.flattenedStdout}\n${result.flattenedStderr}';
     foundError(<String>[
-      if (failureMessage != null) failureMessage,
+      ?failureMessage,
       '${bold}Command: $green$commandDescription$reset',
       if (failureMessage == null)
         '$bold${red}Command exited with exit code ${result.exitCode} but expected ${expectNonZeroExit ? (expectedExitCode ?? 'non-zero') : 'zero'} exit code.$reset',

--- a/dev/bots/utils.dart
+++ b/dev/bots/utils.dart
@@ -458,7 +458,7 @@ Future<void> runDartTest(
     if (coverage != null) '--coverage=$coverage',
     if (perTestTimeout != null) '--timeout=${perTestTimeout.inMilliseconds}ms',
     if (runSkipped) '--run-skipped',
-    if (tags != null) ...tags.map((String t) => '--tags=$t'),
+    ...?tags?.map((String t) => '--tags=$t'),
     if (testPaths != null)
       for (final String testPath in testPaths) testPath,
   ];

--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -58,7 +58,7 @@ TaskFunction createHotModeTest({
       '--no-publish-port',
       '--verbose',
       '--uninstall-first',
-      if (additionalOptions != null) ...additionalOptions,
+      ...?additionalOptions,
     ];
     int hotReloadCount = 0;
     late Map<String, dynamic> smallReloadData;

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -687,7 +687,7 @@ class Tab2ConversationRow extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: isSelf ? CrossAxisAlignment.center : CrossAxisAlignment.end,
         children: <Widget>[
-          if (avatar != null) avatar!,
+          ?avatar,
           CupertinoUserInterfaceLevel(
             data: CupertinoUserInterfaceLevelData.elevated,
             child: Tab2ConversationBubble(

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/home.dart
@@ -36,7 +36,7 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Stack(
       children: <Widget>[
-        if (backdrop != null) backdrop!,
+        ?backdrop,
         Align(alignment: Alignment.bottomRight, child: expandingBottomSheet),
       ],
     );

--- a/dev/integration_tests/flutter_gallery/lib/gallery/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/home.dart
@@ -266,7 +266,7 @@ class _GalleryHomeState extends State<GalleryHome> with SingleTickerProviderStat
   static Widget _topHomeLayout(Widget? currentChild, List<Widget> previousChildren) {
     return Stack(
       alignment: Alignment.topCenter,
-      children: <Widget>[...previousChildren, if (currentChild != null) currentChild],
+      children: <Widget>[...previousChildren, ?currentChild],
     );
   }
 

--- a/dev/packages_autoroller/lib/src/repository.dart
+++ b/dev/packages_autoroller/lib/src/repository.dart
@@ -299,12 +299,7 @@ abstract class Repository {
       }
       authorArg = '--author="$author"';
     }
-    final List<String> commitCmd = <String>[
-      'commit',
-      '--message',
-      message,
-      if (authorArg != null) authorArg,
-    ];
+    final List<String> commitCmd = <String>['commit', '--message', message, ?authorArg];
     stdio.printTrace('Executing git $commitCmd...');
     final io.ProcessResult commitResult = await git.run(
       commitCmd,

--- a/dev/tools/android_driver_extensions/lib/skia_gold.dart
+++ b/dev/tools/android_driver_extensions/lib/skia_gold.dart
@@ -158,6 +158,6 @@ final class _SkiaGoldComparator extends GoldenFileComparator {
       'Golden files in the Flutter framework must end with the file extension '
       '.png.',
     );
-    return Uri.parse(<String>[if (namePrefix != null) namePrefix!, golden.toString()].join('.'));
+    return Uri.parse(<String>[?namePrefix, golden.toString()].join('.'));
   }
 }

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -3526,10 +3526,7 @@ base class _NativeParagraphBuilder extends NativeFieldWrapperClass1 implements P
     final ByteData? encodedStrutStyle;
     if (strutStyle != null && strutStyle._enabled) {
       final String? fontFamily = strutStyle._fontFamily;
-      strutFontFamilies = <String>[
-        if (fontFamily != null) fontFamily,
-        ...?strutStyle._fontFamilyFallback,
-      ];
+      strutFontFamilies = <String>[?fontFamily, ...?strutStyle._fontFamilyFallback];
 
       assert(TextLeadingDistribution.values.length <= 2);
       final TextLeadingDistribution leadingDistribution =

--- a/examples/api/lib/widgets/slotted_render_object_widget/slotted_multi_child_render_object_widget_mixin.0.dart
+++ b/examples/api/lib/widgets/slotted_render_object_widget/slotted_multi_child_render_object_widget_mixin.0.dart
@@ -87,10 +87,7 @@ class RenderDiagonal extends RenderBox
 
   // Returns children in hit test order.
   @override
-  Iterable<RenderBox> get children => <RenderBox>[
-    if (_topLeft != null) _topLeft!,
-    if (_bottomRight != null) _bottomRight!,
-  ];
+  Iterable<RenderBox> get children => <RenderBox>[?_topLeft, ?_bottomRight];
 
   // LAYOUT
 

--- a/packages/flutter/lib/src/cupertino/list_section.dart
+++ b/packages/flutter/lib/src/cupertino/list_section.dart
@@ -501,7 +501,7 @@ class CupertinoListSection extends StatelessWidget {
                 child: headerWidget,
               ),
             ),
-          if (decoratedChildrenGroup != null) decoratedChildrenGroup,
+          ?decoratedChildrenGroup,
           if (footerWidget != null)
             Align(
               alignment: AlignmentDirectional.centerStart,

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -1383,7 +1383,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField>
           children: <Widget>[
             // Insert a prefix at the front if the prefix visibility mode matches
             // the current text state.
-            if (prefixWidget != null) prefixWidget,
+            ?prefixWidget,
             // In the middle part, stack the placeholder on top of the main EditableText
             // if needed.
             Expanded(
@@ -1397,7 +1397,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField>
                 ),
               ),
             ),
-            if (suffixWidget != null) suffixWidget,
+            ?suffixWidget,
           ],
         );
       },

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -910,22 +910,18 @@ class AlertDialog extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  if (icon != null) iconWidget!,
-                  if (title != null) titleWidget!,
-                  if (content != null) contentWidget!,
-                ],
+                children: <Widget>[?iconWidget, ?titleWidget, ?contentWidget],
               ),
             ),
           ),
-        if (actions != null) actionsWidget!,
+        ?actionsWidget,
       ];
     } else {
       columnChildren = <Widget>[
-        if (icon != null) iconWidget!,
-        if (title != null) titleWidget!,
-        if (content != null) Flexible(child: contentWidget!),
-        if (actions != null) actionsWidget!,
+        ?iconWidget,
+        ?titleWidget,
+        if (contentWidget != null) Flexible(child: contentWidget),
+        ?actionsWidget,
       ];
     }
 

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -565,7 +565,7 @@ class FloatingActionButton extends StatelessWidget {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                if (child != null) child!,
+                ?child,
                 if (child != null && isExtended) SizedBox(width: iconLabelSpacing),
                 if (isExtended) _extendedLabel!,
               ],

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2284,7 +2284,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   }
 
   static Widget _topStartLayout(Widget? currentChild, List<Widget> previousChildren) {
-    return Stack(children: <Widget>[...previousChildren, if (currentChild != null) currentChild]);
+    return Stack(children: <Widget>[...previousChildren, ?currentChild]);
   }
 
   @override

--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -2825,7 +2825,7 @@ class _MenuItemLabel extends StatelessWidget {
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              if (leadingIcon != null) leadingIcon!,
+              ?leadingIcon,
               if (child != null)
                 Expanded(
                   child: ClipRect(
@@ -2845,7 +2845,7 @@ class _MenuItemLabel extends StatelessWidget {
       leadings = Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          if (leadingIcon != null) leadingIcon!,
+          ?leadingIcon,
           if (child != null)
             Padding(
               padding: leadingIcon != null

--- a/packages/flutter/lib/src/material/navigation_drawer.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer.dart
@@ -191,9 +191,9 @@ class NavigationDrawer extends StatelessWidget {
         bottom: false,
         child: Column(
           children: <Widget>[
-            if (header != null) header!,
+            ?header,
             Expanded(child: ListView(children: wrappedChildren)),
-            if (footer != null) footer!,
+            ?footer,
           ],
         ),
       ),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -3039,10 +3039,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     if (_currentBottomSheet != null || _dismissedBottomSheets.isNotEmpty) {
       final Widget stack = Stack(
         alignment: Alignment.bottomCenter,
-        children: <Widget>[
-          ..._dismissedBottomSheets,
-          if (_currentBottomSheet != null) _currentBottomSheet!._widget,
-        ],
+        children: <Widget>[..._dismissedBottomSheets, ?_currentBottomSheet?._widget],
       );
       _addIfNonNull(
         children,

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -1382,7 +1382,7 @@ abstract class RenderSliver extends RenderObject {
       final List<DiagnosticsNode> information = <DiagnosticsNode>[
         ErrorSummary('RenderSliver geometry setter called incorrectly.'),
         violation,
-        if (hint != null) hint,
+        ?hint,
         contract,
         describeForError('The RenderSliver in question is'),
       ];

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -231,7 +231,7 @@ class AnimatedSwitcher extends StatefulWidget {
   static Widget defaultLayoutBuilder(Widget? currentChild, List<Widget> previousChildren) {
     return Stack(
       alignment: Alignment.center,
-      children: <Widget>[...previousChildren, if (currentChild != null) currentChild],
+      children: <Widget>[...previousChildren, ?currentChild],
     );
   }
 

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -803,7 +803,7 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
     // localizationsDelegate parameter can be used to override
     // WidgetsLocalizations.delegate.
     return <LocalizationsDelegate<Object?>>[
-      if (_localizationsDelegates != null) ..._localizationsDelegates!,
+      ...?_localizationsDelegates,
       DefaultWidgetsLocalizations.delegate,
     ];
   }

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5971,8 +5971,7 @@ class _NamedRestorationInformation extends _RestorationInformation {
 
   @override
   List<Object> computeSerializableData() {
-    return super.computeSerializableData()
-      ..addAll(<Object>[restorationScopeId, name, if (arguments != null) arguments!]);
+    return super.computeSerializableData()..addAll(<Object>[restorationScopeId, name, ?arguments]);
   }
 
   @override
@@ -6014,11 +6013,8 @@ class _AnonymousRestorationInformation extends _RestorationInformation {
     assert(isRestorable);
     final ui.CallbackHandle? handle = ui.PluginUtilities.getCallbackHandle(routeBuilder);
     assert(handle != null);
-    return super.computeSerializableData()..addAll(<Object>[
-      restorationScopeId,
-      handle!.toRawHandle(),
-      if (arguments != null) arguments!,
-    ]);
+    return super.computeSerializableData()
+      ..addAll(<Object>[restorationScopeId, handle!.toRawHandle(), ?arguments]);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -788,7 +788,7 @@ class PlatformMenuItem with Diagnosticable {
       _kIdKey: getId(item),
       _kLabelKey: item.label,
       _kEnabledKey: item.onSelected != null || item.onSelectedIntent != null,
-      if (shortcut != null) ...shortcut.serializeForMenu().toChannelRepresentation(),
+      ...?shortcut?.serializeForMenu().toChannelRepresentation(),
     };
   }
 

--- a/packages/flutter/lib/src/widgets/sliver_resizing_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_resizing_header.dart
@@ -133,11 +133,7 @@ class _RenderSliverResizingHeader extends RenderSliver
   RenderBox? get child => childForSlot(_Slot.child);
 
   @override
-  Iterable<RenderBox> get children => <RenderBox>[
-    if (minExtentPrototype != null) minExtentPrototype!,
-    if (maxExtentPrototype != null) maxExtentPrototype!,
-    if (child != null) child!,
-  ];
+  Iterable<RenderBox> get children => <RenderBox>[?minExtentPrototype, ?maxExtentPrototype, ?child];
 
   double boxExtent(RenderBox box) {
     assert(box.hasSize);

--- a/packages/flutter/lib/src/widgets/view.dart
+++ b/packages/flutter/lib/src/widgets/view.dart
@@ -879,7 +879,7 @@ class _MultiChildComponentElement extends Element {
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
     return <DiagnosticsNode>[
-      if (_childElement != null) _childElement!.toDiagnosticsNode(),
+      ?_childElement?.toDiagnosticsNode(),
       for (int i = 0; i < _viewElements.length; i++)
         _viewElements[i].toDiagnosticsNode(
           name: 'view ${i + 1}',

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -3808,10 +3808,7 @@ class _WidgetInspectorButtonGroupState extends State<_WidgetInspectorButtonGroup
   @override
   Widget build(BuildContext context) {
     final Widget selectionModeButtons = Column(
-      children: <Widget>[
-        if (_tapBehaviorButton != null) _tapBehaviorButton!,
-        _exitWidgetSelectionButton,
-      ],
+      children: <Widget>[?_tapBehaviorButton, _exitWidgetSelectionButton],
     );
 
     final Widget buttonGroup = Stack(
@@ -3829,7 +3826,7 @@ class _WidgetInspectorButtonGroupState extends State<_WidgetInspectorButtonGroup
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             if (_usesDefaultAlignment) selectionModeButtons,
-            if (_moveExitWidgetSelectionButton != null) _moveExitWidgetSelectionButton!,
+            ?_moveExitWidgetSelectionButton,
             if (!_usesDefaultAlignment) selectionModeButtons,
           ],
         ),
@@ -4086,7 +4083,7 @@ class _Location {
   }
 
   @override
-  String toString() => <String>[if (name != null) name!, file, '$line', '$column'].join(':');
+  String toString() => <String>[?name, file, '$line', '$column'].join(':');
 }
 
 bool _isDebugCreator(DiagnosticsNode node) => node is DiagnosticsDebugCreator;

--- a/packages/flutter/test/material/segmented_button_test.dart
+++ b/packages/flutter/test/material/segmented_button_test.dart
@@ -257,7 +257,7 @@ void main() {
               ButtonSegment<int>(value: 2, label: Text('2')),
               ButtonSegment<int>(value: 3, label: Text('3')),
             ],
-            selected: <int>{if (selected != null) selected},
+            selected: <int>{?selected},
             onSelectionChanged: (Set<int> selected) {
               selectedSegment = selected.isEmpty ? null : selected.first;
               callbackCount += 1;

--- a/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
@@ -92,9 +92,7 @@ void main() {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
     TestAnnotationTarget? annotation;
     setUpMouseTracker(
-      annotationFinder: (Offset position) => <TestAnnotationTarget>[
-        if (annotation != null) annotation,
-      ],
+      annotationFinder: (Offset position) => <TestAnnotationTarget>[?annotation],
       logCursors: logCursors,
     );
 
@@ -155,9 +153,7 @@ void main() {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
     TestAnnotationTarget? annotation;
     setUpMouseTracker(
-      annotationFinder: (Offset position) => <TestAnnotationTarget>[
-        if (annotation != null) annotation,
-      ],
+      annotationFinder: (Offset position) => <TestAnnotationTarget>[?annotation],
       logCursors: logCursors,
     );
 
@@ -219,9 +215,7 @@ void main() {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
     TestAnnotationTarget? annotation;
     setUpMouseTracker(
-      annotationFinder: (Offset position) => <TestAnnotationTarget>[
-        if (annotation != null) annotation,
-      ],
+      annotationFinder: (Offset position) => <TestAnnotationTarget>[?annotation],
       logCursors: logCursors,
     );
 
@@ -328,9 +322,7 @@ void main() {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
     TestAnnotationTarget? annotation;
     setUpMouseTracker(
-      annotationFinder: (Offset position) => <TestAnnotationTarget>[
-        if (annotation != null) annotation,
-      ],
+      annotationFinder: (Offset position) => <TestAnnotationTarget>[?annotation],
       logCursors: logCursors,
     );
 
@@ -374,9 +366,7 @@ void main() {
     final List<_CursorUpdateDetails> logCursors = <_CursorUpdateDetails>[];
     TestAnnotationTarget? annotation;
     setUpMouseTracker(
-      annotationFinder: (Offset position) => <TestAnnotationTarget>[
-        if (annotation != null) annotation,
-      ],
+      annotationFinder: (Offset position) => <TestAnnotationTarget>[?annotation],
       logCursors: logCursors,
     );
 

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -174,9 +174,7 @@ void main() {
 
   testWidgets('AnimatedSwitcher uses custom layout.', (WidgetTester tester) async {
     Widget newLayoutBuilder(Widget? currentChild, List<Widget> previousChildren) {
-      return Column(
-        children: <Widget>[...previousChildren, if (currentChild != null) currentChild],
-      );
+      return Column(children: <Widget>[...previousChildren, ?currentChild]);
     }
 
     await tester.pumpWidget(
@@ -193,7 +191,7 @@ void main() {
   testWidgets('AnimatedSwitcher uses custom transitions.', (WidgetTester tester) async {
     late List<Widget> foundChildren;
     Widget newLayoutBuilder(Widget? currentChild, List<Widget> previousChildren) {
-      foundChildren = <Widget>[if (currentChild != null) currentChild, ...previousChildren];
+      foundChildren = <Widget>[?currentChild, ...previousChildren];
       return Column(children: foundChildren);
     }
 
@@ -327,7 +325,7 @@ void main() {
 
       late List<Widget> foundChildren;
       Widget newLayoutBuilder(Widget? currentChild, List<Widget> previousChildren) {
-        foundChildren = <Widget>[if (currentChild != null) currentChild, ...previousChildren];
+        foundChildren = <Widget>[?currentChild, ...previousChildren];
         return Column(children: foundChildren);
       }
 

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -2093,7 +2093,7 @@ class _Scaffold extends StatelessWidget {
       textDirection: TextDirection.ltr,
       child: Stack(
         children: <Widget>[
-          if (background != null) background!,
+          ?background,
           Align(alignment: Alignment.topLeft, child: topLeft),
         ],
       ),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -124,7 +124,7 @@ void main() {
         'SYMROOT=${fileSystem.path.join(flutterBuildDir.absolute.path, 'Build', 'Products')}',
         if (verbose) 'VERBOSE_SCRIPT_LOGGING=YES' else '-quiet',
         'COMPILER_INDEX_STORE_ENABLE=NO',
-        if (additionalCommandArguments != null) ...additionalCommandArguments,
+        ...?additionalCommandArguments,
       ],
       stdout: '''
 STDOUT STUFF

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -667,10 +667,7 @@ class FakeStopwatch implements Stopwatch {
 
 class FakeStopwatchFactory implements StopwatchFactory {
   FakeStopwatchFactory({Stopwatch? stopwatch, Map<String, Stopwatch>? stopwatches})
-    : stopwatches = <String, Stopwatch>{
-        if (stopwatches != null) ...stopwatches,
-        if (stopwatch != null) '': stopwatch,
-      };
+    : stopwatches = <String, Stopwatch>{...?stopwatches, '': ?stopwatch};
 
   Map<String, Stopwatch> stopwatches;
 

--- a/packages/integration_test/lib/common.dart
+++ b/packages/integration_test/lib/common.dart
@@ -235,7 +235,7 @@ class WebDriverCommand {
   /// Constructor for [WebDriverCommandType.noop] screenshot.
   WebDriverCommand.screenshot(String screenshotName, [Map<String, Object?>? args])
     : type = WebDriverCommandType.screenshot,
-      values = <String, dynamic>{'screenshot_name': screenshotName, if (args != null) 'args': args};
+      values = <String, dynamic>{'screenshot_name': screenshotName, 'args': ?args};
 
   /// Type of the [WebDriverCommand].
   ///


### PR DESCRIPTION
## Description

Continuing the work from @jamilsaadeh97 to replace verbose null checks with modern [null_aware_elements](https://dart.dev/tools/linter-rules/use_null_aware_elements) syntax.

This PR cleans up the remaining files not covered in the previous parts, making the code more concise.

## Related PRs

- https://github.com/flutter/flutter/pull/172198
- https://github.com/flutter/flutter/pull/172306
- https://github.com/flutter/flutter/pull/172307
- https://github.com/flutter/flutter/pull/172322

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
