### PR TITLE
Fix: Assertion failure in RawScrollbarState with dynamic controller assignment

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1456,6 +1456,14 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
     } else if (_effectiveScrollController != null && enableGestures) {
       // Interactive scrollbars need to be properly configured. If it is visible
       // for interaction, ensure we are set up properly.
+      // Don't assert immediately if we're in the middle of updating the widget
+      // as the controller may not be attached yet in that frame.
+      if (_fadeoutAnimationController.status == AnimationStatus.forward &&
+          (widget.thumbVisibility ?? false)) {
+        // When thumbVisibility is true and we're animating forward,
+        // the check is already scheduled by _debugScheduleCheckHasValidScrollPosition.
+        return;
+      }
       assert(_debugCheckHasValidScrollPosition());
     }
   }


### PR DESCRIPTION
Fix: Assertion failure in RawScrollbarState with dynamic controller assignment
fixes: #172614 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.