### PR TITLE
When launching iOS app through Xcode, always use temporary project

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -38,7 +38,6 @@ import 'iproxy.dart';
 import 'mac.dart';
 import 'xcode_build_settings.dart';
 import 'xcode_debug.dart';
-import 'xcodeproj.dart';
 
 const kJITCrashFailureMessage =
     'Crash occurred when compiling unknown function in unoptimized JIT mode in unknown pass';

--- a/packages/flutter_tools/templates/xcode/ios/custom_application_bundle/Runner.xcodeproj.tmpl/xcshareddata/xcschemes/Runner.xcscheme.tmpl
+++ b/packages/flutter_tools/templates/xcode/ios/custom_application_bundle/Runner.xcodeproj.tmpl/xcshareddata/xcschemes/Runner.xcscheme.tmpl
@@ -26,14 +26,14 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      customLLDBInitFile = "{{lldbInitFile}}"
       shouldUseLaunchSchemeArgsEnv = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
+      customLLDBInitFile = "{{lldbInitFile}}"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -25,6 +25,7 @@ import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/mdns_discovery.dart';
+import 'package:flutter_tools/src/xcode_project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -1296,6 +1297,7 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {
     String deviceBundlePath, {
     required TemplateRenderer templateRenderer,
     Directory? projectDestination,
+    required IosProject project,
     bool verboseLogging = false,
   }) async {
     if (expectedBundlePath != null) {

--- a/packages/flutter_tools/test/general.shard/ios/xcode_debug_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcode_debug_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/ios/xcodeproj.dart';
 import 'package:flutter_tools/src/macos/xcode.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
@@ -64,26 +65,6 @@ void main() {
         'succeeds in opening and debugging with launch options, expectedConfigurationBuildDir, and verbose logging',
         () async {
           fakeProcessManager.addCommands(<FakeCommand>[
-            FakeCommand(
-              command: <String>[
-                'xcrun',
-                'osascript',
-                '-l',
-                'JavaScript',
-                pathToXcodeAutomationScript,
-                'check-workspace-opened',
-                '--xcode-path',
-                pathToXcodeApp,
-                '--project-path',
-                project.xcodeProject.path,
-                '--workspace-path',
-                project.xcodeWorkspace.path,
-                '--verbose',
-              ],
-              stdout: '''
-  {"status":false,"errorMessage":"Xcode is not running","debugResult":null}
-  ''',
-            ),
             FakeCommand(
               command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
             ),
@@ -143,7 +124,6 @@ void main() {
           );
 
           expect(logger.errorText, isEmpty);
-          expect(logger.traceText, contains('Error checking if project opened in Xcode'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
           expect(xcodeDebug.startDebugActionProcess, isNull);
           expect(status, true);
@@ -154,25 +134,6 @@ void main() {
         'succeeds in opening and debugging without launch options, expectedConfigurationBuildDir, and verbose logging',
         () async {
           fakeProcessManager.addCommands(<FakeCommand>[
-            FakeCommand(
-              command: <String>[
-                'xcrun',
-                'osascript',
-                '-l',
-                'JavaScript',
-                pathToXcodeAutomationScript,
-                'check-workspace-opened',
-                '--xcode-path',
-                pathToXcodeApp,
-                '--project-path',
-                project.xcodeProject.path,
-                '--workspace-path',
-                project.xcodeWorkspace.path,
-              ],
-              stdout: '''
-  {"status":false,"errorMessage":"Xcode is not running","debugResult":null}
-  ''',
-            ),
             FakeCommand(
               command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
             ),
@@ -220,7 +181,6 @@ void main() {
           );
 
           expect(logger.errorText, isEmpty);
-          expect(logger.traceText, contains('Error checking if project opened in Xcode'));
           expect(fakeProcessManager, hasNoRemainingExpectations);
           expect(xcodeDebug.startDebugActionProcess, isNull);
           expect(status, true);
@@ -229,25 +189,6 @@ void main() {
 
       testWithoutContext('fails if project fails to open', () async {
         fakeProcessManager.addCommands(<FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              'xcrun',
-              'osascript',
-              '-l',
-              'JavaScript',
-              pathToXcodeAutomationScript,
-              'check-workspace-opened',
-              '--xcode-path',
-              pathToXcodeApp,
-              '--project-path',
-              project.xcodeProject.path,
-              '--workspace-path',
-              project.xcodeWorkspace.path,
-            ],
-            stdout: '''
-  {"status":false,"errorMessage":"Xcode is not running","debugResult":null}
-  ''',
-          ),
           FakeCommand(
             command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
             exception: ProcessException('open', <String>[
@@ -285,23 +226,7 @@ void main() {
       testWithoutContext('fails if osascript errors', () async {
         fakeProcessManager.addCommands(<FakeCommand>[
           FakeCommand(
-            command: <String>[
-              'xcrun',
-              'osascript',
-              '-l',
-              'JavaScript',
-              pathToXcodeAutomationScript,
-              'check-workspace-opened',
-              '--xcode-path',
-              pathToXcodeApp,
-              '--project-path',
-              project.xcodeProject.path,
-              '--workspace-path',
-              project.xcodeWorkspace.path,
-            ],
-            stdout: '''
-  {"status":true,"errorMessage":"","debugResult":null}
-  ''',
+            command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
           ),
           FakeCommand(
             command: <String>[
@@ -354,23 +279,7 @@ void main() {
       testWithoutContext('fails if osascript output returns false status', () async {
         fakeProcessManager.addCommands(<FakeCommand>[
           FakeCommand(
-            command: <String>[
-              'xcrun',
-              'osascript',
-              '-l',
-              'JavaScript',
-              pathToXcodeAutomationScript,
-              'check-workspace-opened',
-              '--xcode-path',
-              pathToXcodeApp,
-              '--project-path',
-              project.xcodeProject.path,
-              '--workspace-path',
-              project.xcodeWorkspace.path,
-            ],
-            stdout: '''
-  {"status":true,"errorMessage":null,"debugResult":null}
-  ''',
+            command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
           ),
           FakeCommand(
             command: <String>[
@@ -423,23 +332,7 @@ void main() {
       testWithoutContext('fails if missing debug results', () async {
         fakeProcessManager.addCommands(<FakeCommand>[
           FakeCommand(
-            command: <String>[
-              'xcrun',
-              'osascript',
-              '-l',
-              'JavaScript',
-              pathToXcodeAutomationScript,
-              'check-workspace-opened',
-              '--xcode-path',
-              pathToXcodeApp,
-              '--project-path',
-              project.xcodeProject.path,
-              '--workspace-path',
-              project.xcodeWorkspace.path,
-            ],
-            stdout: '''
-  {"status":true,"errorMessage":null,"debugResult":null}
-  ''',
+            command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
           ),
           FakeCommand(
             command: <String>[
@@ -492,23 +385,7 @@ void main() {
       testWithoutContext('fails if debug results status is not running', () async {
         fakeProcessManager.addCommands(<FakeCommand>[
           FakeCommand(
-            command: <String>[
-              'xcrun',
-              'osascript',
-              '-l',
-              'JavaScript',
-              pathToXcodeAutomationScript,
-              'check-workspace-opened',
-              '--xcode-path',
-              pathToXcodeApp,
-              '--project-path',
-              project.xcodeProject.path,
-              '--workspace-path',
-              project.xcodeWorkspace.path,
-            ],
-            stdout: '''
-  {"status":true,"errorMessage":null,"debugResult":null}
-  ''',
+            command: <String>['open', '-a', pathToXcodeApp, '-g', '-j', '-F', xcworkspace.path],
           ),
           FakeCommand(
             command: <String>[
@@ -1171,6 +1048,7 @@ void main() {
           '/path/to/bundle',
           templateRenderer: globals.templateRenderer,
           projectDestination: projectDirectory,
+          project: FakeIosProject(fileSystem: fileSystem),
         );
 
         final File schemeFile = projectDirectory
@@ -1187,6 +1065,7 @@ void main() {
         expect(projectDirectory.childDirectory('Runner.xcworkspace').existsSync(), isTrue);
         expect(schemeFile.existsSync(), isTrue);
         expect(schemeFile.readAsStringSync(), contains('FilePath = "/path/to/bundle"'));
+        expect(schemeFile.readAsStringSync(), contains('customLLDBInitFile = "/flutter_lldbinit"'));
       } catch (err) {
         fail(err.toString());
       } finally {
@@ -1233,6 +1112,17 @@ class FakeProcess extends Fake implements Process {
   bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
     killed = true;
     return true;
+  }
+}
+
+class FakeIosProject extends Fake implements IosProject {
+  FakeIosProject({required this.fileSystem});
+
+  FileSystem fileSystem;
+
+  @override
+  File get lldbInitFile {
+    return fileSystem.currentDirectory.childFile('flutter_lldbinit');
   }
 }
 


### PR DESCRIPTION
Flutter launches iOS apps through Xcode for iOS 17+ using OSAScript/AppleScript. With newer versions of Xcode, this has become unreliable. AppleScript has trouble finding the project and connecting to it if it's already open. To workaround this, rather than launching the app through the Flutter project's Xcode project, it'll create a temporary Xcode project that directly targets the built app bundle. This is already the method used when using `--use-application-binary`.

Fixes https://github.com/flutter/flutter/issues/144218.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
