### PR TITLE
[Impeller] Log glCheckFrameBufferStatus output when it fails in blit pass.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/blit_command_gles.cc
@@ -5,11 +5,11 @@
 #include "impeller/renderer/backend/gles/blit_command_gles.h"
 
 #include "flutter/fml/closure.h"
-#include "fml/trace_event.h"
 #include "impeller/base/validation.h"
 #include "impeller/core/formats.h"
 #include "impeller/geometry/point.h"
 #include "impeller/renderer/backend/gles/device_buffer_gles.h"
+#include "impeller/renderer/backend/gles/formats_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/texture_gles.h"
 
@@ -74,8 +74,10 @@ static std::optional<GLuint> ConfigureFBO(
     return std::nullopt;
   }
 
-  if (gl.CheckFramebufferStatus(fbo_type) != GL_FRAMEBUFFER_COMPLETE) {
-    VALIDATION_LOG << "Could not create a complete framebuffer.";
+  GLenum status = gl.CheckFramebufferStatus(fbo_type);
+  if (status != GL_FRAMEBUFFER_COMPLETE) {
+    VALIDATION_LOG << "Could not create a complete framebuffer: "
+                   << DebugToFramebufferError(status);
     DeleteFBO(gl, fbo, fbo_type);
     return std::nullopt;
   }


### PR DESCRIPTION
We haven't been able to reproduce https://github.com/flutter/flutter/issues/169203. We should log the error so that future repros are more useful.

We've already started doing this for other usages (https://github.com/flutter/engine/pull/46692).