### PR TITLE
Fix #160622: Restore watchOS Companion App Build Compatibility

### DIFF
--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -733,7 +733,6 @@ def __lldb_init_module(debugger: lldb.SBDebugger, _):
       }
       final Map<String, String>? allBuildSettings = await buildSettingsForBuildInfo(
         buildInfo,
-        deviceId: deviceId,
         scheme: scheme,
         isWatch: true,
       );


### PR DESCRIPTION
This PR is an attempt to fix a regression where Flutter apps with Apple Watch extensions fail to build via `flutter run` since Flutter 3.27.0.

## Background

Flutter projects containing Apple Watch companion apps have been failing with various errors since Flutter 3.27.0:
- `'StateObject' is only available in iOS 14.0 or newer` (watchOS SwiftUI code being compiled with iOS deployment targets)
- `'HKWorkoutSession' is unavailable in iOS` (watchOS-specific APIs being compiled for iOS)
- `Unsupported Swift architecture` (iOS architectures being forced on watchOS targets)
- Missing "Watch companion app found" log during `flutter run`

## Root Cause

The `containsWatchCompanion` method was incorrectly passing an iOS device identifier when querying build settings for watchOS schemes, causing xcodebuild to fail with "Unable to find a destination matching the provided destination specifier". This prevented proper detection of watch companion apps, leading to iOS-specific build settings being incorrectly applied to watchOS targets.

## Solution

This fix removes the `deviceId` parameter when querying build settings for watch schemes, allowing xcodebuild to properly return the watch target's configuration. This solution was identified by @vashworth in https://github.com/flutter/flutter/pull/172436#issuecomment-3140433428—thank you for pinpointing the exact issue!


## Previous Attempt

My initial PR #172436 attempted to restore the conditional `ARCHS` logic that was removed in PR #154645, but that addressed a symptom rather than the root cause. The real issue was that `containsWatchCompanion` was failing to detect the watch app due to the incorrect deviceId parameter.


Fixes #160622

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md