### PR TITLE
fix: get content hash for master on local engine branches (third attempt) 

### DIFF
--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -13,13 +13,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Fetch base commit and origin/master
-        run: |
-          git fetch --no-tags --prune --depth=1 origin ${{ github.event.pull_request.base.sha }}
-
       - name: Generate Hash
         run: |
-          engine_content_hash=$(bin/internal/content_aware_hash.sh)
+          # IMPORTANT: Keep the list of files in sync with bin/internal/content_aware_hash.sh
+          # We call this directly here as we're expected to be in the merge queue (not master)
+          engine_content_hash=$(git ls-tree --format "%(objectname) %(path)" HEAD -- DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin)
           # test notice annotation for retrival from api
           echo "::notice ::{\"engine_content_hash\": \"${engine_content_hash}\"}"
           # test summary writing

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -5,7 +5,7 @@
 # ---------------------------------- NOTE ---------------------------------- #
 #
 # Please keep the logic in this file consistent with the logic in the
-# `content_aware_hash.ps1` script in the same directory to ensure that Flutter
+# `content_aware_hash.sh` script in the same directory to ensure that Flutter
 # continues to work across all platforms!
 #
 # -------------------------------------------------------------------------- #
@@ -23,10 +23,51 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 # Cannot use '*' for files in this command
 # DEPS: tracks third party dependencies related to building the engine
 # engine: all the code in the engine folder
-# bin/internal/content_aware_hash.ps1: script for calculating the hash on windows
-# bin/internal/content_aware_hash.sh: script for calculating the hash on mac/linux
-# .github/workflows/content-aware-hash.yml: github action for CI/CD hashing
+# bin/internal/release-candidate-branch.version: release marker
+$trackedFiles = "DEPS", "engine", "bin/internal/release-candidate-branch.version"
+$baseRef = "HEAD"
+$currentBranch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD).Trim()
+
+# By default, the content hash is based on HEAD.
+# For local development branches, we want to base the hash on the merge-base
+# with the remote tracking branch, so that we don't rebuild the world every
+# time we make a change to the engine.
 #
+# The following conditions are exceptions where we want to use HEAD.
+# 1. The current branch is a release branch (main, master, stable, beta).
+# 2. The current branch is a GitHub temporary merge branch.
+# 3. The current branch is a release candidate branch.
+# 4. The current checkout is a shallow clone.
+$isShallow = Test-Path -Path (Join-Path "$flutterRoot" ".git/shallow")
+if (($currentBranch -ne "main") -and
+    ($currentBranch -ne "master") -and
+    ($currentBranch -ne "stable") -and
+    ($currentBranch -ne "beta") -and
+    (-not $currentBranch.StartsWith("gh-readonly-queue/master/pr-")) -and
+    (-not ($currentBranch -like "flutter-*-candidate.*")) -and
+    (-not $isShallow)) {
+
+    # This is a development branch. Find the merge-base.
+    # We will fallback to origin if upstream is not detected.
+    $remote = "origin"
+    $ErrorActionPreference = 'SilentlyContinue'
+    git -C "$flutterRoot" remote get-url upstream *> $null
+    if ($LASTEXITCODE -eq 0) {
+        $remote = "upstream"
+    }
+
+    # Try to find the merge-base with master, then main.
+    $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/master" 2>$null).Trim()
+    if ([string]::IsNullOrEmpty($mergeBase)) {
+        $mergeBase = (git -C "$flutterRoot" merge-base HEAD "$remote/main" 2>$null).Trim()
+    }
+    $ErrorActionPreference = "Stop"
+
+    if ($mergeBase) {
+        $baseRef = "$mergeBase"
+    }
+}
+
 # Removing the "cmd" requirement enables powershell usage on other hosts
 # 1. git ls-tree | Out-String - combines output of pipeline into a single string
 #    rather than an array for each line.
@@ -36,6 +77,6 @@ $flutterRoot = (Get-Item $progName).parent.parent.FullName
 # 3. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
 # 4. git hash-object with stdin from a pipeline consumes UTF-16, so consume
 #.   the contents of hash.txt
-(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" HEAD DEPS engine bin/internal/release-candidate-branch.version | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
+(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" "$baseRef" -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
 git hash-object hash.txt
 Remove-Item hash.txt

--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -38,11 +38,13 @@ $currentBranch = (git -C "$flutterRoot" rev-parse --abbrev-ref HEAD).Trim()
 # 2. The current branch is a GitHub temporary merge branch.
 # 3. The current branch is a release candidate branch.
 # 4. The current checkout is a shallow clone.
+# 5. There is no current branch. E.g. running on CI/CD.
 $isShallow = Test-Path -Path (Join-Path "$flutterRoot" ".git/shallow")
 if (($currentBranch -ne "main") -and
     ($currentBranch -ne "master") -and
     ($currentBranch -ne "stable") -and
     ($currentBranch -ne "beta") -and
+    ($currentBranch -ne "HEAD") -and
     (-not $currentBranch.StartsWith("gh-readonly-queue/master/pr-")) -and
     (-not ($currentBranch -like "flutter-*-candidate.*")) -and
     (-not $isShallow)) {

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -22,7 +22,48 @@ unset GIT_WORK_TREE
 # Cannot use '*' for files in this command
 # DEPS: tracks third party dependencies related to building the engine
 # engine: all the code in the engine folder
-# bin/internal/content_aware_hash.ps1: script for calculating the hash on windows
-# bin/internal/content_aware_hash.sh: script for calculating the hash on mac/linux
-# .github/workflows/content-aware-hash.yml: github action for CI/CD hashing
-git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" HEAD DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin
+# bin/internal/release-candidate-branch.version: release marker
+TRACKEDFILES=(DEPS engine bin/internal/release-candidate-branch.version)
+BASEREF="HEAD"
+CURRENT_BRANCH="$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)"
+
+# By default, the content hash is based on HEAD.
+# For local development branches, we want to base the hash on the merge-base
+# with the remote tracking branch, so that we don't rebuild the world every
+# time we make a change to the engine.
+#
+# The following conditions are exceptions where we want to use HEAD.
+# 1. The current branch is a release branch (main, master, stable, beta).
+# 2. The current branch is a GitHub temporary merge branch.
+# 3. The current branch is a release candidate branch.
+# 4. The current checkout is a shallow clone.
+if [[ "$CURRENT_BRANCH" != "main" && \
+      "$CURRENT_BRANCH" != "master" && \
+      "$CURRENT_BRANCH" != "stable" && \
+      "$CURRENT_BRANCH" != "beta" && \
+      "$CURRENT_BRANCH" != "gh-readonly-queue/master/pr-"* && \
+      "$CURRENT_BRANCH" != "flutter-"*"-candidate."* && \
+      ! -f "$FLUTTER_ROOT/.git/shallow" ]]; then
+
+  # This is a development branch. Find the merge-base.
+  # We will fallback to origin if upstream is not detected.
+  REMOTE="origin"
+  set +e
+  git -C "$FLUTTER_ROOT" remote get-url upstream >/dev/null 2>&1
+  if [[ $? -eq 0 ]]; then
+    REMOTE="upstream"
+  fi
+
+  # Try to find the merge-base with master, then main.
+  MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/master" 2>/dev/null)
+  if [[ -z "$MERGEBASE" ]]; then
+    MERGEBASE=$(git -C "$FLUTTER_ROOT" merge-base HEAD "$REMOTE/main" 2>/dev/null)
+  fi
+  set -e
+
+  if [[ -n "$MERGEBASE" ]]; then
+    BASEREF="$MERGEBASE"
+  fi
+fi
+
+git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -37,12 +37,14 @@ CURRENT_BRANCH="$(git -C "$FLUTTER_ROOT" rev-parse --abbrev-ref HEAD)"
 # 2. The current branch is a GitHub temporary merge branch.
 # 3. The current branch is a release candidate branch.
 # 4. The current checkout is a shallow clone.
+# 5. There is no current branch. E.g. running on CI/CD.
 if [[ "$CURRENT_BRANCH" != "main" && \
       "$CURRENT_BRANCH" != "master" && \
       "$CURRENT_BRANCH" != "stable" && \
       "$CURRENT_BRANCH" != "beta" && \
       "$CURRENT_BRANCH" != "gh-readonly-queue/master/pr-"* && \
       "$CURRENT_BRANCH" != "flutter-"*"-candidate."* && \
+      "$CURRENT_BRANCH" != "HEAD" && \
       ! -f "$FLUTTER_ROOT/.git/shallow" ]]; then
 
   # This is a development branch. Find the merge-base.

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -22,6 +22,18 @@ import 'package:test/test.dart';
 //////////////////////////////////////////////////////////////////////
 
 void main() {
+  // Want to test the powershell (content_aware_hash.ps1) file, but running
+  // a macOS or Linux machine? You can install powershell and then opt-in to
+  // running `pwsh bin/internal/content_aware_hash.ps1`.
+  //
+  // macOS: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos
+  // linux: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux
+  //
+  // Then, set this variable to true:
+  final bool usePowershellOnPosix = io.Platform.environment['FORCE_POWERSHELL'] == 'true';
+
+  print('env: ${io.Platform.environment}');
+
   const FileSystem localFs = LocalFileSystem();
   final _FlutterRootUnderTest flutterRoot = _FlutterRootUnderTest.findWithin();
 
@@ -58,15 +70,22 @@ void main() {
     return result;
   }
 
+  setUpAll(() async {
+    if (usePowershellOnPosix) {
+      final io.ProcessResult result = io.Process.runSync('pwsh', <String>['--version']);
+      print('Using Powershell (${result.stdout}) on POSIX for local debugging and testing');
+    }
+  });
+
   setUp(() async {
     tmpDir = localFs.systemTempDirectory.createTempSync('content_aware_hash.');
     testRoot = _FlutterRootUnderTest.fromPath(tmpDir.childDirectory('flutter').path);
 
     environment = <String, String>{};
 
-    if (const LocalPlatform().isWindows) {
+    if (const LocalPlatform().isWindows || usePowershellOnPosix) {
       // Copy a minimal set of environment variables needed to run the update_engine_version script in PowerShell.
-      const List<String> powerShellVariables = <String>['SystemRoot', 'Path', 'PATHEXT'];
+      const List<String> powerShellVariables = <String>['SystemRoot', 'PATH', 'PATHEXT'];
       for (final String key in powerShellVariables) {
         final String? value = io.Platform.environment[key];
         if (value != null) {
@@ -106,6 +125,11 @@ void main() {
     final List<String> args;
     if (const LocalPlatform().isWindows) {
       executable = 'powershell';
+      // "ExecutionPolicy Bypass" is required to execute scripts from temp
+      // folders on Windows 11 machines.
+      args = <String>['-ExecutionPolicy', 'Bypass', '-File', testRoot.contentAwareHashPs1.path];
+    } else if (usePowershellOnPosix) {
+      executable = 'pwsh';
       args = <String>[testRoot.contentAwareHashPs1.path];
     } else {
       executable = testRoot.contentAwareHashSh.path;
@@ -114,9 +138,26 @@ void main() {
     return run(executable, args);
   }
 
+  /// Sets up and fetches a [remote] (such as `upstream` or `origin`) for [testRoot.root].
+  ///
+  /// The remote points at itself (`testRoot.root.path`) for ease of testing.
+  void setupRemote({required String remote, String? rootPath}) {
+    run('git', <String>[
+      'remote',
+      'add',
+      remote,
+      rootPath ?? testRoot.root.path,
+    ], workingPath: rootPath);
+    run('git', <String>['fetch', remote], workingPath: rootPath);
+  }
+
   /// Initializes a blank git repo in [testRoot.root].
-  void initGitRepoWithBlankInitialCommit({String? workingPath}) {
-    run('git', <String>['init', '--initial-branch', 'master'], workingPath: workingPath);
+  void initGitRepoWithBlankInitialCommit({
+    String? workingPath,
+    String branch = 'master',
+    String remote = 'upstream',
+  }) {
+    run('git', <String>['init', '--initial-branch', branch], workingPath: workingPath);
     // autocrlf is very important for tests to work on windows.
     run('git', 'config --local core.autocrlf true'.split(' '), workingPath: workingPath);
     run('git', <String>[
@@ -133,6 +174,13 @@ void main() {
       '-m',
       'Initial commit',
     ], workingPath: workingPath);
+
+    setupRemote(remote: remote, rootPath: workingPath);
+  }
+
+  String gitShaFor(String ref, {String? workingPath}) {
+    return (run('git', <String>['rev-parse', ref], workingPath: workingPath).stdout as String)
+        .trim();
   }
 
   void writeFileAndCommit(File file, String contents) {
@@ -141,9 +189,137 @@ void main() {
     run('git', <String>['commit', '--all', '-m', 'changed ${file.basename} to $contents']);
   }
 
-  test('generates a hash', () async {
+  void gitSwitchBranch(String branch, {bool create = true}) {
+    run('git', <String>['switch', if (create) '-c', branch]);
+  }
+
+  // Downstream flutter user tests: (origin|upstream)/(main|master), stable, and
+  // beta should work.
+
+  test('generates a hash or upstream/master', () async {
     initGitRepoWithBlankInitialCommit();
     expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  test('generates a hash for origin/master', () {
+    initGitRepoWithBlankInitialCommit(remote: 'origin');
+    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  test('generates a hash for origin/main', () {
+    initGitRepoWithBlankInitialCommit(remote: 'origin', branch: 'main');
+    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  test('generates a hash for upstream/main', () {
+    initGitRepoWithBlankInitialCommit(branch: 'main');
+    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  group('stable branches calculate hash locally', () {
+    test('with no changes', () {
+      initGitRepoWithBlankInitialCommit(branch: 'main');
+      gitSwitchBranch('stable');
+      expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    });
+
+    test('with engine changes', () {
+      initGitRepoWithBlankInitialCommit(branch: 'main');
+      gitSwitchBranch('stable');
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+
+      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+    });
+  });
+
+  group('beta branches calculate hash locally', () {
+    test('with no changes', () {
+      initGitRepoWithBlankInitialCommit(branch: 'main');
+      gitSwitchBranch('beta');
+      expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    });
+
+    test('with engine changes', () {
+      initGitRepoWithBlankInitialCommit(branch: 'main');
+      gitSwitchBranch('beta');
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+
+      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+    });
+  });
+
+  group('release branches calculate hash locally', () {
+    test('with no changes', () {
+      initGitRepoWithBlankInitialCommit(branch: 'main');
+      gitSwitchBranch('flutter-4.35-candidate.2');
+      expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    });
+
+    test('with engine changes', () {
+      initGitRepoWithBlankInitialCommit(branch: 'main');
+      gitSwitchBranch('flutter-4.35-candidate.2');
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+
+      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+    });
+  });
+
+  test('github special merge group branches calculate hash locally', () {
+    initGitRepoWithBlankInitialCommit(
+      remote: 'origin',
+      branch: 'gh-readonly-queue/master/pr-1234-abcd',
+    );
+    writeFileAndCommit(testRoot.deps, 'deps changed');
+
+    expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+  }); //gh-readonly-queue/master/pr
+
+  test('generates a hash for shallow clones', () {
+    initGitRepoWithBlankInitialCommit(remote: 'origin', branch: 'blip');
+    final String headSha = gitShaFor('HEAD');
+    testRoot.root
+        .childFile(localFs.path.joinAll('.git/shallow'.split('/')))
+        .writeAsStringSync(headSha);
+    writeFileAndCommit(testRoot.deps, 'deps changed');
+    expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+  });
+
+  group('ignores local engine for', () {
+    test('upstream', () {
+      initGitRepoWithBlankInitialCommit();
+      gitSwitchBranch('engineTest');
+      testRoot.deps.writeAsStringSync('deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for non-committed file',
+      );
+
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for committed file',
+      );
+    });
+
+    test('origin', () {
+      initGitRepoWithBlankInitialCommit(remote: 'origin');
+      gitSwitchBranch('engineTest');
+      testRoot.deps.writeAsStringSync('deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for non-committed file',
+      );
+
+      writeFileAndCommit(testRoot.deps, 'deps changed');
+      expect(
+        runContentAwareHash(),
+        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        reason: 'content hash from master for committed file',
+      );
+    });
   });
 
   group('generates a different hash when', () {
@@ -190,6 +366,20 @@ void main() {
     initGitRepoWithBlankInitialCommit();
     testRoot.flutterReadMe.writeAsStringSync('codefu was here');
     expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+  });
+
+  test('missing merge-base defaults to HEAD', () {
+    initGitRepoWithBlankInitialCommit();
+
+    run('git', <String>['branch', '-m', 'no-merge-base'], workingPath: testRoot.root.path);
+    run('git', <String>['remote', 'remove', 'upstream'], workingPath: testRoot.root.path);
+
+    writeFileAndCommit(testRoot.deps, 'deps changed');
+    expect(
+      runContentAwareHash(),
+      processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'),
+      reason: 'content hash from HEAD when no merge-base',
+    );
   });
 }
 

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -216,6 +216,23 @@ void main() {
     expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
   });
 
+  test('generates a hash for CI/CD from HEAD', () {
+    // This test validates the workflow with LUCI recipes in which the git sha
+    // is checked out, not the branch.
+    initGitRepoWithBlankInitialCommit(branch: 'main');
+    writeFileAndCommit(testRoot.deps, 'deps changed');
+
+    final String headSha = gitShaFor('HEAD');
+    run('git', <String>['checkout', '-f', headSha]);
+    run('git', <String>['--no-pager', 'log', '--decorate=short', '--pretty=oneline']);
+    expect(
+      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout as String).trim(),
+      equals('HEAD'),
+    );
+
+    expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+  });
+
   group('stable branches calculate hash locally', () {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
@@ -272,7 +289,7 @@ void main() {
     writeFileAndCommit(testRoot.deps, 'deps changed');
 
     expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
-  }); //gh-readonly-queue/master/pr
+  });
 
   test('generates a hash for shallow clones', () {
     initGitRepoWithBlankInitialCommit(remote: 'origin', branch: 'blip');

--- a/docs/tool/Engine-artifacts.md
+++ b/docs/tool/Engine-artifacts.md
@@ -77,6 +77,30 @@ On Cocoon (Flutter's internal CI/CD) we _often_ set
 [^2]: I.e. experimental branches that do not fall into one of the above.
 [^3]: Only updated through `flutter-x.x-candidate.x` branches.
 
+## Content Hashing
+
+The content hash is a fingerprint of the assets used in producing engine artifacts.
+These include:
+
+- `DEPS`: Used to pull third_party dependencies.
+- `engine/`: The entire engine subfolder[^4].
+- `bin/internal/release-candidate-branch.version`: A signal for release builds, keeping builds hermetic.
+
+The Flutter project has a plethora of users: engineers working from local branches, release branches, GitHub merge queues, and downstream shallow consumers to name the known ones. The following table shows where the content hash is calculated from:
+
+| Branch                  | Hashed From                                                          |
+| ----------------------- | -------------------------------------------------------------------- |
+| `main`                  | HEAD                                                                 |
+| `master`                | HEAD                                                                 |
+| `stable`                | HEAD                                                                 |
+| `beta`                  | HEAD                                                                 |
+| GitHub Merge Queue      | HEAD                                                                 |
+| `flutter-*-candidate.x` | HEAD                                                                 |
+| Shallow Clones          | HEAD                                                                 |
+| **Everything Else**.    | `merge-base` between `HEAD` and`(origin or upstream)/(main or master)` |
+
+[^4]: This is suboptimal from an artifact building perspective, but optimal for the speed of each `dart` and `flutter` call. Flutter is called more often than it is built.
+
 ## References
 
 The script(s) that compute (and test the computation of) the engine version:

--- a/docs/tool/Engine-artifacts.md
+++ b/docs/tool/Engine-artifacts.md
@@ -90,12 +90,11 @@ The Flutter project has a plethora of users: engineers working from local branch
 
 | Branch                  | Hashed From                                                          |
 | ----------------------- | -------------------------------------------------------------------- |
-| `main`                  | HEAD                                                                 |
-| `master`                | HEAD                                                                 |
-| `stable`                | HEAD                                                                 |
-| `beta`                  | HEAD                                                                 |
+| `main`,`master`         | HEAD                                                                 |
+| `stable`, `beta`        | HEAD                                                                 |
 | GitHub Merge Queue      | HEAD                                                                 |
 | `flutter-*-candidate.x` | HEAD                                                                 |
+| `HEAD`                  | HEAD                                                                 |
 | Shallow Clones          | HEAD                                                                 |
 | **Everything Else**.    | `merge-base` between `HEAD` and`(origin or upstream)/(main or master)` |
 


### PR DESCRIPTION
The content hash doesn't exist for local engine changes, except for on
CI. If we detect we're on a branch with committed or uncommitted changes
to engine files; use "master".

towards #171790

re-land attempt for #173114 (try 2)
re-land attempt for #172792 (original)

The first commit in this PR is the previously LGTM'd changes for the above; with tests.

The second commit is the critical change to make this work in post submits (fixes #173143). It turns out that while LUCI reports the GitHub private branches; our recipes directly checkout the git sha. This matters because the content scripts couldn't determine the branch name and the rev-parse was just HEAD. This lead the scripts down the merge-base logic, which returns the previous commit.

A test was added specifically for this.

Alternatively to this change, we could have checked for LUCI_CONTEXT being present in the environment. This is checked by Flutter tools in some cases, but not by any other scripts in `bin/internal`. The downside to checking HEAD: if you have a local branch with engine changes and you move back a revision - `dart`/`flutter` invocations will generate the hash for your local changes and fail.
