### PR TITLE
Make sure that a DrawerButton doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/drawer_button_test.dart
+++ b/packages/flutter/test/material/drawer_button_test.dart
@@ -286,4 +286,16 @@ void main() {
     // The custom callback is called, setting customCallbackWasCalled to true.
     expect(customCallbackWasCalled, true);
   });
+
+  testWidgets('DrawerButton renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(child: Scaffold(body: DrawerButton())),
+        ),
+      ),
+    );
+    final Finder drawerButtonIcon = find.byType(DrawerButtonIcon);
+    expect(tester.getSize(drawerButtonIcon).isEmpty, isTrue);
+  });
 }

--- a/packages/flutter/test/material/drawer_button_test.dart
+++ b/packages/flutter/test/material/drawer_button_test.dart
@@ -287,7 +287,7 @@ void main() {
     expect(customCallbackWasCalled, true);
   });
 
-  testWidgets('DrawerButton renders at zero area', (WidgetTester tester) async {
+  testWidgets('DrawerButton does not crash at zero area', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(
         home: Center(
@@ -295,7 +295,6 @@ void main() {
         ),
       ),
     );
-    final Finder drawerButtonIcon = find.byType(DrawerButtonIcon);
-    expect(tester.getSize(drawerButtonIcon).isEmpty, isTrue);
+    expect(tester.getSize(find.byType(DrawerButton)), Size.zero);
   });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the DrawerButton UI control.