### PR TITLE
ButtonStyleButton `isEnabled` parameter

### DIFF
--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -561,14 +561,24 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
       result = resolvedBackgroundBuilder(context, statesController.value, result);
     }
 
+    // If there are no callbacks when isEnabled is true, we need to provide a
+    // default `onTap` callback to satisfy the underlying InkWell.
+    final bool hasAnyCallback = widget.onPressed != null || widget.onLongPress != null;
+    final bool isEnabled = widget.isEnabled ?? true;
+    final VoidCallback? onLongPress = isEnabled ? widget.onLongPress : null;
+    VoidCallback? onTap = isEnabled ? widget.onPressed : null;
+    if (!hasAnyCallback && isEnabled) {
+      onTap = () {};
+    }
+
     result = AnimatedTheme(
       duration: resolvedAnimationDuration,
       data: theme.copyWith(
         iconTheme: iconTheme.merge(IconThemeData(color: resolvedIconColor, size: resolvedIconSize)),
       ),
       child: InkWell(
-        onTap: widget.onPressed,
-        onLongPress: widget.onLongPress,
+        onTap: onTap,
+        onLongPress: onLongPress,
         onHover: widget.onHover,
         mouseCursor: mouseCursor,
         enableFeedback: resolvedEnableFeedback,

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -561,13 +561,13 @@ class _ButtonStyleState extends State<ButtonStyleButton> with TickerProviderStat
       result = resolvedBackgroundBuilder(context, statesController.value, result);
     }
 
-    // If there are no callbacks when isEnabled is true, we need to provide a
-    // default `onTap` callback to satisfy the underlying InkWell.
+    // If both `onPressed` and `onLongPress` are null, but `isEnabled` is true,
+    // we need to provide a default `onTap` callback to satisfy the underlying InkWell.
     final bool hasAnyCallback = widget.onPressed != null || widget.onLongPress != null;
-    final bool isEnabled = widget.isEnabled ?? true;
-    final VoidCallback? onLongPress = isEnabled ? widget.onLongPress : null;
-    VoidCallback? onTap = isEnabled ? widget.onPressed : null;
-    if (!hasAnyCallback && isEnabled) {
+    final bool? isEnabled = widget.isEnabled;
+    final VoidCallback? onLongPress = isEnabled ?? true ? widget.onLongPress : null;
+    VoidCallback? onTap = isEnabled ?? true ? widget.onPressed : null;
+    if (!hasAnyCallback && (isEnabled ?? false)) {
       onTap = () {};
     }
 

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -100,12 +100,15 @@ abstract class ButtonStyleButton extends StatefulWidget {
 
   /// Whether the button is enabled.
   ///
-  /// If this boolean is null and [onPressed] and [onLongPress] are null, then
-  /// the button will be disabled.
+  /// If this is non-null, this value is used to determine if the button is
+  /// enabled.
+  ///
+  /// If this is null, the button is enabled if [onPressed] or [onLongPress]
+  /// is non-null.
   ///
   /// See also:
   ///
-  /// * [enabled], which is true if the button is enabled
+  /// * [enabled], which is true if the button is enabled.
   final bool? isEnabled;
 
   /// Called when the button is tapped or otherwise activated.

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -85,6 +85,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
     required this.focusNode,
     required this.autofocus,
     required this.clipBehavior,
+    this.isEnabled,
     this.statesController,
     this.isSemanticButton = true,
     @Deprecated(
@@ -96,6 +97,16 @@ abstract class ButtonStyleButton extends StatefulWidget {
     this.tooltip,
     required this.child,
   });
+
+  /// Whether the button is enabled.
+  ///
+  /// If this boolean is null and [onPressed] and [onLongPress] are null, then
+  /// the button will be disabled.
+  ///
+  /// See also:
+  ///
+  /// * [enabled], which is true if the button is enabled
+  final bool? isEnabled;
 
   /// Called when the button is tapped or otherwise activated.
   ///
@@ -239,7 +250,7 @@ abstract class ButtonStyleButton extends StatefulWidget {
   ///
   /// Buttons are disabled by default. To enable a button, set its [onPressed]
   /// or [onLongPress] properties to a non-null value.
-  bool get enabled => onPressed != null || onLongPress != null;
+  bool get enabled => isEnabled ?? (onPressed != null || onLongPress != null);
 
   @override
   State<ButtonStyleButton> createState() => _ButtonStyleState();

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -79,6 +79,7 @@ class ElevatedButton extends ButtonStyleButton {
     super.autofocus = false,
     super.clipBehavior,
     super.statesController,
+    super.isEnabled,
     required super.child,
   });
 

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -81,6 +81,7 @@ class FilledButton extends ButtonStyleButton {
     super.autofocus = false,
     super.clipBehavior = Clip.none,
     super.statesController,
+    super.isEnabled,
     required super.child,
   }) : _variant = _FilledButtonVariant.filled;
 

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -83,6 +83,7 @@ class OutlinedButton extends ButtonStyleButton {
     super.autofocus = false,
     super.clipBehavior,
     super.statesController,
+    super.isEnabled,
     required super.child,
   });
 

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -92,6 +92,7 @@ class TextButton extends ButtonStyleButton {
     super.clipBehavior,
     super.statesController,
     super.isSemanticButton,
+    super.isEnabled,
     required Widget super.child,
   });
 

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -2606,5 +2607,27 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
     expect(textColor(tester, buttonText), hoveredColor);
     expect(iconStyle(tester, buttonIcon).color, hoveredColor);
+  });
+
+  testWidgets('ElevatedButton isEnabled', (WidgetTester tester) async {
+    final ColorScheme colorScheme = ColorScheme.fromSeed(seedColor: Colors.red);
+    final ThemeData theme = ThemeData.from(colorScheme: colorScheme);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: ElevatedButton(isEnabled: true, onPressed: () {}, child: const Text('button')),
+      ),
+    );
+
+    expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).enabled, isTrue);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: ElevatedButton(isEnabled: false, onPressed: () {}, child: const Text('button')),
+      ),
+    );
+    expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).enabled, isFalse);
   });
 }

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -2610,24 +2610,31 @@ void main() {
   });
 
   testWidgets('ElevatedButton isEnabled', (WidgetTester tester) async {
-    final ColorScheme colorScheme = ColorScheme.fromSeed(seedColor: Colors.red);
-    final ThemeData theme = ThemeData.from(colorScheme: colorScheme);
+    Widget buildButton({required bool? isEnabled, required VoidCallback? onPressed}) {
+      return MaterialApp(
+        home: Material(
+          child: ElevatedButton(
+            onPressed: onPressed,
+            isEnabled: isEnabled,
+            child: const Text('button'),
+          ),
+        ),
+      );
+    }
 
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: theme,
-        home: ElevatedButton(isEnabled: true, onPressed: () {}, child: const Text('button')),
-      ),
-    );
-
+    // isEnabled: true takes precedence over onPressed: null
+    await tester.pumpWidget(buildButton(isEnabled: true, onPressed: null));
     expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).enabled, isTrue);
 
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: theme,
-        home: ElevatedButton(isEnabled: false, onPressed: () {}, child: const Text('button')),
-      ),
-    );
+    // isEnabled: false takes precedence over onPressed: () {}
+    await tester.pumpWidget(buildButton(isEnabled: false, onPressed: () {}));
+    expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).enabled, isFalse);
+
+    // Fallback behavior when isEnabled is null
+    await tester.pumpWidget(buildButton(isEnabled: null, onPressed: () {}));
+    expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).enabled, isTrue);
+
+    await tester.pumpWidget(buildButton(isEnabled: null, onPressed: null));
     expect(tester.widget<ElevatedButton>(find.byType(ElevatedButton)).enabled, isFalse);
   });
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR adds an `isEnabled` parameter to `ButtonStyleButton` and all public `Button` widgets that extend it (e.g. `ElevatedButton`). 

The reason for this change is both a) convenience and b) expressiveness. Despite the many improvements Dart has made for more-expressive Flutter code, needing to use a ternary operator on `onPressed` is a verbose and confusing way of handling such simple and common functionality such as displaying a disabled Button.

Fixes:
- https://github.com/flutter/flutter/issues/58867
- https://github.com/flutter/flutter/issues/73700

No breaking changes have been introduced.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
