### PR TITLE
Roll Abseil and remove a workaround for a Fuchsia target that was unable to build Abseil

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -528,7 +528,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + 'c788c52156f3ef7bc7ab769cb03c110a53ac8fcb',
 
   'engine/src/flutter/third_party/abseil-cpp':
-  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + 'ff6504dc527b25fef0f3c531e7dba0ed6b69c162',
+  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + '182d30b2816f3fada3b7707cf9b0eb7d2e71a111',
 
    # Dart packages
   'engine/src/flutter/third_party/pkg/archive':

--- a/engine/src/flutter/impeller/typographer/BUILD.gn
+++ b/engine/src/flutter/impeller/typographer/BUILD.gn
@@ -32,12 +32,8 @@ impeller_component("typographer") {
     "../base",
     "../geometry",
     "../renderer",
+    "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map",
   ]
-
-  if (!is_fuchsia) {
-    public_deps +=
-        [ "//flutter/third_party/abseil-cpp/absl/container:flat_hash_map" ]
-  }
 
   deps = [
     "//flutter/display_list:dl_path",

--- a/engine/src/flutter/impeller/typographer/glyph_atlas.h
+++ b/engine/src/flutter/impeller/typographer/glyph_atlas.h
@@ -9,9 +9,7 @@
 #include <memory>
 #include <optional>
 
-#include "flutter/fml/build_config.h"
 #include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
-
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"
 #include "impeller/typographer/font_glyph_pair.h"
@@ -20,30 +18,6 @@
 namespace impeller {
 
 class FontGlyphAtlas;
-
-/// Helper for AbslHashAdapter. Tallies a hash value with fml::HashCombine.
-template <typename T>
-struct AbslHashAdapterCombiner {
-  std::size_t value = 0;
-
-  template <typename... Args>
-  static AbslHashAdapterCombiner combine(AbslHashAdapterCombiner combiner,
-                                         const Args&... args) {
-    combiner.value = fml::HashCombine(combiner.value, args...);
-    return combiner;
-  }
-};
-
-/// Adapts AbslHashValue functions to be used with std::unordered_map and the
-/// fml hash functions.
-template <typename T>
-struct AbslHashAdapter {
-  constexpr std::size_t operator()(const T& element) const {
-    AbslHashAdapterCombiner<T> combiner;
-    combiner = AbslHashValue(std::move(combiner), element);
-    return combiner.value;
-  }
-};
 
 struct FrameBounds {
   /// The bounds of the glyph within the glyph atlas.

--- a/engine/src/flutter/impeller/typographer/glyph_atlas.h
+++ b/engine/src/flutter/impeller/typographer/glyph_atlas.h
@@ -10,14 +10,7 @@
 #include <optional>
 
 #include "flutter/fml/build_config.h"
-
-#if defined(OS_FUCHSIA)
-// TODO(gaaclarke): Migrate to use absl. I couldn't get it working since absl
-// has special logic in its GN files for Fuchsia that I couldn't sort out.
-#define IMPELLER_TYPOGRAPHER_USE_STD_HASH
-#else
 #include "flutter/third_party/abseil-cpp/absl/container/flat_hash_map.h"
-#endif
 
 #include "impeller/core/texture.h"
 #include "impeller/geometry/rect.h"

--- a/engine/src/flutter/impeller/typographer/glyph_atlas.h
+++ b/engine/src/flutter/impeller/typographer/glyph_atlas.h
@@ -186,17 +186,10 @@ class GlyphAtlas {
   std::shared_ptr<Texture> texture_;
   size_t generation_ = 0;
 
-#if defined(IMPELLER_TYPOGRAPHER_USE_STD_HASH)
-  using FontAtlasMap = std::unordered_map<ScaledFont,
-                                          FontGlyphAtlas,
-                                          AbslHashAdapter<ScaledFont>,
-                                          ScaledFont::Equal>;
-#else
   using FontAtlasMap = absl::flat_hash_map<ScaledFont,
                                            FontGlyphAtlas,
                                            absl::Hash<ScaledFont>,
                                            ScaledFont::Equal>;
-#endif
 
   FontAtlasMap font_atlas_map_;
 
@@ -284,17 +277,10 @@ class FontGlyphAtlas {
  private:
   friend class GlyphAtlas;
 
-#if defined(IMPELLER_TYPOGRAPHER_USE_STD_HASH)
-  using PositionsMap = std::unordered_map<SubpixelGlyph,
-                                          FrameBounds,
-                                          AbslHashAdapter<SubpixelGlyph>,
-                                          SubpixelGlyph::Equal>;
-#else
   using PositionsMap = absl::flat_hash_map<SubpixelGlyph,
                                            FrameBounds,
                                            absl::Hash<SubpixelGlyph>,
                                            SubpixelGlyph::Equal>;
-#endif
 
   PositionsMap positions_;
   FontGlyphAtlas(const FontGlyphAtlas&) = delete;


### PR DESCRIPTION
Flutter was avoiding dependencies on Abseil's flat_hash_map library on Fuchsia because it brought in a time zone library that required the Fuchsia SDK.  This PR rolls Abseil to a commit that fixes the path to the Fuchsia SDK.