### PR TITLE
[ Tool ] Mark IOOverrides subclasses as `final`

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -1300,7 +1300,7 @@ class FakeApplicationPackageFactory implements ApplicationPackageFactory {
 
 class FakeApplicationPackage extends Fake implements ApplicationPackage {}
 
-class TestIOOverrides extends io.IOOverrides {
+final class TestIOOverrides extends io.IOOverrides {
   late Future<io.Socket> Function(Object? host, int port) connectCallback;
 
   @override

--- a/packages/flutter_tools/test/src/io.dart
+++ b/packages/flutter_tools/test/src/io.dart
@@ -19,7 +19,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 ///
 /// The only safe delegate types are those that do not call out to `dart:io`,
 /// like the [MemoryFileSystem].
-class FlutterIOOverrides extends io.IOOverrides {
+final class FlutterIOOverrides extends io.IOOverrides {
   FlutterIOOverrides({FileSystem? fileSystem}) : _fileSystemDelegate = fileSystem;
 
   final FileSystem? _fileSystemDelegate;


### PR DESCRIPTION
IOOverrides will be marked as an abstract base class and will cause analysis errors when the Dart SDK rolls into Flutter.

Related issue: https://github.com/dart-lang/sdk/issues/56468