### PR TITLE
[CP stable] Don't throw on error for mDNS when searching for Dart VML url on core devices

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -951,7 +951,13 @@ void main() {
           expect(launchResult.hasVmService, true);
           expect(await device.stopApp(iosApp), true);
         },
-        overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery()},
+        // If mDNS is not the only method of discovery, it shouldn't throw on error.
+        overrides: <Type, Generator>{
+          MDnsVmServiceDiscovery:
+              () => FakeMDnsVmServiceDiscovery(
+                allowthrowOnMissingLocalNetworkPermissionsError: false,
+              ),
+        },
       );
 
       group('IOSDevice.startApp attaches in debug mode via device logging', () {
@@ -1239,8 +1245,12 @@ class FakeDevicePortForwarder extends Fake implements DevicePortForwarder {
 }
 
 class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery {
-  FakeMDnsVmServiceDiscovery({this.returnsNull = false});
+  FakeMDnsVmServiceDiscovery({
+    this.returnsNull = false,
+    this.allowthrowOnMissingLocalNetworkPermissionsError = true,
+  });
   bool returnsNull;
+  bool allowthrowOnMissingLocalNetworkPermissionsError;
 
   Completer<void> completer = Completer<void>();
   @override
@@ -1252,11 +1262,16 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
     int? deviceVmservicePort,
     bool useDeviceIPAsHost = false,
     Duration timeout = Duration.zero,
+    bool throwOnMissingLocalNetworkPermissionsError = true,
   }) async {
     completer.complete();
     if (returnsNull) {
       return null;
     }
+    expect(
+      throwOnMissingLocalNetworkPermissionsError,
+      allowthrowOnMissingLocalNetworkPermissionsError,
+    );
 
     return Uri.tryParse('http://0.0.0.0:1234');
   }

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -612,7 +612,7 @@ void main() {
             () async => portDiscovery.firstMatchingVmService(client),
             throwsToolExit(
               message:
-                  'Flutter could not connect to the Dart VM service.\n'
+                  'Flutter could not access the local network.\n'
                   '\n'
                   'Please ensure your IDE or terminal app has permission to access '
                   'devices on the local network. This allows Flutter to connect to '
@@ -649,7 +649,7 @@ void main() {
             () async => portDiscovery.firstMatchingVmService(client),
             throwsToolExit(
               message:
-                  'Flutter could not connect to the Dart VM service.\n'
+                  'Flutter could not access the local network.\n'
                   '\n'
                   'Please ensure your IDE or terminal app has permission to access '
                   'devices on the local network. This allows Flutter to connect to '
@@ -657,6 +657,47 @@ void main() {
                   '\n'
                   'You can grant this permission in System Settings > Privacy & '
                   'Security > Local Network.\n',
+            ),
+          );
+        },
+        // [intended] This tool exit message only works for macOS
+        skip: !globals.platform.isMacOS,
+      );
+
+      test(
+        'On macOS, tool prints a helpful message when mDNS lookup throws an uncaught SocketException',
+        () async {
+          final MDnsClient client = FakeMDnsClient(
+            <PtrResourceRecord>[],
+            <String, List<SrvResourceRecord>>{},
+            uncaughtSocketExceptionOnLookup: true,
+          );
+
+          final BufferLogger logger = BufferLogger.test();
+
+          final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
+            mdnsClient: client,
+            logger: logger,
+            analytics: const NoOpAnalytics(),
+          );
+
+          final MDnsVmServiceDiscoveryResult? result = await portDiscovery.firstMatchingVmService(
+            client,
+            throwOnMissingLocalNetworkPermissionsError: false,
+          );
+
+          expect(result, isNull);
+          expect(
+            logger.errorText,
+            contains(
+              'Flutter could not access the local network.\n'
+              '\n'
+              'Please ensure your IDE or terminal app has permission to access '
+              'devices on the local network. This allows Flutter to connect to '
+              'the Dart VM.\n'
+              '\n'
+              'You can grant this permission in System Settings > Privacy & '
+              'Security > Local Network.\n',
             ),
           );
         },


### PR DESCRIPTION
Impacted Users: iOS users on macOS 15
Impact Description: mDNS may cause a crash on macOS 15 if permissions are missing. When possible use device logs to continue the process instead of using mDNS.
Workaround: Enable mDNS permissions
Risk: low
Test Coverage: Yes
Validation Steps: Toggle off Local Network permissions (System Settings > Privacy & Security > Local Network) and do `flutter run` on iOS 17+ physical device. Device should still connect.

Release note: This is a prerequisite to allowing stable branch to be upgraded to macOS 15