### PR TITLE
Emit a warning on `--[no-]disable-dds`, preferring `--no-dds`

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -605,18 +605,14 @@ abstract class FlutterCommand extends Command<void> {
         );
       }
       ddsEnabled = !boolArg('disable-dds');
-      // TODO(ianh): enable the following code once google3 is migrated away from --disable-dds (and add test to flutter_command_test.dart)
-      // ignore: dead_code, literal_only_boolean_expressions
-      if (false) {
-        if (ddsEnabled) {
-          globals.printWarning(
-            '${globals.logger.terminal.warningMark} The "--no-disable-dds" argument is deprecated and redundant, and should be omitted.',
-          );
-        } else {
-          globals.printWarning(
-            '${globals.logger.terminal.warningMark} The "--disable-dds" argument is deprecated. Use "--no-dds" instead.',
-          );
-        }
+      if (ddsEnabled) {
+        globals.printWarning(
+          '${globals.logger.terminal.warningMark} The "--no-disable-dds" argument is deprecated and redundant, and should be omitted.',
+        );
+      } else {
+        globals.printWarning(
+          '${globals.logger.terminal.warningMark} The "--disable-dds" argument is deprecated. Use "--no-dds" instead.',
+        );
       }
     } else {
       ddsEnabled = boolArg('dds');

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -47,7 +47,7 @@ void main() {
     late MemoryFileSystem fileSystem;
     late Platform platform;
     late FileSystemUtils fileSystemUtils;
-    late Logger logger;
+    late BufferLogger logger;
     late FakeProcessManager processManager;
     late PreRunValidator preRunValidator;
 
@@ -728,15 +728,17 @@ void main() {
     );
 
     testUsingContext(
-      'dds options --disable-dds',
+      'dds options --disable-dds works, but is deprecated',
       () async {
         final ddsCommand = FakeDdsCommand();
         final CommandRunner<void> runner = createTestCommandRunner(ddsCommand);
         await runner.run(<String>['test', '--disable-dds']);
         expect(ddsCommand.enableDds, isFalse);
+        expect(logger.warningText, contains('"--disable-dds" argument is deprecated'));
       },
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
+        Logger: () => logger,
         ProcessManager: () => processManager,
       },
     );
@@ -748,9 +750,14 @@ void main() {
         final CommandRunner<void> runner = createTestCommandRunner(ddsCommand);
         await runner.run(<String>['test', '--no-disable-dds']);
         expect(ddsCommand.enableDds, isTrue);
+        expect(
+          logger.warningText,
+          contains('"--no-disable-dds" argument is deprecated and redundant'),
+        );
       },
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
+        Logger: () => logger,
         ProcessManager: () => processManager,
       },
     );


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/150279.

I'll CP this into 3.35, and then we can remove support for the flag on `master`.

(IIRC this only still existed because of google3)