### PR TITLE
Remove deprecated `--[no-]-disable-dds`

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -596,29 +596,7 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
-  late final bool enableDds = () {
-    var ddsEnabled = false;
-    if (argResults?.wasParsed('disable-dds') ?? false) {
-      if (argResults?.wasParsed('dds') ?? false) {
-        throwToolExit(
-          'The "--[no-]dds" and "--[no-]disable-dds" arguments are mutually exclusive. Only specify "--[no-]dds".',
-        );
-      }
-      ddsEnabled = !boolArg('disable-dds');
-      if (ddsEnabled) {
-        globals.printWarning(
-          '${globals.logger.terminal.warningMark} The "--no-disable-dds" argument is deprecated and redundant, and should be omitted.',
-        );
-      } else {
-        globals.printWarning(
-          '${globals.logger.terminal.warningMark} The "--disable-dds" argument is deprecated. Use "--no-dds" instead.',
-        );
-      }
-    } else {
-      ddsEnabled = boolArg('dds');
-    }
-    return ddsEnabled;
-  }();
+  late final bool enableDds = boolArg('dds');
 
   bool get _hostVmServicePortProvided =>
       (argResults?.wasParsed(vmServicePortOption) ?? false) ||

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -727,25 +727,6 @@ void main() {
       },
     );
 
-    testUsingContext(
-      'dds options --no-disable-dds',
-      () async {
-        final ddsCommand = FakeDdsCommand();
-        final CommandRunner<void> runner = createTestCommandRunner(ddsCommand);
-        await runner.run(<String>['test', '--no-disable-dds']);
-        expect(ddsCommand.enableDds, isTrue);
-        expect(
-          logger.warningText,
-          contains('"--no-disable-dds" argument is deprecated and redundant'),
-        );
-      },
-      overrides: <Type, Generator>{
-        FileSystem: () => fileSystem,
-        Logger: () => logger,
-        ProcessManager: () => processManager,
-      },
-    );
-
     group('findTargetDevice', () {
       final device1 = FakeDevice('device1', 'device1');
       final device2 = FakeDevice('device2', 'device2');

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -728,22 +728,6 @@ void main() {
     );
 
     testUsingContext(
-      'dds options --disable-dds works, but is deprecated',
-      () async {
-        final ddsCommand = FakeDdsCommand();
-        final CommandRunner<void> runner = createTestCommandRunner(ddsCommand);
-        await runner.run(<String>['test', '--disable-dds']);
-        expect(ddsCommand.enableDds, isFalse);
-        expect(logger.warningText, contains('"--disable-dds" argument is deprecated'));
-      },
-      overrides: <Type, Generator>{
-        FileSystem: () => fileSystem,
-        Logger: () => logger,
-        ProcessManager: () => processManager,
-      },
-    );
-
-    testUsingContext(
       'dds options --no-disable-dds',
       () async {
         final ddsCommand = FakeDdsCommand();
@@ -758,20 +742,6 @@ void main() {
       overrides: <Type, Generator>{
         FileSystem: () => fileSystem,
         Logger: () => logger,
-        ProcessManager: () => processManager,
-      },
-    );
-
-    testUsingContext(
-      'dds options --dds --disable-dds',
-      () async {
-        final ddsCommand = FakeDdsCommand();
-        final CommandRunner<void> runner = createTestCommandRunner(ddsCommand);
-        await runner.run(<String>['test', '--dds', '--disable-dds']);
-        expect(() => ddsCommand.enableDds, throwsToolExit());
-      },
-      overrides: <Type, Generator>{
-        FileSystem: () => fileSystem,
         ProcessManager: () => processManager,
       },
     );


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/150279.

Made a warning in https://github.com/flutter/flutter/pull/172595 and cherry-picked into the next beta (will be stable) as https://github.com/flutter/flutter/pull/172790.