### PR TITLE
[A11y] RangeSlider should have 2 focus node

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -425,10 +425,21 @@ class RangeSlider extends StatefulWidget {
   )
   final bool? year2023;
 
-  /// Focus node for the start thumb.
+  /// An optional focus node for the start thumb.
+  ///
+  /// If provided, this [FocusNode] can be used by a parent widget to
+  /// programmatically control the focus of the start thumb.
+  ///
+  /// If null, a default [FocusNode] will be created and managed internally.
   final FocusNode? startFocusNode;
 
-  /// Focus node for the end thumb.
+  /// An optional focus node for the end thumb.
+  ///
+  /// If provided, this [FocusNode] can be used by a parent widget to
+  /// programmatically control the focus of the start end.
+  ///
+  /// If null, a default [FocusNode] will be created and managed internally.
+
   final FocusNode? endFocusNode;
 
   // Touch width for the tap boundary of the slider thumbs.
@@ -567,6 +578,8 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
     enableController.dispose();
     startPositionController.dispose();
     endPositionController.dispose();
+    startFocusNode.dispose();
+    endFocusNode.dispose();
     super.dispose();
   }
 
@@ -790,7 +803,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
     return Stack(
       children: <Widget>[
-        //Adds two invisible focus nodes to the range slider for its two thumbs.
+        // Adds two invisible focus nodes to the range slider for its two thumbs.
         Row(
           children: <Widget>[
             Focus(focusNode: startFocusNode, child: const SizedBox.shrink()),

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -781,8 +781,12 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
         // Adds two invisible focus nodes to the range slider for its two thumbs.
         Row(
           children: <Widget>[
-            Focus(focusNode: startFocusNode, child: const SizedBox.shrink()),
-            Focus(focusNode: endFocusNode, child: const SizedBox.shrink()),
+            Focus(
+              focusNode: startFocusNode,
+              includeSemantics: false,
+              child: const SizedBox.shrink(),
+            ),
+            Focus(focusNode: endFocusNode, includeSemantics: false, child: const SizedBox.shrink()),
           ],
         ),
         MouseRegion(

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -174,8 +174,6 @@ class RangeSlider extends StatefulWidget {
       'This feature was deprecated after v3.30.0-0.1.pre.',
     )
     this.year2023,
-    this.startFocusNode,
-    this.endFocusNode,
   }) : assert(min <= max),
        assert(values.start <= values.end),
        assert(values.start >= min && values.start <= max),
@@ -425,23 +423,6 @@ class RangeSlider extends StatefulWidget {
   )
   final bool? year2023;
 
-  /// An optional focus node for the start thumb.
-  ///
-  /// If provided, this [FocusNode] can be used by a parent widget to
-  /// programmatically control the focus of the start thumb.
-  ///
-  /// If null, a default [FocusNode] will be created and managed internally.
-  final FocusNode? startFocusNode;
-
-  /// An optional focus node for the end thumb.
-  ///
-  /// If provided, this [FocusNode] can be used by a parent widget to
-  /// programmatically control the focus of the start end.
-  ///
-  /// If null, a default [FocusNode] will be created and managed internally.
-
-  final FocusNode? endFocusNode;
-
   // Touch width for the tap boundary of the slider thumbs.
   static const double _minTouchTargetWidth = kMinInteractiveDimension;
 
@@ -479,8 +460,8 @@ class RangeSlider extends StatefulWidget {
 class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin {
   static const Duration enableAnimationDuration = Duration(milliseconds: 75);
   static const Duration valueIndicatorAnimationDuration = Duration(milliseconds: 100);
-  late FocusNode startFocusNode;
-  late FocusNode endFocusNode;
+  final FocusNode startFocusNode = FocusNode();
+  final FocusNode endFocusNode = FocusNode();
 
   // Animation controller that is run when the overlay (a.k.a radial reaction)
   // changes visibility in response to user interaction.
@@ -544,8 +525,6 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       vsync: this,
       value: _unlerp(widget.values.end),
     );
-    startFocusNode = widget.startFocusNode ?? FocusNode();
-    endFocusNode = widget.endFocusNode ?? FocusNode();
   }
 
   @override
@@ -562,11 +541,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       } else {
         enableController.reverse();
       }
-      setState(() {
-        if (_showHoverHighlight != (_hovering && isEnabled)) {
-          _showHoverHighlight = _hovering && isEnabled;
-        }
-      });
+      _showHoverHighlight = _hovering && isEnabled;
     }
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -174,6 +174,8 @@ class RangeSlider extends StatefulWidget {
       'This feature was deprecated after v3.30.0-0.1.pre.',
     )
     this.year2023,
+    this.startFocusNode,
+    this.endFocusNode,
   }) : assert(min <= max),
        assert(values.start <= values.end),
        assert(values.start >= min && values.start <= max),
@@ -423,6 +425,12 @@ class RangeSlider extends StatefulWidget {
   )
   final bool? year2023;
 
+  /// Focus node for the start thumb.
+  final FocusNode? startFocusNode;
+
+  /// Focus node for the end thumb.
+  final FocusNode? endFocusNode;
+
   // Touch width for the tap boundary of the slider thumbs.
   static const double _minTouchTargetWidth = kMinInteractiveDimension;
 
@@ -460,6 +468,8 @@ class RangeSlider extends StatefulWidget {
 class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin {
   static const Duration enableAnimationDuration = Duration(milliseconds: 75);
   static const Duration valueIndicatorAnimationDuration = Duration(milliseconds: 100);
+  late FocusNode startFocusNode;
+  late FocusNode endFocusNode;
 
   // Animation controller that is run when the overlay (a.k.a radial reaction)
   // changes visibility in response to user interaction.
@@ -485,10 +495,12 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
   bool _dragging = false;
 
   bool _hovering = false;
+  bool _showHoverHighlight = false;
   void _handleHoverChanged(bool hovering) {
     if (hovering != _hovering) {
       setState(() {
         _hovering = hovering;
+        _showHoverHighlight = hovering && _enabled;
       });
     }
   }
@@ -521,6 +533,8 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       vsync: this,
       value: _unlerp(widget.values.end),
     );
+    startFocusNode = widget.startFocusNode ?? FocusNode();
+    endFocusNode = widget.endFocusNode ?? FocusNode();
   }
 
   @override
@@ -537,6 +551,11 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       } else {
         enableController.reverse();
       }
+      setState(() {
+        if (_showHoverHighlight != (_hovering && isEnabled)) {
+          _showHoverHighlight = _hovering && isEnabled;
+        }
+      });
     }
   }
 
@@ -759,7 +778,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
           onChangeEnd: widget.onChangeEnd != null ? _handleDragEnd : null,
           state: this,
           semanticFormatterCallback: widget.semanticFormatterCallback,
-          hovering: _hovering,
+          hovering: _showHoverHighlight,
         ),
       ),
     );
@@ -769,12 +788,21 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
       result = Padding(padding: padding, child: result);
     }
 
-    return FocusableActionDetector(
-      enabled: _enabled,
-      onShowHoverHighlight: _handleHoverChanged,
-      includeFocusSemantics: false,
-      mouseCursor: effectiveMouseCursor,
-      child: result,
+    return Stack(
+      children: <Widget>[
+        Row(
+          children: <Widget>[
+            Focus(focusNode: startFocusNode, child: const SizedBox.shrink()),
+            Focus(focusNode: endFocusNode, child: const SizedBox.shrink()),
+          ],
+        ),
+        MouseRegion(
+          onEnter: (_) => _handleHoverChanged(true),
+          onExit: (_) => _handleHoverChanged(false),
+          cursor: effectiveMouseCursor,
+          child: result,
+        ),
+      ],
     );
   }
 
@@ -1256,6 +1284,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     _enableAnimation.addListener(markNeedsPaint);
     _state.startPositionController.addListener(markNeedsPaint);
     _state.endPositionController.addListener(markNeedsPaint);
+    _state.startFocusNode.addListener(markNeedsPaint);
+    _state.endFocusNode.addListener(markNeedsPaint);
   }
 
   @override
@@ -1265,6 +1295,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     _enableAnimation.removeListener(markNeedsPaint);
     _state.startPositionController.removeListener(markNeedsPaint);
     _state.endPositionController.removeListener(markNeedsPaint);
+    _state.startFocusNode.addListener(markNeedsPaint);
+    _state.endFocusNode.removeListener(markNeedsPaint);
     super.detach();
   }
 
@@ -1575,6 +1607,40 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     final bool endThumbSelected = _lastThumbSelection == Thumb.end && !hoveringStartThumb;
     final Size resolvedscreenSize = screenSize.isEmpty ? size : screenSize;
 
+    if (_state.startFocusNode.hasFocus) {
+      _sliderTheme.overlayShape!.paint(
+        context,
+        _startThumbCenter,
+        activationAnimation: const AlwaysStoppedAnimation<double>(1.0),
+        enableAnimation: _enableAnimation,
+        isDiscrete: isDiscrete,
+        labelPainter: _startLabelPainter,
+        parentBox: this,
+        sliderTheme: _sliderTheme,
+        textDirection: _textDirection,
+        value: startValue,
+        textScaleFactor: _textScaleFactor,
+        sizeWithOverflow: resolvedscreenSize,
+      );
+    }
+
+    if (_state.endFocusNode.hasFocus) {
+      _sliderTheme.overlayShape!.paint(
+        context,
+        _endThumbCenter,
+        activationAnimation: const AlwaysStoppedAnimation<double>(1.0),
+        enableAnimation: _enableAnimation,
+        isDiscrete: isDiscrete,
+        labelPainter: _endLabelPainter,
+        parentBox: this,
+        sliderTheme: _sliderTheme,
+        textDirection: _textDirection,
+        value: endValue,
+        textScaleFactor: _textScaleFactor,
+        sizeWithOverflow: resolvedscreenSize,
+      );
+    }
+
     if (!_overlayAnimation.isDismissed) {
       if (startThumbSelected || hoveringStartThumb) {
         _sliderTheme.overlayShape!.paint(
@@ -1803,12 +1869,15 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     double increasedValue,
     double decreasedValue,
     VoidCallback increaseAction,
-    VoidCallback decreaseAction,
-  ) {
+    VoidCallback decreaseAction, {
+    required bool focused,
+  }) {
     final SemanticsConfiguration config = SemanticsConfiguration();
     config.isEnabled = isEnabled;
     config.textDirection = textDirection;
     config.isSlider = true;
+    config.isFocusable = true;
+    config.isFocused = focused;
     if (isEnabled) {
       config.onIncrease = increaseAction;
       config.onDecrease = decreaseAction;
@@ -1841,6 +1910,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       _decreasedStartValue,
       _increaseStartAction,
       _decreaseStartAction,
+      focused: _state.startFocusNode.hasFocus,
     );
     final SemanticsConfiguration endSemanticsConfiguration = _createSemanticsConfiguration(
       values.end,
@@ -1848,6 +1918,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       _decreasedEndValue,
       _increaseEndAction,
       _decreaseEndAction,
+      focused: _state.endFocusNode.hasFocus,
     );
 
     // Split the semantics node area between the start and end nodes.

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -1278,7 +1278,9 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     _state.startPositionController.addListener(markNeedsPaint);
     _state.endPositionController.addListener(markNeedsPaint);
     _state.startFocusNode.addListener(markNeedsPaint);
+    _state.startFocusNode.addListener(markNeedsSemanticsUpdate);
     _state.endFocusNode.addListener(markNeedsPaint);
+    _state.endFocusNode.addListener(markNeedsSemanticsUpdate);
   }
 
   @override
@@ -1288,8 +1290,10 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     _enableAnimation.removeListener(markNeedsPaint);
     _state.startPositionController.removeListener(markNeedsPaint);
     _state.endPositionController.removeListener(markNeedsPaint);
-    _state.startFocusNode.addListener(markNeedsPaint);
+    _state.startFocusNode.removeListener(markNeedsPaint);
+    _state.startFocusNode.removeListener(markNeedsSemanticsUpdate);
     _state.endFocusNode.removeListener(markNeedsPaint);
+    _state.endFocusNode.removeListener(markNeedsSemanticsUpdate);
     super.detach();
   }
 

--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -790,6 +790,7 @@ class _RangeSliderState extends State<RangeSlider> with TickerProviderStateMixin
 
     return Stack(
       children: <Widget>[
+        //Adds two invisible focus nodes to the range slider for its two thumbs.
         Row(
           children: <Widget>[
             Focus(focusNode: startFocusNode, child: const SizedBox.shrink()),

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2570,8 +2570,8 @@ void main() {
     final Finder rangeSliderFinder = find.byType(RangeSlider);
     expect(rangeSliderFinder, findsOneWidget);
     final dynamic rangeSliderState = tester.firstState(find.byType(RangeSlider));
-    final FocusNode startFocusNode = rangeSliderState.startFocusNode;
-    final FocusNode endFocusNode = rangeSliderState.endFocusNode;
+    final FocusNode startFocusNode = rangeSliderState.startFocusNode as FocusNode;
+    final FocusNode endFocusNode = rangeSliderState.endFocusNode as FocusNode;
 
     startFocusNode.requestFocus();
     await tester.pumpAndSettle();
@@ -2604,9 +2604,8 @@ void main() {
 
     await tester.pumpAndSettle();
     final dynamic rangeSliderState = tester.firstState(find.byType(RangeSlider));
-    final FocusNode startFocusNode = rangeSliderState.startFocusNode;
-    final FocusNode endFocusNode = rangeSliderState.endFocusNode;
-
+    final FocusNode startFocusNode = rangeSliderState.startFocusNode as FocusNode;
+    final FocusNode endFocusNode = rangeSliderState.endFocusNode as FocusNode;
     // Focus on the start thumb
     startFocusNode.requestFocus();
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2561,10 +2561,8 @@ void main() {
                       });
                     },
                     onChangeStart: (RangeValues newValues) {
-                      onChangeStartCalled = true;
                     },
                     onChangeEnd: (RangeValues newValues) {
-                      onChangeEndCalled = true;
                     },
                     startFocusNode: startFocusNode,
                     endFocusNode: endFocusNode,

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/src/physics/utils.dart' show nearEqual;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -1927,6 +1928,7 @@ void main() {
               matchesSemantics(
                 isEnabled: true,
                 isSlider: true,
+                isFocusable: true,
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
@@ -1938,6 +1940,7 @@ void main() {
               matchesSemantics(
                 isEnabled: true,
                 isSlider: true,
+                isFocusable: true,
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
@@ -1985,6 +1988,7 @@ void main() {
               matchesSemantics(
                 isEnabled: true,
                 isSlider: true,
+                isFocusable: true,
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
@@ -1996,6 +2000,7 @@ void main() {
               matchesSemantics(
                 isEnabled: true,
                 isSlider: true,
+                isFocusable: true,
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
@@ -2069,6 +2074,7 @@ void main() {
               matchesSemantics(
                 isEnabled: true,
                 isSlider: true,
+                isFocusable: true,
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
@@ -2079,6 +2085,7 @@ void main() {
               matchesSemantics(
                 isEnabled: true,
                 isSlider: true,
+                isFocusable: true,
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
@@ -2454,11 +2461,6 @@ void main() {
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), disabledCursor);
 
     await tester.pumpWidget(buildFrame(enabled: true));
-    expect(
-      RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
-      SystemMouseCursors.none,
-    );
-
     await gesture.moveTo(tester.getCenter(find.byType(RangeSlider))); // start hover
     await tester.pumpAndSettle();
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), hoveredCursor);
@@ -2533,6 +2535,172 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(RangeSlider))),
       isNot(paints..circle(color: theme.colorScheme.primary.withOpacity(0.12))),
+    );
+  });
+
+  testWidgets('RangeSlider can be focused using keyboard focus', (WidgetTester tester) async {
+    RangeValues values = const RangeValues(20, 80);
+    bool onChangeStartCalled = false;
+    bool onChangeEndCalled = false;
+    final startFocusNode = FocusNode();
+    final endFocusNode = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Material(
+            child: StatefulBuilder(
+              builder: (BuildContext context, StateSetter setState) {
+                return Center(
+                  child: RangeSlider(
+                    values: values,
+                    min: 0,
+                    max: 100,
+                    onChanged: (RangeValues newValues) {
+                      setState(() {
+                        values = newValues;
+                      });
+                    },
+                    onChangeStart: (RangeValues newValues) {
+                      onChangeStartCalled = true;
+                    },
+                    onChangeEnd: (RangeValues newValues) {
+                      onChangeEndCalled = true;
+                    },
+                    startFocusNode: startFocusNode,
+                    endFocusNode: endFocusNode,
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+    // Focus on the start thumb
+    final Finder rangeSliderFinder = find.byType(RangeSlider);
+    expect(rangeSliderFinder, findsOneWidget);
+    startFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus, startFocusNode);
+
+    // Tab to focus on the end thumb
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus, endFocusNode);
+  });
+
+  testWidgets('Keyboard focus also changes semantics focus', (WidgetTester tester) async {
+    final startFocusNode = FocusNode();
+    final endFocusNode = FocusNode();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Theme(
+          data: ThemeData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: Material(
+              child: RangeSlider(
+                values: const RangeValues(10.0, 30.0),
+                max: 100.0,
+                onChanged: (RangeValues v) {},
+                startFocusNode: startFocusNode,
+                endFocusNode: endFocusNode,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Focus on the start thumb
+    startFocusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus, startFocusNode);
+
+    final SemanticsNode semanticsNode = tester.getSemantics(find.byType(RangeSlider));
+    expect(
+      semanticsNode,
+      matchesSemantics(
+        scopesRoute: true,
+        children: <Matcher>[
+          matchesSemantics(
+            children: <Matcher>[
+              matchesSemantics(
+                isEnabled: true,
+                isSlider: true,
+                isFocusable: true,
+                isFocused: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '10%',
+                increasedValue: '15%',
+                decreasedValue: '5%',
+                rect: const Rect.fromLTRB(75.2, 276.0, 123.2, 324.0),
+              ),
+              matchesSemantics(
+                isEnabled: true,
+                isSlider: true,
+                isFocusable: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '30%',
+                increasedValue: '35%',
+                decreasedValue: '25%',
+                rect: const Rect.fromLTRB(225.6, 276.0, 273.6, 324.0),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    // Tab to focus on the end thumb
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle();
+    expect(FocusManager.instance.primaryFocus, endFocusNode);
+
+    expect(
+      semanticsNode,
+      matchesSemantics(
+        scopesRoute: true,
+        children: <Matcher>[
+          matchesSemantics(
+            children: <Matcher>[
+              matchesSemantics(
+                isEnabled: true,
+                isSlider: true,
+                isFocusable: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '10%',
+                increasedValue: '15%',
+                decreasedValue: '5%',
+                rect: const Rect.fromLTRB(75.2, 276.0, 123.2, 324.0),
+              ),
+              matchesSemantics(
+                isEnabled: true,
+                isSlider: true,
+                isFocusable: true,
+                isFocused: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '30%',
+                increasedValue: '35%',
+                decreasedValue: '25%',
+                rect: const Rect.fromLTRB(225.6, 276.0, 273.6, 324.0),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   });
 

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2569,9 +2569,10 @@ void main() {
     // Focus on the start thumb
     final Finder rangeSliderFinder = find.byType(RangeSlider);
     expect(rangeSliderFinder, findsOneWidget);
-    final dynamic rangeSliderState = tester.firstState(find.byType(RangeSlider));
-    final FocusNode startFocusNode = rangeSliderState.startFocusNode as FocusNode;
-    final FocusNode endFocusNode = rangeSliderState.endFocusNode as FocusNode;
+    final FocusNode startFocusNode =
+        (tester.firstState(find.byType(RangeSlider)) as dynamic).startFocusNode as FocusNode;
+    final FocusNode endFocusNode =
+        (tester.firstState(find.byType(RangeSlider)) as dynamic).endFocusNode as FocusNode;
 
     startFocusNode.requestFocus();
     await tester.pumpAndSettle();
@@ -2603,9 +2604,10 @@ void main() {
     );
 
     await tester.pumpAndSettle();
-    final dynamic rangeSliderState = tester.firstState(find.byType(RangeSlider));
-    final FocusNode startFocusNode = rangeSliderState.startFocusNode as FocusNode;
-    final FocusNode endFocusNode = rangeSliderState.endFocusNode as FocusNode;
+    final FocusNode startFocusNode =
+        (tester.firstState(find.byType(RangeSlider)) as dynamic).startFocusNode as FocusNode;
+    final FocusNode endFocusNode =
+        (tester.firstState(find.byType(RangeSlider)) as dynamic).endFocusNode as FocusNode;
     // Focus on the start thumb
     startFocusNode.requestFocus();
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2540,11 +2540,10 @@ void main() {
 
   testWidgets('RangeSlider can be focused using keyboard focus', (WidgetTester tester) async {
     RangeValues values = const RangeValues(20, 80);
-    bool onChangeStartCalled = false;
-    bool onChangeEndCalled = false;
-    final startFocusNode = FocusNode();
-    final endFocusNode = FocusNode();
-
+    final FocusNode startFocusNode = FocusNode();
+    final FocusNode endFocusNode = FocusNode();
+    addTearDown(startFocusNode.dispose);
+    addTearDown(endFocusNode.dispose);
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -2555,7 +2554,6 @@ void main() {
                 return Center(
                   child: RangeSlider(
                     values: values,
-                    min: 0,
                     max: 100,
                     onChanged: (RangeValues newValues) {
                       setState(() {
@@ -2592,8 +2590,10 @@ void main() {
   });
 
   testWidgets('Keyboard focus also changes semantics focus', (WidgetTester tester) async {
-    final startFocusNode = FocusNode();
-    final endFocusNode = FocusNode();
+    final FocusNode startFocusNode = FocusNode();
+    final FocusNode endFocusNode = FocusNode();
+    addTearDown(startFocusNode.dispose);
+    addTearDown(endFocusNode.dispose);
     await tester.pumpWidget(
       MaterialApp(
         home: Theme(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2560,10 +2560,8 @@ void main() {
                         values = newValues;
                       });
                     },
-                    onChangeStart: (RangeValues newValues) {
-                    },
-                    onChangeEnd: (RangeValues newValues) {
-                    },
+                    onChangeStart: (RangeValues newValues) {},
+                    onChangeEnd: (RangeValues newValues) {},
                     startFocusNode: startFocusNode,
                     endFocusNode: endFocusNode,
                   ),

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2540,8 +2540,6 @@ void main() {
 
   testWidgets('RangeSlider can be focused using keyboard focus', (WidgetTester tester) async {
     RangeValues values = const RangeValues(20, 80);
-    final FocusNode startFocusNode = FocusNode();
-    final FocusNode endFocusNode = FocusNode();
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -2560,8 +2558,6 @@ void main() {
                     },
                     onChangeStart: (RangeValues newValues) {},
                     onChangeEnd: (RangeValues newValues) {},
-                    startFocusNode: startFocusNode,
-                    endFocusNode: endFocusNode,
                   ),
                 );
               },
@@ -2573,6 +2569,10 @@ void main() {
     // Focus on the start thumb
     final Finder rangeSliderFinder = find.byType(RangeSlider);
     expect(rangeSliderFinder, findsOneWidget);
+    final dynamic rangeSliderState = tester.firstState(find.byType(RangeSlider));
+    final FocusNode startFocusNode = rangeSliderState.startFocusNode;
+    final FocusNode endFocusNode = rangeSliderState.endFocusNode;
+
     startFocusNode.requestFocus();
     await tester.pumpAndSettle();
     expect(FocusManager.instance.primaryFocus, startFocusNode);
@@ -2584,8 +2584,6 @@ void main() {
   });
 
   testWidgets('Keyboard focus also changes semantics focus', (WidgetTester tester) async {
-    final FocusNode startFocusNode = FocusNode();
-    final FocusNode endFocusNode = FocusNode();
     await tester.pumpWidget(
       MaterialApp(
         home: Theme(
@@ -2597,8 +2595,6 @@ void main() {
                 values: const RangeValues(10.0, 30.0),
                 max: 100.0,
                 onChanged: (RangeValues v) {},
-                startFocusNode: startFocusNode,
-                endFocusNode: endFocusNode,
               ),
             ),
           ),
@@ -2607,6 +2603,9 @@ void main() {
     );
 
     await tester.pumpAndSettle();
+    final dynamic rangeSliderState = tester.firstState(find.byType(RangeSlider));
+    final FocusNode startFocusNode = rangeSliderState.startFocusNode;
+    final FocusNode endFocusNode = rangeSliderState.endFocusNode;
 
     // Focus on the start thumb
     startFocusNode.requestFocus();

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2542,8 +2542,6 @@ void main() {
     RangeValues values = const RangeValues(20, 80);
     final FocusNode startFocusNode = FocusNode();
     final FocusNode endFocusNode = FocusNode();
-    addTearDown(startFocusNode.dispose);
-    addTearDown(endFocusNode.dispose);
     await tester.pumpWidget(
       MaterialApp(
         home: Directionality(
@@ -2588,8 +2586,6 @@ void main() {
   testWidgets('Keyboard focus also changes semantics focus', (WidgetTester tester) async {
     final FocusNode startFocusNode = FocusNode();
     final FocusNode endFocusNode = FocusNode();
-    addTearDown(startFocusNode.dispose);
-    addTearDown(endFocusNode.dispose);
     await tester.pumpWidget(
       MaterialApp(
         home: Theme(


### PR DESCRIPTION
internal: b/430179234 : in a11y mode, you can't use tab to focus on the handles of the rangeslider, only use a11y shortcut to focus on them. 

rangeSlider is a widget with 1 renderObject but 2 semanticsNode because it has 2 inputs, each handle of the rangeSlider has its own actions.  To achieve that, rangeSlider creates its semantics node using the assembleSemantics function. 

For the same reason, rangeSlider should have 2 focus nodes instead of 1, and it should be linked to semantics to support tab to navigate in a11y mode. 

This PR is to add 2 focus nodes to the range slider, link them to a11y and  also highlight the thumb when focused.


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
