### PR TITLE
Made `android_gradle_print_build_variants_test.dart` more robust

### DIFF
--- a/packages/flutter_tools/test/integration.shard/android_gradle_print_build_variants_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_print_build_variants_test.dart
@@ -53,13 +53,10 @@ void main() {
       // Verify that gradlew has a javaVersion task.
       expect(result.exitCode, 0);
       // Verify the format is a number on its own line.
-      const expectedLines = <String>[
-        'BuildVariant: debug',
-        'BuildVariant: release',
-        'BuildVariant: profile',
-      ];
       final List<String> actualLines = LineSplitter.split(result.stdout.toString()).toList();
-      expect(const ListEquality<String>().equals(actualLines, expectedLines), isTrue);
+      expect(actualLines, contains('BuildVariant: debug'), reason: 'actual: $actualLines');
+      expect(actualLines, contains('BuildVariant: release'), reason: 'actual: $actualLines');
+      expect(actualLines, contains('BuildVariant: profile'), reason: 'actual: $actualLines');
     },
   );
 }

--- a/packages/flutter_tools/test/integration.shard/android_gradle_print_build_variants_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_gradle_print_build_variants_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert';
 
-import 'package:collection/collection.dart';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/android/gradle_utils.dart' show getGradlewFileName;
 import 'package:flutter_tools/src/base/io.dart';


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/172908

It's uncertain if this will fix the issue since we don't know why the old matcher failed.  This may fix it, or it may just give us more information to debug with.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
