### PR TITLE
Fix an `omit-type` lint that is breaking the tree

### DIFF
--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -933,7 +933,7 @@ void main() {
   );
 
   testWithoutContext('respects custom user data directory flag', () async {
-    const String customUserDataDir = '/custom/chrome/data/dir';
+    const customUserDataDir = '/custom/chrome/data/dir';
     processManager.addCommand(
       const FakeCommand(
         command: <String>[


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/169445 was stale (not re-based), causing a tree failure.

Let's just land this versus reverting.