### PR TITLE
[ Tool ] Don't use .NET APIs in `update_engine_version.ps1`

### DIFF
--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -61,11 +61,11 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 }
 
 # Write the engine version out so downstream tools know what to look for.
-Set-Content -Path $flutterRoot/bin/cache/engine.stamp -Value $engineVersion -Encoding UTF8
+Set-Content -Path $flutterRoot/bin/cache/engine.stamp -Value $engineVersion -Encoding Ascii
 
 # The realm on CI is passed in.
 if ($Env:FLUTTER_REALM) {
-    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value $Env:FLUTTER_REALM -Encoding UTF8
+    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value $Env:FLUTTER_REALM -Encoding Ascii
 } else {
-    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value "" -Encoding UTF8
+    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value "" -Encoding Ascii
 }

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -61,12 +61,11 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 }
 
 # Write the engine version out so downstream tools know what to look for.
-$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-[System.IO.File]::WriteAllText("$flutterRoot/bin/cache/engine.stamp", $engineVersion, $utf8NoBom)
+Set-Content -Path $flutterRoot/bin/cache/engine.stamp -Value $engineVersion -Encoding UTF8
 
 # The realm on CI is passed in.
 if ($Env:FLUTTER_REALM) {
-    [System.IO.File]::WriteAllText("$flutterRoot/bin/cache/engine.realm", $Env:FLUTTER_REALM, $utf8NoBom)
+    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value $Env:FLUTTER_REALM -Encoding UTF8
 } else {
-    [System.IO.File]::WriteAllText("$flutterRoot/bin/cache/engine.realm", "", $utf8NoBom)
+    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value "" -Encoding UTF8
 }

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -64,8 +64,8 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 Set-Content -Path $flutterRoot/bin/cache/engine.stamp -Value $engineVersion -Encoding Ascii
 
 # The realm on CI is passed in.
-if ($Env:FLUTTER_REALM) {
-    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value $Env:FLUTTER_REALM -Encoding Ascii
+if ($env:FLUTTER_REALM) {
+    Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value $env:FLUTTER_REALM -Encoding Ascii
 } else {
     Set-Content -Path $flutterRoot/bin/cache/engine.realm -Value "" -Encoding Ascii
 }


### PR DESCRIPTION
Powershell instances running in `ConstrainedLanguage` mode can't always access .NET APIs due to system administrator security configurations, including gWindows VMs.

This change removes the use of `System.*` APIs from update_engine_version.ps1 in favor of dedicated Powershell APIs.

Fixes https://github.com/flutter/flutter/issues/172895