### PR TITLE
Fix: Use route navigator for CupertinoSheetRoute pop

### DIFF
--- a/packages/flutter/lib/src/cupertino/sheet.dart
+++ b/packages/flutter/lib/src/cupertino/sheet.dart
@@ -894,8 +894,7 @@ class _CupertinoDragGestureController<T> {
     } else {
       if (isCurrent) {
         // This route is destined to pop at this point. Reuse navigator's pop.
-        final NavigatorState rootNavigator = Navigator.of(navigator.context, rootNavigator: true);
-        rootNavigator.pop();
+        navigator.pop();
       }
 
       if (popDragController.isAnimating) {

--- a/packages/flutter/test/cupertino/sheet_test.dart
+++ b/packages/flutter/test/cupertino/sheet_test.dart
@@ -1141,6 +1141,94 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('drag dismiss uses route navigator instead of root navigator', (
+      WidgetTester tester,
+    ) async {
+      final GlobalKey homeKey = GlobalKey();
+      final GlobalKey nestedNavigatorKey = GlobalKey<NavigatorState>();
+      final GlobalKey sheetKey = GlobalKey();
+      bool wasPopped = false;
+      bool rootNavigatorPopped = false;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: PopScope(
+            onPopInvokedWithResult: (bool didPop, Object? result) {
+              if (didPop) {
+                rootNavigatorPopped = true;
+              }
+            },
+            child: CupertinoPageScaffold(
+              key: homeKey,
+              child: Navigator(
+                key: nestedNavigatorKey,
+                onGenerateRoute: (RouteSettings settings) {
+                  return CupertinoPageRoute<void>(
+                    settings: settings,
+                    builder: (BuildContext context) {
+                      return Center(
+                        child: Column(
+                          children: <Widget>[
+                            const Text('Page 1'),
+                            CupertinoButton(
+                              onPressed: () {
+                                Navigator.push<void>(
+                                  context,
+                                  CupertinoSheetRoute<void>(
+                                    builder: (BuildContext context) {
+                                      return PopScope(
+                                        onPopInvokedWithResult: (bool didPop, Object? result) {
+                                          if (didPop) {
+                                            wasPopped = true;
+                                          }
+                                        },
+                                        child: CupertinoPageScaffold(
+                                          key: sheetKey,
+                                          child: const Center(child: Text('Page 2')),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                );
+                              },
+                              child: const Text('Push Page 2'),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Page 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page 2'), findsOneWidget);
+      expect(wasPopped, false);
+      expect(rootNavigatorPopped, false);
+
+      // Start drag gesture and drag down far enough to trigger dismissal
+      final TestGesture gesture = await tester.startGesture(const Offset(100, 200));
+      await gesture.moveBy(const Offset(0, 350));
+      await tester.pump();
+
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Verify the sheet was dismissed and the PopScope callback was triggered
+      expect(find.text('Page 2'), findsNothing);
+      expect(find.text('Page 1'), findsOneWidget);
+      // Verify that the nested navigator was used (sheet PopScope triggered)
+      // but the root navigator was NOT used (root PopScope not triggered)
+      expect(wasPopped, true);
+      expect(rootNavigatorPopped, false);
+    });
+
     testWidgets('dragging does not move the sheet when enableDrag is false', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
Use route navigator for CupertinoSheetRoute pop
Fixes: #172010 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.