### PR TITLE
Revert #160653 Fix view removal process for AutofillContextAction.cancel

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -2827,11 +2827,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   [self removeEnableFlutterTextInputViewAccessibilityTimer];
   _activeView.accessibilityEnabled = NO;
   [_activeView resignFirstResponder];
-  // Removes the focus from the `_activeView` (UIView<UITextInput>)
-  // when the user stops typing (keyboard is hidden).
-  // For more details, refer to the discussion at:
-  // https://github.com/flutter/engine/pull/57209#discussion_r1905942577
-  [self cleanUpViewHierarchy:YES clearText:YES delayRemoval:NO];
+  [_activeView removeFromSuperview];
+  [_inputHider removeFromSuperview];
 }
 
 - (void)triggerAutofillSave:(BOOL)saveEntries {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -2812,27 +2812,6 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   XCTAssertNil(textInputPlugin.activeView.textInputDelegate);
 }
 
-- (void)testAutoFillDoesNotTriggerOnHideButTriggersOnCommit {
-  // Regression test for https://github.com/flutter/flutter/issues/145681.
-  NSMutableDictionary* configuration = self.mutableTemplateCopy;
-  [configuration setValue:@{
-    @"uniqueIdentifier" : @"field1",
-    @"hints" : @[ UITextContentTypePassword ],
-    @"editingValue" : @{@"text" : @""}
-  }
-                   forKey:@"autofill"];
-  [configuration setValue:@[ [configuration copy] ] forKey:@"fields"];
-
-  [self setClientId:123 configuration:configuration];
-  XCTAssertEqual(self.viewsVisibleToAutofill.count, 1ul);
-
-  [self setTextInputHide];
-  // Before the fix in https://github.com/flutter/flutter/pull/160653, it was 0ul.
-  XCTAssertEqual(self.viewsVisibleToAutofill.count, 1ul);
-
-  [self commitAutofillContextAndVerify];
-}
-
 #pragma mark - Accessibility - Tests
 
 - (void)testUITextInputAccessibilityNotHiddenWhenShowed {


### PR DESCRIPTION
Between #145681 (autofill save prompt shows up for password fields when you dismiss the keyboard) and #172250 (calling `TextInput.hide` causes the current active text field to lose its text) the latter seems to be the worse bug. The framework `EditableText` implementation only calls `TextInput.hide` when switching input controls, so #172250 typically does not affect flutter text fields itself, but becomes a problem if the app wishes to add UI (similar to the iOS down-arrow button that would show up above the keyboard when you're filling out a form)  to dismiss the keyboard.

This reopens #145681. See https://github.com/flutter/flutter/issues/145681#issuecomment-3098865633

@koji-1009 does reverting sound ok to you?

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
