### PR TITLE
Fix Gemini Code Assist for GitHub config yaml

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -17,4 +17,4 @@ ignore_patterns:
   - bin/internal/*.version
   - engine/src/flutter/ci/licenses_golden/**
   # Avoid code reviews on all third_party files.
-  - */third_party/*
+  - "**/third_party/**"

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -17,4 +17,4 @@ ignore_patterns:
   - bin/internal/*.version
   - engine/src/flutter/ci/licenses_golden/**
   # Avoid code reviews on all third_party files.
-  - **/third_party/**
+  - */third_party/*

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -14,7 +14,7 @@ code_review:
 ignore_patterns:
   # Avoid code reviews on rolls.
   - DEPS
-  - bin/internal/*.version
-  - engine/src/flutter/ci/licenses_golden/**
+  - "bin/internal/*.version"
+  - "engine/src/flutter/ci/licenses_golden/**"
   # Avoid code reviews on all third_party files.
   - "**/third_party/**"


### PR DESCRIPTION
Gemini Code Assist for GitHub config seems incorrect, though the comment doesn't tell us what's wrong.

https://github.com/flutter/flutter/pull/172886#issuecomment-3130134128

<img width="814" height="111" alt="Screenshot 2025-07-28 at 4 45 41 PM" src="https://github.com/user-attachments/assets/6763a74b-3b14-4ef0-8234-4eaa70a72358" />


Speculating the yaml doesn't like the `**`.

Introduced in https://github.com/flutter/flutter/pull/172785