### PR TITLE
Make sure that an ActionChip doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/action_chip_test.dart
+++ b/packages/flutter/test/material/action_chip_test.dart
@@ -586,4 +586,18 @@ void main() {
       SystemMouseCursors.forbidden,
     );
   });
+
+  testWidgets('ActionChip renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: Scaffold(body: ActionChip(label: Text('X'))),
+          ),
+        ),
+      ),
+    );
+    final Finder xText = find.text('X');
+    expect(tester.getSize(xText).isEmpty, isTrue);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the ActionChip UI control.