### PR TITLE
Add `--profile-startup` switch

### DIFF
--- a/engine/src/flutter/common/settings.h
+++ b/engine/src/flutter/common/settings.h
@@ -158,6 +158,7 @@ struct Settings {
   bool purge_persistent_cache = false;
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
+  bool profile_startup = false;
   bool disable_dart_asserts = false;
   bool enable_serial_gc = false;
   bool profile_microtasks = false;

--- a/engine/src/flutter/shell/common/switches.cc
+++ b/engine/src/flutter/shell/common/switches.cc
@@ -294,6 +294,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.enable_dart_profiling =
       command_line.HasOption(FlagForSwitch(Switch::EnableDartProfiling));
 
+  settings.profile_startup =
+      command_line.HasOption(FlagForSwitch(Switch::ProfileStartup));
+
   settings.enable_software_rendering =
       command_line.HasOption(FlagForSwitch(Switch::EnableSoftwareRendering));
 

--- a/engine/src/flutter/shell/common/switches.h
+++ b/engine/src/flutter/shell/common/switches.h
@@ -95,6 +95,14 @@ DEF_SWITCH(EnableDartProfiling,
            "enable-dart-profiling",
            "Enable Dart profiling. Profiling information can be viewed from "
            "Dart / Flutter DevTools.")
+DEF_SWITCH(
+    ProfileStartup,
+    "profile-startup",
+    "Make the profiler discard new samples once the profiler sample buffer is "
+    "full. When this flag is not set, the profiler sample buffer is used as a "
+    "ring buffer, meaning that once it is full, new samples start overwriting "
+    "the oldest ones. This switch is only meaningful when set in conjunction "
+    "with --enable-dart-profiling.")
 DEF_SWITCH(EndlessTraceBuffer,
            "endless-trace-buffer",
            "Enable an endless trace buffer. The default is a ring buffer. "

--- a/engine/src/flutter/shell/common/switches_unittests.cc
+++ b/engine/src/flutter/shell/common/switches_unittests.cc
@@ -122,6 +122,23 @@ TEST(SwitchesTest, NoEnableImpeller) {
   }
 }
 
+TEST(SwitchesTest, ProfileStartup) {
+  {
+    fml::CommandLine command_line =
+        fml::CommandLineFromInitializerList({"command", "--profile-startup"});
+    EXPECT_TRUE(command_line.HasOption("profile-startup"));
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.profile_startup, true);
+  }
+  {
+    // default
+    fml::CommandLine command_line =
+        fml::CommandLineFromInitializerList({"command"});
+    Settings settings = SettingsFromCommandLine(command_line);
+    EXPECT_EQ(settings.profile_startup, false);
+  }
+}
+
 #if !FLUTTER_RELEASE
 TEST(SwitchesTest, EnableAsserts) {
   fml::CommandLine command_line = fml::CommandLineFromInitializerList(

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -32,6 +32,8 @@ public class FlutterShellArgs {
   public static final String ARG_USE_TEST_FONTS = "--use-test-fonts";
   public static final String ARG_KEY_ENABLE_DART_PROFILING = "enable-dart-profiling";
   public static final String ARG_ENABLE_DART_PROFILING = "--enable-dart-profiling";
+  public static final String ARG_KEY_PROFILE_STARTUP = "profile-startup";
+  public static final String ARG_PROFILE_STARTUP = "--profile-startup";
   public static final String ARG_KEY_ENABLE_SOFTWARE_RENDERING = "enable-software-rendering";
   public static final String ARG_ENABLE_SOFTWARE_RENDERING = "--enable-software-rendering";
   public static final String ARG_KEY_SKIA_DETERMINISTIC_RENDERING = "skia-deterministic-rendering";
@@ -94,6 +96,9 @@ public class FlutterShellArgs {
     }
     if (intent.getBooleanExtra(ARG_KEY_ENABLE_DART_PROFILING, false)) {
       args.add(ARG_ENABLE_DART_PROFILING);
+    }
+    if (intent.getBooleanExtra(ARG_KEY_PROFILE_STARTUP, false)) {
+      args.add(ARG_PROFILE_STARTUP);
     }
     if (intent.getBooleanExtra(ARG_KEY_ENABLE_SOFTWARE_RENDERING, false)) {
       args.add(ARG_ENABLE_SOFTWARE_RENDERING);

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -200,6 +200,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
     settings.enable_dart_profiling = enableDartProfiling.boolValue;
   }
 
+  NSNumber* profileStartup = [mainBundle objectForInfoDictionaryKey:@"FLTProfileStartup"];
+  // Change the default only if the option is present.
+  if (profileStartup != nil) {
+    settings.profile_startup = profileStartup.boolValue;
+  }
+
   // Leak Dart VM settings, set whether leave or clean up the VM after the last shell shuts down.
   NSNumber* leakDartVM = [mainBundle objectForInfoDictionaryKey:@"FLTLeakDartVM"];
   // It will change the default leak_vm value in settings only if the key exists.


### PR DESCRIPTION
This PR adds a switch that can be used to set [the Dart VM's `profile_startup` flag](https://github.com/dart-lang/sdk/blob/21ce423b262bf68b1807a24f1e5082411f33d2b8/runtime/vm/profiler.cc#L68).