### PR TITLE
[ios26]Do not report error for Info.plist key not found

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -115,7 +115,7 @@ class Context {
     if (verbose) {
       print('♦ $bin ${args.join(' ')}');
     }
-    final ProcessResult result = Process.runSync(bin, args, workingDirectory: workingDirectory);
+    final ProcessResult result = runSyncProcess(bin, args, workingDirectory: workingDirectory);
     if (verbose) {
       print((result.stdout as String).trim());
     }
@@ -145,6 +145,17 @@ class Context {
       throw Exception('Command "$bin ${args.join(' ')}" exited with code ${result.exitCode}');
     }
     return result;
+  }
+
+  // TODO(hellohuanlin): Instead of using inheritance to stub the function in
+  // the subclass, we should favor composition by injecting the dependencies.
+  // See: https://github.com/flutter/flutter/issues/173133
+  ProcessResult runSyncProcess(
+    String bin,
+    List<String> args, {
+    String? workingDirectory,
+  }) {
+    return Process.runSync(bin, args, workingDirectory: workingDirectory);
   }
 
   /// Log message to stderr.

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -122,7 +122,7 @@ class Context {
     final String resultStderr = result.stderr.toString().trim();
     if (resultStderr.isNotEmpty) {
       final errorOutput = StringBuffer();
-      if (result.exitCode != 0) {
+      if (!allowFail && result.exitCode != 0) {
         // "error:" prefix makes this show up as an Xcode compilation error.
         errorOutput.write('error: ');
       }

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -122,6 +122,9 @@ class Context {
     final String resultStderr = result.stderr.toString().trim();
     if (resultStderr.isNotEmpty) {
       final errorOutput = StringBuffer();
+      // If allowFail, do not fail Xcode build. An example is on macOS 26,
+      // plutil reports NSBonjourServices key not found via stderr (rather than
+      // stdout on older macOS), and it should not cause compile failure.
       if (!allowFail && result.exitCode != 0) {
         // "error:" prefix makes this show up as an Xcode compilation error.
         errorOutput.write('error: ');

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -150,11 +150,7 @@ class Context {
   // TODO(hellohuanlin): Instead of using inheritance to stub the function in
   // the subclass, we should favor composition by injecting the dependencies.
   // See: https://github.com/flutter/flutter/issues/173133
-  ProcessResult runSyncProcess(
-    String bin,
-    List<String> args, {
-    String? workingDirectory,
-  }) {
+  ProcessResult runSyncProcess(String bin, List<String> args, {String? workingDirectory}) {
     return Process.runSync(bin, args, workingDirectory: workingDirectory);
   }
 

--- a/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
@@ -393,8 +393,7 @@ void main() {
     test('Missing NSBonjourServices key in Info.plist should not fail Xcode compilation', () {
       final Directory buildDir = fileSystem.directory('/path/to/builds')
         ..createSync(recursive: true);
-      final File infoPlist = buildDir.childFile('Info.plist')
-        ..createSync();
+      final File infoPlist = buildDir.childFile('Info.plist')..createSync();
       final context = TestContext(
         <String>['test_vm_service_bonjour_service'],
         <String, String>{
@@ -424,7 +423,7 @@ void main() {
               '-json',
               '["_dartVmService._tcp"]',
               infoPlist.path,
-            ]
+            ],
           ),
           FakeCommand(
             command: <String>[
@@ -443,68 +442,71 @@ void main() {
       expect(context.stderr, isNot(contains('error: ')));
     });
 
-    test('Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation', () {
-      final Directory buildDir = fileSystem.directory('/path/to/builds')
-        ..createSync(recursive: true);
-      final File infoPlist = buildDir.childFile('Info.plist')
-        ..createSync();
-      final context = TestContext(
-        <String>['test_vm_service_bonjour_service'],
-        <String, String>{
-          'CONFIGURATION': 'Debug',
-          'BUILT_PRODUCTS_DIR': buildDir.path,
-          'INFOPLIST_PATH': 'Info.plist',
-        },
-        commands: <FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-extract',
-              'NSBonjourServices',
-              'xml1',
-              '-o',
-              '-',
-              infoPlist.path,
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-insert',
-              'NSBonjourServices.0',
-              '-string',
-              '_dartVmService._tcp',
-              infoPlist.path,
-            ]
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-extract',
-              'NSLocalNetworkUsageDescription',
-              'xml1',
-              '-o',
-              '-',
-              infoPlist.path,
-            ],
-            exitCode: 1,
-            stderr: 'No value at that key path or invalid key path: NSLocalNetworkUsageDescription',
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-insert',
-              'NSLocalNetworkUsageDescription',
-              '-string',
-              'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
-              infoPlist.path,
-            ]
-          ),
-        ],
-        fileSystem: fileSystem,
-      )..run();
-      expect(context.stderr, isNot(contains('error: ')));
-    });
+    test(
+      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation',
+      () {
+        final Directory buildDir = fileSystem.directory('/path/to/builds')
+          ..createSync(recursive: true);
+        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+        final context = TestContext(
+          <String>['test_vm_service_bonjour_service'],
+          <String, String>{
+            'CONFIGURATION': 'Debug',
+            'BUILT_PRODUCTS_DIR': buildDir.path,
+            'INFOPLIST_PATH': 'Info.plist',
+          },
+          commands: <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSBonjourServices',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSBonjourServices.0',
+                '-string',
+                '_dartVmService._tcp',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSLocalNetworkUsageDescription',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+              exitCode: 1,
+              stderr:
+                  'No value at that key path or invalid key path: NSLocalNetworkUsageDescription',
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSLocalNetworkUsageDescription',
+                '-string',
+                'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
+                infoPlist.path,
+              ],
+            ),
+          ],
+          fileSystem: fileSystem,
+        )..run();
+        expect(context.stderr, isNot(contains('error: ')));
+      },
+    );
   });
 
   for (final platform in platforms) {
@@ -1170,11 +1172,7 @@ class TestContext extends Context {
   }
 
   @override
-  ProcessResult runSyncProcess(
-    String bin,
-    List<String> args, {
-    String? workingDirectory,
-  }) {
+  ProcessResult runSyncProcess(String bin, List<String> args, {String? workingDirectory}) {
     return processManager.runSync(
       <dynamic>[bin, ...args],
       workingDirectory: workingDirectory,

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -150,6 +150,7 @@ void main() {
         expect(actualInfoPlist, contains('dartVmService'));
         expect(actualInfoPlist, contains('NSLocalNetworkUsageDescription'));
 
+        expect(result.stderr, isNot(startsWith("error:")));
         expect(result, const ProcessResultMatcher());
       });
     }
@@ -196,6 +197,8 @@ void main() {
 </dict>
 </plist>
 ''');
+
+        expect(result.stderr, isNot(startsWith("error:")));
         expect(result, const ProcessResultMatcher());
       },
     );

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -150,7 +150,7 @@ void main() {
         expect(actualInfoPlist, contains('dartVmService'));
         expect(actualInfoPlist, contains('NSLocalNetworkUsageDescription'));
 
-        expect(result.stderr, isNot(startsWith("error:")));
+        expect(result.stderr, isNot(startsWith('error:')));
         expect(result, const ProcessResultMatcher());
       });
     }
@@ -198,7 +198,7 @@ void main() {
 </plist>
 ''');
 
-        expect(result.stderr, isNot(startsWith("error:")));
+        expect(result.stderr, isNot(startsWith('error:')));
         expect(result, const ProcessResultMatcher());
       },
     );


### PR DESCRIPTION
In xcode_backend's `runSync` function, there's a flag parameter `allowFail`. The purpose of this flag is that, when enabled, even if command fails, we should not fail Xcode. 

However, the current implementation has a bug, that even when `allowFail = true`, we still prefix `"error:"` string to `stderr`, which causes Xcode compilation error. 

Before macOS 26, plutil used `stdout` rather than `stderr`, so the bug was not surfaced. On macOS 26, pltuil uses `stderr` instead (which makes sense), so the bug is surfaced now. 

Note: even if plutil doesn't change behavior on macOS 26, if I randomly come across this code, I'd still fix the logic error. 

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/172627

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
