### PR TITLE
Migrate to list and builder Sliver convenience constructors

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/contacts_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/contacts_demo.dart
@@ -181,8 +181,8 @@ class ContactsDemoState extends State<ContactsDemo> {
                 ),
               ),
             ),
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            SliverList.list(
+              children: <Widget>[
                 AnnotatedRegion<SystemUiOverlayStyle>(
                   value: SystemUiOverlayStyle.dark,
                   child: _ContactCategory(
@@ -306,7 +306,7 @@ class ContactsDemoState extends State<ContactsDemo> {
                     _ContactItem(lines: const <String>['Last day in office', 'August 9th, 2018']),
                   ],
                 ),
-              ]),
+              ],
             ),
           ],
         ),

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -165,8 +165,9 @@ class CupertinoDemoTab1 extends StatelessWidget {
             padding: MediaQuery.of(
               context,
             ).removePadding(removeTop: true, removeLeft: true, removeRight: true).padding,
-            sliver: SliverList(
-              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            sliver: SliverList.builder(
+              itemCount: _kChildCount,
+              itemBuilder: (BuildContext context, int index) {
                 return Tab1RowItem(
                   index: index,
                   lastItem: index == _kChildCount - 1,
@@ -174,7 +175,7 @@ class CupertinoDemoTab1 extends StatelessWidget {
                   colorName: colorNameItems![index],
                   randomSeed: randomSeed,
                 );
-              }, childCount: _kChildCount),
+              },
             ),
           ),
         ],

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_refresh_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_refresh_demo.dart
@@ -71,15 +71,16 @@ class _CupertinoRefreshControlDemoState extends State<CupertinoRefreshControlDem
             ),
             SliverSafeArea(
               top: false, // Top safe area is consumed by the navigation bar.
-              sliver: SliverList(
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+              sliver: SliverList.builder(
+                itemCount: 20,
+                itemBuilder: (BuildContext context, int index) {
                   return _ListItem(
                     name: randomizedContacts[index][0],
                     place: randomizedContacts[index][1],
                     date: randomizedContacts[index][2],
                     called: randomizedContacts[index][3] == 'true',
                   );
-                }, childCount: 20),
+                },
               ),
             ),
           ],

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/tabs_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/tabs_demo.dart
@@ -174,15 +174,16 @@ class TabsDemo extends StatelessWidget {
                         ),
                         SliverPadding(
                           padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-                          sliver: SliverFixedExtentList(
+                          sliver: SliverFixedExtentList.builder(
                             itemExtent: _CardDataItem.height,
-                            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                            itemCount: _allPages[page]!.length,
+                            itemBuilder: (BuildContext context, int index) {
                               final _CardData data = _allPages[page]![index];
                               return Padding(
                                 padding: const EdgeInsets.symmetric(vertical: 8.0),
                                 child: _CardDataItem(page: page, data: data),
                               );
-                            }, childCount: _allPages[page]!.length),
+                            },
                           ),
                         ),
                       ],

--- a/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/pesto_demo.dart
@@ -138,13 +138,14 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
     );
     return SliverPadding(
       padding: padding,
-      sliver: SliverGrid(
+      sliver: SliverGrid.builder(
         gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
           maxCrossAxisExtent: _kRecipePageMaxWidth,
           crossAxisSpacing: 8.0,
           mainAxisSpacing: 8.0,
         ),
-        delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+        itemCount: widget.recipes!.length,
+        itemBuilder: (BuildContext context, int index) {
           final Recipe? recipe = widget.recipes![index];
           return RecipeCard(
             recipe: recipe,
@@ -152,7 +153,7 @@ class _RecipeGridPageState extends State<RecipeGridPage> {
               showRecipePage(context, recipe);
             },
           );
-        }, childCount: widget.recipes!.length),
+        },
       ),
     );
   }

--- a/dev/integration_tests/new_gallery/lib/demos/cupertino/cupertino_navigation_bar_demo.dart
+++ b/dev/integration_tests/new_gallery/lib/demos/cupertino/cupertino_navigation_bar_demo.dart
@@ -51,8 +51,9 @@ class _FirstPage extends StatelessWidget {
           const CupertinoSliverNavigationBar(automaticallyImplyLeading: false),
           SliverPadding(
             padding: MediaQuery.of(context).removePadding(removeTop: true).padding,
-            sliver: SliverList(
-              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            sliver: SliverList.builder(
+              itemCount: 20,
+              itemBuilder: (BuildContext context, int index) {
                 final String title = GalleryLocalizations.of(
                   context,
                 )!.starterAppDrawerItem(index + 1);
@@ -65,7 +66,7 @@ class _FirstPage extends StatelessWidget {
                   },
                   title: Text(title),
                 );
-              }, childCount: 20),
+              },
             ),
           ),
         ],

--- a/examples/api/lib/cupertino/refresh/cupertino_sliver_refresh_control.0.dart
+++ b/examples/api/lib/cupertino/refresh/cupertino_sliver_refresh_control.0.dart
@@ -57,11 +57,9 @@ class _RefreshControlExampleState extends State<RefreshControlExample> {
               });
             },
           ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate(
-              (BuildContext context, int index) => items[index],
-              childCount: items.length,
-            ),
+          SliverList.builder(
+            itemCount: items.length,
+            itemBuilder: (BuildContext context, int index) => items[index],
           ),
         ],
       ),

--- a/examples/api/lib/material/app_bar/sliver_app_bar.1.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.1.dart
@@ -52,14 +52,15 @@ class _SliverAppBarExampleState extends State<SliverAppBarExample> {
               child: Center(child: Text('Scroll to see the SliverAppBar in effect.')),
             ),
           ),
-          SliverList(
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+          SliverList.builder(
+            itemCount: 20,
+            itemBuilder: (BuildContext context, int index) {
               return Container(
                 color: index.isOdd ? Colors.white : Colors.black12,
                 height: 100.0,
                 child: Center(child: Text('$index', textScaler: const TextScaler.linear(5))),
               );
-            }, childCount: 20),
+            },
           ),
         ],
       ),

--- a/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.4.dart
@@ -43,14 +43,15 @@ class _StretchableSliverAppBarState extends State<StretchableSliverAppBar> {
                 background: FlutterLogo(),
               ),
             ),
-            SliverList(
-              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            SliverList.builder(
+              itemCount: 20,
+              itemBuilder: (BuildContext context, int index) {
                 return Container(
                   color: index.isOdd ? Colors.white : Colors.black12,
                   height: 100.0,
                   child: Center(child: Text('$index', textScaler: const TextScaler.linear(5.0))),
                 );
-              }, childCount: 20),
+              },
             ),
           ],
         ),

--- a/examples/api/lib/material/flexible_space_bar/flexible_space_bar.0.dart
+++ b/examples/api/lib/material/flexible_space_bar/flexible_space_bar.0.dart
@@ -57,8 +57,8 @@ class FlexibleSpaceBarExampleApp extends StatelessWidget {
                 ),
               ),
             ),
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
+            SliverList.list(
+              children: const <Widget>[
                 ListTile(
                   leading: Icon(Icons.wb_sunny),
                   title: Text('Sunday'),
@@ -70,7 +70,7 @@ class FlexibleSpaceBarExampleApp extends StatelessWidget {
                   subtitle: Text('sunny, h: 80, l: 65'),
                 ),
                 // ListTiles++
-              ]),
+              ],
             ),
           ],
         ),

--- a/examples/api/lib/widgets/implicit_animations/sliver_animated_opacity.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/sliver_animated_opacity.0.dart
@@ -50,11 +50,12 @@ class _SliverAnimatedOpacityExampleState extends State<SliverAnimatedOpacityExam
           opacity: _visible ? 1.0 : 0.0,
           duration: widget.duration,
           curve: widget.curve,
-          sliver: SliverFixedExtentList(
+          sliver: SliverFixedExtentList.builder(
             itemExtent: 100.0,
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            itemCount: 5,
+            itemBuilder: (BuildContext context, int index) {
               return Container(color: index.isEven ? Colors.indigo[200] : Colors.orange[200]);
-            }, childCount: 5),
+            },
           ),
         ),
         SliverToBoxAdapter(

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
@@ -94,23 +94,21 @@ class NestedScrollViewExample extends StatelessWidget {
                           // fixed-height list items, hence the use of
                           // SliverFixedExtentList. However, one could use any
                           // sliver widget here, e.g. SliverList or SliverGrid.
-                          sliver: SliverFixedExtentList(
+                          sliver: SliverFixedExtentList.builder(
                             // The items in this example are fixed to 48 pixels
                             // high. This matches the Material Design spec for
                             // ListTile widgets.
                             itemExtent: 48.0,
-                            delegate: SliverChildBuilderDelegate(
-                              (BuildContext context, int index) {
-                                // This builder is called for each child.
-                                // In this example, we just number each list item.
-                                return ListTile(title: Text('Item $index'));
-                              },
-                              // The childCount of the SliverChildBuilderDelegate
-                              // specifies how many children this inner list
-                              // has. In this example, each tab has a list of
-                              // exactly 30 items, but this is arbitrary.
-                              childCount: 30,
-                            ),
+                            // The itemCount of the SliverFixedExtentList.builder
+                            // specifies how many children this inner list
+                            // has. In this example, each tab has a list of
+                            // exactly 30 items, but this is arbitrary.
+                            itemCount: 30,
+                            itemBuilder: (BuildContext context, int index) {
+                              // This builder is called for each child.
+                              // In this example, we just number each list item.
+                              return ListTile(title: Text('Item $index'));
+                            },
                           ),
                         ),
                       ],

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.2.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.2.dart
@@ -49,12 +49,11 @@ class NestedScrollViewExample extends StatelessWidget {
                 SliverOverlapInjector(
                   handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                 ),
-                SliverFixedExtentList(
+                SliverFixedExtentList.builder(
                   itemExtent: 48.0,
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) => ListTile(title: Text('Item $index')),
-                    childCount: 30,
-                  ),
+                  itemCount: 30,
+                  itemBuilder: (BuildContext context, int index) =>
+                      ListTile(title: Text('Item $index')),
                 ),
               ],
             );

--- a/examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.0.dart
+++ b/examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.0.dart
@@ -91,14 +91,15 @@ class _ScrollEndNotificationExampleState extends State<ScrollEndNotificationExam
               child: CustomScrollView(
                 controller: scrollController,
                 slivers: <Widget>[
-                  SliverFixedExtentList(
+                  SliverFixedExtentList.builder(
                     itemExtent: itemExtent,
-                    delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    itemCount: itemCount,
+                    itemBuilder: (BuildContext context, int index) {
                       return Item(
                         title: 'Item $index',
                         color: Color.lerp(Colors.red, Colors.blue, index / itemCount)!,
                       );
-                    }, childCount: itemCount),
+                    },
                   ),
                 ],
               ),

--- a/examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.1.dart
+++ b/examples/api/lib/widgets/scroll_end_notification/scroll_end_notification.1.dart
@@ -165,8 +165,9 @@ class ItemList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+    return SliverList.builder(
+      itemCount: itemCount,
+      itemBuilder: (BuildContext context, int index) {
         return Card(
           color: colorScheme.onSecondary,
           child: SizedBox(
@@ -177,7 +178,7 @@ class ItemList extends StatelessWidget {
             ),
           ),
         );
-      }, childCount: itemCount),
+      },
     );
   }
 }

--- a/examples/api/lib/widgets/scroll_position/is_scrolling_listener.0.dart
+++ b/examples/api/lib/widgets/scroll_position/is_scrolling_listener.0.dart
@@ -100,14 +100,15 @@ class _IsScrollingListenerExampleState extends State<IsScrollingListenerExample>
             child: CustomScrollView(
               controller: scrollController,
               slivers: <Widget>[
-                SliverFixedExtentList(
+                SliverFixedExtentList.builder(
                   itemExtent: itemExtent,
-                  delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                  itemCount: itemCount,
+                  itemBuilder: (BuildContext context, int index) {
                     return Item(
                       title: 'Item $index',
                       color: Color.lerp(Colors.red, Colors.blue, index / itemCount)!,
                     );
-                  }, childCount: itemCount),
+                  },
                 ),
               ],
             ),

--- a/examples/api/lib/widgets/scroll_view/custom_scroll_view.1.dart
+++ b/examples/api/lib/widgets/scroll_view/custom_scroll_view.1.dart
@@ -47,26 +47,28 @@ class _CustomScrollViewExampleState extends State<CustomScrollViewExample> {
       body: CustomScrollView(
         center: centerKey,
         slivers: <Widget>[
-          SliverList(
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+          SliverList.builder(
+            itemCount: top.length,
+            itemBuilder: (BuildContext context, int index) {
               return Container(
                 alignment: Alignment.center,
                 color: Colors.blue[200 + top[index] % 4 * 100],
                 height: 100 + top[index] % 4 * 20.0,
                 child: Text('Item: ${top[index]}'),
               );
-            }, childCount: top.length),
+            },
           ),
-          SliverList(
+          SliverList.builder(
             key: centerKey,
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            itemCount: bottom.length,
+            itemBuilder: (BuildContext context, int index) {
               return Container(
                 alignment: Alignment.center,
                 color: Colors.blue[200 + bottom[index] % 4 * 100],
                 height: 100 + bottom[index] % 4 * 20.0,
                 child: Text('Item: ${bottom[index]}'),
               );
-            }, childCount: bottom.length),
+            },
           ),
         ],
       ),

--- a/examples/api/lib/widgets/sliver/decorated_sliver.0.dart
+++ b/examples/api/lib/widgets/sliver/decorated_sliver.0.dart
@@ -40,8 +40,8 @@ class SliverDecorationExample extends StatelessWidget {
               stops: <double>[0.4, 0.8],
             ),
           ),
-          sliver: SliverList(
-            delegate: SliverChildListDelegate(<Widget>[
+          sliver: SliverList.list(
+            children: <Widget>[
               SizedBox(
                 height: 200.0,
                 child: Center(
@@ -51,7 +51,7 @@ class SliverDecorationExample extends StatelessWidget {
                   ),
                 ),
               ),
-            ]),
+            ],
           ),
         ),
         DecoratedSliver(
@@ -72,8 +72,8 @@ class SliverDecorationExample extends StatelessWidget {
               ],
             ),
           ),
-          sliver: SliverList(
-            delegate: SliverChildListDelegate(<Widget>[
+          sliver: SliverList.list(
+            children: <Widget>[
               SizedBox(
                 height: 500.0,
                 child: Container(
@@ -82,7 +82,7 @@ class SliverDecorationExample extends StatelessWidget {
                   child: Text('A blue sky', style: Theme.of(context).textTheme.titleLarge),
                 ),
               ),
-            ]),
+            ],
           ),
         ),
       ],

--- a/examples/api/lib/widgets/sliver/pinned_header_sliver.0.dart
+++ b/examples/api/lib/widgets/sliver/pinned_header_sliver.0.dart
@@ -101,13 +101,14 @@ class ItemList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+    return SliverList.builder(
+      itemCount: itemCount,
+      itemBuilder: (BuildContext context, int index) {
         return Card(
           color: colorScheme.onSecondary,
           child: ListTile(textColor: colorScheme.secondary, title: Text('Item $index')),
         );
-      }, childCount: itemCount),
+      },
     );
   }
 }

--- a/examples/api/lib/widgets/sliver/pinned_header_sliver.1.dart
+++ b/examples/api/lib/widgets/sliver/pinned_header_sliver.1.dart
@@ -184,13 +184,14 @@ class ItemList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+    return SliverList.builder(
+      itemCount: itemCount,
+      itemBuilder: (BuildContext context, int index) {
         return Card(
           color: colorScheme.onSecondary,
           child: ListTile(textColor: colorScheme.secondary, title: Text('Item $index')),
         );
-      }, childCount: itemCount),
+      },
     );
   }
 }

--- a/examples/api/lib/widgets/sliver/sliver_floating_header.0.dart
+++ b/examples/api/lib/widgets/sliver/sliver_floating_header.0.dart
@@ -91,13 +91,14 @@ class ItemList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+    return SliverList.builder(
+      itemCount: itemCount,
+      itemBuilder: (BuildContext context, int index) {
         return Card(
           color: colorScheme.onSecondary,
           child: ListTile(textColor: colorScheme.secondary, title: Text('Item $index')),
         );
-      }, childCount: itemCount),
+      },
     );
   }
 }

--- a/examples/api/lib/widgets/sliver/sliver_resizing_header.0.dart
+++ b/examples/api/lib/widgets/sliver/sliver_resizing_header.0.dart
@@ -108,13 +108,14 @@ class ItemList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colorScheme = Theme.of(context).colorScheme;
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+    return SliverList.builder(
+      itemCount: itemCount,
+      itemBuilder: (BuildContext context, int index) {
         return Card(
           color: colorScheme.onSecondary,
           child: ListTile(textColor: colorScheme.secondary, title: Text('Item $index')),
         );
-      }, childCount: itemCount),
+      },
     );
   }
 }

--- a/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.1.dart
+++ b/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.1.dart
@@ -29,11 +29,12 @@ class SliverFillRemainingExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return CustomScrollView(
       slivers: <Widget>[
-        SliverFixedExtentList(
+        SliverFixedExtentList.builder(
           itemExtent: 100.0,
-          delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+          itemCount: 3,
+          itemBuilder: (BuildContext context, int index) {
             return Container(color: index.isEven ? Colors.amber[200] : Colors.blue[200]);
-          }, childCount: 3),
+          },
         ),
         SliverFillRemaining(
           hasScrollBody: false,

--- a/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.2.dart
+++ b/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.2.dart
@@ -29,11 +29,12 @@ class SliverFillRemainingExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return CustomScrollView(
       slivers: <Widget>[
-        SliverFixedExtentList(
+        SliverFixedExtentList.builder(
           itemExtent: 130.0,
-          delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+          itemCount: 5,
+          itemBuilder: (BuildContext context, int index) {
             return Container(color: index.isEven ? Colors.indigo[200] : Colors.orange[200]);
-          }, childCount: 5),
+          },
         ),
         const SliverFillRemaining(
           hasScrollBody: false,

--- a/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
@@ -65,11 +65,12 @@ class _SliverFadeTransitionExampleState extends State<SliverFadeTransitionExampl
       slivers: <Widget>[
         SliverFadeTransition(
           opacity: animation,
-          sliver: SliverFixedExtentList(
+          sliver: SliverFixedExtentList.builder(
             itemExtent: 100.0,
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            itemCount: 5,
+            itemBuilder: (BuildContext context, int index) {
               return Container(color: index.isEven ? Colors.indigo[200] : Colors.orange[200]);
-            }, childCount: 5),
+            },
           ),
         ),
       ],

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -1129,15 +1129,15 @@ class _PackageLicensePageState extends State<_PackageLicensePage> {
           ),
           SliverPadding(
             padding: padding,
-            sliver: SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) => Localizations.override(
+            sliver: SliverList.builder(
+              itemCount: listWidgets.length,
+              itemBuilder: (BuildContext context, int index) {
+                return Localizations.override(
                   locale: const Locale('en', 'US'),
                   context: context,
                   child: listWidgets[index],
-                ),
-                childCount: listWidgets.length,
-              ),
+                );
+              },
             ),
           ),
         ],

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1520,7 +1520,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///
 ///
 /// {@tool dartpad}
-/// This sample shows a [SliverAppBar] and it's behavior when using the
+/// This sample shows a [SliverAppBar] and its behavior when using the
 /// [pinned], [snap] and [floating] parameters.
 ///
 /// ** See code in examples/api/lib/material/app_bar/sliver_app_bar.1.dart **

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2139,18 +2139,16 @@ class _CalendarDateRangePickerState extends State<_CalendarDateRangePicker> {
               controller: _controller,
               center: _sliverAfterKey,
               slivers: <Widget>[
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) => _buildMonthItem(context, index, true),
-                    childCount: _initialMonthIndex,
-                  ),
+                SliverList.builder(
+                  itemCount: _initialMonthIndex,
+                  itemBuilder: (BuildContext context, int index) =>
+                      _buildMonthItem(context, index, true),
                 ),
-                SliverList(
+                SliverList.builder(
                   key: _sliverAfterKey,
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) => _buildMonthItem(context, index, false),
-                    childCount: _numberOfMonths - _initialMonthIndex,
-                  ),
+                  itemCount: _numberOfMonths - _initialMonthIndex,
+                  itemBuilder: (BuildContext context, int index) =>
+                      _buildMonthItem(context, index, false),
                 ),
               ],
             ),

--- a/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
+++ b/packages/flutter/lib/src/widgets/automatic_keep_alive.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+/// @docImport 'scroll_delegate.dart';
 /// @docImport 'scroll_view.dart';
 library;
 

--- a/packages/flutter/lib/src/widgets/pinned_header_sliver.dart
+++ b/packages/flutter/lib/src/widgets/pinned_header_sliver.dart
@@ -31,7 +31,7 @@ import 'framework.dart';
 ///
 /// {@tool dartpad}
 /// A more elaborate example which creates an app bar that's similar to the one
-/// that appears in the iOS Settings app. In this example the pinned header
+/// that appears in the iOS Settings app. In this example, the pinned header
 /// starts out transparent and the first item in the list serves as the app's
 /// "Settings" title. When the title item has been scrolled completely behind
 /// the pinned header, the header animates its opacity from 0 to 1 and its

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -677,23 +677,21 @@ class SliverVariedExtentList extends SliverMultiBoxAdaptorWidget {
 /// list, shows twenty boxes in a pretty teal grid:
 ///
 /// ```dart
-/// SliverGrid(
+/// SliverGrid.builder(
 ///   gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
 ///     maxCrossAxisExtent: 200.0,
 ///     mainAxisSpacing: 10.0,
 ///     crossAxisSpacing: 10.0,
 ///     childAspectRatio: 4.0,
 ///   ),
-///   delegate: SliverChildBuilderDelegate(
-///     (BuildContext context, int index) {
-///       return Container(
-///         alignment: Alignment.center,
-///         color: Colors.teal[100 * (index % 9)],
-///         child: Text('grid item $index'),
-///       );
-///     },
-///     childCount: 20,
-///   ),
+///   itemCount: 20,
+///   itemBuilder: (BuildContext context, int index) {
+///     return Container(
+///       alignment: Alignment.center,
+///       color: Colors.teal[100 * (index % 9)],
+///       child: Text('grid item $index'),
+///     );
+///   },
 /// )
 /// ```
 /// {@end-tool}

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -21,10 +21,11 @@ void main() {
 
   int testListLength = 10;
   SliverList buildAListOfStuff() {
-    return SliverList(
-      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+    return SliverList.builder(
+      itemCount: testListLength,
+      itemBuilder: (BuildContext context, int index) {
         return SizedBox(height: 200.0, child: Center(child: Text(index.toString())));
-      }, childCount: testListLength),
+      },
     );
   }
 
@@ -1824,11 +1825,9 @@ void main() {
           physics: const BouncingScrollPhysics(),
           slivers: <Widget>[
             const CupertinoSliverRefreshControl(),
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) => const SizedBox(height: 100),
-                childCount: 20,
-              ),
+            SliverList.builder(
+              itemCount: 20,
+              itemBuilder: (BuildContext context, int index) => const SizedBox(height: 100),
             ),
           ],
         ),

--- a/packages/flutter/test/gestures/gesture_config_regression_test.dart
+++ b/packages/flutter/test/gestures/gesture_config_regression_test.dart
@@ -23,9 +23,9 @@ class NestedScrollableCase extends StatelessWidget {
     return Scaffold(
       body: CustomScrollView(
         slivers: <Widget>[
-          SliverFixedExtentList(
+          SliverFixedExtentList.builder(
             itemExtent: 50.0,
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            itemBuilder: (BuildContext context, int index) {
               return Container(
                 alignment: Alignment.center,
                 child: GestureDetector(
@@ -40,7 +40,7 @@ class NestedScrollableCase extends StatelessWidget {
                   child: Text('List Item $index', key: ValueKey<int>(index)),
                 ),
               );
-            }),
+            },
           ),
         ],
       ),
@@ -58,9 +58,9 @@ class NestedDraggableCase extends StatelessWidget {
     return Scaffold(
       body: CustomScrollView(
         slivers: <Widget>[
-          SliverFixedExtentList(
+          SliverFixedExtentList.builder(
             itemExtent: 50.0,
-            delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            itemBuilder: (BuildContext context, int index) {
               return Container(
                 alignment: Alignment.center,
                 child: Draggable<Object>(
@@ -78,7 +78,7 @@ class NestedDraggableCase extends StatelessWidget {
                   },
                 ),
               );
-            }),
+            },
           ),
         ],
       ),

--- a/packages/flutter/test/material/app_bar_sliver_test.dart
+++ b/packages/flutter/test/material/app_bar_sliver_test.dart
@@ -849,10 +849,8 @@ void main() {
                     ? const FlexibleSpaceBar(title: Text('SliverAppBar'))
                     : null,
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  Container(height: contentHeight, color: Colors.teal),
-                ]),
+              SliverList.list(
+                children: <Widget>[Container(height: contentHeight, color: Colors.teal)],
               ),
             ],
           ),
@@ -1554,8 +1552,9 @@ void main() {
                   forceMaterialTransparency: forceMaterialTransparency,
                   title: const Text('AppBar'),
                 ),
-                SliverList(
-                  delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                SliverList.builder(
+                  itemCount: 20,
+                  itemBuilder: (BuildContext context, int index) {
                     return SizedBox(
                       height: appBarHeight,
                       child: index == 0
@@ -1565,7 +1564,7 @@ void main() {
                             )
                           : const SizedBox(),
                     );
-                  }, childCount: 20),
+                  },
                 ),
               ],
             ),
@@ -2038,10 +2037,8 @@ void main() {
                       background: Container(height: appBarHeight, color: Colors.orange),
                     ),
                   ),
-                  SliverList(
-                    delegate: SliverChildListDelegate(<Widget>[
-                      Container(height: 1200.0, color: Colors.teal),
-                    ]),
+                  SliverList.list(
+                    children: <Widget>[Container(height: 1200.0, color: Colors.teal)],
                   ),
                 ],
               ),

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -246,11 +246,11 @@ void main() {
                 title: Text('Title'),
                 flexibleSpace: FlexibleSpaceBar(background: Text('Expanded title')),
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  for (int i = 0; i < 50; i++)
-                    SizedBox(height: 200, child: Center(child: Text('Item $i'))),
-                ]),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                },
               ),
             ],
           ),
@@ -512,11 +512,11 @@ void main() {
                 title: Text('Title'),
                 flexibleSpace: FlexibleSpaceBar(background: Text('Expanded title')),
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  for (int i = 0; i < 50; i++)
-                    SizedBox(height: 200, child: Center(child: Text('Item $i'))),
-                ]),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                },
               ),
             ],
           ),
@@ -893,11 +893,11 @@ void main() {
                     centerTitle: false,
                   ),
                 ),
-                SliverList(
-                  delegate: SliverChildListDelegate(<Widget>[
-                    for (int i = 0; i < 3; i++)
-                      SizedBox(height: 200.0, child: Center(child: Text('Item $i'))),
-                  ]),
+                SliverList.builder(
+                  itemCount: 50,
+                  itemBuilder: (BuildContext context, int index) {
+                    return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                  },
                 ),
               ],
             ),
@@ -963,11 +963,11 @@ void main() {
                     centerTitle: false,
                   ),
                 ),
-                SliverList(
-                  delegate: SliverChildListDelegate(<Widget>[
-                    for (int i = 0; i < 3; i++)
-                      SizedBox(height: 200.0, child: Center(child: Text('Item $i'))),
-                  ]),
+                SliverList.builder(
+                  itemCount: 50,
+                  itemBuilder: (BuildContext context, int index) {
+                    return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                  },
                 ),
               ],
             ),
@@ -1024,11 +1024,11 @@ void main() {
                   ),
                 ),
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  for (int i = 0; i < 3; i += 1)
-                    SizedBox(height: 200.0, child: Center(child: Text('Item $i'))),
-                ]),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                },
               ),
             ],
           ),
@@ -1079,11 +1079,11 @@ void main() {
                   ),
                 ),
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  for (int i = 0; i < 3; i += 1)
-                    SizedBox(height: 200.0, child: Center(child: Text('Item $i'))),
-                ]),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                },
               ),
             ],
           ),
@@ -1137,11 +1137,11 @@ void main() {
                   ),
                 ),
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  for (int i = 0; i < 3; i += 1)
-                    SizedBox(height: 200.0, child: Center(child: Text('Item $i'))),
-                ]),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                },
               ),
             ],
           ),
@@ -1197,11 +1197,11 @@ void main() {
                   ),
                 ),
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  for (int i = 0; i < 3; i += 1)
-                    SizedBox(height: 200.0, child: Center(child: Text('Item $i'))),
-                ]),
+              SliverList.builder(
+                itemCount: 50,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                },
               ),
             ],
           ),

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -894,9 +894,9 @@ void main() {
                   ),
                 ),
                 SliverList.builder(
-                  itemCount: 50,
+                  itemCount: 3,
                   itemBuilder: (BuildContext context, int index) {
-                    return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                    return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
                   },
                 ),
               ],
@@ -964,9 +964,9 @@ void main() {
                   ),
                 ),
                 SliverList.builder(
-                  itemCount: 50,
+                  itemCount: 3,
                   itemBuilder: (BuildContext context, int index) {
-                    return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                    return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
                   },
                 ),
               ],
@@ -1025,9 +1025,9 @@ void main() {
                 ),
               ),
               SliverList.builder(
-                itemCount: 50,
+                itemCount: 3,
                 itemBuilder: (BuildContext context, int index) {
-                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
                 },
               ),
             ],
@@ -1080,9 +1080,9 @@ void main() {
                 ),
               ),
               SliverList.builder(
-                itemCount: 50,
+                itemCount: 3,
                 itemBuilder: (BuildContext context, int index) {
-                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
                 },
               ),
             ],
@@ -1138,9 +1138,9 @@ void main() {
                 ),
               ),
               SliverList.builder(
-                itemCount: 50,
+                itemCount: 3,
                 itemBuilder: (BuildContext context, int index) {
-                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
                 },
               ),
             ],
@@ -1198,9 +1198,9 @@ void main() {
                 ),
               ),
               SliverList.builder(
-                itemCount: 50,
+                itemCount: 3,
                 itemBuilder: (BuildContext context, int index) {
-                  return SizedBox(height: 200, child: Center(child: Text('Item $index')));
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
                 },
               ),
             ],

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -543,13 +543,11 @@ void main() {
               ),
               SliverPadding(
                 padding: const EdgeInsets.only(top: appBarHeight),
-                sliver: SliverList(
-                  delegate: SliverChildListDelegate(
-                    List<Widget>.generate(
-                      10,
-                      (int index) => SizedBox(height: 100.0, child: Text('B$index')),
-                    ),
-                  ),
+                sliver: SliverList.builder(
+                  itemCount: 10,
+                  itemBuilder: (BuildContext context, int index) {
+                    return SizedBox(height: 100.0, child: Text('B$index'));
+                  },
                 ),
               ),
             ],
@@ -586,13 +584,11 @@ void main() {
             primary: true,
             slivers: <Widget>[
               const SliverAppBar(title: Text('Title')),
-              SliverList(
-                delegate: SliverChildListDelegate(
-                  List<Widget>.generate(
-                    20,
-                    (int index) => SizedBox(height: 100.0, child: Text('$index')),
-                  ),
-                ),
+              SliverList.builder(
+                itemCount: 20,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 100.0, child: Text('$index'));
+                },
               ),
             ],
           ),

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -837,30 +837,21 @@ void main() {
             center: centerKey,
             reverse: true,
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildListDelegate(
-                  List<Widget>.generate(
-                    10,
-                    (int index) => SizedBox(height: itemHeight, child: Text('Item ${-index - 1}')),
-                  ),
-                ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: itemHeight, child: Text('Item ${-index - 1}'));
+                },
               ),
-              SliverList(
+              SliverList.list(
                 key: centerKey,
-                delegate: SliverChildListDelegate(
-                  List<Widget>.generate(
-                    1,
-                    (int index) => const SizedBox(height: itemHeight, child: Text('Item 0')),
-                  ),
-                ),
+                children: const <Widget>[SizedBox(height: itemHeight, child: Text('Item 0'))],
               ),
-              SliverList(
-                delegate: SliverChildListDelegate(
-                  List<Widget>.generate(
-                    10,
-                    (int index) => SizedBox(height: itemHeight, child: Text('Item ${index + 1}')),
-                  ),
-                ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: itemHeight, child: Text('Item ${index + 1}'));
+                },
               ),
             ],
           ),

--- a/packages/flutter/test/widgets/animated_grid_test.dart
+++ b/packages/flutter/test/widgets/animated_grid_test.dart
@@ -431,11 +431,8 @@ void main() {
           textDirection: TextDirection.ltr,
           child: CustomScrollView(
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  const SizedBox(height: 100),
-                  const SizedBox(height: 100),
-                ]),
+              SliverList.list(
+                children: const <Widget>[SizedBox(height: 100), SizedBox(height: 100)],
               ),
               SliverAnimatedGrid(
                 key: listKey,

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -398,11 +398,8 @@ void main() {
           textDirection: TextDirection.ltr,
           child: CustomScrollView(
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildListDelegate(<Widget>[
-                  const SizedBox(height: 100),
-                  const SizedBox(height: 100),
-                ]),
+              SliverList.list(
+                children: const <Widget>[SizedBox(height: 100), SizedBox(height: 100)],
               ),
               SliverAnimatedList(
                 key: listKey,

--- a/packages/flutter/test/widgets/box_sliver_mismatch_test.dart
+++ b/packages/flutter/test/widgets/box_sliver_mismatch_test.dart
@@ -16,15 +16,13 @@ void main() {
       await tester.pumpWidget(
         DecoratedBox(
           decoration: const BoxDecoration(),
-          child: SliverList(delegate: SliverChildListDelegate(const <Widget>[])),
+          child: SliverList.list(children: const <Widget>[]),
         ),
       );
 
       expect(tester.takeException(), isFlutterError);
 
-      await tester.pumpWidget(
-        Row(children: <Widget>[SliverList(delegate: SliverChildListDelegate(const <Widget>[]))]),
-      );
+      await tester.pumpWidget(Row(children: <Widget>[SliverList.list(children: const <Widget>[])]));
 
       expect(tester.takeException(), isFlutterError);
     },

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1121,9 +1121,7 @@ void main() {
             child: CustomScrollView(
               controller: scrollController,
               slivers: <Widget>[
-                SliverList(
-                  delegate: SliverChildListDelegate(<Widget>[Text('child', key: GlobalKey())]),
-                ),
+                SliverList.list(children: <Widget>[Text('child', key: GlobalKey())]),
               ],
             ),
           ),

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -998,25 +998,23 @@ void main() {
                                   // SliverFixedExtentList. However, one could use any
                                   // sliver widget here, e.g. SliverList or
                                   // SliverGrid.
-                                  sliver: SliverFixedExtentList(
+                                  sliver: SliverFixedExtentList.builder(
                                     // The items in this example are fixed to 48
                                     // pixels high. This matches the Material Design
                                     // spec for ListTile widgets.
                                     itemExtent: 48.0,
-                                    delegate: SliverChildBuilderDelegate(
-                                      (BuildContext context, int index) {
-                                        // This builder is called for each child.
-                                        // In this example, we just number each list
-                                        // item.
-                                        return ListTile(title: Text('Item $index'));
-                                      },
-                                      // The childCount of the
-                                      // SliverChildBuilderDelegate specifies how many
-                                      // children this inner list has. In this
-                                      // example, each tab has a list of exactly 30
-                                      // items, but this is arbitrary.
-                                      childCount: 30,
-                                    ),
+                                    // The itemCount of the
+                                    // SliverFixedExtentList.builder specifies
+                                    // how many children this inner list has. In
+                                    // this example, each tab has a list of exactly
+                                    // 30 items, but this is arbitrary.
+                                    itemCount: 30,
+                                    itemBuilder: (BuildContext context, int index) {
+                                      // This builder is called for each child.
+                                      // In this example, we just number each list
+                                      // item.
+                                      return ListTile(title: Text('Item $index'));
+                                    },
                                   ),
                                 ),
                               ],
@@ -1670,12 +1668,11 @@ void main() {
                     SliverOverlapInjector(
                       handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     ),
-                    SliverFixedExtentList(
+                    SliverFixedExtentList.builder(
                       itemExtent: 50.0,
-                      delegate: SliverChildBuilderDelegate(
-                        (BuildContext context, int index) => ListTile(title: Text('Item $index')),
-                        childCount: 30,
-                      ),
+                      itemCount: 30,
+                      itemBuilder: (BuildContext context, int index) =>
+                          ListTile(title: Text('Item $index')),
                     ),
                   ],
                 );
@@ -2633,10 +2630,11 @@ void main() {
                 },
                 body: CustomScrollView(
                   slivers: <Widget>[
-                    SliverList(
-                      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    SliverList.builder(
+                      itemCount: 10,
+                      itemBuilder: (BuildContext context, int index) {
                         return const Text('');
-                      }, childCount: 10),
+                      },
                     ),
                   ],
                 ),
@@ -2715,11 +2713,12 @@ void main() {
               slivers: <Widget>[
                 SliverPadding(
                   padding: const EdgeInsets.all(8.0),
-                  sliver: SliverFixedExtentList(
+                  sliver: SliverFixedExtentList.builder(
                     itemExtent: 48.0,
-                    delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    itemCount: 30,
+                    itemBuilder: (BuildContext context, int index) {
                       return ListTile(title: Text('Item $index'));
-                    }, childCount: 30),
+                    },
                   ),
                 ),
               ],
@@ -2770,11 +2769,12 @@ void main() {
                 slivers: <Widget>[
                   SliverPadding(
                     padding: const EdgeInsets.all(8.0),
-                    sliver: SliverFixedExtentList(
+                    sliver: SliverFixedExtentListbuilder(
                       itemExtent: 48.0,
-                      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                      itemCount: 30,
+                      itemBuilder: (BuildContext context, int index) {
                         return ListTile(title: Text('Item $index'));
-                      }, childCount: 30),
+                      },
                     ),
                   ),
                 ],
@@ -2823,12 +2823,11 @@ void main() {
                     SliverOverlapInjector(
                       handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     ),
-                    SliverFixedExtentList(
+                    SliverFixedExtentList.builder(
                       itemExtent: 50.0,
-                      delegate: SliverChildBuilderDelegate(
-                        (BuildContext context, int index) => ListTile(title: Text('Item $index')),
-                        childCount: 30,
-                      ),
+                      itemCount: 30,
+                      itemBuilder: (BuildContext context, int index) =>
+                          ListTile(title: Text('Item $index')),
                     ),
                   ],
                 );
@@ -2912,12 +2911,11 @@ void main() {
                     SliverOverlapInjector(
                       handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     ),
-                    SliverFixedExtentList(
+                    SliverFixedExtentList.builder(
                       itemExtent: 50.0,
-                      delegate: SliverChildBuilderDelegate(
-                        (BuildContext context, int index) => ListTile(title: Text('Item $index')),
-                        childCount: 30,
-                      ),
+                      itemCount: 30,
+                      itemBuilder: (BuildContext context, int index) =>
+                          ListTile(title: Text('Item $index')),
                     ),
                   ],
                 );
@@ -3321,13 +3319,11 @@ void main() {
                 ),
                 SliverPadding(
                   padding: const EdgeInsets.all(8.0),
-                  sliver: SliverList(
-                    delegate: SliverChildBuilderDelegate(childCount: 30, (
-                      BuildContext context,
-                      int index,
-                    ) {
+                  sliver: SliverList.builder(
+                    itemCount: 30,
+                    itemBuilder: (BuildContext context, int index) {
                       return ListTile(title: Text('Item $index'));
-                    }),
+                    },
                   ),
                 ),
               ],

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -2769,7 +2769,7 @@ void main() {
                 slivers: <Widget>[
                   SliverPadding(
                     padding: const EdgeInsets.all(8.0),
-                    sliver: SliverFixedExtentListbuilder(
+                    sliver: SliverFixedExtentList.builder(
                       itemExtent: 48.0,
                       itemCount: 30,
                       itemBuilder: (BuildContext context, int index) {

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -431,18 +431,14 @@ void main() {
             center: centerKey,
             physics: const AlwaysScrollableScrollPhysics(),
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('First sliver $index'),
-                  childCount: 2,
-                ),
+              SliverList.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) => Text('First sliver $index'),
               ),
-              SliverList(
+              SliverList.builder(
                 key: centerKey,
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Second sliver $index'),
-                  childCount: 5,
-                ),
+                itemCount: 5,
+                itemBuilder: (BuildContext context, int index) => Text('Second sliver $index'),
               ),
             ],
           ),
@@ -486,18 +482,14 @@ void main() {
                 center: centerKey,
                 physics: const AlwaysScrollableScrollPhysics(),
                 slivers: <Widget>[
-                  SliverList(
-                    delegate: SliverChildBuilderDelegate(
-                      (BuildContext context, int index) => Text('First sliver $index'),
-                      childCount: 2,
-                    ),
+                  SliverList.builder(
+                    itemCount: 2,
+                    itemBuilder: (BuildContext context, int index) => Text('First sliver $index'),
                   ),
-                  SliverList(
+                  SliverList.builder(
                     key: centerKey,
-                    delegate: SliverChildBuilderDelegate(
-                      (BuildContext context, int index) => Text('Second sliver $index'),
-                      childCount: 5,
-                    ),
+                    itemCount: 5,
+                    itemBuilder: (BuildContext context, int index) => Text('Second sliver $index'),
                   ),
                 ],
               ),

--- a/packages/flutter/test/widgets/pinned_header_sliver_test.dart
+++ b/packages/flutter/test/widgets/pinned_header_sliver_test.dart
@@ -15,11 +15,9 @@ void main() {
             reverse: reverse,
             slivers: <Widget>[
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver')),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Item $index'),
-                  childCount: 100,
-                ),
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
               ),
             ],
           ),
@@ -156,11 +154,9 @@ void main() {
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 0')),
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 1')),
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 2')),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Item $index'),
-                  childCount: 100,
-                ),
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
               ),
             ],
           ),
@@ -189,32 +185,24 @@ void main() {
         home: Scaffold(
           body: CustomScrollView(
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Item 0.$index'),
-                  childCount: 2,
-                ),
+              SliverList.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) => Text('Item 0.$index'),
               ),
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 0')),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Item 1.$index'),
-                  childCount: 2,
-                ),
+              SliverList.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) => Text('Item 1.$index'),
               ),
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 1')),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Item 2.$index'),
-                  childCount: 2,
-                ),
+              SliverList.builder(
+                itemCount: 2,
+                itemBuilder: (BuildContext context, int index) => Text('Item 2.$index'),
               ),
               const PinnedHeaderSliver(child: Text('PinnedHeaderSliver 2')),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('Item $index'),
-                  childCount: 100,
-                ),
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) => Text('Item $index'),
               ),
             ],
           ),

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -307,9 +307,9 @@ void main() {
           builder: (BuildContext outerContext, StateSetter setState) {
             return CustomScrollView(
               slivers: <Widget>[
-                SliverFixedExtentList(
+                SliverFixedExtentList.list(
                   itemExtent: 50.0,
-                  delegate: SliverChildListDelegate(<Widget>[const Text('before')]),
+                  children: const <Widget>[Text('before')],
                 ),
                 SliverReorderableList(
                   itemCount: 0,
@@ -325,9 +325,9 @@ void main() {
                     return SizedBox(height: 100, child: Text('item ${items[index]}'));
                   },
                 ),
-                SliverFixedExtentList(
+                SliverFixedExtentList.list(
                   itemExtent: 50.0,
-                  delegate: SliverChildListDelegate(<Widget>[const Text('after')]),
+                  children: const <Widget>[Text('after')],
                 ),
               ],
             );

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -897,22 +897,20 @@ void main() {
         child: CustomScrollView(
           dragStartBehavior: DragStartBehavior.down,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(
-                kStates.map<Widget>((String state) {
-                  return GestureDetector(
-                    dragStartBehavior: DragStartBehavior.down,
-                    onTap: () {
-                      log.add(state);
-                    },
-                    child: Container(
-                      height: 200.0,
-                      color: const Color(0xFF0000FF),
-                      child: Text(state),
-                    ),
-                  );
-                }).toList(),
-              ),
+            SliverList.list(
+              children: kStates.map<Widget>((String state) {
+                return GestureDetector(
+                  dragStartBehavior: DragStartBehavior.down,
+                  onTap: () {
+                    log.add(state);
+                  },
+                  child: Container(
+                    height: 200.0,
+                    color: const Color(0xFF0000FF),
+                    child: Text(state),
+                  ),
+                );
+              }).toList(),
             ),
           ],
         ),
@@ -950,19 +948,17 @@ void main() {
           dragStartBehavior: DragStartBehavior.down,
           keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(
-                focusNodes.map((FocusNode focusNode) {
-                  return Container(
-                    height: 50,
-                    color: Colors.green,
-                    child: TextField(
-                      focusNode: focusNode,
-                      style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-                    ),
-                  );
-                }).toList(),
-              ),
+            SliverList.list(
+              children: focusNodes.map((FocusNode focusNode) {
+                return Container(
+                  height: 50,
+                  color: Colors.green,
+                  child: TextField(
+                    focusNode: focusNode,
+                    style: const TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+                  ),
+                );
+              }).toList(),
             ),
           ],
         ),

--- a/packages/flutter/test/widgets/scrollable_restoration_test.dart
+++ b/packages/flutter/test/widgets/scrollable_restoration_test.dart
@@ -14,13 +14,11 @@ void main() {
           restorationId: 'list',
           cacheExtent: 0,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(
-                List<Widget>.generate(
-                  50,
-                  (int index) => SizedBox(height: 50, child: Text('Tile $index')),
-                ),
-              ),
+            SliverList.builder(
+              itemCount: 50,
+              itemBuilder: (BuildContext context, int index) {
+                return SizedBox(height: 50, child: Text('Tile $index'));
+              },
             ),
           ],
         ),

--- a/packages/flutter/test/widgets/scrollable_semantics_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_test.dart
@@ -268,7 +268,7 @@ void main() {
                       expandedHeight: kExpandedAppBarHeight,
                       flexibleSpace: FlexibleSpaceBar(title: Text('App Bar')),
                     ),
-                    SliverList(delegate: SliverChildListDelegate(containers)),
+                    SliverList.list(children: containers),
                   ],
                 );
               },

--- a/packages/flutter/test/widgets/scrollable_semantics_traversal_order_test.dart
+++ b/packages/flutter/test/widgets/scrollable_semantics_traversal_order_test.dart
@@ -37,7 +37,7 @@ void main() {
             child: CustomScrollView(
               controller: controller,
               semanticChildCount: 30,
-              slivers: <Widget>[SliverList(delegate: SliverChildListDelegate(listChildren))],
+              slivers: <Widget>[SliverList.list(children: listChildren)],
             ),
           ),
         ),
@@ -187,9 +187,10 @@ void main() {
             child: CustomScrollView(
               controller: controller,
               slivers: <Widget>[
-                SliverFixedExtentList(
+                SliverFixedExtentList.list(
                   itemExtent: 200.0,
-                  delegate: SliverChildListDelegate(listChildren, addSemanticIndexes: false),
+                  addSemanticIndexes: false,
+                  children: listChildren,
                 ),
               ],
             ),

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2726,8 +2726,9 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                 child: CustomScrollView(
                   controller: scrollController,
                   slivers: <Widget>[
-                    SliverList(
-                      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    SliverList.builder(
+                      itemCount: 100,
+                      builder: (BuildContext context, int index) {
                         final double height;
                         if (index < 10) {
                           height = 100;
@@ -2735,7 +2736,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                           height = 500;
                         }
                         return SizedBox(height: height, child: Text('$index'));
-                      }, childCount: 100),
+                      },
                     ),
                   ],
                 ),
@@ -2794,8 +2795,9 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
               child: CustomScrollView(
                 controller: scrollController,
                 slivers: <Widget>[
-                  SliverList(
-                    delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                  SliverList.builder(
+                    itemCount: 100,
+                    itemBuilder: (BuildContext context, int index) {
                       final double height;
                       if (index < 10) {
                         height = 500;
@@ -2803,7 +2805,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                         height = 100;
                       }
                       return SizedBox(height: height, child: Text('$index'));
-                    }, childCount: 100),
+                    },
                   ),
                 ],
               ),
@@ -2907,14 +2909,15 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                   controller: scrollController,
                   reverse: reverse,
                   slivers: <Widget>[
-                    SliverList(
-                      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    SliverList.builder(
+                      itemCount: 10,
+                      itemBuilder: (BuildContext context, int index) {
                         return Container(
                           height: 100,
                           alignment: Alignment.center,
                           child: Text('$index'),
                         );
-                      }, childCount: 10),
+                      },
                     ),
                   ],
                 ),
@@ -3055,14 +3058,15 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                   reverse: reverse,
                   scrollDirection: Axis.horizontal,
                   slivers: <Widget>[
-                    SliverList(
-                      delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                    SliverList.builder(
+                      itemCount: 10,
+                      itemBuilder: (BuildContext context, int index) {
                         return Container(
                           width: 100,
                           alignment: Alignment.center,
                           child: Text('$index'),
                         );
-                      }, childCount: 10),
+                      },
                     ),
                   ],
                 ),

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2728,7 +2728,7 @@ The provided ScrollController cannot be shared by multiple ScrollView widgets.''
                   slivers: <Widget>[
                     SliverList.builder(
                       itemCount: 100,
-                      builder: (BuildContext context, int index) {
+                      itemBuilder: (BuildContext context, int index) {
                         final double height;
                         if (index < 10) {
                           height = 100;

--- a/packages/flutter/test/widgets/sliver_appbar_opacity_test.dart
+++ b/packages/flutter/test/widgets/sliver_appbar_opacity_test.dart
@@ -263,12 +263,11 @@ class _TestWidget extends StatelessWidget {
                 ? null
                 : PreferredSize(preferredSize: const Size.fromHeight(35.0), child: Container()),
           ),
-          SliverList(
-            delegate: SliverChildListDelegate(
-              List<Widget>.generate(20, (int i) {
-                return SizedBox(height: 100.0, child: Text('Tile $i'));
-              }),
-            ),
+          SliverList.builder(
+            itemCount: 20,
+            itemBuilder: (BuildContext context, int index) {
+              return SizedBox(height: 100.0, child: Text('Tile $index'));
+            },
           ),
         ],
       ),

--- a/packages/flutter/test/widgets/sliver_constraints_test.dart
+++ b/packages/flutter/test/widgets/sliver_constraints_test.dart
@@ -16,14 +16,14 @@ void main() {
           slivers: <Widget>[
             const SliverToBoxAdapter(child: SizedBox(width: double.infinity, height: 150.0)),
             const SliverToBoxAdapter(child: SizedBox(width: double.infinity, height: 150.0)),
-            SliverList(
-              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+            SliverList.builder(
+              itemBuilder: (BuildContext context, int index) {
                 if (index < 100) {
                   return const SizedBox(width: double.infinity, height: 150.0);
                 } else {
                   return null;
                 }
-              }),
+              },
             ),
             const SliverToBoxAdapter(
               key: Key('final_sliver'),

--- a/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
+++ b/packages/flutter/test/widgets/sliver_fill_remaining_test.dart
@@ -297,12 +297,10 @@ void main() {
         (WidgetTester tester) async {
           final GlobalKey key = GlobalKey();
           final List<Widget> slivers = <Widget>[
-            SliverFixedExtentList(
+            SliverFixedExtentList.builder(
               itemExtent: 150,
-              delegate: SliverChildBuilderDelegate(
-                (BuildContext context, int index) => Container(color: Colors.amber),
-                childCount: 5,
-              ),
+              itemCount: 5,
+              itemBuilder: (BuildContext context, int index) => Container(color: Colors.amber),
             ),
             SliverFillRemaining(
               hasScrollBody: false,
@@ -586,12 +584,10 @@ void main() {
             final ScrollController controller = ScrollController();
             addTearDown(controller.dispose);
             final List<Widget> slivers = <Widget>[
-              SliverFixedExtentList(
+              SliverFixedExtentList.builder(
                 itemExtent: 150,
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Container(color: Colors.amber),
-                  childCount: 5,
-                ),
+                itemCount: 5,
+                itemBuilder: (BuildContext context, int index) => Container(color: Colors.amber),
               ),
               SliverFillRemaining(
                 hasScrollBody: false,
@@ -651,14 +647,15 @@ void main() {
             final ScrollController controller = ScrollController();
             addTearDown(controller.dispose);
             final List<Widget> slivers = <Widget>[
-              SliverFixedExtentList(
+              SliverFixedExtentList.builder(
                 itemExtent: 150,
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                itemCount: 5,
+                itemBuilder: (BuildContext context, int index) {
                   return Semantics(
                     label: index.toString(),
                     child: Container(color: Colors.amber),
                   );
-                }, childCount: 5),
+                },
               ),
               SliverFillRemaining(
                 hasScrollBody: false,
@@ -974,12 +971,10 @@ void main() {
             final ScrollController controller = ScrollController();
             addTearDown(controller.dispose);
             final List<Widget> slivers = <Widget>[
-              SliverFixedExtentList(
+              SliverFixedExtentList.builder(
                 itemExtent: 150,
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Container(color: Colors.amber),
-                  childCount: 5,
-                ),
+                itemCount: 5,
+                itemBuilder: (BuildContext context, int index) => Container(color: Colors.amber),
               ),
               SliverFillRemaining(
                 hasScrollBody: false,
@@ -1025,14 +1020,15 @@ void main() {
           final ScrollController controller = ScrollController();
           addTearDown(controller.dispose);
           final List<Widget> slivers = <Widget>[
-            SliverFixedExtentList(
+            SliverFixedExtentList.builder(
               itemExtent: 150,
-              delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+              itemCount: 5,
+              itemBuilder: (BuildContext context, int index) {
                 return Semantics(
                   label: index.toString(),
                   child: Container(color: Colors.amber),
                 );
-              }, childCount: 5),
+              },
             ),
             SliverFillRemaining(
               hasScrollBody: false,

--- a/packages/flutter/test/widgets/sliver_floating_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_floating_header_test.dart
@@ -20,13 +20,14 @@ void main() {
                   Axis.horizontal => const SizedBox(width: 200, child: Text('header')),
                 },
               ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) {
                   return switch (axis) {
                     Axis.vertical => SizedBox(height: 100, child: Text('item $index')),
                     Axis.horizontal => SizedBox(width: 100, child: Text('item $index')),
                   };
-                }, childCount: 100),
+                },
               ),
             ],
           ),
@@ -187,10 +188,11 @@ void main() {
                 ),
                 child: SizedBox(height: 200, child: Text('header')),
               ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) {
                   return SizedBox(height: 100, child: Text('item $index'));
-                }, childCount: 100),
+                },
               ),
             ],
           ),
@@ -246,10 +248,11 @@ void main() {
                 snapMode: snapMode,
                 child: const SizedBox(height: 200, child: Text('header')),
               ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) {
                   return SizedBox(height: 100, child: Text('item $index'));
-                }, childCount: 100),
+                },
               ),
             ],
           ),

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -375,12 +375,11 @@ Widget _buildSliverListRenderWidgetChild(List<String> items, ScrollController co
           child: CustomScrollView(
             controller: controller,
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildListDelegate(
-                  items.map<Widget>((String item) {
-                    return Chip(key: Key(item), label: Text('Tile $item'));
-                  }).toList(),
-                ),
+              SliverList.builder(
+                itemCount: items.length,
+                itemBuilder: (BuildContext context, int index) {
+                  return Chip(key: Key(items[index]), label: Text('Tile ${items[index]}'));
+                },
               ),
             ],
           ),

--- a/packages/flutter/test/widgets/sliver_resizing_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_resizing_header_test.dart
@@ -23,11 +23,9 @@ void main() {
                 maxExtentPrototype: maxPrototype,
                 child: const SizedBox.expand(child: Text('header')),
               ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('item $index'),
-                  childCount: 100,
-                ),
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) => Text('item $index'),
               ),
             ],
           ),
@@ -181,11 +179,9 @@ void main() {
                 maxExtentPrototype: SizedBox(height: 300),
                 child: SizedBox.expand(child: Text('header')),
               ),
-              SliverList(
-                delegate: SliverChildBuilderDelegate(
-                  (BuildContext context, int index) => Text('item $index'),
-                  childCount: 100,
-                ),
+              SliverList.builder(
+                itemCount: 100,
+                itemBuilder: (BuildContext context, int index) => Text('item $index'),
               ),
             ],
           ),
@@ -219,11 +215,9 @@ void main() {
                   maxExtentPrototype: SizedBox(height: 100),
                   child: SizedBox.expand(child: Text('header')),
                 ),
-                SliverList(
-                  delegate: SliverChildBuilderDelegate(
-                    (BuildContext context, int index) => Text('item $index'),
-                    childCount: 100,
-                  ),
+                SliverList.builder(
+                  itemCount: 100,
+                  itemBuilder: (BuildContext context, int index) => Text('item $index'),
                 ),
               ],
             ),

--- a/packages/flutter/test/widgets/sliver_semantics_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantics_test.dart
@@ -50,7 +50,7 @@ void _tests() {
                     expandedHeight: appBarExpandedHeight,
                     title: Text('Semantics Test with Slivers'),
                   ),
-                  SliverList(delegate: SliverChildListDelegate(listChildren)),
+                  SliverList.list(children: listChildren),
                 ],
               ),
             ),
@@ -429,7 +429,7 @@ void _tests() {
                 child: CustomScrollView(
                   slivers: <Widget>[
                     const SliverAppBar(pinned: true, expandedHeight: 100.0, title: Text('AppBar')),
-                    SliverList(delegate: SliverChildListDelegate(listChildren)),
+                    SliverList.list(children: listChildren),
                   ],
                   controller: controller,
                 ),
@@ -645,7 +645,7 @@ void _tests() {
                   reverse: true, // This is the important setting for this test.
                   slivers: <Widget>[
                     const SliverAppBar(pinned: true, expandedHeight: 100.0, title: Text('AppBar')),
-                    SliverList(delegate: SliverChildListDelegate(listChildren)),
+                    SliverList.list(children: listChildren),
                   ],
                   controller: controller,
                 ),
@@ -875,7 +875,7 @@ void _tests() {
                       offset: offset,
                       center: forwardAppBarKey,
                       slivers: <Widget>[
-                        SliverList(delegate: SliverChildListDelegate(backwardChildren)),
+                        SliverList.list(children: backwardChildren),
                         const SliverAppBar(
                           pinned: true,
                           expandedHeight: 100.0,
@@ -891,7 +891,7 @@ void _tests() {
                             title: Text('Forward app bar', textDirection: TextDirection.ltr),
                           ),
                         ),
-                        SliverList(delegate: SliverChildListDelegate(forwardChildren)),
+                        SliverList.list(children: forwardChildren),
                       ],
                     );
                   },

--- a/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_pinned_test.dart
@@ -243,14 +243,14 @@ void main() {
               title: Text('A'),
             ),
             const SliverAppBar(primary: false, pinned: true, title: Text('B')),
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
+            SliverList.list(
+              children: const <Widget>[
                 Text('C'),
                 Text('D'),
                 SizedBox(height: 500.0),
                 Text('E'),
                 SizedBox(height: 500.0),
-              ]),
+              ],
             ),
           ],
         ),
@@ -312,12 +312,11 @@ void main() {
               controller: controller,
               slivers: <Widget>[
                 const SliverAppBar(pinned: true, floating: true, expandedHeight: 120.0),
-                SliverList(
-                  delegate: SliverChildListDelegate(
-                    List<Widget>.generate(20, (int i) {
-                      return SizedBox(height: 100.0, child: Text('Tile $i'));
-                    }),
-                  ),
+                SliverList.builder(
+                  itemCount: 20,
+                  itemBuilder: (BuildContext context, int index) {
+                    return SizedBox(height: 100.0, child: Text('Tile $index'));
+                  },
                 ),
               ],
             ),

--- a/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_floating_test.dart
@@ -296,11 +296,7 @@ void main() {
           physics: const BouncingScrollPhysics(),
           slivers: <Widget>[
             SliverPersistentHeader(delegate: TestDelegate(), floating: true),
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
-                const SizedBox(height: 300.0, child: Text('X')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 300.0, child: Text('X'))]),
           ],
         ),
       ),

--- a/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_pinned_test.dart
@@ -293,11 +293,7 @@ void main() {
           physics: const BouncingScrollPhysics(),
           slivers: <Widget>[
             SliverPersistentHeader(delegate: TestDelegate(), pinned: true),
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
-                const SizedBox(height: 300.0, child: Text('X')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 300.0, child: Text('X'))]),
           ],
         ),
       ),

--- a/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
+++ b/packages/flutter/test/widgets/slivers_appbar_scrolling_test.dart
@@ -94,11 +94,7 @@ void main() {
           physics: const BouncingScrollPhysics(),
           slivers: <Widget>[
             SliverPersistentHeader(delegate: TestDelegate()),
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
-                const SizedBox(height: 300.0, child: Text('X')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 300.0, child: Text('X'))]),
           ],
         ),
       ),

--- a/packages/flutter/test/widgets/slivers_block_global_key_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_global_key_test.dart
@@ -36,16 +36,10 @@ Future<void> test(WidgetTester tester, double offset, List<int> keys) {
         cacheExtent: 0.0,
         offset: viewportOffset,
         slivers: <Widget>[
-          SliverList(
-            delegate: SliverChildListDelegate(
-              keys.map<Widget>((int key) {
-                return SizedBox(
-                  key: GlobalObjectKey(key),
-                  height: 100.0,
-                  child: GenerationText(key),
-                );
-              }).toList(),
-            ),
+          SliverList.list(
+            children: keys.map<Widget>((int key) {
+              return SizedBox(key: GlobalObjectKey(key), height: 100.0, child: GenerationText(key));
+            }).toList(),
           ),
         ],
       ),

--- a/packages/flutter/test/widgets/slivers_block_test.dart
+++ b/packages/flutter/test/widgets/slivers_block_test.dart
@@ -15,14 +15,14 @@ Future<void> test(WidgetTester tester, double offset) {
       child: Viewport(
         offset: viewportOffset,
         slivers: <Widget>[
-          SliverList(
-            delegate: SliverChildListDelegate(const <Widget>[
+          SliverList.list(
+            children: const <Widget>[
               SizedBox(height: 400.0, child: Text('a')),
               SizedBox(height: 400.0, child: Text('b')),
               SizedBox(height: 400.0, child: Text('c')),
               SizedBox(height: 400.0, child: Text('d')),
               SizedBox(height: 400.0, child: Text('e')),
-            ]),
+            ],
           ),
         ],
       ),
@@ -122,12 +122,12 @@ void main() {
         child: Viewport(
           offset: offset,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            SliverList.list(
+              children: <Widget>[
                 const SizedBox(height: 251.0, child: Text('a')),
                 const SizedBox(height: 252.0, child: Text('b')),
                 SizedBox(key: key1, height: 253.0, child: const Text('c')),
-              ]),
+              ],
             ),
           ],
         ),
@@ -144,12 +144,12 @@ void main() {
         child: Viewport(
           offset: offset,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            SliverList.list(
+              children: <Widget>[
                 SizedBox(key: key1, height: 253.0, child: const Text('c')),
                 const SizedBox(height: 251.0, child: Text('a')),
                 const SizedBox(height: 252.0, child: Text('b')),
-              ]),
+              ],
             ),
           ],
         ),
@@ -166,12 +166,12 @@ void main() {
         child: Viewport(
           offset: offset,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            SliverList.list(
+              children: <Widget>[
                 const SizedBox(height: 251.0, child: Text('a')),
                 SizedBox(key: key1, height: 253.0, child: const Text('c')),
                 const SizedBox(height: 252.0, child: Text('b')),
-              ]),
+              ],
             ),
           ],
         ),
@@ -188,11 +188,11 @@ void main() {
         child: Viewport(
           offset: offset,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
+            SliverList.list(
+              children: const <Widget>[
                 SizedBox(height: 251.0, child: Text('a')),
                 SizedBox(height: 252.0, child: Text('b')),
-              ]),
+              ],
             ),
           ],
         ),
@@ -205,12 +205,12 @@ void main() {
         child: Viewport(
           offset: offset,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            SliverList.list(
+              children: <Widget>[
                 const SizedBox(height: 251.0, child: Text('a')),
                 SizedBox(key: key1, height: 253.0, child: const Text('c')),
                 const SizedBox(height: 252.0, child: Text('b')),
-              ]),
+              ],
             ),
           ],
         ),
@@ -303,11 +303,7 @@ void main() {
         child: Viewport(
           offset: offset1,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
-                SizedBox(height: 400.0, child: Text('a')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 400.0, child: Text('a'))]),
           ],
         ),
       ),
@@ -324,11 +320,7 @@ void main() {
         child: Viewport(
           offset: offset2,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
-                SizedBox(height: 400.0, child: Text('a')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 400.0, child: Text('a'))]),
           ],
         ),
       ),
@@ -345,11 +337,7 @@ void main() {
         child: Viewport(
           offset: offset3,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
-                SizedBox(height: 4000.0, child: Text('a')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 4000.0, child: Text('a'))]),
           ],
         ),
       ),
@@ -366,11 +354,7 @@ void main() {
         child: Viewport(
           offset: offset4,
           slivers: <Widget>[
-            SliverList(
-              delegate: SliverChildListDelegate(const <Widget>[
-                SizedBox(height: 4000.0, child: Text('a')),
-              ]),
-            ),
+            SliverList.list(children: const <Widget>[SizedBox(height: 4000.0, child: Text('a'))]),
           ],
         ),
       ),

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -148,8 +148,8 @@ void main() {
                         floating: true,
                       ),
                       SliverToBoxAdapter(child: Container(height: 5.0)),
-                      SliverList(
-                        delegate: SliverChildListDelegate(<Widget>[
+                      SliverList.list(
+                        children: <Widget>[
                           Container(height: 50.0),
                           Container(height: 50.0),
                           Container(height: 50.0),
@@ -165,7 +165,7 @@ void main() {
                           Container(height: 50.0),
                           Container(height: 50.0),
                           Container(height: 50.0),
-                        ]),
+                        ],
                       ),
                       SliverPersistentHeader(delegate: TestSliverPersistentHeaderDelegate(250.0)),
                       SliverPersistentHeader(delegate: TestSliverPersistentHeaderDelegate(250.0)),

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -497,7 +497,7 @@ class SwitchingSliverListTest extends StatelessWidget {
           height: 100,
           child: CustomScrollView(
             cacheExtent: 0,
-            slivers: <Widget>[SliverList(delegate: SliverChildListDelegate(children))],
+            slivers: <Widget>[SliverList.list(children: children)],
           ),
         ),
       ),

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -36,18 +36,16 @@ Future<void> testSliverFixedExtentList(WidgetTester tester, List<String> items) 
       textDirection: TextDirection.ltr,
       child: CustomScrollView(
         slivers: <Widget>[
-          SliverFixedExtentList(
+          SliverFixedExtentList.builder(
             itemExtent: 900,
-            delegate: SliverChildBuilderDelegate(
-              (BuildContext context, int index) {
-                return Center(key: ValueKey<String>(items[index]), child: KeepAlive(items[index]));
-              },
-              childCount: items.length,
-              findChildIndexCallback: (Key key) {
-                final ValueKey<String> valueKey = key as ValueKey<String>;
-                return items.indexOf(valueKey.value);
-              },
-            ),
+            itemCount: items.length,
+            itemBuilder: (BuildContext context, int index) {
+              return Center(key: ValueKey<String>(items[index]), child: KeepAlive(items[index]));
+            },
+            findChildIndexCallback: (Key key) {
+              final ValueKey<String> valueKey = key as ValueKey<String>;
+              return items.indexOf(valueKey.value);
+            },
           ),
         ],
       ),
@@ -197,20 +195,16 @@ void main() {
             textDirection: TextDirection.ltr,
             child: CustomScrollView(
               slivers: <Widget>[
-                SliverList(
-                  delegate: SliverChildListDelegate(const <Widget>[
+                SliverList.list(
+                  children: const <Widget>[
                     SizedBox(height: 22.2, child: Text('TOP')),
                     SizedBox(height: 22.2),
                     SizedBox(height: 22.2),
-                  ]),
+                  ],
                 ),
-                SliverFixedExtentList(
+                SliverFixedExtentList.list(
                   itemExtent: 22.2,
-                  delegate: SliverChildListDelegate(const <Widget>[
-                    SizedBox(),
-                    Text('A'),
-                    SizedBox(),
-                  ]),
+                  children: const <Widget>[SizedBox(), Text('A'), SizedBox()],
                 ),
                 SliverGrid(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
@@ -220,12 +214,12 @@ void main() {
                     SizedBox(),
                   ]),
                 ),
-                SliverList(
-                  delegate: SliverChildListDelegate(const <Widget>[
+                SliverList.list(
+                  children: const <Widget>[
                     SizedBox(height: 22.2),
                     SizedBox(height: 22.2),
                     SizedBox(height: 22.2, child: Text('BOTTOM')),
-                  ]),
+                  ],
                 ),
               ],
             ),
@@ -274,26 +268,22 @@ void main() {
               textDirection: TextDirection.ltr,
               child: CustomScrollView(
                 slivers: <Widget>[
-                  SliverGrid(
+                  SliverGrid.builder(
                     gridDelegate: TestGridDelegate(replace),
-                    delegate: SliverChildBuilderDelegate(
-                      (BuildContext context, int index) {
-                        final int item = replace ? replacedItems[index] : items[index];
-                        return Container(
-                          key: ValueKey<int>(item),
-                          alignment: Alignment.center,
-                          child: Text('item $item'),
-                        );
-                      },
-                      childCount: replace ? 7 : 6,
-                      findChildIndexCallback: (Key key) {
-                        final int item = (key as ValueKey<int>).value;
-                        final int index = replace
-                            ? replacedItems.indexOf(item)
-                            : items.indexOf(item);
-                        return index >= 0 ? index : null;
-                      },
-                    ),
+                    itemCount: replace ? 7 : 6,
+                    itemBuilder: (BuildContext context, int index) {
+                      final int item = replace ? replacedItems[index] : items[index];
+                      return Container(
+                        key: ValueKey<int>(item),
+                        alignment: Alignment.center,
+                        child: Text('item $item'),
+                      );
+                    },
+                    findChildIndexCallback: (Key key) {
+                      final int item = (key as ValueKey<int>).value;
+                      final int index = replace ? replacedItems.indexOf(item) : items.indexOf(item);
+                      return index >= 0 ? index : null;
+                    },
                   ),
                 ],
               ),
@@ -377,9 +367,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: CustomScrollView(
           controller: controller,
-          slivers: <Widget>[
-            SliverFixedExtentList(itemExtent: 900, delegate: SliverChildListDelegate(children)),
-          ],
+          slivers: <Widget>[SliverFixedExtentList.list(itemExtent: 900, children: children)],
         ),
       ),
     );
@@ -403,9 +391,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: CustomScrollView(
           controller: controller,
-          slivers: <Widget>[
-            SliverFixedExtentList(itemExtent: 900, delegate: SliverChildListDelegate(children)),
-          ],
+          slivers: <Widget>[SliverFixedExtentList.list(itemExtent: 900, children: children)],
         ),
       ),
     );
@@ -464,18 +450,18 @@ void main() {
             height: 4,
             child: CustomScrollView(
               slivers: <Widget>[
-                SliverGrid(
+                SliverGrid.list(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2,
                     crossAxisSpacing: 8,
                     mainAxisSpacing: 8,
                   ),
-                  delegate: SliverChildListDelegate(<Widget>[
+                  children: <Widget>[
                     const Center(child: Text('A')),
                     const Center(child: Text('B')),
                     const Center(child: Text('C')),
                     const Center(child: Text('D')),
-                  ]),
+                  ],
                 ),
               ],
             ),
@@ -505,9 +491,7 @@ void main() {
         theme: ThemeData(useMaterial3: false),
         home: Scaffold(
           body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList(delegate: SliverChildBuilderDelegate(buildItem, childCount: 30)),
-            ],
+            slivers: <Widget>[SliverList.builder(itemCount: 30, itemBuilder: buildItem)],
           ),
         ),
       ),
@@ -529,9 +513,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: CustomScrollView(
-            slivers: <Widget>[
-              SliverList(delegate: SliverChildBuilderDelegate(buildItem, childCount: 30)),
-            ],
+            slivers: <Widget>[SliverList.builder(itemCount: 30, itemBuilder: buildItem)],
           ),
         ),
       ),
@@ -655,14 +637,14 @@ void main() {
             controller: controller,
             cacheExtent: 0,
             slivers: <Widget>[
-              SliverFixedExtentList(
+              SliverFixedExtentList.builder(
                 itemExtent: 200,
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                itemBuilder: (BuildContext context, int index) {
                   if (index <= 6) {
                     return Center(child: Text('Page $index'));
                   }
                   return null;
-                }),
+                },
               ),
             ],
           ),
@@ -705,14 +687,14 @@ void main() {
             controller: controller,
             cacheExtent: 0,
             slivers: <Widget>[
-              SliverFixedExtentList(
+              SliverFixedExtentList.builder(
                 itemExtent: 200,
-                delegate: SliverChildBuilderDelegate((BuildContext context, int index) {
+                itemBuilder: (BuildContext context, int index) {
                   if (index <= 6) {
                     return Center(child: Text('Page $index'));
                   }
                   return null;
-                }),
+                },
               ),
             ],
           ),
@@ -1036,12 +1018,8 @@ void main() {
           body: CustomScrollView(
             physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()),
             slivers: <Widget>[
-              SliverList(
-                delegate: SliverChildListDelegate(const <Widget>[
-                  SizedBox.shrink(),
-                  Text('index 1'),
-                  Text('index 2'),
-                ]),
+              SliverList.list(
+                children: const <Widget>[SizedBox.shrink(), Text('index 1'), Text('index 2')],
               ),
             ],
           ),
@@ -1537,9 +1515,7 @@ class TestSliverFixedExtentList extends StatelessWidget {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: CustomScrollView(
-        slivers: <Widget>[
-          SliverFixedExtentList(itemExtent: 10.0, delegate: SliverChildListDelegate(children)),
-        ],
+        slivers: <Widget>[SliverFixedExtentList.list(itemExtent: 10.0, children: children)],
       ),
     );
   }

--- a/packages/flutter/test/widgets/slivers_test.dart
+++ b/packages/flutter/test/widgets/slivers_test.dart
@@ -450,18 +450,18 @@ void main() {
             height: 4,
             child: CustomScrollView(
               slivers: <Widget>[
-                SliverGrid.list(
+                SliverGrid(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 2,
                     crossAxisSpacing: 8,
                     mainAxisSpacing: 8,
                   ),
-                  children: <Widget>[
+                  delegate: SliverChildListDelegate(<Widget>[
                     const Center(child: Text('A')),
                     const Center(child: Text('B')),
                     const Center(child: Text('C')),
                     const Center(child: Text('D')),
-                  ],
+                  ]),
                 ),
               ],
             ),

--- a/packages/flutter/test/widgets/sliversemantics_test.dart
+++ b/packages/flutter/test/widgets/sliversemantics_test.dart
@@ -459,11 +459,11 @@ void _tests() {
         slivers: <Widget>[
           SliverSemantics(
             container: true,
-            sliver: SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            sliver: SliverList.list(
+              children: <Widget>[
                 Semantics(hint: 'hint one', child: const SizedBox(height: 10.0)),
                 Semantics(hint: 'hint two', child: const SizedBox(height: 10.0)),
-              ]),
+              ],
             ),
           ),
         ],
@@ -557,11 +557,11 @@ void _tests() {
         slivers: <Widget>[
           SliverSemantics(
             container: true,
-            sliver: SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            sliver: SliverList.list(
+              children: <Widget>[
                 Semantics(value: 'value one', child: const SizedBox(height: 10.0)),
                 Semantics(value: 'value two', child: const SizedBox(height: 10.0)),
-              ]),
+              ],
             ),
           ),
         ],
@@ -655,11 +655,11 @@ void _tests() {
         slivers: <Widget>[
           SliverSemantics(
             container: true,
-            sliver: SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            sliver: SliverList.list(
+              children: <Widget>[
                 Semantics(hint: 'hint', child: const SizedBox(height: 10.0)),
                 Semantics(value: 'value', child: const SizedBox(height: 10.0)),
-              ]),
+              ],
             ),
           ),
         ],
@@ -753,11 +753,11 @@ void _tests() {
         slivers: <Widget>[
           SliverSemantics(
             container: true,
-            sliver: SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            sliver: SliverList.list(
+              children: <Widget>[
                 Semantics(container: true, child: const Text('child 1')),
                 Semantics(container: true, child: const Text('child 2')),
-              ]),
+              ],
             ),
           ),
         ],
@@ -2366,8 +2366,8 @@ void _tests() {
           SliverSemantics(
             blockUserActions: true,
             explicitChildNodes: true,
-            sliver: SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            sliver: SliverList.list(
+              children: <Widget>[
                 Semantics(
                   key: key1,
                   label: 'label1',
@@ -2380,7 +2380,7 @@ void _tests() {
                   onTap: () {},
                   child: const SizedBox(height: 10),
                 ),
-              ]),
+              ],
             ),
           ),
         ],
@@ -2442,8 +2442,8 @@ void _tests() {
           SliverSemantics(
             key: key,
             container: true,
-            sliver: SliverList(
-              delegate: SliverChildListDelegate(<Widget>[
+            sliver: SliverList.list(
+              children: <Widget>[
                 Semantics(
                   blockUserActions: true,
                   label: 'label1',
@@ -2451,7 +2451,7 @@ void _tests() {
                   child: const SizedBox(height: 10),
                 ),
                 Semantics(label: 'label2', onLongPress: () {}, child: const SizedBox(height: 10)),
-              ]),
+              ],
             ),
           ),
         ],


### PR DESCRIPTION
In 2022, we introduced new convenience constructors like `SliverList.builder` and `SliverList.list`. Unfortunately, LLMs like Gemini seem to prefer the delegate pattern even when these convenience constructors are usable. This updates Flutter's docs, code, and tests to use these convenience constructors where possible. Hopefully this will nudge LLMs to consider using the new APIs :)

I migrated 80% of the code by hand, and 20% using Gemini CLI. See [go/loic-ai-log](http://goto.google.com/loic-ai-log) (Google internal) for details.

There's a few locations that I wasn't able to migrate to the convenience constructors due to missing APIs. I filed the following issues:

1. https://github.com/flutter/flutter/issues/173018
2. https://github.com/flutter/flutter/issues/173019

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
