### PR TITLE
Adapt xcresult parser for Xcode 16 changes

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcresult.dart
+++ b/packages/flutter_tools/lib/src/ios/xcresult.dart
@@ -421,7 +421,7 @@ bool _shouldDiscardIssue({
   return false;
 }
 
-/// [NEW] Helper to parse issues from the new (Xcode 16+) flat list format.
+/// Helper to parse issues from the new (Xcode 16+) flat list format.
 List<XCResultIssue> _parseIssuesFromNewFormat({
   required XCResultIssueType type,
   required Object? jsonList,
@@ -451,7 +451,7 @@ List<XCResultIssue> _parseIssuesFromNewFormat({
   return issues;
 }
 
-/// [OLD] Renamed helper to parse issues from the old (pre-Xcode 16) format.
+/// Renamed helper to parse issues from the old (pre-Xcode 16) format.
 List<XCResultIssue> _parseIssuesFromXcode15Format({
   required XCResultIssueType type,
   required Map<String, Object?> issueSummariesJson,
@@ -480,7 +480,7 @@ List<XCResultIssue> _parseIssuesFromXcode15Format({
   return issues;
 }
 
-/// [OLD] Helper to parse issues from the `actions` block in the old format.
+/// Helper to parse issues from the `actions` block in the old format.
 List<XCResultIssue> _parseActionIssues(
   Map<String, Object?> actionsMap, {
   required List<XCResultIssueDiscarder> issueDiscarders,

--- a/packages/flutter_tools/lib/src/ios/xcresult.dart
+++ b/packages/flutter_tools/lib/src/ios/xcresult.dart
@@ -116,7 +116,7 @@ class XCResult {
       final Object? errorSummaries = issuesMap['errorSummaries'];
       if (errorSummaries is Map<String, Object?>) {
         issues.addAll(
-          _parseIssuesFromOldFormat(
+          _parseIssuesFromXcode15Format(
             type: XCResultIssueType.error,
             issueSummariesJson: errorSummaries,
             issueDiscarder: issueDiscarders,
@@ -126,7 +126,7 @@ class XCResult {
       final Object? warningSummaries = issuesMap['warningSummaries'];
       if (warningSummaries is Map<String, Object?>) {
         issues.addAll(
-          _parseIssuesFromOldFormat(
+          _parseIssuesFromXcode15Format(
             type: XCResultIssueType.warning,
             issueSummariesJson: warningSummaries,
             issueDiscarder: issueDiscarders,
@@ -452,7 +452,7 @@ List<XCResultIssue> _parseIssuesFromNewFormat({
 }
 
 /// [OLD] Renamed helper to parse issues from the old (pre-Xcode 16) format.
-List<XCResultIssue> _parseIssuesFromOldFormat({
+List<XCResultIssue> _parseIssuesFromXcode15Format({
   required XCResultIssueType type,
   required Map<String, Object?> issueSummariesJson,
   required List<XCResultIssueDiscarder> issueDiscarder,
@@ -552,7 +552,7 @@ List<XCResultIssue> _parseActionIssues(
     final Object? testFailureSummaries = actionResultIssues['testFailureSummaries'];
     if (testFailureSummaries is Map<String, Object?>) {
       issues.addAll(
-        _parseIssuesFromOldFormat(
+        _parseIssuesFromXcode15Format(
           type: XCResultIssueType.error,
           issueSummariesJson: testFailureSummaries,
           issueDiscarder: issueDiscarders,

--- a/packages/flutter_tools/lib/src/ios/xcresult.dart
+++ b/packages/flutter_tools/lib/src/ios/xcresult.dart
@@ -43,32 +43,16 @@ class XCResultGenerator {
     final bool useNewCommand = xcodeVersion != null && xcodeVersion >= Version(16, 0, 0);
 
     // Base command for xcrun
-    final command = <String>[
-      ...xcode.xcrunCommand(),
-      'xcresulttool',
-    ];
+    final command = <String>[...xcode.xcrunCommand(), 'xcresulttool'];
 
     // Determine the correct subcommand and arguments based on the Xcode version.
     if (useNewCommand) {
       // For Xcode 16+, the 'get' command requires a specific subcommand.
       // 'build-results' is the correct choice for parsing compilation/build errors.
-      command.addAll(<String>[
-        'get',
-        'build-results',
-        '--path',
-        resultPath,
-        '--format',
-        'json',
-      ]);
+      command.addAll(<String>['get', 'build-results', '--path', resultPath, '--format', 'json']);
     } else {
       // For older versions of Xcode, the original 'get' command works directly.
-      command.addAll(<String>[
-        'get',
-        '--path',
-        resultPath,
-        '--format',
-        'json',
-      ]);
+      command.addAll(<String>['get', '--path', resultPath, '--format', 'json']);
     }
 
     // Run the constructed command.
@@ -106,25 +90,28 @@ class XCResult {
     // Detect the format. The new format has top-level 'errors' or 'warnings' keys.
     if (resultJson.containsKey('errors') || resultJson.containsKey('warnings')) {
       // ---- NEW (Xcode 16+) PARSING LOGIC ----
-      issues.addAll(_parseIssuesFromNewFormat(
-        type: XCResultIssueType.error,
-        jsonList: resultJson['errors'],
-        issueDiscarders: issueDiscarders,
-      ));
-      issues.addAll(_parseIssuesFromNewFormat(
-        type: XCResultIssueType.warning,
-        jsonList: resultJson['warnings'],
-        issueDiscarders: issueDiscarders,
-      ));
-
+      issues.addAll(
+        _parseIssuesFromNewFormat(
+          type: XCResultIssueType.error,
+          jsonList: resultJson['errors'],
+          issueDiscarders: issueDiscarders,
+        ),
+      );
+      issues.addAll(
+        _parseIssuesFromNewFormat(
+          type: XCResultIssueType.warning,
+          jsonList: resultJson['warnings'],
+          issueDiscarders: issueDiscarders,
+        ),
+      );
     } else {
       // ---- OLD (pre-Xcode 16) PARSING LOGIC ----
       final Object? issuesMap = resultJson['issues'];
 
       if (issuesMap is! Map<String, Object?>) {
-          // The key exists but is not a map, which is an error for the old format.
-          return XCResult.failed(errorMessage: 'xcresult parser: Failed to parse the issues map.');
-        }
+        // The key exists but is not a map, which is an error for the old format.
+        return XCResult.failed(errorMessage: 'xcresult parser: Failed to parse the issues map.');
+      }
 
       final Object? errorSummaries = issuesMap['errorSummaries'];
       if (errorSummaries is Map<String, Object?>) {
@@ -146,7 +133,7 @@ class XCResult {
           ),
         );
       }
-          final Object? actionsMap = resultJson['actions'];
+      final Object? actionsMap = resultJson['actions'];
       if (actionsMap is Map<String, Object?>) {
         final List<XCResultIssue> actionIssues = _parseActionIssues(
           actionsMap,
@@ -156,7 +143,11 @@ class XCResult {
       }
     }
 
-    if (issues.isEmpty && resultJson['issues'] == null && resultJson['actions'] == null && resultJson['errors'] == null && resultJson['warnings'] == null) {
+    if (issues.isEmpty &&
+        resultJson['issues'] == null &&
+        resultJson['actions'] == null &&
+        resultJson['errors'] == null &&
+        resultJson['warnings'] == null) {
       return XCResult.failed(errorMessage: 'xcresult parser: Failed to parse the issues map.');
     }
 
@@ -271,7 +262,9 @@ class XCResultIssue {
     if (sourceUrl != null) {
       location = _convertUrlToLocationString(sourceUrl);
       if (location == null) {
-        warnings.add('(XCResult) The `sourceURL` exists but it failed to be parsed. url: $sourceUrl');
+        warnings.add(
+          '(XCResult) The `sourceURL` exists but it failed to be parsed. url: $sourceUrl',
+        );
       }
     }
 
@@ -545,11 +538,17 @@ List<XCResultIssue> _parseActionIssues(
   }
 
   for (final Object? actionValue in actionsValues) {
-    if (actionValue is! Map<String, Object?>) { continue; }
+    if (actionValue is! Map<String, Object?>) {
+      continue;
+    }
     final Object? actionResult = actionValue['actionResult'];
-    if (actionResult is! Map<String, Object?>) { continue; }
+    if (actionResult is! Map<String, Object?>) {
+      continue;
+    }
     final Object? actionResultIssues = actionResult['issues'];
-    if (actionResultIssues is! Map<String, Object?>) { continue; }
+    if (actionResultIssues is! Map<String, Object?>) {
+      continue;
+    }
     final Object? testFailureSummaries = actionResultIssues['testFailureSummaries'];
     if (testFailureSummaries is Map<String, Object?>) {
       issues.addAll(

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
@@ -89,7 +89,6 @@ void main() {
       ),
     );
     fakeProcessManager.addCommands(<FakeCommand>[
-      // Use the new, refactored command setup.
       setUpFakeXCResultCommand(
         stdout: resultJson,
         tempResultPath: _tempResultPath,

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
@@ -73,7 +73,8 @@ void main() {
     int exitCode = 0,
     String stderr = '',
     // Default to an OLD version of Xcode.
-    // This ensures existing tests that don't specify a version still test the old code path.
+    // This ensures that tests which don't explicitly set an Xcode version still cover
+    // the logic for pre-Xcode 16 platforms.
     Version? xcodeVersion = const Version.withText(15, 0, 0, '15.0'),
   }) {
     final fakeProcessManager = FakeProcessManager.list(<FakeCommand>[

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
@@ -28,7 +28,6 @@ void main() {
 
     final List<String> command;
     if (useNewCommand) {
-      // Command for Xcode 16+
       command = <String>[
         ...xcode.xcrunCommand(),
         'xcresulttool',
@@ -40,7 +39,6 @@ void main() {
         'json',
       ];
     } else {
-      // Command for Xcode < 16 (no --legacy flag needed)
       command = <String>[
         ...xcode.xcrunCommand(),
         'xcresulttool',
@@ -72,7 +70,7 @@ void main() {
     required String resultJson,
     int exitCode = 0,
     String stderr = '',
-    // Default to an OLD version of Xcode.
+    // Default to an pre-Xcode 16 version of Xcode.
     // This ensures that tests which don't explicitly set an Xcode version still cover
     // the logic for pre-Xcode 16 platforms.
     Version? xcodeVersion = const Version.withText(15, 0, 0, '15.0'),
@@ -106,7 +104,6 @@ void main() {
   }
 
   testWithoutContext('correctly parses new format (Xcode 16+) JSON with issues', () async {
-    // Setup generator to use the new command and data
     final XCResultGenerator generator = setupGenerator(
       resultJson: kNewFormatResultJsonWithIssues,
       xcodeVersion: Version(16, 0, 0),

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test.dart
@@ -17,49 +17,50 @@ void main() {
   // Creates a FakeCommand for the xcresult get call to build the app
   // in the given configuration.
   FakeCommand setUpFakeXCResultCommand({
-  required String stdout,
-  required String tempResultPath,
-  required Xcode xcode,
-  required Version? xcodeVersion,
-  int exitCode = 0,
-  String stderr = '',
-}) {
-  final bool useNewCommand = xcodeVersion != null && xcodeVersion >= Version(16, 0, 0);
+    required String stdout,
+    required String tempResultPath,
+    required Xcode xcode,
+    required Version? xcodeVersion,
+    int exitCode = 0,
+    String stderr = '',
+  }) {
+    final bool useNewCommand = xcodeVersion != null && xcodeVersion >= Version(16, 0, 0);
 
-  final List<String> command;
-  if (useNewCommand) {
-    // Command for Xcode 16+
-    command = <String>[
-      ...xcode.xcrunCommand(),
-      'xcresulttool',
-      'get',
-      'build-results',
-      '--path',
-      tempResultPath,
-      '--format',
-      'json',
-    ];
-  } else {
-    // Command for Xcode < 16 (no --legacy flag needed)
-    command = <String>[
-      ...xcode.xcrunCommand(),
-      'xcresulttool',
-      'get',
-      '--path',
-      tempResultPath,
-      '--format',
-      'json',
-    ];
+    final List<String> command;
+    if (useNewCommand) {
+      // Command for Xcode 16+
+      command = <String>[
+        ...xcode.xcrunCommand(),
+        'xcresulttool',
+        'get',
+        'build-results',
+        '--path',
+        tempResultPath,
+        '--format',
+        'json',
+      ];
+    } else {
+      // Command for Xcode < 16 (no --legacy flag needed)
+      command = <String>[
+        ...xcode.xcrunCommand(),
+        'xcresulttool',
+        'get',
+        '--path',
+        tempResultPath,
+        '--format',
+        'json',
+      ];
+    }
+
+    return FakeCommand(
+      command: command,
+      stdout: stdout,
+      stderr: stderr,
+      exitCode: exitCode,
+      onRun: (_) {},
+    );
   }
 
-  return FakeCommand(
-    command: command,
-    stdout: stdout,
-    stderr: stderr,
-    exitCode: exitCode,
-    onRun: (_) {},
-  );
-}
   const kWhichSysctlCommand = FakeCommand(command: <String>['which', 'sysctl']);
 
   const kx64CheckCommand = FakeCommand(
@@ -68,77 +69,81 @@ void main() {
   );
 
   XCResultGenerator setupGenerator({
-  required String resultJson,
-  int exitCode = 0,
-  String stderr = '',
-  // Default to an OLD version of Xcode.
-  // This ensures existing tests that don't specify a version still test the old code path.
-  Version? xcodeVersion = const Version.withText(15, 0, 0, '15.0'),
-}) {
-  final fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
-    kWhichSysctlCommand,
-    kx64CheckCommand,
-  ]);
-  final xcode = Xcode.test(
-    processManager: fakeProcessManager,
-    xcodeProjectInterpreter: XcodeProjectInterpreter.test(
+    required String resultJson,
+    int exitCode = 0,
+    String stderr = '',
+    // Default to an OLD version of Xcode.
+    // This ensures existing tests that don't specify a version still test the old code path.
+    Version? xcodeVersion = const Version.withText(15, 0, 0, '15.0'),
+  }) {
+    final fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
+      kWhichSysctlCommand,
+      kx64CheckCommand,
+    ]);
+    final xcode = Xcode.test(
       processManager: fakeProcessManager,
-      version: xcodeVersion,
-    ),
-  );
-  fakeProcessManager.addCommands(<FakeCommand>[
-    // Use the new, refactored command setup.
-    setUpFakeXCResultCommand(
-      stdout: resultJson,
-      tempResultPath: _tempResultPath,
-      xcode: xcode,
-      exitCode: exitCode,
-      stderr: stderr,
-      xcodeVersion: xcodeVersion,
-    ),
-  ]);
-  final processUtils = ProcessUtils(
-    processManager: fakeProcessManager,
-    logger: BufferLogger.test(),
-  );
-  return XCResultGenerator(resultPath: _tempResultPath, xcode: xcode, processUtils: processUtils);
-}
+      xcodeProjectInterpreter: XcodeProjectInterpreter.test(
+        processManager: fakeProcessManager,
+        version: xcodeVersion,
+      ),
+    );
+    fakeProcessManager.addCommands(<FakeCommand>[
+      // Use the new, refactored command setup.
+      setUpFakeXCResultCommand(
+        stdout: resultJson,
+        tempResultPath: _tempResultPath,
+        xcode: xcode,
+        exitCode: exitCode,
+        stderr: stderr,
+        xcodeVersion: xcodeVersion,
+      ),
+    ]);
+    final processUtils = ProcessUtils(
+      processManager: fakeProcessManager,
+      logger: BufferLogger.test(),
+    );
+    return XCResultGenerator(resultPath: _tempResultPath, xcode: xcode, processUtils: processUtils);
+  }
 
-testWithoutContext('correctly parses new format (Xcode 16+) JSON with issues', () async {
-  // Setup generator to use the new command and data
-  final XCResultGenerator generator = setupGenerator(
-    resultJson: kNewFormatResultJsonWithIssues,
-    xcodeVersion: Version(16, 0, 0),
-  );
-  final XCResult result = await generator.generate();
+  testWithoutContext('correctly parses new format (Xcode 16+) JSON with issues', () async {
+    // Setup generator to use the new command and data
+    final XCResultGenerator generator = setupGenerator(
+      resultJson: kNewFormatResultJsonWithIssues,
+      xcodeVersion: Version(16, 0, 0),
+    );
+    final XCResult result = await generator.generate();
 
-  expect(result.issues.length, 2);
-  expect(result.parseSuccess, isTrue);
-  expect(result.parsingErrorMessage, isNull);
+    expect(result.issues.length, 2);
+    expect(result.parseSuccess, isTrue);
+    expect(result.parsingErrorMessage, isNull);
 
-  final XCResultIssue error = result.issues.firstWhere((issue) => issue.type == XCResultIssueType.error);
-  expect(error.subType, 'Swift Compiler Error');
-  expect(error.message, "consecutive statements on a line must be separated by ';'");
-  expect(error.location, '/Users/m/Projects/test_create/ios/Runner/AppDelegate.swift:11:82');
+    final XCResultIssue error = result.issues.firstWhere(
+      (issue) => issue.type == XCResultIssueType.error,
+    );
+    expect(error.subType, 'Swift Compiler Error');
+    expect(error.message, "consecutive statements on a line must be separated by ';'");
+    expect(error.location, '/Users/m/Projects/test_create/ios/Runner/AppDelegate.swift:11:82');
 
-  final XCResultIssue warning = result.issues.firstWhere((issue) => issue.type == XCResultIssueType.warning);
-  expect(warning.subType, 'Deprecation');
-  expect(warning.message, "'openURL' was deprecated in iOS 10.0");
-  expect(warning.location, '/Users/m/Projects/test_create/ios/Runner/AppDelegate.swift:15:20');
-});
+    final XCResultIssue warning = result.issues.firstWhere(
+      (issue) => issue.type == XCResultIssueType.warning,
+    );
+    expect(warning.subType, 'Deprecation');
+    expect(warning.message, "'openURL' was deprecated in iOS 10.0");
+    expect(warning.location, '/Users/m/Projects/test_create/ios/Runner/AppDelegate.swift:15:20');
+  });
 
-testWithoutContext('correctly handles new format (Xcode 16+) with invalid sourceURL', () async {
-  final XCResultGenerator generator = setupGenerator(
-    resultJson: kNewFormatResultJsonWithInvalidUrl,
-    xcodeVersion: Version(16, 0, 0),
-  );
-  final XCResult result = await generator.generate();
+  testWithoutContext('correctly handles new format (Xcode 16+) with invalid sourceURL', () async {
+    final XCResultGenerator generator = setupGenerator(
+      resultJson: kNewFormatResultJsonWithInvalidUrl,
+      xcodeVersion: Version(16, 0, 0),
+    );
+    final XCResult result = await generator.generate();
 
-  expect(result.issues.length, 1);
-  final XCResultIssue error = result.issues.first;
-  expect(error.location, isNull);
-  expect(error.warnings.first, contains('failed to be parsed'));
-});
+    expect(result.issues.length, 1);
+    final XCResultIssue error = result.issues.first;
+    expect(error.location, isNull);
+    expect(error.warnings.first, contains('failed to be parsed'));
+  });
 
   testWithoutContext('correctly parse sample result json when there are issues.', () async {
     final XCResultGenerator generator = setupGenerator(resultJson: kSampleResultJsonWithIssues);
@@ -310,7 +315,6 @@ testWithoutContext('correctly handles new format (Xcode 16+) with invalid source
     final XCResultGenerator generator = setupGenerator(
       resultJson: kSampleResultJsonNoIssues,
       xcodeVersion: Version(15, 0, 0),
-
     );
     final XCResult result = await generator.generate();
     expect(result.issues.length, 0);

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
@@ -12,7 +12,7 @@ const kSampleResultJsonInvalidIssuesMap = r'''
 }
 ''';
 
-  /// Simulates the output of `xcrun xcresulttool get build-results` on Xcode 16+.
+/// Simulates the output of `xcrun xcresulttool get build-results` on Xcode 16+.
 const kNewFormatResultJsonWithIssues = r'''
 {
   "actionTitle": "Build Runner",

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
@@ -12,6 +12,48 @@ const kSampleResultJsonInvalidIssuesMap = r'''
 }
 ''';
 
+  /// Simulates the output of `xcrun xcresulttool get build-results` on Xcode 16+.
+const kNewFormatResultJsonWithIssues = r'''
+{
+  "actionTitle": "Build Runner",
+  "status": "failed",
+  "errorCount": 1,
+  "warningCount": 1,
+  "errors": [
+    {
+      "issueType": "Swift Compiler Error",
+      "message": "consecutive statements on a line must be separated by ';'",
+      "sourceURL": "file:///Users/m/Projects/test_create/ios/Runner/AppDelegate.swift#CharacterRangeLen=0&EndingColumnNumber=82&EndingLineNumber=11&StartingColumnNumber=82&StartingLineNumber=11"
+    }
+  ],
+  "warnings": [
+    {
+      "issueType": "Deprecation",
+      "message": "'openURL' was deprecated in iOS 10.0",
+      "sourceURL": "file:///Users/m/Projects/test_create/ios/Runner/AppDelegate.swift#CharacterRangeLen=0&EndingColumnNumber=30&EndingLineNumber=15&StartingColumnNumber=20&StartingLineNumber=15"
+    }
+  ],
+  "analyzerWarnings": []
+}
+''';
+
+/// Simulates the output for the new format with a malformed sourceURL.
+const kNewFormatResultJsonWithInvalidUrl = r'''
+{
+  "status": "failed",
+  "errorCount": 1,
+  "errors": [
+    {
+      "issueType": "Swift Compiler Error",
+      "message": "consecutive statements on a line must be separated by ';'",
+      "sourceURL": "invalid-url-format"
+    }
+  ],
+  "warnings": [],
+  "analyzerWarnings": []
+}
+''';
+
 /// An example xcresult bundle json that contains warnings and errors that needs to be discarded per https://github.com/flutter/flutter/issues/95354.
 const kSampleResultJsonWithIssuesToBeDiscarded = r'''
 {


### PR DESCRIPTION
This PR updates the iOS build process to support breaking changes in Xcode 16's xcresulttool. The xcresulttool get command, which Flutter uses to parse native build issues, is deprecated and replaced by the new xcresulttool get build-results command. This new command also introduces a completely new, flatter JSON output format.

To address this while maintaining backwards compatibility, this change introduces a two-part solution:
- The XCResultGenerator now detects the Xcode version and conditionally calls the appropriate command (get build-results for Xcode 16+ and get for older versions).
- The XCResult parser has been refactored to be "bilingual," meaning it can intelligently detect the JSON structure and parse both the old (nested) and new (flat) formats correctly.
- This ensures that native iOS build errors and warnings continue to be correctly parsed and displayed to the user on all supported Xcode versions.



Fixes #151502 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
