### PR TITLE
Revert "Remove 2023 deprecated `'platforms'` key from daemon output (#172593)"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -599,7 +599,11 @@ class DaemonDomain extends Domain {
 
       PlatformType.values.forEach(handlePlatformType);
 
-      return <String, Object>{'platformTypes': platformTypesMap};
+      return <String, Object>{
+        // TODO(fujino): delete this key https://github.com/flutter/flutter/issues/140473
+        'platforms': platformTypes,
+        'platformTypes': platformTypesMap,
+      };
     } on Exception catch (err, stackTrace) {
       sendEvent('log', <String, Object?>{
         'log': 'Failed to parse project metadata',
@@ -609,6 +613,7 @@ class DaemonDomain extends Domain {
       // On any sort of failure, fall back to Android and iOS for backwards
       // compatibility.
       return const <String, Object>{
+        'platforms': <String>['android', 'ios'],
         'platformTypes': <String, Object>{
           'android': <String, Object>{'isSupported': true},
           'ios': <String, Object>{'isSupported': true},

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -124,6 +124,7 @@ void main() {
         expect(response.data['id'], 0);
         expect(response.data['result'], isNotEmpty);
         expect(response.data['result']! as Map<String, Object?>, const <String, Object>{
+          'platforms': <String>['macos', 'windows'],
           'platformTypes': <String, Map<String, Object>>{
             'web': <String, Object>{
               'isSupported': false,


### PR DESCRIPTION
This reverts commit cfe6f3d95b3fb1ccf2cf944eab0273efc944bcf3.

The change broke the vscode extension. The extension has been updated in https://github.com/Dart-Code/Dart-Code/pull/5610 but it is worth keeping this for a little while longer.
