### PR TITLE
[CP stable] Run tests on either macOS 14 or 15 (#171076)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -142,7 +142,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       device_type: none
       $flutter/osx_sdk : >-
         {
@@ -158,7 +158,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       device_type: none
       cpu: arm64
       $flutter/osx_sdk : >-
@@ -177,7 +177,7 @@ platform_properties:
         ]
       device_type: none
       mac_model: "Macmini8,1"
-      os: Mac-14
+      os: Mac-14|Mac-15
       tags: >
         ["devicelab", "hostonly", "mac"]
       $flutter/osx_sdk : >-
@@ -194,7 +194,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -212,7 +212,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       device_type: none
       cpu: x86
       $flutter/osx_sdk : >-
@@ -227,7 +227,7 @@ platform_properties:
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: x86
       device_type: "msm8952"
   mac_arm64_android:
@@ -237,7 +237,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:35v1"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: arm64
       device_type: "msm8952"
 
@@ -249,7 +249,7 @@ platform_properties:
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: x86
       device_type: "mokey"
   mac_arm64_mokey:
@@ -259,7 +259,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:35v1"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: arm64
       device_type: "mokey"
 
@@ -270,7 +270,7 @@ platform_properties:
           {"dependency": "android_sdk", "version": "version:35v1"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: x86
       device_type: "Pixel 7 Pro"
   mac_ios:
@@ -284,7 +284,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: x86
       device_os: iOS-17|iOS-18
       $flutter/osx_sdk : >-
@@ -302,7 +302,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "version:to_2025"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: x86
       device_os: iOS-17|iOS-18
       $flutter/osx_sdk : >-
@@ -320,7 +320,7 @@ platform_properties:
           {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"},
           {"dependency": "apple_signing", "version": "none"}
         ]
-      os: Mac-14
+      os: Mac-14|Mac-15
       cpu: arm64
       device_os: iOS-17|iOS-18
       $flutter/osx_sdk : >-
@@ -5451,7 +5451,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery__transition_perf_e2e_ios
       drone_dimensions: >
-        ["device_os=iOS-17|iOS-18","os=Mac-14", "cpu=x86"]
+        ["device_os=iOS-17|iOS-18","os=Mac-14|Mac-15", "cpu=x86"]
 
   - name: Mac_ios animated_blur_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -30,7 +30,7 @@ platform_properties:
           {"dependency": "open_jdk", "version": "version:17"}
         ]
       device_type: none
-      os: Mac-14
+      os: Mac-14|Mac-15
       $flutter/osx_sdk : >-
         {
           "sdk_version": "16c5032a"
@@ -471,7 +471,7 @@ targets:
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform
     drone_dimensions:
-      - os=Mac-14
+      - os=Mac-14|Mac-15
 
   - name: Mac clangd
     recipe: engine_v2/builder
@@ -500,7 +500,7 @@ targets:
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform
     drone_dimensions:
-      - os=Mac-14
+      - os=Mac-14|Mac-15
       - cpu=x86
 
   - name: Linux windows_android_aot_engine

--- a/engine/src/flutter/ci/builders/linux_web_engine_test.json
+++ b/engine/src/flutter/ci/builders/linux_web_engine_test.json
@@ -419,7 +419,7 @@
       "recipe": "engine_v2/tester_engine",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "cpu=arm64"
       ],
       "gclient_variables": {

--- a/engine/src/flutter/ci/builders/local_engine.json
+++ b/engine/src/flutter/ci/builders/local_engine.json
@@ -3,7 +3,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -36,7 +36,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -70,7 +70,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -103,7 +103,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -136,7 +136,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -170,7 +170,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -206,7 +206,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -344,7 +344,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -377,7 +377,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -410,7 +410,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -494,7 +494,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -578,7 +578,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -610,7 +610,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -643,7 +643,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -676,7 +676,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -815,7 +815,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -899,7 +899,7 @@
     {
       "cas_archive": false,
       "drone_dimensions": [
-        "os=Mac-14",
+        "os=Mac-14|Mac-15",
         "device_type=none"
       ],
       "gclient_variables": {
@@ -1037,7 +1037,7 @@
       "name": "macos/wasm_release",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-14"
+        "os=Mac-14|Mac-15"
       ],
       "gclient_variables": {
         "download_android_deps": false,
@@ -1067,7 +1067,7 @@
       "name": "macos/wasm_debug_unopt",
       "drone_dimensions": [
         "device_type=none",
-        "os=Mac-14"
+        "os=Mac-14|Mac-15"
       ],
       "gclient_variables": {
         "download_android_deps": false,

--- a/engine/src/flutter/ci/builders/mac_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/mac_android_aot_engine.json
@@ -22,7 +22,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -80,7 +80,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -140,7 +140,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -200,7 +200,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -258,7 +258,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -318,7 +318,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {

--- a/engine/src/flutter/ci/builders/mac_clang_tidy.json
+++ b/engine/src/flutter/ci/builders/mac_clang_tidy.json
@@ -3,7 +3,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -36,7 +36,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -74,7 +74,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -129,7 +129,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -184,7 +184,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -239,7 +239,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -294,7 +294,7 @@
             "recipe": "engine_v2/tester_engine",
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/engine/src/flutter/ci/builders/mac_host_engine.json
+++ b/engine/src/flutter/ci/builders/mac_host_engine.json
@@ -18,7 +18,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -85,7 +85,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -141,7 +141,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -206,7 +206,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -257,7 +257,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -308,7 +308,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -371,7 +371,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -425,7 +425,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -478,7 +478,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -544,7 +544,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -601,7 +601,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -657,7 +657,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -723,7 +723,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -778,7 +778,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -833,7 +833,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -900,7 +900,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -958,7 +958,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -1015,7 +1015,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/engine/src/flutter/ci/builders/mac_ios_engine.json
+++ b/engine/src/flutter/ci/builders/mac_ios_engine.json
@@ -15,7 +15,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -62,7 +62,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -111,7 +111,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -158,7 +158,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -205,7 +205,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -252,7 +252,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -301,7 +301,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -352,7 +352,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -401,7 +401,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -450,7 +450,7 @@
         {
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/engine/src/flutter/ci/builders/mac_unopt.json
+++ b/engine/src/flutter/ci/builders/mac_unopt.json
@@ -4,7 +4,7 @@
             "cas_archive": false,
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -57,7 +57,7 @@
             "cas_archive": false,
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -108,7 +108,7 @@
             "cas_archive": false,
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -165,7 +165,7 @@
             ],
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -224,7 +224,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=x86"
             ],
             "gclient_variables": {
@@ -281,7 +281,7 @@
             "cas_archive": false,
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -350,7 +350,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {
@@ -418,7 +418,7 @@
             },
             "drone_dimensions": [
                 "device_type=none",
-                "os=Mac-14",
+                "os=Mac-14|Mac-15",
                 "cpu=arm64"
             ],
             "gclient_variables": {

--- a/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
+++ b/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
@@ -100,7 +100,7 @@ class GenerateBuilderJsonCommand extends Command<bool> {
         packageLock,
         'Mac',
         BrowserName.safari,
-        specificOS: 'Mac-14',
+        specificOS: 'Mac-14|Mac-15',
         cpu: 'arm64',
       ),
     ];


### PR DESCRIPTION
Impacted Users: Flutter Infra and Release teams
Impact Description: Allows Flutter CI tests to run on macOS 15
Workaround: N/A
Risk: low
Test Coverage: Yes
Validation Steps: N/A

Release note: This is a prerequisite to allowing stable branch to be upgraded to macOS 15

Should **NOT** be landed until the following land:
* https://github.com/flutter/flutter/pull/172461
* https://github.com/flutter/flutter/pull/172462 land.