### PR TITLE
Fix SegmentedButton border doesn't reflect states

### DIFF
--- a/dev/tools/gen_defaults/lib/segmented_button_template.dart
+++ b/dev/tools/gen_defaults/lib/segmented_button_template.dart
@@ -47,79 +47,79 @@ class _${blockName}DefaultsM3 extends SegmentedButtonThemeData {
   late final ColorScheme _colors = _theme.colorScheme;
   @override ButtonStyle? get style {
     return ButtonStyle(
-      textStyle: MaterialStatePropertyAll<TextStyle?>(${textStyle('$tokenGroup.label-text')}),
-      backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.disabled)) {
+      textStyle: WidgetStatePropertyAll<TextStyle?>(${textStyle('$tokenGroup.label-text')}),
+      backgroundColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
           return ${componentColor('$tokenGroup.disabled')};
         }
-        if (states.contains(MaterialState.selected)) {
+        if (states.contains(WidgetState.selected)) {
           return ${componentColor('$tokenGroup.selected.container')};
         }
         return ${componentColor('$tokenGroup.unselected.container')};
       }),
-      foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.disabled)) {
+      foregroundColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
           return ${componentColor('$tokenGroup.disabled.label-text')};
         }
-        if (states.contains(MaterialState.selected)) {
-          if (states.contains(MaterialState.pressed)) {
+        if (states.contains(WidgetState.selected)) {
+          if (states.contains(WidgetState.pressed)) {
             return ${componentColor('$tokenGroup.selected.pressed.label-text')};
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return ${componentColor('$tokenGroup.selected.hover.label-text')};
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return ${componentColor('$tokenGroup.selected.focus.label-text')};
           }
           return ${componentColor('$tokenGroup.selected.label-text')};
         } else {
-          if (states.contains(MaterialState.pressed)) {
+          if (states.contains(WidgetState.pressed)) {
             return ${componentColor('$tokenGroup.unselected.pressed.label-text')};
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return ${componentColor('$tokenGroup.unselected.hover.label-text')};
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return ${componentColor('$tokenGroup.unselected.focus.label-text')};
           }
           return ${componentColor('$tokenGroup.unselected.label-text')};
         }
       }),
-      overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.selected)) {
-          if (states.contains(MaterialState.pressed)) {
+      overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.selected)) {
+          if (states.contains(WidgetState.pressed)) {
             return ${_stateColor(tokenGroup, 'selected', 'pressed')};
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return ${_stateColor(tokenGroup, 'selected', 'hover')};
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return ${_stateColor(tokenGroup, 'selected', 'focus')};
           }
         } else {
-          if (states.contains(MaterialState.pressed)) {
+          if (states.contains(WidgetState.pressed)) {
             return ${_stateColor(tokenGroup, 'unselected', 'pressed')};
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return ${_stateColor(tokenGroup, 'unselected', 'hover')};
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return ${_stateColor(tokenGroup, 'unselected', 'focus')};
           }
         }
         return null;
       }),
-      surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
-      elevation: const MaterialStatePropertyAll<double>(0),
-      iconSize: const MaterialStatePropertyAll<double?>(${getToken('$tokenGroup.with-icon.icon.size')}),
-      side: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.disabled)) {
+      surfaceTintColor: const WidgetStatePropertyAll<Color>(Colors.transparent),
+      elevation: const WidgetStatePropertyAll<double>(0),
+      iconSize: const WidgetStatePropertyAll<double?>(${getToken('$tokenGroup.with-icon.icon.size')}),
+      side: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
           return ${border("$tokenGroup.disabled.outline")};
         }
         return ${border("$tokenGroup.outline")};
       }),
-      shape: const MaterialStatePropertyAll<OutlinedBorder>(${shape(tokenGroup, '')}),
-      minimumSize: const MaterialStatePropertyAll<Size?>(Size.fromHeight(${getToken('$tokenGroup.container.height')})),
+      shape: const WidgetStatePropertyAll<OutlinedBorder>(${shape(tokenGroup, '')}),
+      minimumSize: const WidgetStatePropertyAll<Size?>(Size.fromHeight(${getToken('$tokenGroup.container.height')})),
     );
   }
   @override

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -307,12 +307,12 @@ class SegmentedButton<T> extends StatefulWidget {
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
   }) {
-    final MaterialStateProperty<Color?>? overlayColorProp =
+    final WidgetStateProperty<Color?>? overlayColorProp =
         (foregroundColor == null && selectedForegroundColor == null && overlayColor == null)
         ? null
         : switch (overlayColor) {
             (final Color overlayColor) when overlayColor.value == 0 =>
-              const MaterialStatePropertyAll<Color?>(Colors.transparent),
+              const WidgetStatePropertyAll<Color?>(Colors.transparent),
             _ => _SegmentedButtonDefaultsM3.resolveStateColor(
               foregroundColor,
               selectedForegroundColor,
@@ -401,6 +401,14 @@ class SegmentedButton<T> extends StatefulWidget {
   ///   * [ButtonStyle.enableFeedback]
   ///   * [ButtonStyle.alignment]
   ///   * [ButtonStyle.splashFactory]
+  ///
+  /// If [ButtonStyle.side] is provided, [WidgetStateProperty.resolve] is used
+  /// for the following [WidgetState]s:
+  ///
+  ///  * [WidgetState.focused].
+  ///  * [WidgetState.hovered].
+  ///  * [WidgetState.disabled].
+  ///  * [WidgetState.selected].
   final ButtonStyle? style;
 
   /// Determines if the [selectedIcon] (usually an icon using [Icons.check])
@@ -436,6 +444,16 @@ class SegmentedButton<T> extends StatefulWidget {
 @visibleForTesting
 class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
   bool get _enabled => widget.onSelectionChanged != null;
+  bool _hovering = false;
+  bool _focused = false;
+  bool get _selected => widget.selected.isNotEmpty;
+
+  Set<WidgetState> get _states => <WidgetState>{
+    if (!_enabled) WidgetState.disabled,
+    if (_hovering) WidgetState.hovered,
+    if (_focused) WidgetState.focused,
+    if (_selected) WidgetState.selected,
+  };
 
   /// Controllers for the [ButtonSegment]s.
   @visibleForTesting
@@ -492,10 +510,7 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
     final SegmentedButtonThemeData theme = SegmentedButtonTheme.of(context);
     final SegmentedButtonThemeData defaults = _SegmentedButtonDefaultsM3(context);
     final TextDirection textDirection = Directionality.of(context);
-
-    const Set<MaterialState> enabledState = <MaterialState>{};
     const Set<MaterialState> disabledState = <MaterialState>{MaterialState.disabled};
-    final Set<MaterialState> currentState = _enabled ? enabledState : disabledState;
 
     P? effectiveValue<P>(P? Function(ButtonStyle? style) getProperty) {
       late final P? widgetValue = getProperty(widget.style);
@@ -508,9 +523,7 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
       MaterialStateProperty<P>? Function(ButtonStyle? style) getProperty, [
       Set<MaterialState>? states,
     ]) {
-      return effectiveValue(
-        (ButtonStyle? style) => getProperty(style)?.resolve(states ?? currentState),
-      );
+      return effectiveValue((ButtonStyle? style) => getProperty(style)?.resolve(states ?? _states));
     }
 
     ButtonStyle segmentStyleFor(ButtonStyle? style) {
@@ -524,7 +537,7 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
         padding: style?.padding,
         iconColor: style?.iconColor,
         iconSize: style?.iconSize,
-        shape: const MaterialStatePropertyAll<OutlinedBorder>(RoundedRectangleBorder()),
+        shape: const WidgetStatePropertyAll<OutlinedBorder>(RoundedRectangleBorder()),
         mouseCursor: style?.mouseCursor,
         visualDensity: style?.visualDensity,
         tapTargetSize: style?.tapTargetSize,
@@ -555,12 +568,22 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
         segment,
         () => MaterialStatesController(),
       );
-      controller.update(MaterialState.selected, segmentSelected);
+      controller.update(WidgetState.selected, segmentSelected);
 
       final Widget button = icon != null
           ? TextButton.icon(
               style: segmentStyle,
               statesController: controller,
+              onHover: (bool hovering) {
+                setState(() {
+                  _hovering = hovering;
+                });
+              },
+              onFocusChange: (bool focused) {
+                setState(() {
+                  _focused = focused;
+                });
+              },
               onPressed: (_enabled && segment.enabled)
                   ? () => _handleOnPressed(segment.value)
                   : null,
@@ -570,6 +593,16 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
           : TextButton(
               style: segmentStyle,
               statesController: controller,
+              onHover: (bool hovering) {
+                setState(() {
+                  _hovering = hovering;
+                });
+              },
+              onFocusChange: (bool focused) {
+                setState(() {
+                  _focused = focused;
+                });
+              },
               onPressed: (_enabled && segment.enabled)
                   ? () => _handleOnPressed(segment.value)
                   : null,
@@ -589,32 +622,31 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
       );
     }
 
-    final OutlinedBorder resolvedEnabledBorder =
-        resolve<OutlinedBorder?>((ButtonStyle? style) => style?.shape, disabledState) ??
+    final OutlinedBorder effectiveBorder =
+        resolve<OutlinedBorder?>((ButtonStyle? style) => style?.shape) ??
         const RoundedRectangleBorder();
     final OutlinedBorder resolvedDisabledBorder =
         resolve<OutlinedBorder?>((ButtonStyle? style) => style?.shape, disabledState) ??
         const RoundedRectangleBorder();
-    final BorderSide enabledSide =
-        resolve<BorderSide?>((ButtonStyle? style) => style?.side, enabledState) ?? BorderSide.none;
+    final BorderSide effectiveSide =
+        resolve<BorderSide?>((ButtonStyle? style) => style?.side) ?? BorderSide.none;
     final BorderSide disabledSide =
         resolve<BorderSide?>((ButtonStyle? style) => style?.side, disabledState) ?? BorderSide.none;
-    final OutlinedBorder enabledBorder = resolvedEnabledBorder.copyWith(side: enabledSide);
+
+    final OutlinedBorder enabledBorder = effectiveBorder.copyWith(side: effectiveSide);
     final OutlinedBorder disabledBorder = resolvedDisabledBorder.copyWith(side: disabledSide);
     final VisualDensity resolvedVisualDensity =
         segmentStyle.visualDensity ??
         segmentThemeStyle.visualDensity ??
         Theme.of(context).visualDensity;
     final EdgeInsetsGeometry resolvedPadding =
-        resolve<EdgeInsetsGeometry?>((ButtonStyle? style) => style?.padding, enabledState) ??
-        EdgeInsets.zero;
+        resolve<EdgeInsetsGeometry?>((ButtonStyle? style) => style?.padding) ?? EdgeInsets.zero;
     final MaterialTapTargetSize resolvedTapTargetSize =
         segmentStyle.tapTargetSize ??
         segmentThemeStyle.tapTargetSize ??
         Theme.of(context).materialTapTargetSize;
     final double fontSize =
-        resolve<TextStyle?>((ButtonStyle? style) => style?.textStyle, enabledState)?.fontSize ??
-        20.0;
+        resolve<TextStyle?>((ButtonStyle? style) => style?.textStyle)?.fontSize ?? 20.0;
 
     final List<Widget> buttons = widget.segments.map(buttonFor).toList();
 
@@ -1153,79 +1185,79 @@ class _SegmentedButtonDefaultsM3 extends SegmentedButtonThemeData {
   late final ColorScheme _colors = _theme.colorScheme;
   @override ButtonStyle? get style {
     return ButtonStyle(
-      textStyle: MaterialStatePropertyAll<TextStyle?>(Theme.of(context).textTheme.labelLarge),
-      backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.disabled)) {
+      textStyle: WidgetStatePropertyAll<TextStyle?>(Theme.of(context).textTheme.labelLarge),
+      backgroundColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
           return null;
         }
-        if (states.contains(MaterialState.selected)) {
+        if (states.contains(WidgetState.selected)) {
           return _colors.secondaryContainer;
         }
         return null;
       }),
-      foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.disabled)) {
+      foregroundColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
           return _colors.onSurface.withOpacity(0.38);
         }
-        if (states.contains(MaterialState.selected)) {
-          if (states.contains(MaterialState.pressed)) {
+        if (states.contains(WidgetState.selected)) {
+          if (states.contains(WidgetState.pressed)) {
             return _colors.onSecondaryContainer;
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return _colors.onSecondaryContainer;
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return _colors.onSecondaryContainer;
           }
           return _colors.onSecondaryContainer;
         } else {
-          if (states.contains(MaterialState.pressed)) {
+          if (states.contains(WidgetState.pressed)) {
             return _colors.onSurface;
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return _colors.onSurface;
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return _colors.onSurface;
           }
           return _colors.onSurface;
         }
       }),
-      overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.selected)) {
-          if (states.contains(MaterialState.pressed)) {
+      overlayColor: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.selected)) {
+          if (states.contains(WidgetState.pressed)) {
             return _colors.onSecondaryContainer.withOpacity(0.1);
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return _colors.onSecondaryContainer.withOpacity(0.08);
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return _colors.onSecondaryContainer.withOpacity(0.1);
           }
         } else {
-          if (states.contains(MaterialState.pressed)) {
+          if (states.contains(WidgetState.pressed)) {
             return _colors.onSurface.withOpacity(0.1);
           }
-          if (states.contains(MaterialState.hovered)) {
+          if (states.contains(WidgetState.hovered)) {
             return _colors.onSurface.withOpacity(0.08);
           }
-          if (states.contains(MaterialState.focused)) {
+          if (states.contains(WidgetState.focused)) {
             return _colors.onSurface.withOpacity(0.1);
           }
         }
         return null;
       }),
-      surfaceTintColor: const MaterialStatePropertyAll<Color>(Colors.transparent),
-      elevation: const MaterialStatePropertyAll<double>(0),
-      iconSize: const MaterialStatePropertyAll<double?>(18.0),
-      side: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-        if (states.contains(MaterialState.disabled)) {
+      surfaceTintColor: const WidgetStatePropertyAll<Color>(Colors.transparent),
+      elevation: const WidgetStatePropertyAll<double>(0),
+      iconSize: const WidgetStatePropertyAll<double?>(18.0),
+      side: WidgetStateProperty.resolveWith((Set<WidgetState> states) {
+        if (states.contains(WidgetState.disabled)) {
           return BorderSide(color: _colors.onSurface.withOpacity(0.12));
         }
         return BorderSide(color: _colors.outline);
       }),
-      shape: const MaterialStatePropertyAll<OutlinedBorder>(StadiumBorder()),
-      minimumSize: const MaterialStatePropertyAll<Size?>(Size.fromHeight(40.0)),
+      shape: const WidgetStatePropertyAll<OutlinedBorder>(StadiumBorder()),
+      minimumSize: const WidgetStatePropertyAll<Size?>(Size.fromHeight(40.0)),
     );
   }
   @override

--- a/packages/flutter/lib/src/material/segmented_button_theme.dart
+++ b/packages/flutter/lib/src/material/segmented_button_theme.dart
@@ -40,6 +40,14 @@ class SegmentedButtonThemeData with Diagnosticable {
   /// values override the default values used by [SegmentedButton].
   ///
   /// If [style] is null, then this theme doesn't override anything.
+  ///
+  /// If [ButtonStyle.side] is provided, [WidgetStateProperty.resolve] is used
+  /// for the following [WidgetState]s:
+  ///
+  ///  * [WidgetState.focused].
+  ///  * [WidgetState.hovered].
+  ///  * [WidgetState.disabled].
+  ///  * [WidgetState.selected].
   final ButtonStyle? style;
 
   /// Override for [SegmentedButton.selectedIcon] property.


### PR DESCRIPTION
## Description

This PR fixes `SegmentedButton` border side not depending on the current state.

It's based on one @TahaTesser 's great PR: see https://github.com/flutter/flutter/pull/161942. 🙏 
I updated some logic related to disabled border which led to Taha’s PR failing internal Google tests.
I also added a test to verify the disabled border.

<details><summary>Code sample for screenshots</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const SegmentedButtonApp());
}

enum Calendar { day, week, month, year }

class SegmentedButtonApp extends StatefulWidget {
  const SegmentedButtonApp({super.key});

  @override
  State<SegmentedButtonApp> createState() => _SegmentedButtonAppState();
}

class _SegmentedButtonAppState extends State<SegmentedButtonApp> {
  Calendar? calendarView;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        segmentedButtonTheme: SegmentedButtonThemeData(
          style: ButtonStyle(
            side: WidgetStateProperty.fromMap(<WidgetStatesConstraint, BorderSide?>{
              WidgetState.disabled: const BorderSide(color: Colors.grey, width: 2),
              WidgetState.selected & WidgetState.hovered: const BorderSide(
                color: Colors.blue,
                width: 2,
              ),
              WidgetState.selected & WidgetState.focused: const BorderSide(
                color: Colors.pinkAccent,
                width: 2,
              ),
              WidgetState.hovered: const BorderSide(color: Colors.green, width: 2),
              WidgetState.focused: const BorderSide(color: Colors.purple, width: 2),
              WidgetState.any: const BorderSide(color: Colors.amber, width: 2),
            }),
          ),
        ),
      ),
      home: Scaffold(
        body: Center(
          child: SegmentedButton<Calendar>(
            segments: const <ButtonSegment<Calendar>>[
              ButtonSegment<Calendar>(
                value: Calendar.day,
                label: Text('Day'),
                icon: Icon(Icons.calendar_view_day),
                enabled: false,
              ),
              ButtonSegment<Calendar>(
                value: Calendar.week,
                label: Text('Week'),
                icon: Icon(Icons.calendar_view_week),
              ),
              ButtonSegment<Calendar>(
                value: Calendar.month,
                label: Text('Month'),
                icon: Icon(Icons.calendar_view_month),
              ),
              ButtonSegment<Calendar>(
                value: Calendar.year,
                label: Text('Year'),
                icon: Icon(Icons.calendar_today),
              ),
            ],
            selected: <Calendar>{?calendarView},
            emptySelectionAllowed: true,
            onSelectionChanged: (Set<Calendar> newSelection) {
              setState(() {
                calendarView = newSelection.isEmpty ? null : newSelection.first;
              });
            },
          ),
        ),
        floatingActionButton: FloatingActionButton(onPressed: () {}, child: const Icon(Icons.add)),
      ),
    );
  }
}

``` 

</details> 

# Before

https://github.com/user-attachments/assets/1581f431-f87a-4af3-8ef6-f1f0d170e54a


# After

https://github.com/user-attachments/assets/156a8a64-3d9f-4323-9a1d-60624f5ac5d4


## Related Issue

Fixes [SegmentedButton does not set its MaterialState for side ](https://github.com/flutter/flutter/issues/159884)

## Tests

Adds 2 tests.
