### PR TITLE
[ Widget Preview ] Add `--web-server` support

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -26,6 +26,7 @@ import '../project.dart';
 import '../resident_runner.dart';
 import '../runner/flutter_command.dart';
 import '../runner/flutter_command_runner.dart';
+import '../web/web_device.dart';
 import '../widget_preview/analytics.dart';
 import '../widget_preview/dependency_graph.dart';
 import '../widget_preview/dtd_services.dart';
@@ -138,6 +139,12 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     addPubOptions();
     argParser
       ..addFlag(
+        kWebServer,
+        help:
+            'Serve the widget preview environment using the web-server device instead of the '
+            'browser.',
+      )
+      ..addFlag(
         kLaunchPreviewer,
         defaultsTo: true,
         help: 'Launches the widget preview environment.',
@@ -150,12 +157,14 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
         help:
             'Generated the widget preview environment scaffolding at a given location '
             'for testing purposes.',
+        hide: !verbose,
       );
   }
 
   static const kWidgetPreviewScaffoldName = 'widget_preview_scaffold';
   static const kLaunchPreviewer = 'launch-previewer';
   static const kHeadless = 'headless';
+  static const kWebServer = 'web-server';
   static const kWidgetPreviewScaffoldOutputDir = 'scaffold-output-dir';
 
   /// Environment variable used to pass the DTD URI to the widget preview scaffold.
@@ -358,16 +367,23 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
 
   Future<int> runPreviewEnvironment({required FlutterProject widgetPreviewScaffoldProject}) async {
     try {
-      // Since the only target supported by the widget preview scaffold is the web
-      // device, only a single web device should be returned.
-      final List<Device> devices = await deviceManager!.getDevices(
-        filter: DeviceDiscoveryFilter(
-          supportFilter: DeviceDiscoverySupportFilter.excludeDevicesUnsupportedByFlutterOrProject(
-            flutterProject: widgetPreviewScaffoldProject,
+      final List<Device> devices;
+      if (boolArg(kWebServer)) {
+        // The web-server device is hidden by default, make it visible before trying to look it up.
+        WebServerDevice.showWebServerDevice = true;
+        devices = await deviceManager!.getDevicesById(WebServerDevice.kWebServerDeviceId);
+      } else {
+        // Since the only target supported by the widget preview scaffold is the web
+        // device, only a single web device should be returned.
+        devices = await deviceManager!.getDevices(
+          filter: DeviceDiscoveryFilter(
+            supportFilter: DeviceDiscoverySupportFilter.excludeDevicesUnsupportedByFlutterOrProject(
+              flutterProject: widgetPreviewScaffoldProject,
+            ),
+            deviceConnectionInterface: DeviceConnectionInterface.attached,
           ),
-          deviceConnectionInterface: DeviceConnectionInterface.attached,
-        ),
-      );
+        );
+      }
       assert(devices.length == 1);
       final Device device = devices.first;
 

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -369,9 +369,14 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     try {
       final List<Device> devices;
       if (boolArg(kWebServer)) {
-        // The web-server device is hidden by default, make it visible before trying to look it up.
-        WebServerDevice.showWebServerDevice = true;
-        devices = await deviceManager!.getDevicesById(WebServerDevice.kWebServerDeviceId);
+        try {
+          // The web-server device is hidden by default, make it visible before trying to look it up.
+          WebServerDevice.showWebServerDevice = true;
+          devices = await deviceManager!.getDevicesById(WebServerDevice.kWebServerDeviceId);
+        } finally {
+          // Reset the flag to false to avoid affecting other commands.
+          WebServerDevice.showWebServerDevice = false;
+        }
       } else {
         // Since the only target supported by the widget preview scaffold is the web
         // device, only a single web device should be returned.

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -26,6 +26,13 @@ const firstLaunchMessagesWeb = <String>[
   'Done loading previews.',
 ];
 
+const firstLaunchMessagesWebServer = <String>[
+  'Creating widget preview scaffolding at:',
+  'Launching the Widget Preview Scaffold...',
+  'lib/main.dart is being served at',
+  'Done loading previews.',
+];
+
 const subsequentLaunchMessagesWeb = <String>[
   'Launching the Widget Preview Scaffold...',
   'Done loading previews.',
@@ -53,7 +60,11 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  Future<void> runWidgetPreview({required List<String> expectedMessages, Uri? dtdUri}) async {
+  Future<void> runWidgetPreview({
+    required List<String> expectedMessages,
+    Uri? dtdUri,
+    bool useWebServer = false,
+  }) async {
     expect(expectedMessages, isNotEmpty);
     var i = 0;
     process = await processManager.start(<String>[
@@ -62,6 +73,7 @@ void main() {
       'start',
       '--verbose',
       '--${WidgetPreviewStartCommand.kHeadless}',
+      if (useWebServer) '--${WidgetPreviewStartCommand.kWebServer}',
       if (dtdUri != null) '--${FlutterGlobalOptions.kDtdUrl}=$dtdUri',
     ], workingDirectory: tempDir.path);
 
@@ -99,6 +111,10 @@ void main() {
   group('flutter widget-preview start', () {
     testWithoutContext('smoke test', () async {
       await runWidgetPreview(expectedMessages: firstLaunchMessagesWeb);
+    });
+
+    testWithoutContext('--web-server starts a web server instance', () async {
+      await runWidgetPreview(expectedMessages: firstLaunchMessagesWebServer, useWebServer: true);
     });
 
     testWithoutContext('does not recreate project on subsequent runs', () async {

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -29,7 +29,7 @@ const firstLaunchMessagesWeb = <String>[
 const firstLaunchMessagesWebServer = <String>[
   'Creating widget preview scaffolding at:',
   'Launching the Widget Preview Scaffold...',
-  'lib/main.dart is being served at',
+  'main.dart is being served at',
   'Done loading previews.',
 ];
 


### PR DESCRIPTION
This allows for the widget preview environment to be launched using the `web-server` device instead of just opening Chrome.