### PR TITLE
Make sure that a BackButton doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -336,4 +336,16 @@ void main() {
     // The custom callback is called, setting customCallbackWasCalled to true.
     expect(customCallbackWasCalled, true);
   });
+
+  testWidgets('BackButton renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(child: Scaffold(body: BackButton())),
+        ),
+      ),
+    );
+    final Finder backButtonIcon = find.byType(BackButtonIcon);
+    expect(tester.getSize(backButtonIcon).isEmpty, isTrue);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the BackButton UI control.