### PR TITLE
fix: size-exp naming

### DIFF
--- a/engine/src/flutter/build/zip_bundle.gni
+++ b/engine/src/flutter/build/zip_bundle.gni
@@ -16,6 +16,9 @@ if (flutter_runtime_mode == "jit_release") {
   if (dart_dynamic_modules) {
     android_zip_archive_dir += "-ddm"
   }
+  if (dart_disable_secure_socket) {
+    android_zip_archive_dir += "-size-exp"
+  }
 }
 
 # Creates a zip file in the $root_build_dir/zip_archives folder.


### PR DESCRIPTION
@jason-simmons found the reason the `-size-exp` doesn't build

luci build: https://ci.chromium.org/b/8708539853637018417