### PR TITLE
Add `onReorderUpdate` callback to ReorderableListView

### DIFF
--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -81,6 +81,7 @@ class ReorderableListView extends StatefulWidget {
     required this.onReorder,
     this.onReorderStart,
     this.onReorderEnd,
+    this.onReorderUpdate,
     this.itemExtent,
     this.itemExtentBuilder,
     this.prototypeItem,
@@ -152,6 +153,7 @@ class ReorderableListView extends StatefulWidget {
     required this.onReorder,
     this.onReorderStart,
     this.onReorderEnd,
+    this.onReorderUpdate,
     this.itemExtent,
     this.itemExtentBuilder,
     this.prototypeItem,
@@ -197,6 +199,9 @@ class ReorderableListView extends StatefulWidget {
 
   /// {@macro flutter.widgets.reorderable_list.onReorderEnd}
   final void Function(int index)? onReorderEnd;
+
+  /// {@macro flutter.widgets.reorderable_list.onReorderUpdate}
+  final ReorderUpdateCallback? onReorderUpdate;
 
   /// {@macro flutter.widgets.reorderable_list.proxyDecorator}
   final ReorderItemProxyDecorator? proxyDecorator;
@@ -484,6 +489,7 @@ class _ReorderableListViewState extends State<ReorderableListView> {
               _dragging.value = false;
               widget.onReorderEnd?.call(index);
             },
+            onReorderUpdate: widget.onReorderUpdate,
             proxyDecorator: widget.proxyDecorator ?? _proxyDecorator,
             autoScrollerVelocityScalar: widget.autoScrollerVelocityScalar,
             dragBoundaryProvider: widget.dragBoundaryProvider,


### PR DESCRIPTION
## Description

This PR adds an `onReorderUpdate` callback to `ReorderableListView` that fires continuously during drag operations, enabling developers to provide immediate feedback as items move between positions. This addresses a long-standing limitation where developers only had access to start/end callbacks, making it impossible to provide immediate user feedback during reordering.

<p align="center">
  <img src="https://github.com/user-attachments/assets/aece20c5-8242-4ddc-b0b7-23bed59aa9d9" alt="demo2" width="250">
</p>

_This video demonstrates the new `onReorderUpdate` callback, showing real-time feedback during drag operations._

## Motivation

Developers have long requested the ability to provide immediate feedback during reorder operations (see #139187). Currently, `ReorderableListView` only provides callbacks at the start and end of a drag, limiting the ability to create responsive, modern UIs with haptic feedback, visual indicators, or sound effects during dragging.

This PR is part of a series of `ReorderableList` enhancements I've developed for [TimeFinder](https://timefinder.app):
- #172740
- #172380
- #173241
- #172739

## Usage Example

```dart
ReorderableListView(
  onReorder: (oldIndex, newIndex) {
    // Final reorder logic
  },
  onReorderUpdate: (fromIndex, toIndex) {
    // Fires continuously as the item moves
    // fromIndex: original position
    // toIndex: where the item would end up if dropped now
    HapticFeedback.lightImpact();
  },
  children: [...],
)
```

## Implementation Details

### API Changes
1. Added `ReorderUpdateCallback` typedef: `void Function(int fromIndex, int toIndex)`
2. Added optional `onReorderUpdate` parameter to `ReorderableListView`, `ReorderableList`, and `SliverReorderableList`
3. The callback fires from `_dragUpdateItems()` whenever the potential drop position changes

### Index Handling

Flutter's reordering API uses a specific convention that requires careful handling:

**The Challenge**: The `onReorder` callback receives `newIndex` as an insertion point *before* the dragged item is removed from the list. For example:
- List: `[A, B, C, D]`
- Dragging B (index 1) to after C
- `onReorder` receives: `oldIndex=1, newIndex=3` (not 2)
- Final position after move: index 2

This convention (documented in `ReorderCallback`) works fine for the final `onReorder` callback but presents challenges for continuous updates where developers expect intuitive "final position" values.

**The Solution**: This PR includes a helper method that converts insertion points to final positions:

```dart
static int _insertionPointToFinalIndex({
  required int insertionPoint,
  required int originalIndex,
}) {
  return insertionPoint > originalIndex ? insertionPoint - 1 : insertionPoint;
}
```

This ensures `onReorderUpdate` provides intuitive values that match what developers expect and what they would implement in their `onReorder` handler.

### Preventing Redundant Callbacks

The implementation tracks the previous final index to ensure callbacks only fire when the actual destination position changes, preventing unnecessary updates when the internal `_insertIndex` changes without affecting the final position.

## Related Issues

Resolves #139187

This addresses needs expressed in third-party packages that have attempted to work around this limitation:
- [super_drag_and_drop](https://pub.dev/packages/super_drag_and_drop) - Drag progress callbacks
- [floating_draggable_widget](https://pub.dev/packages/floating_draggable_widget) - onDragEvent listeners
- [drag_and_drop_lists](https://pub.dev/packages/drag_and_drop_lists) - Continuous feedback support

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

## Breaking Change

Does your PR require Flutter developers to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change
- [x] No, this is not a breaking change

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests