### PR TITLE
[iOS] Improve error message for code signing failures

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -483,7 +483,7 @@ class IOSDevice extends Device {
             debuggingOptions.usingCISystem && debuggingOptions.disablePortPublication,
       );
       if (!buildResult.success) {
-        _logger.printError('Could not build the precompiled application for the device.');
+        _logger.printError('Error: could not code sign the application.');
         await diagnoseXcodeBuildFailure(
           buildResult,
           analytics: globals.analytics,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -970,16 +970,21 @@ Future<bool> _handleIssues(
     logger.printError(noDevelopmentTeamInstruction, emphasis: true);
   } else if (hasProvisioningProfileIssue) {
     logger.printError('');
-    logger.printError(
-      'It appears that there was a problem signing your application prior to installation on the device.',
-    );
+    logger.printError('Error: could not code sign the application.');
     logger.printError('');
-    logger.printError(
-      'Verify that the Bundle Identifier in your project is your signing id in Xcode',
-    );
-    logger.printError('  open ios/Runner.xcworkspace');
+    logger.printError('To fix this:');
     logger.printError('');
-    logger.printError("Also try selecting 'Product > Build' to fix the problem.");
+    logger.printError('1. Open the project in Xcode:');
+    logger.printError('   open ios/Runner.xcworkspace');
+    logger.printError('');
+    logger.printError('2. Open the Runner target and the Signing & Capabilities tab.');
+    logger.printError('   Verify that the Team is correct.');
+    logger.printError('   Verify that the Bundle Identifier is correct.');
+    logger.printError('');
+    logger.printError('3. Open Xcode > Settings > Accounts.');
+    logger.printError('   Verify that you are signed in to the correct Apple Developer account.');
+    logger.printError('');
+    logger.printError('4. Fix any issues reported by Product > Build.');
   } else if (missingPlatform != null) {
     logger.printError(missingPlatformInstructions(missingPlatform), emphasis: true);
   } else if (duplicateModules.isNotEmpty) {


### PR DESCRIPTION
- Replaces the generic "Could not build the precompiled application for the device." with "Error: could not code sign the application."
- Updates troubleshooting steps to provide a clear, step-by-step guide for resolving iOS code signing issues in Xcode.
- Addresses issue #167595.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.