### PR TITLE
Update `dev/bots/post_process_docs.dart` to use `flutter.version.json`

### DIFF
--- a/dev/bots/post_process_docs.dart
+++ b/dev/bots/post_process_docs.dart
@@ -46,8 +46,12 @@ Future<void> postProcess() async {
 
   // Generate versions file.
   await runProcessWithValidations(<String>['flutter', '--version'], docsPath);
-  final File versionFile = File('version');
-  final String version = versionFile.readAsStringSync();
+  final File versionFile = File(path.join(checkoutPath, 'bin', 'cache', 'flutter.version.json'));
+  final String version = () {
+    final Map<String, Object?> json =
+        jsonDecode(versionFile.readAsStringSync()) as Map<String, Object?>;
+    return json['flutterVersion']! as String;
+  }();
   // Recreate footer
   final String publishPath = path.join(docsPath, '..', 'docs', 'doc', 'flutter', 'footer.js');
   final File footerFile = File(publishPath)..createSync(recursive: true);


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/171900.

The "legacy" (`//version`) file has been "legacy" for years. This PR allows deprecating and removing it in the near future.

Example of `//bin/cache/flutter.version.json`:
```json
{
  "frameworkVersion": "3.33.0-1.0.pre-1070",
  "channel": "master",
  "repositoryUrl": "unknown source",
  "frameworkRevision": "be9526fbaaaab9474e95d196b70c41297eeda2d0",
  "frameworkCommitDate": "2025-07-22 11:34:11 -0700",
  "engineRevision": "be9526fbaaaab9474e95d196b70c41297eeda2d0",
  "engineCommitDate": "2025-07-22 18:34:11.000Z",
  "engineContentHash": "70fb28dde094789120421d4e807a9c37a0131296",
  "engineBuildDate": "2025-07-22 11:47:42.829",
  "dartSdkVersion": "3.10.0 (build 3.10.0-15.0.dev)",
  "devToolsVersion": "2.48.0",
  "flutterVersion": "3.33.0-1.0.pre-1070"
}
```

Example of `//version`:
```txt
3.33.0-1.0.pre-1070
```