### PR TITLE
[a11y] add RangeSlider to a11y test app as additional use-case

### DIFF
--- a/dev/a11y_assessments/GEMINI.md
+++ b/dev/a11y_assessments/GEMINI.md
@@ -1,0 +1,9 @@
+This directory contains the source code for a test app used to test widget accessibility.
+
+The directory structure is as follows:
+
+* lib/use_cases contains widgets implementing specific use-cases that the team
+  has decided to be important to test.
+* lib/use_cases/use_cases.dart provides a basic framework for use-cases, and a
+  list of use-cases included in the app.
+* lib/common contains code shared by multiple use-cases.

--- a/dev/a11y_assessments/lib/main.dart
+++ b/dev/a11y_assessments/lib/main.dart
@@ -62,6 +62,8 @@ class HomePage extends StatefulWidget {
 class HomePageState extends State<HomePage> {
   final ScrollController scrollController = ScrollController();
 
+  bool _showAdditionalUseCases = false;
+
   @override
   void dispose() {
     scrollController.dispose();
@@ -86,16 +88,34 @@ class HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+    final List<UseCase> effectiveUseCases = useCases.where((UseCase useCase) {
+      return _showAdditionalUseCases || useCase.useCaseCategory == UseCaseCategory.core;
+    }).toList();
+
     return Scaffold(
       appBar: AppBar(
         title: Semantics(headingLevel: 1, child: const Text('Accessibility Assessments')),
+        actions: <Widget>[
+          Tooltip(
+            message: 'Show additional use cases',
+            waitDuration: const Duration(milliseconds: 500),
+            child: Switch(
+              value: _showAdditionalUseCases,
+              onChanged: (bool newValue) {
+                setState(() {
+                  _showAdditionalUseCases = newValue;
+                });
+              },
+            ),
+          ),
+        ],
       ),
       body: Center(
         child: ListView(
           controller: scrollController,
           children: List<Widget>.generate(
-            useCases.length,
-            (int index) => _buildUseCaseItem(index, useCases[index]),
+            effectiveUseCases.length,
+            (int index) => _buildUseCaseItem(index, effectiveUseCases[index]),
           ),
         ),
       ),

--- a/dev/a11y_assessments/lib/use_cases/action_chip.dart
+++ b/dev/a11y_assessments/lib/use_cases/action_chip.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class ActionChipUseCase extends UseCase {
+  ActionChipUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'ActionChip';
 

--- a/dev/a11y_assessments/lib/use_cases/app_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/app_bar.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'use_cases.dart';
 
 class AppBarUseCase extends UseCase {
+  AppBarUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'AppBar';
 

--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class AutoCompleteUseCase extends UseCase {
+  AutoCompleteUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'AutoComplete';
 

--- a/dev/a11y_assessments/lib/use_cases/badge.dart
+++ b/dev/a11y_assessments/lib/use_cases/badge.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class BadgeUseCase extends UseCase {
+  BadgeUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'Badge';
 

--- a/dev/a11y_assessments/lib/use_cases/card.dart
+++ b/dev/a11y_assessments/lib/use_cases/card.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class CardUseCase extends UseCase {
+  CardUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'Card';
 

--- a/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/check_box_list_tile.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class CheckBoxListTile extends UseCase {
+  CheckBoxListTile() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'CheckBoxListTile';
 

--- a/dev/a11y_assessments/lib/use_cases/date_picker.dart
+++ b/dev/a11y_assessments/lib/use_cases/date_picker.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class DatePickerUseCase extends UseCase {
+  DatePickerUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'DatePicker';
 

--- a/dev/a11y_assessments/lib/use_cases/dialog.dart
+++ b/dev/a11y_assessments/lib/use_cases/dialog.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class DialogUseCase extends UseCase {
+  DialogUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'Dialog';
 

--- a/dev/a11y_assessments/lib/use_cases/drawer.dart
+++ b/dev/a11y_assessments/lib/use_cases/drawer.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class DrawerUseCase extends UseCase {
+  DrawerUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'drawer';
 

--- a/dev/a11y_assessments/lib/use_cases/expansion_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/expansion_tile.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class ExpansionTileUseCase extends UseCase {
+  ExpansionTileUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'ExpansionTile';
 

--- a/dev/a11y_assessments/lib/use_cases/material_banner.dart
+++ b/dev/a11y_assessments/lib/use_cases/material_banner.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class MaterialBannerUseCase extends UseCase {
+  MaterialBannerUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'MaterialBanner';
 

--- a/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_bar.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class NavigationBarUseCase extends UseCase {
+  NavigationBarUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'NavigationBar';
 

--- a/dev/a11y_assessments/lib/use_cases/navigation_drawer.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_drawer.dart
@@ -21,6 +21,8 @@ const List<ExampleDestination> destinations = <ExampleDestination>[
 ];
 
 class NavigationDrawerUseCase extends UseCase {
+  NavigationDrawerUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'NavigationDrawer';
 

--- a/dev/a11y_assessments/lib/use_cases/navigation_rail.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_rail.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class NavigationRailUseCase extends UseCase {
+  NavigationRailUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'NavigationRail';
 

--- a/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/radio_list_tile.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class RadioListTileUseCase extends UseCase {
+  RadioListTileUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'RadioListTile';
 

--- a/dev/a11y_assessments/lib/use_cases/range_slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/range_slider.dart
@@ -6,14 +6,14 @@ import 'package:flutter/material.dart';
 import '../utils.dart';
 import 'use_cases.dart';
 
-class SliderUseCase extends UseCase {
-  SliderUseCase() : super(useCaseCategory: UseCaseCategory.core);
+class RangeSliderUseCase extends UseCase {
+  RangeSliderUseCase() : super(useCaseCategory: UseCaseCategory.additional);
 
   @override
-  String get name => 'Slider';
+  String get name => 'RangeSlider';
 
   @override
-  String get route => '/slider';
+  String get route => '/range-slider';
 
   @override
   Widget build(BuildContext context) => const MainWidget();
@@ -27,32 +27,31 @@ class MainWidget extends StatefulWidget {
 }
 
 class MainWidgetState extends State<MainWidget> {
-  double currentSliderValue = 20;
-  static const String accessibilityLabel = 'Accessibility Test Slider';
+  RangeValues _currentRangeValues = const RangeValues(20, 60);
 
-  String pageTitle = getUseCaseName(SliderUseCase());
+  String pageTitle = getUseCaseName(RangeSliderUseCase());
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        title: Semantics(headingLevel: 1, child: Text('$pageTitle demo')),
+        title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
       ),
       body: Center(
-        child: Semantics(
-          label: accessibilityLabel,
-          child: Slider(
-            value: currentSliderValue,
-            max: 100,
-            divisions: 5,
-            label: currentSliderValue.round().toString(),
-            onChanged: (double value) {
-              setState(() {
-                currentSliderValue = value;
-              });
-            },
+        child: RangeSlider(
+          values: _currentRangeValues,
+          max: 100,
+          divisions: 5,
+          labels: RangeLabels(
+            _currentRangeValues.start.round().toString(),
+            _currentRangeValues.end.round().toString(),
           ),
+          onChanged: (RangeValues values) {
+            setState(() {
+              _currentRangeValues = values;
+            });
+          },
         ),
       ),
     );

--- a/dev/a11y_assessments/lib/use_cases/snack_bar.dart
+++ b/dev/a11y_assessments/lib/use_cases/snack_bar.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class SnackBarUseCase extends UseCase {
+  SnackBarUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'SnackBar';
 

--- a/dev/a11y_assessments/lib/use_cases/switch_list_tile.dart
+++ b/dev/a11y_assessments/lib/use_cases/switch_list_tile.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class SwitchListTileUseCase extends UseCase {
+  SwitchListTileUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'SwitchListTile';
 

--- a/dev/a11y_assessments/lib/use_cases/tab_bar_view.dart
+++ b/dev/a11y_assessments/lib/use_cases/tab_bar_view.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'use_cases.dart';
 
 class TabBarViewUseCase extends UseCase {
+  TabBarViewUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'TabBarView';
 

--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class TextButtonUseCase extends UseCase {
+  TextButtonUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'TextButton';
 

--- a/dev/a11y_assessments/lib/use_cases/text_field.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class TextFieldUseCase extends UseCase {
+  TextFieldUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'TextField';
 

--- a/dev/a11y_assessments/lib/use_cases/text_field_password.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_field_password.dart
@@ -7,6 +7,8 @@ import '../utils.dart';
 import 'use_cases.dart';
 
 class TextFieldPasswordUseCase extends UseCase {
+  TextFieldPasswordUseCase() : super(useCaseCategory: UseCaseCategory.core);
+
   @override
   String get name => 'TextField password';
 

--- a/dev/a11y_assessments/lib/use_cases/use_cases.dart
+++ b/dev/a11y_assessments/lib/use_cases/use_cases.dart
@@ -20,6 +20,7 @@ import 'navigation_bar.dart';
 import 'navigation_drawer.dart';
 import 'navigation_rail.dart';
 import 'radio_list_tile.dart';
+import 'range_slider.dart';
 import 'slider.dart';
 import 'snack_bar.dart';
 import 'switch_list_tile.dart';
@@ -28,7 +29,22 @@ import 'text_button.dart';
 import 'text_field.dart';
 import 'text_field_password.dart';
 
+/// The category a use-case falls under.
+enum UseCaseCategory {
+  /// An essential use-case requested to be covered for the purpose of various
+  /// a11y certifications.
+  core,
+
+  /// An additional use-case that the team considers important to cover, even if
+  /// nobody requested this as part of any certification process.
+  additional,
+}
+
 abstract class UseCase {
+  UseCase({required this.useCaseCategory});
+
+  final UseCaseCategory useCaseCategory;
+
   String get name;
   String get route;
 
@@ -43,6 +59,7 @@ final List<UseCase> useCases = <UseCase>[
   CheckBoxListTile(),
   DialogUseCase(),
   SliderUseCase(),
+  RangeSliderUseCase(),
   TextFieldUseCase(),
   TextFieldPasswordUseCase(),
   DatePickerUseCase(),

--- a/dev/a11y_assessments/test/accessibility_guideline_test.dart
+++ b/dev/a11y_assessments/test/accessibility_guideline_test.dart
@@ -11,6 +11,11 @@ void main() {
   for (final UseCase useCase in useCases) {
     testWidgets('testing accessibility guideline for ${useCase.name}', (WidgetTester tester) async {
       await tester.pumpWidget(const App());
+
+      // Tap on the switch to show all use-cases, not just the core ones.
+      await tester.tap(find.byTooltip('Show additional use cases'));
+      await tester.pumpAndSettle();
+
       final ScrollController controller = tester
           .state<HomePageState>(find.byType(HomePage))
           .scrollController;

--- a/dev/a11y_assessments/test/range_slider_test.dart
+++ b/dev/a11y_assessments/test/range_slider_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:a11y_assessments/use_cases/range_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'test_utils.dart';
+
+void main() {
+  testWidgets('range slider use-case works', (WidgetTester tester) async {
+    await pumpsUseCase(tester, RangeSliderUseCase());
+    expect(find.byType(RangeSlider), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Add `RangeSlider` as an additional use-case to the a11y_assessments app. As part of that this PR adds a `Switch` to the app bar of the app to reveal the additional use-cases. Each use-case is annotated to be either a `core` or `additional` using a new `enum`, which is also introduced in this PR.