### PR TITLE
animate cupertino time picker hour label

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -53,6 +53,10 @@ const double _kTimerPickerLabelFontSize = 17.0;
 // The width of each column of the countdown time picker.
 const double _kTimerPickerColumnIntrinsicWidth = 106;
 
+// Value derived by analyzing the animation duration of a video captured from the Clock app
+// running on an iPhone 16 with iOS 18.
+const Duration _kTimePickerLabelAnimationDuration = Duration(milliseconds: 200);
+
 TextStyle _themeTextStyle(BuildContext context, {bool isValid = true}) {
   final TextStyle style = CupertinoTheme.of(context).textTheme.dateTimePickerTextStyle;
   return isValid
@@ -2347,6 +2351,7 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
 
     if (widget.mode != CupertinoTimerPickerMode.ms) {
       selectedHour = widget.initialTimerDuration.inHours;
+      lastSelectedHour = selectedHour;
     }
 
     if (widget.mode != CupertinoTimerPickerMode.hm) {
@@ -2461,32 +2466,35 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
   // `pickerPadding ` is the additional padding the corresponding picker has to apply
   // around the `Text`, in order to extend its separators towards the closest
   // horizontal edge of the encompassing widget.
-  Widget _buildLabel(String text, EdgeInsetsDirectional pickerPadding) {
-    final padding = EdgeInsetsDirectional.only(
+  // Wraps [child] in the standard label container: an IgnorePointer with the
+  // correct start padding, centered alignment, and fixed height.
+  Widget _buildLabelContainer(EdgeInsetsDirectional pickerPadding, Widget child) {
+    final EdgeInsets padding = EdgeInsetsDirectional.only(
       start: numberLabelWidth + _kTimerPickerLabelPadSize + pickerPadding.start,
-    );
+    ).resolve(textDirection);
 
     return IgnorePointer(
       child: Padding(
-        padding: padding.resolve(textDirection),
+        padding: padding,
         child: Align(
           alignment: AlignmentDirectional.centerStart.resolve(textDirection),
-          child: SizedBox(
-            height: numberLabelHeight,
-            child: Baseline(
-              baseline: numberLabelBaseline,
-              baselineType: TextBaseline.alphabetic,
-              child: Text(
-                text,
-                style: const TextStyle(
-                  fontSize: _kTimerPickerLabelFontSize,
-                  fontWeight: FontWeight.w600,
-                ),
-                maxLines: 1,
-                softWrap: false,
-              ),
-            ),
-          ),
+          child: SizedBox(height: numberLabelHeight, child: child),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLabel(String text, EdgeInsetsDirectional pickerPadding) {
+    return _buildLabelContainer(
+      pickerPadding,
+      Baseline(
+        baseline: numberLabelBaseline,
+        baselineType: TextBaseline.alphabetic,
+        child: Text(
+          text,
+          style: const TextStyle(fontSize: _kTimerPickerLabelFontSize, fontWeight: FontWeight.w600),
+          maxLines: 1,
+          softWrap: false,
         ),
       ),
     );
@@ -2564,12 +2572,48 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
           },
           child: _buildHourPicker(additionalPadding, selectionOverlay),
         ),
-        _buildLabel(
-          localizations.timerPickerHourLabel(lastSelectedHour ?? selectedHour!) ?? '',
-          additionalPadding,
+        _buildAnimatedLabel(
+          labelBuilder: (int value) => localizations.timerPickerHourLabel(value) ?? '',
+          currentValue: lastSelectedHour ?? selectedHour!,
+          additionalPadding: additionalPadding,
         ),
       ],
     );
+  }
+
+  Widget _buildAnimatedLabel({
+    required String Function(int) labelBuilder,
+    required int currentValue,
+    required EdgeInsetsDirectional additionalPadding,
+  }) {
+    // Since the base value will always be one, we define the baseLabel getting the
+    // label equivalent to it.
+    final String baseLabel = labelBuilder(1);
+    final String currentLabel = labelBuilder(currentValue);
+
+    final int commonPrefixLength = _findCommonPrefixLength(baseLabel, currentLabel);
+    final String prefix = currentLabel.substring(0, commonPrefixLength);
+    final String suffix = currentLabel.substring(commonPrefixLength);
+
+    final labelStyle = TextStyle(fontSize: _kTimerPickerLabelFontSize, fontWeight: FontWeight.w600);
+
+    return _buildLabelContainer(
+      additionalPadding,
+      _AnimatedLabelSwitcher(
+        prefix: prefix,
+        suffix: suffix,
+        labelStyle: labelStyle,
+        textBaseline: numberLabelBaseline,
+      ),
+    );
+  }
+
+  int _findCommonPrefixLength(String baseLabel, String currentLabel) {
+    if (currentLabel.startsWith(baseLabel)) {
+      return baseLabel.length;
+    }
+
+    return currentLabel.length;
   }
 
   Widget _buildMinutePicker(EdgeInsetsDirectional additionalPadding, Widget? selectionOverlay) {
@@ -2947,6 +2991,48 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
           ),
         );
       },
+    );
+  }
+}
+
+class _AnimatedLabelSwitcher extends StatelessWidget {
+  const _AnimatedLabelSwitcher({
+    required this.prefix,
+    required this.suffix,
+    required this.labelStyle,
+    required this.textBaseline,
+  });
+
+  final String prefix;
+  final String suffix;
+  final TextStyle labelStyle;
+  final double textBaseline;
+
+  @override
+  Widget build(BuildContext context) {
+    final TextStyle effectiveStyle = DefaultTextStyle.of(context).style.merge(labelStyle);
+
+    return Baseline(
+      baseline: textBaseline,
+      baselineType: TextBaseline.alphabetic,
+      child: RichText(
+        text: TextSpan(
+          style: effectiveStyle,
+          children: <InlineSpan>[
+            TextSpan(text: prefix),
+            WidgetSpan(
+              alignment: PlaceholderAlignment.baseline,
+              baseline: TextBaseline.alphabetic,
+              child: AnimatedSwitcher(
+                duration: _kTimePickerLabelAnimationDuration,
+                child: Text(key: ValueKey<String>(suffix), suffix, style: labelStyle),
+              ),
+            ),
+          ],
+        ),
+        maxLines: 1,
+        softWrap: false,
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -2586,34 +2586,17 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
     required int currentValue,
     required EdgeInsetsDirectional additionalPadding,
   }) {
-    // Since the base value will always be one, we define the baseLabel getting the
-    // label equivalent to it.
-    final String baseLabel = labelBuilder(1);
-    final String currentLabel = labelBuilder(currentValue);
-
-    final int commonPrefixLength = _findCommonPrefixLength(baseLabel, currentLabel);
-    final String prefix = currentLabel.substring(0, commonPrefixLength);
-    final String suffix = currentLabel.substring(commonPrefixLength);
-
-    final labelStyle = TextStyle(fontSize: _kTimerPickerLabelFontSize, fontWeight: FontWeight.w600);
+    const labelStyle = TextStyle(fontSize: _kTimerPickerLabelFontSize, fontWeight: FontWeight.w600);
 
     return _buildLabelContainer(
       additionalPadding,
       _AnimatedLabelSwitcher(
-        prefix: prefix,
-        suffix: suffix,
+        labelBuilder: labelBuilder,
+        currentValue: currentValue,
         labelStyle: labelStyle,
         textBaseline: numberLabelBaseline,
       ),
     );
-  }
-
-  int _findCommonPrefixLength(String baseLabel, String currentLabel) {
-    if (currentLabel.startsWith(baseLabel)) {
-      return baseLabel.length;
-    }
-
-    return currentLabel.length;
   }
 
   Widget _buildMinutePicker(EdgeInsetsDirectional additionalPadding, Widget? selectionOverlay) {
@@ -2995,25 +2978,88 @@ class _CupertinoTimerPickerState extends State<CupertinoTimerPicker> {
   }
 }
 
-class _AnimatedLabelSwitcher extends StatelessWidget {
+/// A widget that animates label text transitions by keeping a stable prefix
+/// and cross-fading the suffix.
+///
+/// When the label changes, the longest common prefix between the old and new
+/// labels is computed. The shared prefix remains visible (no opacity dip),
+/// while only the differing suffixes cross-fade.
+///
+/// This handles two scenarios:
+/// 1. **Happy path** (e.g., English "hour"/"hours"): labelBuilder(1) is a
+///    prefix of labelBuilder(n), so the split is trivial.
+/// 2. **Non-prefix path** (e.g., Czech "hodina"/"hodiny"): labelBuilder(1)
+///    is NOT a prefix of labelBuilder(n), but they still share a common
+///    prefix ("hodin") that can remain stable during the transition.
+class _AnimatedLabelSwitcher extends StatefulWidget {
   const _AnimatedLabelSwitcher({
-    required this.prefix,
-    required this.suffix,
+    required this.labelBuilder,
+    required this.currentValue,
     required this.labelStyle,
     required this.textBaseline,
   });
 
-  final String prefix;
-  final String suffix;
+  final String Function(int) labelBuilder;
+  final int currentValue;
   final TextStyle labelStyle;
   final double textBaseline;
 
   @override
+  State<_AnimatedLabelSwitcher> createState() => _AnimatedLabelSwitcherState();
+}
+
+class _AnimatedLabelSwitcherState extends State<_AnimatedLabelSwitcher> {
+  /// The label text that was displayed before the current transition started,
+  /// used to compute the common prefix with the new label so that the stable
+  /// portion doesn't fade.
+  late String _previousLabel;
+
+  @override
+  void initState() {
+    super.initState();
+    _previousLabel = widget.labelBuilder(widget.currentValue);
+  }
+
+  @override
+  void didUpdateWidget(_AnimatedLabelSwitcher oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final String oldLabel = oldWidget.labelBuilder(oldWidget.currentValue);
+    final String newLabel = widget.labelBuilder(widget.currentValue);
+    if (oldLabel != newLabel) {
+      // The label changed. Save the old label so that build() can compute
+      // the common prefix between old and new for the animation.
+      _previousLabel = oldLabel;
+    }
+    // When the label hasn't changed, _previousLabel stays as-is. This keeps
+    // the prefix/suffix split stable across rebuilds. If a locale change
+    // causes the same value to produce a different label string, the prefix
+    // will change and the AnimatedSwitcher (keyed on prefix) will be
+    // recreated, avoiding a cross-fade between mismatched suffixes.
+  }
+
+  /// Returns the length of the longest common prefix between [a] and [b].
+  static int _commonPrefixLength(String a, String b) {
+    final int minLen = a.length < b.length ? a.length : b.length;
+    for (int i = 0; i < minLen; i++) {
+      if (a.codeUnitAt(i) != b.codeUnitAt(i)) {
+        return i;
+      }
+    }
+    return minLen;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final TextStyle effectiveStyle = DefaultTextStyle.of(context).style.merge(labelStyle);
+    final String currentLabel = widget.labelBuilder(widget.currentValue);
+
+    final int commonPrefixLen = _commonPrefixLength(_previousLabel, currentLabel);
+    final String prefix = currentLabel.substring(0, commonPrefixLen);
+    final String suffix = currentLabel.substring(commonPrefixLen);
+
+    final TextStyle effectiveStyle = DefaultTextStyle.of(context).style.merge(widget.labelStyle);
 
     return Baseline(
-      baseline: textBaseline,
+      baseline: widget.textBaseline,
       baselineType: TextBaseline.alphabetic,
       child: RichText(
         text: TextSpan(
@@ -3024,8 +3070,15 @@ class _AnimatedLabelSwitcher extends StatelessWidget {
               alignment: PlaceholderAlignment.baseline,
               baseline: TextBaseline.alphabetic,
               child: AnimatedSwitcher(
+                // Key the AnimatedSwitcher on the prefix so that when the
+                // prefix changes (e.g., after a locale change), the switcher
+                // is recreated rather than trying to cross-fade mismatched
+                // suffixes. In the normal case (e.g., "hour" → "hours"),
+                // the prefix stays the same so the switcher persists and
+                // animates the suffix transition correctly.
+                key: ValueKey<String>(prefix),
                 duration: _kTimePickerLabelAnimationDuration,
-                child: Text(key: ValueKey<String>(suffix), suffix, style: labelStyle),
+                child: Text(key: ValueKey<String>(suffix), suffix, style: widget.labelStyle),
               ),
             ),
           ],

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -23,6 +23,29 @@ import 'package:flutter_test/flutter_test.dart';
 const Offset _kRowOffset = Offset(0.0, -50.0);
 
 void main() {
+  Finder findAnimatedLabelWithText(String expectedText) {
+    return find.byWidgetPredicate((Widget widget) {
+      if (widget is RichText) {
+        final TextSpan rootSpan = widget.text as TextSpan;
+        final StringBuffer buffer = StringBuffer();
+        rootSpan.visitChildren((InlineSpan inlineSpan) {
+          if (inlineSpan is TextSpan) {
+            buffer.write(inlineSpan.text);
+          } else if (inlineSpan is WidgetSpan) {
+            final AnimatedSwitcher switcher = inlineSpan.child as AnimatedSwitcher;
+            final Text? textChild = switcher.child as Text?;
+            if (textChild != null) {
+              buffer.write(textChild.data);
+            }
+          }
+          return true;
+        });
+        return buffer.toString() == expectedText;
+      }
+      return false;
+    });
+  }
+
   group('Countdown timer picker', () {
     testWidgets('initialTimerDuration falls within limit', (WidgetTester tester) async {
       expect(() {
@@ -121,8 +144,8 @@ void main() {
 
       Offset lastOffset = tester.getTopLeft(find.text('12'));
 
-      expect(tester.getTopLeft(find.text('hours')).dx > lastOffset.dx, true);
-      lastOffset = tester.getTopLeft(find.text('hours'));
+      expect(tester.getTopLeft(findAnimatedLabelWithText('hours')).dx > lastOffset.dx, true);
+      lastOffset = tester.getTopLeft(findAnimatedLabelWithText('hours'));
 
       expect(tester.getTopLeft(find.text('30')).dx > lastOffset.dx, true);
       lastOffset = tester.getTopLeft(find.text('30'));
@@ -153,8 +176,8 @@ void main() {
 
       Offset lastOffset = tester.getTopLeft(find.text('12'));
 
-      expect(tester.getTopLeft(find.text('hours')).dx > lastOffset.dx, false);
-      lastOffset = tester.getTopLeft(find.text('hours'));
+      expect(tester.getTopLeft(findAnimatedLabelWithText('hours')).dx > lastOffset.dx, false);
+      lastOffset = tester.getTopLeft(findAnimatedLabelWithText('hours'));
 
       expect(tester.getTopLeft(find.text('30')).dx > lastOffset.dx, false);
       lastOffset = tester.getTopLeft(find.text('30'));
@@ -1804,8 +1827,8 @@ void main() {
     );
 
     expect(duration, isNull);
-    expect(find.text('hour'), findsNothing);
-    expect(find.text('hours'), findsOneWidget);
+
+    expect(findAnimatedLabelWithText('hours'), findsOneWidget);
 
     await tester.drag(
       find.text('2'),
@@ -1814,14 +1837,67 @@ void main() {
     ); // see top of file
     // Duration should change but not the label.
     expect(duration!.inHours, 1);
-    expect(find.text('hour'), findsNothing);
-    expect(find.text('hours'), findsOneWidget);
+    expect(findAnimatedLabelWithText('hours'), findsOneWidget);
     await tester.pumpAndSettle();
 
     // Now the label should change.
     expect(duration!.inHours, 1);
-    expect(find.text('hours'), findsNothing);
-    expect(find.text('hour'), findsOneWidget);
+    expect(findAnimatedLabelWithText('hour'), findsOneWidget);
+  });
+
+  testWidgets('TimerPicker hour label suffix fades in and out', (WidgetTester tester) async {
+    Duration? duration;
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox(
+            width: 320,
+            height: 216,
+            child: CupertinoTimerPicker(
+              mode: CupertinoTimerPickerMode.hm,
+              initialTimerDuration: const Duration(hours: 1, minutes: 30),
+              onTimerDurationChanged: (Duration d) {
+                duration = d;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(findAnimatedLabelWithText('hour'), findsOneWidget);
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('1').first));
+    await gesture.moveBy(const Offset(0, -30));
+    await tester.pump();
+    expect(duration!.inHours, 2);
+    expect(findAnimatedLabelWithText('hour'), findsOneWidget);
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(findAnimatedLabelWithText('hours'), findsOneWidget);
+
+    await tester.drag(find.text('2'), Offset(0, -_kRowOffset.dy), warnIfMissed: false);
+
+    // Pump frame-by-frame until the scroll settles and the suffix animation begins.
+    while (findAnimatedLabelWithText('hour').evaluate().isEmpty) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    // Pump half the animation duration (100ms of 200ms) to land at mid-fade.
+    await tester.pump(const Duration(milliseconds: 100));
+
+    // The departing 's' suffix should be mid-fade.
+    final Finder suffixFade = find.ancestor(
+      of: find.text('s'),
+      matching: find.byType(FadeTransition),
+    );
+    expect(suffixFade, findsOneWidget);
+    final double suffixOpacity = tester.widget<FadeTransition>(suffixFade).opacity.value;
+    expect(suffixOpacity, greaterThan(0.0));
+    expect(suffixOpacity, lessThan(1.0));
+
+    await tester.pumpAndSettle();
+    expect(findAnimatedLabelWithText('hour'), findsOneWidget);
   });
 
   testWidgets('TimerPicker has intrinsic width and height', (WidgetTester tester) async {
@@ -2150,25 +2226,32 @@ void main() {
       );
     }
 
+    Color hourLabelColor() {
+      final Finder suffixText = find.descendant(
+        of: find.byType(AnimatedSwitcher),
+        matching: find.byType(Text),
+      );
+      final RenderParagraph p = tester.renderObject(suffixText.first);
+      return p.text.style!.color!;
+    }
+
     // CupertinoTimerPicker with light theme.
     await tester.pumpWidget(buildTimerPicker(Brightness.light));
-    RenderParagraph paragraph = tester.renderObject(find.text('hours'));
     final Color expectedLight = CupertinoColors.label.resolveFrom(
       tester.element(find.byType(CupertinoTimerPicker)),
     );
-    expect(paragraph.text.style!.color, expectedLight);
+    expect(hourLabelColor(), expectedLight);
     // Text style should not return unresolved color.
-    expect(paragraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
+    expect(hourLabelColor().toString().contains('UNRESOLVED'), isFalse);
 
-    // CupertinoTimerPicker with light theme.
+    // CupertinoTimerPicker with dark theme.
     await tester.pumpWidget(buildTimerPicker(Brightness.dark));
-    paragraph = tester.renderObject(find.text('hours'));
     final Color expectedDark = CupertinoColors.label.resolveFrom(
       tester.element(find.byType(CupertinoTimerPicker)),
     );
-    expect(paragraph.text.style!.color, expectedDark);
+    expect(hourLabelColor(), expectedDark);
     // Text style should not return unresolved color.
-    expect(paragraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
+    expect(hourLabelColor().toString().contains('UNRESOLVED'), isFalse);
   });
 
   testWidgets('TimerPicker minDate - maxDate with minuteInterval', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1883,10 +1883,10 @@ void main() {
       await tester.pump(const Duration(milliseconds: 16));
     }
 
-    // Pump half the animation duration (100ms of 200ms) to land at mid-fade.
-    await tester.pump(const Duration(milliseconds: 100));
-
     // The departing 's' suffix should be mid-fade.
+    // Pump a small amount to ensure the animation has started but is still in progress.
+    await tester.pump(const Duration(milliseconds: 50));
+
     final Finder suffixFade = find.ancestor(
       of: find.text('s'),
       matching: find.byType(FadeTransition),


### PR DESCRIPTION
This PR adds the `buildAnimatedLabel` function to the CupertinoTimePicker widget, allowing the creation of a label with a FadeTransition in this component. It also uses this new function to build de hour label, because this label has this animation in the native implementation, as can be seen in the below visual reference:

https://github.com/user-attachments/assets/5a63a1ee-037e-4cc1-adf9-205357dca7ee

Closes https://github.com/flutter/flutter/issues/27515

| Before | After |
| ---- | ---- |
| <video src="https://github.com/user-attachments/assets/be7f4ca8-b8bc-448f-aa5c-e12770205777"> | <video src="https://github.com/user-attachments/assets/a9b06eb0-fd91-463d-a49d-fe66488b6562"> |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
