### PR TITLE
fix: get content hash for master on local engine branches

### DIFF
--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -13,13 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Fetch base commit and origin/master
-        run: |
-          git fetch --no-tags --prune --depth=1 origin ${{ github.event.pull_request.base.sha }}
-
       - name: Generate Hash
         run: |
-          engine_content_hash=$(bin/internal/content_aware_hash.sh)
+          # IMPORTANT: Keep the list of files in sync with bin/internal/content_aware_hash.sh
+          # We call this directly here as we're expected to be in the merge queue (not master)
+          engine_content_hash=$(git ls-tree --format "%(objectname) %(path)" HEAD -- DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin)
           # test notice annotation for retrival from api
           echo "::notice ::{\"engine_content_hash\": \"${engine_content_hash}\"}"
           # test summary writing

--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -22,4 +22,3 @@ jobs:
           echo "::notice ::{\"engine_content_hash\": \"${engine_content_hash}\"}"
           # test summary writing
           echo "{\"engine_content_hash\": \"${engine_content_hash}\"" >> $GITHUB_STEP_SUMMARY
-

--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -22,3 +22,4 @@ jobs:
           echo "::notice ::{\"engine_content_hash\": \"${engine_content_hash}\"}"
           # test summary writing
           echo "{\"engine_content_hash\": \"${engine_content_hash}\"" >> $GITHUB_STEP_SUMMARY
+

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -36,6 +36,28 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 # 3. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
 # 4. git hash-object with stdin from a pipeline consumes UTF-16, so consume
 #.   the contents of hash.txt
-(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" HEAD DEPS engine bin/internal/release-candidate-branch.version | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
+$trackedFiles = "DEPS", "engine", "bin/internal/release-candidate-branch.version"
+$baseRef = "HEAD"
+
+$ErrorActionPreference = "Continue"
+# We will fallback to origin/master if upstream is not detected.
+git -C "$flutterRoot" remote get-url upstream *> $null
+$exitCode = $?
+$ErrorActionPreference = "Stop"
+if ($exitCode) {
+    $mergeBase = (git -C "$flutterRoot"  merge-base HEAD upstream/master)
+} else {
+    $mergeBase = (git -C "$flutterRoot"  merge-base HEAD origin/master)
+}
+
+# Check to see if we're in a local development branch and the branch has any
+# changes to engine code - including non-committed changes.
+if ((git -C "$flutterRoot" rev-parse --abbrev-ref HEAD) -ne "master") {
+    git -C "$flutterRoot" diff --quiet "$(git -C "$flutterRoot" merge-base $mergeBase HEAD)" -- $trackedFiles | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        $baseRef = "$mergeBase"
+    }
+}
+(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" $baseRef -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
 git hash-object hash.txt
 Remove-Item hash.txt

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -55,13 +55,13 @@ if (($currentBranch -ne "main") -and
     if ($LASTEXITCODE -eq 0) {
         $remote = "upstream"
     }
-    $ErrorActionPreference = "Stop"
 
     # Try to find the merge-base with master, then main.
     $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/master" 2>$null).Trim()
     if ([string]::IsNullOrEmpty($mergeBase)) {
         $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/main" 2>$null).Trim()
     }
+    $ErrorActionPreference = "Stop"
 
     $baseRef = $mergeBase
 }

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -63,7 +63,9 @@ if (($currentBranch -ne "main") -and
     }
     $ErrorActionPreference = "Stop"
 
-    $baseRef = $mergeBase
+    if ($mergeBase) {
+        $baseRef = $mergeBase
+    }
 }
 
 # Removing the "cmd" requirement enables powershell usage on other hosts

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -63,14 +63,7 @@ if (($currentBranch -ne "main") -and
         $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/main" 2>$null).Trim()
     }
 
-    # If we found a merge-base, check for changes to the engine.
-    # If there are changes, use the merge-base as the base for the hash.
-    if (-not [string]::IsNullOrEmpty($mergeBase)) {
-        git -C "$flutterRoot" diff --quiet "$mergeBase" -- $trackedFiles
-        if ($LASTEXITCODE -ne 0) {
-            $baseRef = $mergeBase
-        }
-    }
+    $baseRef = $mergeBase
 }
 
 # Removing the "cmd" requirement enables powershell usage on other hosts

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -5,7 +5,7 @@
 # ---------------------------------- NOTE ---------------------------------- #
 #
 # Please keep the logic in this file consistent with the logic in the
-# `content_aware_hash.ps1` script in the same directory to ensure that Flutter
+# `content_aware_hash.sh` script in the same directory to ensure that Flutter
 # continues to work across all platforms!
 #
 # -------------------------------------------------------------------------- #
@@ -23,10 +23,54 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 # Cannot use '*' for files in this command
 # DEPS: tracks third party dependencies related to building the engine
 # engine: all the code in the engine folder
-# bin/internal/content_aware_hash.ps1: script for calculating the hash on windows
-# bin/internal/content_aware_hash.sh: script for calculating the hash on mac/linux
-# .github/workflows/content-aware-hash.yml: github action for CI/CD hashing
+# bin/internal/release-candidate-branch.version: release marker
+$trackedFiles = "DEPS", "engine", "bin/internal/release-candidate-branch.version"
+$baseRef = "HEAD"
+$currentBranch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD).Trim()
+
+# By default, the content hash is based on HEAD.
+# For local development branches, we want to base the hash on the merge-base
+# with the remote tracking branch, so that we don't rebuild the world every
+# time we make a change to the engine.
 #
+# The following conditions are exceptions where we want to use HEAD.
+# 1. The current branch is a release branch (main, master, stable, beta).
+# 2. The current branch is a GitHub temporary merge branch.
+# 3. The current branch is a release candidate branch.
+# 4. The current checkout is a shallow clone.
+$isShallow = Test-Path -Path (Join-Path $flutterRoot ".git/shallow")
+if (($currentBranch -ne "main") -and
+    ($currentBranch -ne "master") -and
+    ($currentBranch -ne "stable") -and
+    ($currentBranch -ne "beta") -and
+    (-not $currentBranch.StartsWith("gh-readonly-queue/master/pr-")) -and
+    (-not ($currentBranch -like "flutter-*-candidate.*")) -and
+    (-not $isShallow)) {
+
+    # This is a development branch. Find the merge-base.
+    # We will fallback to origin if upstream is not detected.
+    $remote = "origin"
+    git -C "$flutterRoot" remote get-url upstream *> $null
+    if ($LASTEXITCODE -eq 0) {
+        $remote = "upstream"
+    }
+
+    # Try to find the merge-base with master, then main.
+    $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/master" 2>$null).Trim()
+    if ([string]::IsNullOrEmpty($mergeBase)) {
+        $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/main" 2>$null).Trim()
+    }
+
+    # If we found a merge-base, check for changes to the engine.
+    # If there are changes, use the merge-base as the base for the hash.
+    if (-not [string]::IsNullOrEmpty($mergeBase)) {
+        git -C "$flutterRoot" diff --quiet "$mergeBase" -- $trackedFiles
+        if ($LASTEXITCODE -ne 0) {
+            $baseRef = $mergeBase
+        }
+    }
+}
+
 # Removing the "cmd" requirement enables powershell usage on other hosts
 # 1. git ls-tree | Out-String - combines output of pipeline into a single string
 #    rather than an array for each line.
@@ -36,28 +80,6 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 # 3. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
 # 4. git hash-object with stdin from a pipeline consumes UTF-16, so consume
 #.   the contents of hash.txt
-$trackedFiles = "DEPS", "engine", "bin/internal/release-candidate-branch.version"
-$baseRef = "HEAD"
-
-$ErrorActionPreference = "Continue"
-# We will fallback to origin/master if upstream is not detected.
-git -C "$flutterRoot" remote get-url upstream *> $null
-$exitCode = $?
-$ErrorActionPreference = "Stop"
-if ($exitCode) {
-    $mergeBase = (git -C "$flutterRoot"  merge-base HEAD upstream/master)
-} else {
-    $mergeBase = (git -C "$flutterRoot"  merge-base HEAD origin/master)
-}
-
-# Check to see if we're in a local development branch and the branch has any
-# changes to engine code - including non-committed changes.
-if ((git -C "$flutterRoot" rev-parse --abbrev-ref HEAD) -ne "master") {
-    git -C "$flutterRoot" diff --quiet "$(git -C "$flutterRoot" merge-base $mergeBase HEAD)" -- $trackedFiles | Out-Null
-    if ($LASTEXITCODE -ne 0) {
-        $baseRef = "$mergeBase"
-    }
-}
 (git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" $baseRef -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
 git hash-object hash.txt
 Remove-Item hash.txt

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -50,10 +50,12 @@ if (($currentBranch -ne "main") -and
     # This is a development branch. Find the merge-base.
     # We will fallback to origin if upstream is not detected.
     $remote = "origin"
+    $ErrorActionPreference = 'SilentlyContinue'
     git -C "$flutterRoot" remote get-url upstream *> $null
     if ($LASTEXITCODE -eq 0) {
         $remote = "upstream"
     }
+    $ErrorActionPreference = "Stop"
 
     # Try to find the merge-base with master, then main.
     $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/master" 2>$null).Trim()

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -38,7 +38,7 @@ $currentBranch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD).Trim()
 # 2. The current branch is a GitHub temporary merge branch.
 # 3. The current branch is a release candidate branch.
 # 4. The current checkout is a shallow clone.
-$isShallow = Test-Path -Path (Join-Path $flutterRoot ".git/shallow")
+$isShallow = Test-Path -Path (Join-Path "$flutterRoot" ".git/shallow")
 if (($currentBranch -ne "main") -and
     ($currentBranch -ne "master") -and
     ($currentBranch -ne "stable") -and
@@ -64,7 +64,7 @@ if (($currentBranch -ne "main") -and
     $ErrorActionPreference = "Stop"
 
     if ($mergeBase) {
-        $baseRef = $mergeBase
+        $baseRef = "$mergeBase"
     }
 }
 
@@ -77,6 +77,6 @@ if (($currentBranch -ne "main") -and
 # 3. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
 # 4. git hash-object with stdin from a pipeline consumes UTF-16, so consume
 #.   the contents of hash.txt
-(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" $baseRef -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
+(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" "$baseRef" -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
 git hash-object hash.txt
 Remove-Item hash.txt

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -25,4 +25,24 @@ unset GIT_WORK_TREE
 # bin/internal/content_aware_hash.ps1: script for calculating the hash on windows
 # bin/internal/content_aware_hash.sh: script for calculating the hash on mac/linux
 # .github/workflows/content-aware-hash.yml: github action for CI/CD hashing
-git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" HEAD DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin
+TRACKEDFILES="DEPS engine bin/internal/release-candidate-branch.version"
+BASEREF="HEAD"
+
+set +e
+# We will fallback to origin/master if upstream is not detected.
+git -C "$FLUTTER_ROOT" remote get-url upstream >/dev/null 2>&1
+exit_code=$?
+set -e
+if [[ $exit_code -eq 0 ]]; then
+  MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD upstream/master)
+else
+  MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD origin/master)
+fi
+
+# Check to see if we're in a local development branch and the branch has any
+# changes to engine code - including non-committed changes.
+if [ "$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)" != "master" ] && \
+    ! git -C "$FLUTTER_ROOT" diff --quiet "$MERGEBASE" -- $TRACKEDFILES; then
+  BASEREF="$MERGEBASE"
+fi
+git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" $BASEREF -- $TRACKEDFILES | git hash-object --stdin

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -61,7 +61,9 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   fi
   set -e
 
-  BASEREF="$MERGEBASE"
+  if [[ -n "$MERGEBASE" ]]; then
+    BASEREF="$MERGEBASE";
+  fi
 fi
 
 git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" $BASEREF -- $TRACKEDFILES | git hash-object --stdin

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -23,9 +23,9 @@ unset GIT_WORK_TREE
 # DEPS: tracks third party dependencies related to building the engine
 # engine: all the code in the engine folder
 # bin/internal/release-candidate-branch.version: release marker
-TRACKEDFILES="DEPS engine bin/internal/release-candidate-branch.version"
+TRACKEDFILES=(DEPS engine bin/internal/release-candidate-branch.version)
 BASEREF="HEAD"
-CURRENT_BRANCH=$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)
+CURRENT_BRANCH="$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)"
 
 # By default, the content hash is based on HEAD.
 # For local development branches, we want to base the hash on the merge-base
@@ -62,8 +62,8 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   set -e
 
   if [[ -n "$MERGEBASE" ]]; then
-    BASEREF="$MERGEBASE";
+    BASEREF="$MERGEBASE"
   fi
 fi
 
-git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" $BASEREF -- $TRACKEDFILES | git hash-object --stdin
+git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -61,13 +61,7 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   fi
   set -e
 
-  # If we found a merge-base, check for changes to the engine.
-  # If there are changes, use the merge-base as the base for the hash.
-  if [[ -n "$MERGEBASE" ]]; then
-    if ! git -C "$FLUTTER_ROOT" diff --quiet "$MERGEBASE" -- $TRACKEDFILES; then
-      BASEREF="$MERGEBASE"
-    fi
-  fi
+  BASEREF="$MERGEBASE"
 fi
 
 git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" $BASEREF -- $TRACKEDFILES | git hash-object --stdin

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -114,8 +114,21 @@ void main() {
     return run(executable, args);
   }
 
+  /// Sets up and fetches a [remote] (such as `upstream` or `origin`) for [testRoot.root].
+  ///
+  /// The remote points at itself (`testRoot.root.path`) for ease of testing.
+  void setupRemote({required String remote, String? rootPath}) {
+    run('git', <String>[
+      'remote',
+      'add',
+      remote,
+      rootPath ?? testRoot.root.path,
+    ], workingPath: rootPath);
+    run('git', <String>['fetch', remote], workingPath: rootPath);
+  }
+
   /// Initializes a blank git repo in [testRoot.root].
-  void initGitRepoWithBlankInitialCommit({String? workingPath}) {
+  void initGitRepoWithBlankInitialCommit({String? workingPath, String remote = 'upstream'}) {
     run('git', <String>['init', '--initial-branch', 'master'], workingPath: workingPath);
     // autocrlf is very important for tests to work on windows.
     run('git', 'config --local core.autocrlf true'.split(' '), workingPath: workingPath);
@@ -133,6 +146,8 @@ void main() {
       '-m',
       'Initial commit',
     ], workingPath: workingPath);
+
+    setupRemote(remote: remote, rootPath: workingPath);
   }
 
   void writeFileAndCommit(File file, String contents) {
@@ -141,9 +156,56 @@ void main() {
     run('git', <String>['commit', '--all', '-m', 'changed ${file.basename} to $contents']);
   }
 
+  void gitSwitchBranch(String branch, {bool create = true}) {
+    run('git', <String>['switch', if (create) '-c', branch]);
+  }
+
   test('generates a hash', () async {
     initGitRepoWithBlankInitialCommit();
     expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  test('generates a hash for origin', () {
+    initGitRepoWithBlankInitialCommit(remote: 'origin');
+    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  group('ignores local engine for', () {
+    test('upstream', () {
+      initGitRepoWithBlankInitialCommit();
+      gitSwitchBranch('engineTest');
+      testRoot.deps.writeAsStringSync('deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for non-committed file',
+      );
+
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for committed file',
+      );
+    });
+
+    test('origin', () {
+      initGitRepoWithBlankInitialCommit(remote: 'origin');
+      gitSwitchBranch('engineTest');
+      testRoot.deps.writeAsStringSync('deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for non-committed file',
+      );
+
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for committed file',
+      );
+    });
   });
 
   group('generates a different hash when', () {

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -125,8 +125,8 @@ void main() {
     final List<String> args;
     if (const LocalPlatform().isWindows) {
       executable = 'powershell';
-      // ExecutionPolicy required to execute scripts from temp files on
-      // Windows 11.
+      // "ExecutionPolicy Bypass" is required to execute scripts from temp
+      // folders on Windows 11 machines.
       args = <String>['-ExecutionPolicy', 'Bypass', '-File', testRoot.contentAwareHashPs1.path];
     } else if (usePowershellOnPosix) {
       executable = 'pwsh';

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -108,11 +108,11 @@ void main() {
     // Git adds a lot of files, we don't want to test for them.
     final Directory gitDir = testRoot.root.childDirectory('.git');
     if (gitDir.existsSync()) {
-      // gitDir.deleteSync(recursive: true);
+      gitDir.deleteSync(recursive: true);
     }
 
     // Now do cleanup so even if the next step fails, we still deleted tmp.
-    // tmpDir.deleteSync(recursive: true);
+    tmpDir.deleteSync(recursive: true);
   });
 
   /// Runs `bin/internal/content_aware_hash.{sh|ps1}` and returns the process result.

--- a/docs/tool/Engine-artifacts.md
+++ b/docs/tool/Engine-artifacts.md
@@ -77,6 +77,30 @@ On Cocoon (Flutter's internal CI/CD) we _often_ set
 [^2]: I.e. experimental branches that do not fall into one of the above.
 [^3]: Only updated through `flutter-x.x-candidate.x` branches.
 
+## Content Hashing
+
+The content hash is a fingerprint of the assets used in producing engine artifacts.
+These include:
+
+- `DEPS`: Used to pull third_party dependencies.
+- `engine/`: The entire engine subfolder[^4].
+- `bin/internal/release-candidate-branch.version`: A signal for release builds, keeping builds hermetic.
+
+The Flutter project has a plethora of users: engineers working from local branches, release branches, GitHub merge queues, and downstream shallow consumers to name the known ones. The following table shows where the content hash is calculated from:
+
+| Branch                  | Hashed From                                                          |
+| ----------------------- | -------------------------------------------------------------------- |
+| `main`                  | HEAD                                                                 |
+| `master`                | HEAD                                                                 |
+| `stable`                | HEAD                                                                 |
+| `beta`                  | HEAD                                                                 |
+| GitHub Merge Queue      | HEAD                                                                 |
+| `flutter-*-candidate.x` | HEAD                                                                 |
+| Shallow Clones          | HEAD                                                                 |
+| **Everything Else**.    | `merge-base` between `HEAD` and`(origin or upstream)/(main or master)` |
+
+[^4]: This is suboptimal from an artifact building perspective, but optimal for the speed of each `dart` and `flutter` call. Flutter is called more often than it is built.
+
 ## References
 
 The script(s) that compute (and test the computation of) the engine version:


### PR DESCRIPTION
The content hash doesn't exist for local engine changes, except for on CI. If we detect we're on a branch with committed or uncommitted changes to engine files; use "master".

towards #171790

re-land attempt for #172792  with the following changes:

1. content_aware_hash.(ps1|sh) now consider multiple branches to choose between HEAD and merge-base.
2. content_aware_hash_test.dart updated for these new requirements 
3. content_aware_hash_test.dart allows for forcing powershell on mac for testing
4. updated docs/tool/Engine-artifacts.md documentation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
