### PR TITLE
Omit `w` (widget tree), `t` (render tree) from `flutter run --profile` `h`

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1463,9 +1463,9 @@ abstract class ResidentRunner extends ResidentHandlers {
       commandHelp.s.print();
     }
     if (supportsServiceProtocol) {
-      commandHelp.w.print();
-      commandHelp.t.print();
       if (isRunningDebug) {
+        commandHelp.w.print();
+        commandHelp.t.print();
         commandHelp.L.print();
         commandHelp.f.print();
         commandHelp.S.print();


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/91690.