### PR TITLE
add bundletool to FGP

### DIFF
--- a/packages/flutter_tools/gradle/build.gradle.kts
+++ b/packages/flutter_tools/gradle/build.gradle.kts
@@ -48,6 +48,13 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     }
 }
 
+val bundleToolOnly: Configuration by configurations.creating
+
+tasks.register<JavaExec>("bundleTool") {
+    mainClass.set("com.android.tools.build.bundletool.BundleToolMain")
+    classpath = bundleToolOnly
+}
+
 dependencies {
     // Versions available https://mvnrepository.com/artifact/androidx.annotation/annotation-jvm.
     // Version release notes https://developer.android.com/jetpack/androidx/releases/annotation
@@ -63,6 +70,7 @@ dependencies {
     //  * ndkVersion constant in packages/flutter_tools/lib/src/android/gradle_utils.dart
     //  * ndkVersion in FlutterExtension in packages/flutter_tools/gradle/src/main/kotlin/FlutterExtension.kt
     compileOnly("com.android.tools.build:gradle:8.9.1")
+    bundleToolOnly("com.android.tools.build:bundletool:1.18.1")
 
     testImplementation(kotlin("test"))
     testImplementation("com.android.tools.build:gradle:8.9.1")

--- a/packages/flutter_tools/test/integration.shard/flutter_bundletool_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_bundletool_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/android/gradle_utils.dart' show getGradlewFileName;
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = createResolvedTempDirectorySync('bundletool_test.');
+  });
+
+  tearDown(() {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext('bundletool gradle task executes and contains help text', () async {
+    // Create a new flutter project.
+    ProcessResult result = await processManager.run(<String>[
+      flutterBin,
+      'create',
+      tempDir.path,
+      '--project-name=testapp',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+    // Ensure that gradle files exists from templates.
+    result = await processManager.run(<String>[
+      flutterBin,
+      'build',
+      'apk',
+      '--config-only',
+    ], workingDirectory: tempDir.path);
+    expect(result.exitCode, 0);
+
+    final Directory androidApp = tempDir.childDirectory('android');
+    result = await processManager.run(<String>[
+      '.${platform.pathSeparator}${getGradlewFileName(platform)}',
+      ...getLocalEngineArguments(),
+      '-q',
+      ':gradle:bundleTool',
+      '--args=help',
+    ], workingDirectory: androidApp.path);
+    expect(result.exitCode, 0);
+    // Ensure bundletool is installed and can be invoked.
+    expect(result.stdout.toString(), contains("Use 'bundletool help"));
+  });
+}


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/166751

This adds the `bundletool` dependency to the FGP project and exposes the CLI interface via a gradle task for the flutter tool.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
