### PR TITLE
Roll Skia from 409e1c7ba09b to a42898e5d622 (29 revisions)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -14,7 +14,7 @@ vars = {
   'flutter_git': 'https://flutter.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
-  'skia_revision': '409e1c7ba09b636989516c348776a8e354c22d25',
+  'skia_revision': 'a42898e5d62262353a3a8b4ed4ccac7fd324ceff',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/engine/src/flutter/ci/licenses_golden/excluded_files
+++ b/engine/src/flutter/ci/licenses_golden/excluded_files
@@ -3057,8 +3057,6 @@
 ../../../flutter/third_party/skia/docker/README.md
 ../../../flutter/third_party/skia/docker/binary-size/Dockerfile
 ../../../flutter/third_party/skia/docker/cmake-release/Dockerfile
-../../../flutter/third_party/skia/docker/skia-build-tools/Dockerfile
-../../../flutter/third_party/skia/docker/skia-release/Dockerfile
 ../../../flutter/third_party/skia/docker/skia-wasm-release/Dockerfile
 ../../../flutter/third_party/skia/docker/skia-with-swift-shader-base/Dockerfile
 ../../../flutter/third_party/skia/docs

--- a/engine/src/flutter/ci/licenses_golden/licenses_skia
+++ b/engine/src/flutter/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: 374d16fd1a763b745147801a4e9da4af
+Signature: 49645cb667704d8f562787284096f6e9
 
 ====================================================================================================
 LIBRARY: etc1
@@ -9897,8 +9897,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: skia
+ORIGIN: ../../../flutter/third_party/skia/src/core/SkPathPriv.cpp + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/src/gpu/vk/VulkanPreferredFeatures.cpp + ../../../flutter/third_party/skia/LICENSE
 TYPE: LicenseType.bsd
+FILE: ../../../flutter/third_party/skia/src/core/SkPathPriv.cpp
 FILE: ../../../flutter/third_party/skia/src/gpu/vk/VulkanPreferredFeatures.cpp
 ----------------------------------------------------------------------------------------------------
 Copyright 2025 Google Inc.
@@ -10042,11 +10044,15 @@ LIBRARY: skia
 ORIGIN: ../../../flutter/third_party/skia/gm/tablemaskfilter.cpp + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/src/core/SkPathRaw.cpp + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/src/core/SkPathRaw.h + ../../../flutter/third_party/skia/LICENSE
+ORIGIN: ../../../flutter/third_party/skia/src/core/SkPathRawShapes.cpp + ../../../flutter/third_party/skia/LICENSE
+ORIGIN: ../../../flutter/third_party/skia/src/core/SkPathRawShapes.h + ../../../flutter/third_party/skia/LICENSE
 ORIGIN: ../../../flutter/third_party/skia/tools.go + ../../../flutter/third_party/skia/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../flutter/third_party/skia/gm/tablemaskfilter.cpp
 FILE: ../../../flutter/third_party/skia/src/core/SkPathRaw.cpp
 FILE: ../../../flutter/third_party/skia/src/core/SkPathRaw.h
+FILE: ../../../flutter/third_party/skia/src/core/SkPathRawShapes.cpp
+FILE: ../../../flutter/third_party/skia/src/core/SkPathRawShapes.h
 FILE: ../../../flutter/third_party/skia/tools.go
 ----------------------------------------------------------------------------------------------------
 Copyright 2025 Google LLC.


### PR DESCRIPTION
manual land of https://github.com/flutter/flutter/pull/172881

https://skia.googlesource.com/skia.git/+log/409e1c7ba09b..a42898e5d622

2025-07-28 recipe-mega-autoroller@chops-service-accounts.iam.gserviceaccount.com Roll recipe dependencies (trivial). 2025-07-28 michaelludwig@google.com Revert "[graphite] Add option to avoid clear load op conversion" 2025-07-28 mike@reedtribe.org Defer drawOval to SkDraw 2025-07-28 mike@reedtribe.org Factor out rrect deducer, so it can be used outside of pathref 2025-07-28 recipe-mega-autoroller@chops-service-accounts.iam.gserviceaccount.com Roll recipe dependencies (trivial). 2025-07-28 mike@reedtribe.org Refactor IsRectContour for other clients 2025-07-28 mike@reedtribe.org Share code from PathRawShapes 2025-07-28 drott@chromium.org [Fontations] Roll Fontations 2025-07-28 robertphillips@google.com [graphite] Fix thread race in Dawn backend 2025-07-28 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from dfe81c21c267 to aef5b0045b59 (1 revision) 2025-07-28 skia-autoroll@skia-public.iam.gserviceaccount.com Roll ANGLE from d38531e82fd8 to c8209fec9a5f (6 revisions) 2025-07-28 skia-autoroll@skia-public.iam.gserviceaccount.com Roll SwiftShader from a84d1801cf7b to 8802b4ec130b (1 revision) 2025-07-28 skia-autoroll@skia-public.iam.gserviceaccount.com Roll Skia Infra from 8aa65434c8ed to 4695e6b7d184 (7 revisions) 2025-07-28 skia-autoroll@skia-public.iam.gserviceaccount.com Roll Dawn from 3d2423f23524 to 2fa5446206bd (15 revisions) 2025-07-27 skia-recreate-skps@skia-swarming-bots.iam.gserviceaccount.com Update SKP version 2025-07-27 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from 1e5f8fd67984 to dfe81c21c267 (1 revision) 2025-07-26 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from f4b5d4a14233 to 1e5f8fd67984 (1 revision) 2025-07-26 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from 75a29db5e706 to f4b5d4a14233 (3 revisions) 2025-07-25 ccameron@chromium.org HDR v2: Make more paths robust to new version 2025-07-25 robertphillips@google.com [graphite] Fix bug(s) in PipelineKey serialization 2025-07-25 skia-autoroll@skia-public.iam.gserviceaccount.com Roll vulkan-deps from b16be89ea18d to 75a29db5e706 (3 revisions) 2025-07-25 mike@reedtribe.org Reapply "Add defaults for path enums, declare as 8-bit" 2025-07-25 mike@reedtribe.org Update Matrix PolyToPoly to take spans 2025-07-25 michaelludwig@google.com Stick to 1/2 scale for final blur decimation step 2025-07-25 kjlubick@google.com Remove old docker images related to fiddler 2025-07-25 mike@reedtribe.org skscan to take pathraw 2025-07-25 skia-autoroll@skia-public.iam.gserviceaccount.com Roll ANGLE from f94510ab8d9e to d38531e82fd8 (13 revisions) 2025-07-25 skia-autoroll@skia-public.iam.gserviceaccount.com Roll Skia Infra from 2fdfa81e82dc to 8aa65434c8ed (8 revisions) 2025-07-25 skia-autoroll@skia-public.iam.gserviceaccount.com Roll Dawn from b6b32cb6d1a1 to 3d2423f23524 (14 revisions)

If this roll has caused a breakage, revert this CL and stop the roller using the controls here:
https://autoroll.skia.org/r/skia-flutter-autoroll
Please CC jmbetancourt@google.com,jsimmons@google.com,kjlubick@google.com on the revert to ensure that a human is aware of the problem.

To file a bug in Skia: https://bugs.chromium.org/p/skia/issues/entry
To file a bug in Flutter: https://github.com/flutter/flutter/issues/new/choose

To report a problem with the AutoRoller itself, please file a bug: https://issues.skia.org/issues/new?component=1389291&template=1850622

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+doc/main/autoroll/README.md
