### PR TITLE
Disable smooth resizing when UI and platform threads are merged.

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_software.h
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_software.h
@@ -10,6 +10,7 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_compositor.h"
 #include "flutter/shell/platform/linux/fl_renderable.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 
 G_BEGIN_DECLS
 
@@ -28,12 +29,13 @@ G_DECLARE_FINAL_TYPE(FlCompositorSoftware,
 
 /**
  * fl_compositor_software_new:
+ * @engine: an #FlEngine.
  *
  * Creates a new software rendering compositor.
  *
  * Returns: a new #FlCompositorSoftware.
  */
-FlCompositorSoftware* fl_compositor_software_new();
+FlCompositorSoftware* fl_compositor_software_new(FlEngine* engine);
 
 G_END_DECLS
 

--- a/engine/src/flutter/shell/platform/linux/fl_compositor_software_test.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_software_test.cc
@@ -13,8 +13,10 @@
 
 TEST(FlCompositorSoftwareTest, Render) {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project);
 
-  g_autoptr(FlCompositorSoftware) compositor = fl_compositor_software_new();
+  g_autoptr(FlCompositorSoftware) compositor =
+      fl_compositor_software_new(engine);
 
   unsigned char image_data[1024 * 1024 * 4];
   cairo_surface_t* surface = cairo_image_surface_create_for_data(

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -703,6 +703,12 @@ G_MODULE_EXPORT FlEngine* fl_engine_new_headless(FlDartProject* project) {
   return fl_engine_new(project);
 }
 
+gboolean fl_engine_get_has_ui_on_platform_thread(FlEngine* self) {
+  g_return_val_if_fail(FL_IS_ENGINE(self), FALSE);
+  return fl_dart_project_get_ui_thread_policy(self->project) ==
+         FL_UI_THREAD_POLICY_RUN_ON_PLATFORM_THREAD;
+}
+
 FlutterRendererType fl_engine_get_renderer_type(FlEngine* self) {
   g_return_val_if_fail(FL_IS_ENGINE(self), static_cast<FlutterRendererType>(0));
   return self->renderer_type;
@@ -765,8 +771,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   custom_task_runners.struct_size = sizeof(FlutterCustomTaskRunners);
   custom_task_runners.platform_task_runner = &platform_task_runner;
 
-  if (fl_dart_project_get_ui_thread_policy(self->project) ==
-      FL_UI_THREAD_POLICY_RUN_ON_PLATFORM_THREAD) {
+  if (fl_engine_get_has_ui_on_platform_thread(self)) {
     custom_task_runners.ui_task_runner = &platform_task_runner;
   }
 

--- a/engine/src/flutter/shell/platform/linux/fl_engine_private.h
+++ b/engine/src/flutter/shell/platform/linux/fl_engine_private.h
@@ -63,6 +63,16 @@ FlEngine* fl_engine_new_with_binary_messenger(
     FlBinaryMessenger* binary_messenger);
 
 /**
+ * fl_engine_get_has_ui_on_platform_thread:
+ * @engine: an #FlEngine.
+ *
+ * Checks if UI updates are done on the platform thread.
+ *
+ * Returns: %TRUE if UI updates occur on the platform thread.
+ */
+gboolean fl_engine_get_has_ui_on_platform_thread(FlEngine* engine);
+
+/**
  * fl_engine_get_renderer_type:
  * @engine: an #FlEngine.
  *

--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -457,7 +457,7 @@ static void setup_opengl(FlView* self) {
 }
 
 static void setup_software(FlView* self) {
-  self->compositor = FL_COMPOSITOR(fl_compositor_software_new());
+  self->compositor = FL_COMPOSITOR(fl_compositor_software_new(self->engine));
 }
 
 static void realize_cb(FlView* self) {


### PR DESCRIPTION
We can't get this without returning the thread to Flutter, thus breaking the GTK draw update.
