### PR TITLE
fix: get content hash for master on local engine branches

### DIFF
--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -15,7 +15,9 @@ jobs:
 
       - name: Generate Hash
         run: |
-          engine_content_hash=$(bin/internal/content_aware_hash.sh)
+          # IMPORTANT: Keep the list of files in sync with bin/internal/content_aware_hash.sh
+          # We call this directly here as we're expected to be in the merge queue (not master)
+          engine_content_hash=$(git ls-tree --format "%(objectname) %(path)" HEAD -- DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin)
           # test notice annotation for retrival from api
           echo "::notice ::{\"engine_content_hash\": \"${engine_content_hash}\"}"
           # test summary writing

--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -13,10 +13,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Fetch base commit and origin/master
-        run: |
-          git fetch --no-tags --prune --depth=1 origin ${{ github.event.pull_request.base.sha }}
-
       - name: Generate Hash
         run: |
           engine_content_hash=$(bin/internal/content_aware_hash.sh)

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -25,4 +25,12 @@ unset GIT_WORK_TREE
 # bin/internal/content_aware_hash.ps1: script for calculating the hash on windows
 # bin/internal/content_aware_hash.sh: script for calculating the hash on mac/linux
 # .github/workflows/content-aware-hash.yml: github action for CI/CD hashing
-git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" HEAD DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin
+TRACKEDFILES="DEPS engine bin/internal/release-candidate-branch.version"
+BASEREF="HEAD"
+# Check to see if we're in a local development branch and the branch has any
+# changes to engine code - including non-committed changes.
+if [ "$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)" != "master" ] && \
+    ! git -C "$FLUTTER_ROOT" diff --quiet "$(git -C "$FLUTTER_ROOT" merge-base master HEAD)" -- $TRACKEDFILES; then
+  BASEREF="master"
+fi
+git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" $BASEREF -- $TRACKEDFILES | git hash-object --stdin


### PR DESCRIPTION
The content hash doesn't exist for local engine changes, except for on CI. If we detect we're on a branch with committed or uncommitted changes to engine files; use "master".

towards  #171790 
