### PR TITLE
fix: :bug: Add equality and hashCode implementations to ResizeImage

### DIFF
--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1250,6 +1250,7 @@ enum ResizeImagePolicy {
 ///
 ///  * [ui.FlutterView.devicePixelRatio], used to convert between physical and
 ///    logical pixels.
+@immutable
 class ResizeImage extends ImageProvider<ResizeImageKey> {
   /// Creates an ImageProvider that decodes the image to the specified size.
   ///
@@ -1462,6 +1463,25 @@ class ResizeImage extends ImageProvider<ResizeImageKey> {
     completer = Completer<ResizeImageKey>();
     return completer.future;
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ResizeImage &&
+        imageProvider == other.imageProvider &&
+        width == other.width &&
+        height == other.height &&
+        policy == other.policy &&
+        allowUpscaling == other.allowUpscaling;
+  }
+
+  @override
+  int get hashCode => Object.hash(imageProvider, width, height, policy, allowUpscaling);
 }
 
 /// The strategy for [Image.network] and [NetworkImage] to decide whether to

--- a/packages/flutter/test/painting/image_provider_resize_image_test.dart
+++ b/packages/flutter/test/painting/image_provider_resize_image_test.dart
@@ -21,6 +21,44 @@ void main() {
   });
 
   group('ResizeImage', () {
+    group('equality and hashCode', () {
+      test('Two identical instances should be equal and have same hashCode', () {
+        final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+        final ResizeImage resizeImage1 = ResizeImage(
+          MemoryImage(bytes),
+          width: 100,
+          height: 200,
+          policy: ResizeImagePolicy.fit,
+          allowUpscaling: true,
+        );
+        final ResizeImage resizeImage2 = ResizeImage(
+          MemoryImage(bytes),
+          width: 100,
+          height: 200,
+          policy: ResizeImagePolicy.fit,
+          allowUpscaling: true,
+        );
+
+        expect(resizeImage1 == resizeImage2, isTrue);
+        expect(resizeImage1.hashCode, equals(resizeImage2.hashCode));
+      });
+
+      test('Different ResizeImage instances should not be equal', () {
+        final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+        final ResizeImage resizeImage1 = ResizeImage(MemoryImage(bytes), width: 100, height: 200);
+        final ResizeImage resizeImage2 = ResizeImage(MemoryImage(bytes), width: 150, height: 200);
+
+        expect(resizeImage1 == resizeImage2, isFalse);
+      });
+
+      test('Reflexivity: instance should be equal to itself', () {
+        final Uint8List bytes = Uint8List.fromList(kTransparentImage);
+        final ResizeImage resizeImage = ResizeImage(MemoryImage(bytes), width: 100, height: 200);
+
+        expect(resizeImage == resizeImage, isTrue);
+      });
+    });
+
     group('resizing', () {
       test('upscales to the correct dimensions', () async {
         final Uint8List bytes = Uint8List.fromList(kTransparentImage);


### PR DESCRIPTION
This PR adds implementations for `==` and `hashCode` in the `ResizeImage` class.

#### Reason

Previously, `ResizeImage` instances with identical configuration (e.g., same width, height, image provider, and allowUpscaling flag) were not treated as equal. As a result, comparing two such instances would always return false, even when they have the same values.

#### Fixes

Closes #172642 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
