### PR TITLE
[Impeller] Improvements to the Vulkan pipeline cache data writer

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
@@ -107,7 +107,7 @@ TEST(PipelineCacheDataVKTest, WritesIncompleteCacheData) {
   ASSERT_TRUE(mapping);
   PipelineCacheHeaderVK header;
   ASSERT_GE(mapping->GetSize(), sizeof(header));
-  memcpy(&header, mapping->GetMapping(), sizeof(header));
+  std::memcpy(&header, mapping->GetMapping(), sizeof(header));
   ASSERT_EQ(mapping->GetSize(), sizeof(header) + header.data_size);
 }
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_data_vk_unittests.cc
@@ -10,6 +10,7 @@
 #include "impeller/renderer/backend/vulkan/context_vk.h"
 #include "impeller/renderer/backend/vulkan/pipeline_cache_data_vk.h"
 #include "impeller/renderer/backend/vulkan/surface_context_vk.h"
+#include "impeller/renderer/backend/vulkan/test/mock_vulkan.h"
 
 namespace impeller::testing {
 
@@ -90,6 +91,24 @@ TEST(PipelineCacheDataVKTest, CanCreateFromDeviceProperties) {
   for (size_t i = 0; i < uuid.size(); i++) {
     EXPECT_EQ(header.uuid[i], uuid.at(i));
   }
+}
+
+TEST(PipelineCacheDataVKTest, WritesIncompleteCacheData) {
+  fml::ScopedTemporaryDirectory temp_dir;
+  auto context = MockVulkanContextBuilder().Build();
+  auto cache = context->GetDevice().createPipelineCacheUnique({});
+  const auto& caps = CapabilitiesVK::Cast(*context->GetCapabilities());
+
+  ASSERT_TRUE(PipelineCacheDataPersist(
+      temp_dir.fd(), caps.GetPhysicalDeviceProperties(), cache.value));
+
+  std::unique_ptr<fml::FileMapping> mapping = fml::FileMapping::CreateReadOnly(
+      temp_dir.fd(), "flutter.impeller.vkcache");
+  ASSERT_TRUE(mapping);
+  PipelineCacheHeaderVK header;
+  ASSERT_GE(mapping->GetSize(), sizeof(header));
+  memcpy(&header, mapping->GetMapping(), sizeof(header));
+  ASSERT_EQ(mapping->GetSize(), sizeof(header) + header.data_size);
 }
 
 using PipelineCacheDataVKPlaygroundTest = PlaygroundTest;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
@@ -108,6 +108,9 @@ vk::UniquePipeline PipelineCacheVK::CreatePipeline(
 }
 
 void PipelineCacheVK::PersistCacheToDisk() {
+  // PersistCacheToDisk is run on a worker thread pool.  Calls to
+  // PipelineCacheDataPersist should be serialized so that multiple worker
+  // threads do not concurrently write to the cache file.
   Lock persist_lock(persist_mutex_);
   if (!is_valid_) {
     return;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
@@ -107,7 +107,8 @@ vk::UniquePipeline PipelineCacheVK::CreatePipeline(
   return std::move(pipeline);
 }
 
-void PipelineCacheVK::PersistCacheToDisk() const {
+void PipelineCacheVK::PersistCacheToDisk() {
+  Lock persist_lock(persist_mutex_);
   if (!is_valid_) {
     return;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_PIPELINE_CACHE_VK_H_
 
 #include "flutter/fml/file.h"
+#include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 #include "impeller/renderer/backend/vulkan/device_holder_vk.h"
 
@@ -31,7 +32,7 @@ class PipelineCacheVK {
 
   const CapabilitiesVK* GetCapabilities() const;
 
-  void PersistCacheToDisk() const;
+  void PersistCacheToDisk();
 
  private:
   const std::shared_ptr<const Capabilities> caps_;
@@ -39,6 +40,7 @@ class PipelineCacheVK {
   const fml::UniqueFD cache_directory_;
   vk::UniquePipelineCache cache_;
   bool is_valid_ = false;
+  Mutex persist_mutex_;
 
   PipelineCacheVK(const PipelineCacheVK&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -772,7 +772,7 @@ VkResult vkGetPipelineCacheData(VkDevice device,
     const std::array<uint8_t, 5> cache_data{1, 2, 3, 4, 5};
     size_t dst_buffer_size = *pDataSize;
     size_t length = std::min(dst_buffer_size, cache_data.size());
-    memcpy(pData, cache_data.data(), length);
+    std::memcpy(pData, cache_data.data(), length);
     *pDataSize = length;
     return (dst_buffer_size >= length) ? VK_SUCCESS : VK_INCOMPLETE;
   } else {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -764,6 +764,23 @@ void vkTrimCommandPool(VkDevice device,
   mock_device->AddCalledFunction("vkTrimCommandPool");
 }
 
+VkResult vkGetPipelineCacheData(VkDevice device,
+                                VkPipelineCache pipelineCache,
+                                size_t* pDataSize,
+                                void* pData) {
+  if (pData) {
+    const std::array<uint8_t, 5> cache_data{1, 2, 3, 4, 5};
+    size_t dst_buffer_size = *pDataSize;
+    size_t length = std::min(dst_buffer_size, cache_data.size());
+    memcpy(pData, cache_data.data(), length);
+    *pDataSize = length;
+    return (dst_buffer_size >= length) ? VK_SUCCESS : VK_INCOMPLETE;
+  } else {
+    *pDataSize = 10;
+    return VK_SUCCESS;
+  }
+}
+
 PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
                                             const char* pName) {
   if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
@@ -917,6 +934,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyFramebuffer);
   } else if (strcmp("vkTrimCommandPool", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkTrimCommandPool);
+  } else if (strcmp("vkGetPipelineCacheData", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkGetPipelineCacheData);
   }
   return noop;
 }


### PR DESCRIPTION
PipelineCacheDataPersist runs on a worker thread pool.  The raster thread may be executing rendering operations while PipelineCacheDataPersist is reading the state of the pipeline cache.

PipelineCacheDataPersist calls vkGetPipelineCacheData to get the size required for the cache data buffer and then calls it again to fill the buffer.  If the cache state changed between those two calls, then the count of bytes written may be less than the size returned by the first call.  In that case, PipelineCacheDataPersist should only write the portion of the buffer that was filled.

This PR also adds a mutex to PipelineCacheVK::PersistCacheToDisk. PipelineLibraryVK could queue multiple PersistCacheToDisk tasks to different worker pool threads.  These tasks should not run concurrently.

See https://github.com/flutter/flutter/issues/172624