### PR TITLE
Fix RichText widget to use empty list instead of null for children

### DIFF
--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -736,7 +736,7 @@ class Text extends StatelessWidget {
             style: effectiveTextStyle,
             text: data,
             locale: locale,
-            children: textSpan != null ? <InlineSpan>[textSpan!] : null,
+            children: textSpan != null ? <InlineSpan>[textSpan!] : <InlineSpan>[],
           ),
         ),
       );


### PR DESCRIPTION
---

**Description**:

Fixes [https://github.com/flutter/flutter/issues/172188](https://github.com/flutter/flutter/issues/172188)


**Before**:

```dart
children: textSpan != null ? <InlineSpan>[textSpan!] : null,
```

**After**:

```dart
children: textSpan != null ? <InlineSpan>[textSpan!] : const <InlineSpan>[],
```

**Why**:

* Prevents unnecessary null handling.
* Aligns with null-safety best practices.
* Ensures `RichText` is always initialized with a non-null `children` list.


---