### PR TITLE
[dync_modules] enable iOS ddm build in the merge queue

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -484,13 +484,12 @@ targets:
 
   - name: Mac mac_ios_engine_ddm
     recipe: engine_v2/engine_v2
-    bringup: true
     timeout: 240
     enabled_branches:
       # Don't run this on release branches
       - master
-    backfill: false
     properties:
+      release_build: "true"
       add_recipes_cq: "true"
       config_name: mac_ios_engine_ddm
       $flutter/osx_sdk : >-


### PR DESCRIPTION
Similar to https://github.com/flutter/flutter/pull/168233, but this time for iOS
Follow-up to https://github.com/flutter/flutter/pull/168717

As we start to work more seriously with ddm we'd like to have these builds always available instead of on demand only.