### PR TITLE
fix: only use library props for libraries

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/plugins/PluginHandler.kt
@@ -11,6 +11,7 @@ import com.flutter.gradle.FlutterPluginUtils.addApiDependencies
 import com.flutter.gradle.FlutterPluginUtils.buildModeFor
 import com.flutter.gradle.FlutterPluginUtils.getAndroidExtension
 import com.flutter.gradle.FlutterPluginUtils.getCompileSdkFromProject
+import com.flutter.gradle.FlutterPluginUtils.isBuiltAsApp
 import com.flutter.gradle.FlutterPluginUtils.supportsBuildMode
 import com.flutter.gradle.NativePluginLoaderReflectionBridge
 import org.gradle.api.Project
@@ -177,7 +178,23 @@ class PluginHandler(
 
             // Copy build types from the app to the plugin.
             // This allows to build apps with plugins and custom build types or flavors.
-            getAndroidExtension(pluginProject).buildTypes.addAll(getAndroidExtension(project).buildTypes)
+            // However, only copy if the plugin is also an app project, since library projects
+            // cannot have applicationIdSuffix and other app-specific properties.
+            if (isBuiltAsApp(pluginProject)) {
+                getAndroidExtension(pluginProject).buildTypes.addAll(getAndroidExtension(project).buildTypes)
+            } else {
+                // For library projects, create compatible build types without app-specific properties
+                getAndroidExtension(project).buildTypes.forEach { appBuildType ->
+                    if (getAndroidExtension(pluginProject).buildTypes.findByName(appBuildType.name) == null) {
+                        getAndroidExtension(pluginProject).buildTypes.create(appBuildType.name) {
+                            // Copy library-compatible properties only
+                            isDebuggable = appBuildType.isDebuggable
+                            isMinifyEnabled = appBuildType.isMinifyEnabled
+                            // Note: applicationIdSuffix and other app-specific properties are intentionally not copied
+                        }
+                    }
+                }
+            }
 
             // The embedding is API dependency of the plugin, so the AGP is able to desugar
             // default method implementations when the interface is implemented by a plugin.

--- a/packages/flutter_tools/gradle/src/test/kotlin/plugins/PluginHandlerTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/plugins/PluginHandlerTest.kt
@@ -488,7 +488,10 @@ class PluginHandlerTest {
         every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
     }
 
-    private fun setupPluginMocks(project: Project, pluginHandler: PluginHandler) {
+    private fun setupPluginMocks(
+        project: Project,
+        pluginHandler: PluginHandler
+    ) {
         mockkObject(NativePluginLoaderReflectionBridge)
         every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns listOf(cameraDependency)
         every { project.extraProperties } returns mockk()


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

With the change to copy the build types to libraries, there is no check whether all the properties are valid for libraries. For example, applicationIdSuffix is only valid for an Android app, not a library. This adds a check where we are copying to, and only adds the valid properties.

#169215

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
