### PR TITLE
Fix directional focus in nested scrollables with different axis

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -815,7 +815,6 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     TraversalDirection direction, {
     bool forward = true,
   }) {
-    final ScrollableState? focusedScrollable = Scrollable.maybeOf(focusedChild.context!);
     switch (direction) {
       case TraversalDirection.down:
       case TraversalDirection.up:
@@ -828,9 +827,14 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         if (eligibleNodes.isEmpty) {
           break;
         }
-        if (focusedScrollable != null && !focusedScrollable.position.atEdge) {
+        final ScrollableState? focusedScrollable = Scrollable.maybeOf(
+          focusedChild.context!,
+          axis: Axis.vertical,
+        );
+        if (focusedScrollable != null) {
           final Iterable<FocusNode> filteredEligibleNodes = eligibleNodes.where(
-            (FocusNode node) => Scrollable.maybeOf(node.context!) == focusedScrollable,
+            (FocusNode node) =>
+                Scrollable.maybeOf(node.context!, axis: Axis.vertical) == focusedScrollable,
           );
           if (filteredEligibleNodes.isNotEmpty) {
             eligibleNodes = filteredEligibleNodes;
@@ -879,9 +883,14 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         if (eligibleNodes.isEmpty) {
           break;
         }
-        if (focusedScrollable != null && !focusedScrollable.position.atEdge) {
+        final ScrollableState? focusedScrollable = Scrollable.maybeOf(
+          focusedChild.context!,
+          axis: Axis.horizontal,
+        );
+        if (focusedScrollable != null) {
           final Iterable<FocusNode> filteredEligibleNodes = eligibleNodes.where(
-            (FocusNode node) => Scrollable.maybeOf(node.context!) == focusedScrollable,
+            (FocusNode node) =>
+                Scrollable.maybeOf(node.context!, axis: Axis.horizontal) == focusedScrollable,
           );
           if (filteredEligibleNodes.isNotEmpty) {
             eligibleNodes = filteredEligibleNodes;

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -2881,7 +2881,6 @@ void main() {
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
       },
-      skip: isBrowser,
       variant: KeySimulatorTransitModeVariant.all(),
     );
 
@@ -3007,7 +3006,6 @@ void main() {
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
       },
-      skip: isBrowser,
       variant: KeySimulatorTransitModeVariant.all(),
     );
 

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -2562,14 +2563,14 @@ void main() {
         expect(controller.offset, equals(0.0));
 
         // Go down until we hit the bottom of the visible area.
-        for (int i = 1; i <= 4; ++i) {
+        for (int i = 1; i <= 3; ++i) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
           await tester.pump();
           expect(controller.offset, equals(0.0), reason: 'Focusing item $i caused a scroll');
         }
 
         // Now keep going down, and the scrollable should scroll automatically.
-        for (int i = 5; i <= 10; ++i) {
+        for (int i = 4; i <= 10; ++i) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
           await tester.pump();
           final double expectedOffset = 100.0 * (i - 5) + 200.0;
@@ -2687,14 +2688,14 @@ void main() {
         expect(controller.offset, equals(0.0));
 
         // Go right until we hit the right of the visible area.
-        for (int i = 1; i <= 6; ++i) {
+        for (int i = 1; i <= 5; ++i) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
           await tester.pump();
           expect(controller.offset, equals(0.0), reason: 'Focusing item $i caused a scroll');
         }
 
         // Now keep going right, and the scrollable should scroll automatically.
-        for (int i = 7; i <= 10; ++i) {
+        for (int i = 6; i <= 10; ++i) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
           await tester.pump();
           final double expectedOffset = 100.0 * (i - 5);
@@ -2754,6 +2755,258 @@ void main() {
         expect(controller.offset, equals(0.0));
       },
       // https://github.com/flutter/flutter/issues/35347
+      skip: isBrowser,
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
+
+    testWidgets(
+      'Focus traversal with horizontal scrollables inside a vertical scrollable handles vertical navigation correctly',
+      (WidgetTester tester) async {
+        // Tester view size is 800x600
+
+        const double cellHeight = 100;
+
+        const int rowCount = 10;
+        const int buttonsPerRow = 5;
+
+        // Create focus nodes for all elements
+        final FocusNode stickyButtonNode = FocusNode(debugLabel: 'Sticky Button');
+        addTearDown(stickyButtonNode.dispose);
+
+        final List<List<FocusNode>> gridNodes = List<List<FocusNode>>.generate(
+          rowCount,
+          (int row) => List<FocusNode>.generate(
+            buttonsPerRow,
+            (int col) => FocusNode(debugLabel: 'Button $row-$col'),
+          ),
+        );
+        addTearDown(() {
+          for (final FocusNode node in gridNodes.flattened) {
+            node.dispose();
+          }
+        });
+
+        final ScrollController verticalController = ScrollController();
+        addTearDown(verticalController.dispose);
+
+        final List<ScrollController> horizontalControllers = List<ScrollController>.generate(
+          rowCount,
+          (int index) => ScrollController(debugLabel: 'Horizontal Controller $index'),
+        );
+        addTearDown(() {
+          for (final ScrollController controller in horizontalControllers) {
+            controller.dispose();
+          }
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Column(
+              children: <Widget>[
+                Focus(
+                  focusNode: stickyButtonNode,
+                  child: Container(height: cellHeight, color: Colors.blue),
+                ),
+                Expanded(
+                  child: ListView.separated(
+                    controller: verticalController,
+                    itemCount: rowCount,
+                    separatorBuilder: (_, _) => const SizedBox(height: 32),
+                    itemBuilder: (BuildContext context, int rowIndex) {
+                      return SizedBox(
+                        height: cellHeight,
+                        child: ListView.builder(
+                          controller: horizontalControllers[rowIndex],
+                          scrollDirection: Axis.horizontal,
+                          itemCount: buttonsPerRow,
+                          itemBuilder: (BuildContext context, int colIndex) {
+                            return Focus(
+                              focusNode: gridNodes[rowIndex][colIndex],
+                              child: Container(
+                                width: cellHeight,
+                                height: cellHeight,
+                                color: Colors.primaries[rowIndex % Colors.primaries.length],
+                              ),
+                            );
+                          },
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        // Start by focusing the sticky button
+        stickyButtonNode.requestFocus();
+        await tester.pump();
+        expect(stickyButtonNode.hasPrimaryFocus, isTrue);
+
+        // Navigate down to the first row - should focus one of the widgets in the first row
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pump();
+
+        // Find which column in the first row got focused
+        int focusedColumn = -1;
+        for (int col = 0; col < buttonsPerRow; col++) {
+          if (gridNodes[0][col].hasPrimaryFocus) {
+            focusedColumn = col;
+            break;
+          }
+        }
+        expect(focusedColumn, greaterThanOrEqualTo(0)); // Ensure something in first row is focused
+
+        // Navigate down through the rows
+        for (int row = 1; row < rowCount; row++) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.pump();
+          expect(gridNodes[row][focusedColumn].hasPrimaryFocus, isTrue);
+          // Verify vertical scroll happened from the 5th row onwards (500px)
+          if (row >= 5) {
+            expect(verticalController.offset, greaterThan(0));
+          }
+        }
+
+        // Navigate back up - should go to previous rows, not sticky button
+        for (int row = rowCount - 2; row >= 0; row--) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+          await tester.pump();
+          expect(gridNodes[row][focusedColumn].hasPrimaryFocus, isTrue);
+        }
+
+        // Only now should we reach the sticky button
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pump();
+        expect(stickyButtonNode.hasPrimaryFocus, isTrue);
+      },
+      skip: isBrowser,
+      variant: KeySimulatorTransitModeVariant.all(),
+    );
+
+    testWidgets(
+      'Focus traversal with vertical scrollables inside a horizontal scrollable handles horizontal navigation correctly',
+      (WidgetTester tester) async {
+        // Tester view size is 800x600
+
+        const double cellWidth = 100;
+
+        const int columnCount = 10;
+        const int buttonsPerColumn = 10;
+
+        // Create focus nodes for all elements
+        final FocusNode stickyButtonNode = FocusNode(debugLabel: 'Sticky Button');
+        addTearDown(stickyButtonNode.dispose);
+
+        final List<List<FocusNode>> gridNodes = List<List<FocusNode>>.generate(
+          columnCount,
+          (int column) => List<FocusNode>.generate(
+            buttonsPerColumn,
+            (int row) => FocusNode(debugLabel: 'Button $column-$row'),
+          ),
+        );
+        addTearDown(() {
+          for (final FocusNode node in gridNodes.flattened) {
+            node.dispose();
+          }
+        });
+
+        final ScrollController horizontalController = ScrollController();
+        addTearDown(horizontalController.dispose);
+
+        final List<ScrollController> verticalControllers = List<ScrollController>.generate(
+          columnCount,
+          (int index) => ScrollController(debugLabel: 'Vertical Controller $index'),
+        );
+        addTearDown(() {
+          for (final ScrollController controller in verticalControllers) {
+            controller.dispose();
+          }
+        });
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Row(
+              children: <Widget>[
+                Focus(
+                  focusNode: stickyButtonNode,
+                  child: Container(width: cellWidth, color: Colors.blue),
+                ),
+                Expanded(
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    controller: horizontalController,
+                    itemCount: columnCount,
+                    separatorBuilder: (_, _) => const SizedBox(width: 32),
+                    itemBuilder: (BuildContext context, int columnIndex) {
+                      return SizedBox(
+                        width: cellWidth,
+                        child: ListView.builder(
+                          controller: verticalControllers[columnIndex],
+                          itemCount: buttonsPerColumn,
+                          itemBuilder: (BuildContext context, int rowIndex) {
+                            return Focus(
+                              focusNode: gridNodes[columnIndex][rowIndex],
+                              child: Container(
+                                width: cellWidth,
+                                height: cellWidth,
+                                color: Colors.red,
+                              ),
+                            );
+                          },
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+
+        // Start by focusing the sticky button
+        stickyButtonNode.requestFocus();
+        await tester.pump();
+        expect(stickyButtonNode.hasPrimaryFocus, isTrue);
+
+        // Navigate right to the first column - should focus one of the widgets in the first column
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pump();
+
+        // Find which row in the first column got focused
+        int focusedRow = -1;
+        for (int row = 0; row < buttonsPerColumn; row++) {
+          if (gridNodes[0][row].hasPrimaryFocus) {
+            focusedRow = row;
+            break;
+          }
+        }
+        expect(focusedRow, greaterThanOrEqualTo(0)); // Ensure something in first column is focused
+
+        // Navigate right through the columns
+        for (int column = 1; column < columnCount; column++) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+          await tester.pump();
+          expect(gridNodes[column][focusedRow].hasPrimaryFocus, isTrue);
+          // Verify horizontal scroll happened from the 7th column onwards (700px)
+          if (column >= 6) {
+            expect(horizontalController.offset, greaterThan(0));
+          }
+        }
+
+        // Navigate back left - should go to previous columns, not sticky button
+        for (int column = columnCount - 2; column >= 0; column--) {
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+          await tester.pump();
+          expect(gridNodes[column][focusedRow].hasPrimaryFocus, isTrue);
+        }
+
+        // Only now should we reach the sticky button
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pump();
+        expect(stickyButtonNode.hasPrimaryFocus, isTrue);
+      },
       skip: isBrowser,
       variant: KeySimulatorTransitModeVariant.all(),
     );

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -2881,6 +2881,8 @@ void main() {
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
       },
+      // https://github.com/flutter/flutter/issues/35347
+      skip: isBrowser,
       variant: KeySimulatorTransitModeVariant.all(),
     );
 
@@ -3006,6 +3008,8 @@ void main() {
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
       },
+      // https://github.com/flutter/flutter/issues/35347
+      skip: isBrowser,
       variant: KeySimulatorTransitModeVariant.all(),
     );
 

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -2762,14 +2762,14 @@ void main() {
     testWidgets(
       'Focus traversal with horizontal scrollables inside a vertical scrollable handles vertical navigation correctly',
       (WidgetTester tester) async {
-        // Tester view size is 800x600
+        // Tester view size is 800x600.
 
         const double cellHeight = 100;
 
         const int rowCount = 10;
         const int buttonsPerRow = 5;
 
-        // Create focus nodes for all elements
+        // Create focus nodes for all elements.
         final FocusNode stickyButtonNode = FocusNode(debugLabel: 'Sticky Button');
         addTearDown(stickyButtonNode.dispose);
 
@@ -2839,16 +2839,16 @@ void main() {
           ),
         );
 
-        // Start by focusing the sticky button
+        // Start by focusing the sticky button.
         stickyButtonNode.requestFocus();
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
 
-        // Navigate down to the first row - should focus one of the widgets in the first row
+        // Navigate down to the first row - should focus one of the widgets in the first row.
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
         await tester.pump();
 
-        // Find which column in the first row got focused
+        // Find which column in the first row got focused.
         int focusedColumn = -1;
         for (int col = 0; col < buttonsPerRow; col++) {
           if (gridNodes[0][col].hasPrimaryFocus) {
@@ -2856,27 +2856,27 @@ void main() {
             break;
           }
         }
-        expect(focusedColumn, greaterThanOrEqualTo(0)); // Ensure something in first row is focused
+        expect(focusedColumn, greaterThanOrEqualTo(0)); // Ensure something in first row is focused.
 
-        // Navigate down through the rows
+        // Navigate down through the rows.
         for (int row = 1; row < rowCount; row++) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
           await tester.pump();
           expect(gridNodes[row][focusedColumn].hasPrimaryFocus, isTrue);
-          // Verify vertical scroll happened from the 5th row onwards (500px)
+          // Verify vertical scroll happened from the 5th row onwards (500px).
           if (row >= 5) {
             expect(verticalController.offset, greaterThan(0));
           }
         }
 
-        // Navigate back up - should go to previous rows, not sticky button
+        // Navigate back up - should go to previous rows, not sticky button.
         for (int row = rowCount - 2; row >= 0; row--) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
           await tester.pump();
           expect(gridNodes[row][focusedColumn].hasPrimaryFocus, isTrue);
         }
 
-        // Only now should we reach the sticky button
+        // Only now should we reach the sticky button.
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
@@ -2887,14 +2887,14 @@ void main() {
     testWidgets(
       'Focus traversal with vertical scrollables inside a horizontal scrollable handles horizontal navigation correctly',
       (WidgetTester tester) async {
-        // Tester view size is 800x600
+        // Tester view size is 800x600.
 
         const double cellWidth = 100;
 
         const int columnCount = 10;
         const int buttonsPerColumn = 10;
 
-        // Create focus nodes for all elements
+        // Create focus nodes for all elements.
         final FocusNode stickyButtonNode = FocusNode(debugLabel: 'Sticky Button');
         addTearDown(stickyButtonNode.dispose);
 
@@ -2964,16 +2964,16 @@ void main() {
           ),
         );
 
-        // Start by focusing the sticky button
+        // Start by focusing the sticky button.
         stickyButtonNode.requestFocus();
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);
 
-        // Navigate right to the first column - should focus one of the widgets in the first column
+        // Navigate right to the first column - should focus one of the widgets in the first column.
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
         await tester.pump();
 
-        // Find which row in the first column got focused
+        // Find which row in the first column got focused.
         int focusedRow = -1;
         for (int row = 0; row < buttonsPerColumn; row++) {
           if (gridNodes[0][row].hasPrimaryFocus) {
@@ -2981,27 +2981,27 @@ void main() {
             break;
           }
         }
-        expect(focusedRow, greaterThanOrEqualTo(0)); // Ensure something in first column is focused
+        expect(focusedRow, greaterThanOrEqualTo(0)); // Ensure something in first column is focused.
 
-        // Navigate right through the columns
+        // Navigate right through the columns.
         for (int column = 1; column < columnCount; column++) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
           await tester.pump();
           expect(gridNodes[column][focusedRow].hasPrimaryFocus, isTrue);
-          // Verify horizontal scroll happened from the 7th column onwards (700px)
+          // Verify horizontal scroll happened from the 7th column onwards (700px).
           if (column >= 6) {
             expect(horizontalController.offset, greaterThan(0));
           }
         }
 
-        // Navigate back left - should go to previous columns, not sticky button
+        // Navigate back left - should go to previous columns, not sticky button.
         for (int column = columnCount - 2; column >= 0; column--) {
           await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
           await tester.pump();
           expect(gridNodes[column][focusedRow].hasPrimaryFocus, isTrue);
         }
 
-        // Only now should we reach the sticky button
+        // Only now should we reach the sticky button.
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
         await tester.pump();
         expect(stickyButtonNode.hasPrimaryFocus, isTrue);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Related issue : #172854 
Fixes #160431

This PR fixes the focus when navigating with keyboard arrows or TV remote d-pad in a nested lists with different axis and a fixed focusable at the top.
It's a common setup for apps that deal with images or videos.

The problem is that when the vertical scrollbar has scrolled and you want to scroll back to the top without the mouse, only using keyboard up arrow to jump from widgets to widgets in the list until reaching the top, the fixed top focusable widget wrongly takes the focus instead of letting the vertical scrollable scroll.

I think the video bellow explain the problem better.

| Before this PR | After this PR |
|--------|--------|
| https://github.com/user-attachments/assets/54160e0c-abe5-4181-9aea-8351ce5f35b5 | https://github.com/user-attachments/assets/eee32175-37eb-44a6-a7c2-a751fc82d592 |

Note that I had to edit two existing tests because they were failing with my edits. However, I think these tests were testing a bad behavior.

For example here is the visualization of the `Focus traversal inside a vertical scrollable scrolls to stay visible` test case before this PR :

https://github.com/user-attachments/assets/be843ae8-a0df-411e-971c-3bf763c457e0


Test was green bug the focus behavior is weird. When pressing arrow down from item 3 we would expect a scroll and item 4 to be focused, here it's footer that is focused and when we press arrow down again item 5 is focused and item 4 is skipped.

Here is the behavior after this PR and the test edited :


https://github.com/user-attachments/assets/b90757a8-042d-4d53-b7e6-19b9141cc83f


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md