### PR TITLE
Feat: Add custom scripts support in flutter cli

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -28,6 +28,7 @@ import 'src/commands/doctor.dart';
 import 'src/commands/downgrade.dart';
 import 'src/commands/drive.dart';
 import 'src/commands/emulators.dart';
+import 'src/commands/exec.dart';
 import 'src/commands/generate.dart';
 import 'src/commands/generate_localizations.dart';
 import 'src/commands/ide_config.dart';
@@ -245,6 +246,7 @@ List<FlutterCommand> generateCommands({required bool verboseHelp, required bool 
       ),
       RunCommand(verboseHelp: verboseHelp),
       ScreenshotCommand(fs: globals.fs),
+      ExecCommand(),
       ShellCompletionCommand(),
       TestCommand(
         verboseHelp: verboseHelp,

--- a/packages/flutter_tools/lib/src/commands/exec.dart
+++ b/packages/flutter_tools/lib/src/commands/exec.dart
@@ -1,0 +1,183 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import '../base/common.dart';
+import '../base/process.dart';
+import '../globals.dart' as globals;
+import '../project.dart';
+import '../runner/flutter_command.dart';
+
+class ExecCommand extends FlutterCommand {
+  ExecCommand() {
+    requiresPubspecYaml();
+    argParser.addFlag(
+      'list',
+      abbr: 'l',
+      negatable: false,
+      help: 'List all available scripts defined in pubspec.yaml.',
+    );
+  }
+
+  @override
+  String get name => 'exec';
+
+  @override
+  String get description => 'Execute scripts defined in pubspec.yaml.';
+
+  @override
+  String get category => FlutterCommandCategory.project;
+
+  @override
+  String get invocation => '${runner?.executableName} $name <script-name>';
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final FlutterProject project = FlutterProject.current();
+    final Map<String, String>? scripts = project.manifest.scripts;
+
+    // Handle --list flag
+    if (boolArg('list')) {
+      if (scripts == null || scripts.isEmpty) {
+        globals.printStatus('No scripts defined in pubspec.yaml');
+      } else {
+        globals.printStatus('Available scripts:');
+        for (final MapEntry<String, String> script in scripts.entries) {
+          globals.printStatus('  ${script.key}: ${script.value}');
+        }
+      }
+      return const FlutterCommandResult(ExitStatus.success);
+    }
+
+    // Get script name from arguments
+    final List<String> args = argResults?.rest ?? <String>[];
+    if (args.isEmpty) {
+      throwToolExit('No script name provided. Use "flutter exec --list" to see available scripts.');
+    }
+
+    final String scriptName = args.first;
+
+    // Check if scripts are defined
+    if (scripts == null || scripts.isEmpty) {
+      throwToolExit('No scripts defined in pubspec.yaml');
+    }
+
+    // Check if the script exists
+    final String? command = scripts[scriptName];
+    if (command == null) {
+      throwToolExit(
+        'Script "$scriptName" not found in pubspec.yaml.\n'
+        'Available scripts: ${scripts.keys.join(', ')}',
+      );
+    }
+
+    // Execute the script
+    globals.printStatus('Running script "$scriptName": $command');
+
+    // Parse command to handle shell operators and quoted arguments
+    final List<String> commandToRun = _parseShellCommand(command);
+
+    // Run the command
+    final processUtils = ProcessUtils(
+      processManager: globals.processManager,
+      logger: globals.logger,
+    );
+
+    final RunResult result = await processUtils.run(
+      commandToRun,
+      workingDirectory: project.directory.path,
+      allowReentrantFlutter: true,
+    );
+
+    if (result.exitCode != 0) {
+      if (result.stdout.isNotEmpty) {
+        globals.printStatus(result.stdout);
+      }
+      if (result.stderr.isNotEmpty) {
+        globals.printError(result.stderr);
+      }
+      throwToolExit('Script "$scriptName" failed with exit code ${result.exitCode}');
+    }
+
+    if (result.stdout.isNotEmpty) {
+      globals.printStatus(result.stdout);
+    }
+
+    return const FlutterCommandResult(ExitStatus.success);
+  }
+
+  /// Parses a shell command string, handling quoted arguments and shell operators.
+  ///
+  /// For commands containing shell operators (&&, ||, |, ;) or complex quoting,
+  /// delegates to the system shell. Otherwise, performs proper argument parsing
+  /// that respects quoted strings.
+  List<String> _parseShellCommand(String command) {
+    // Check if command contains shell operators that require shell execution
+    final shellOperators = <String>['&&', '||', '|', ';', '>', '<', '>>'];
+    final bool hasShellOperators = shellOperators.any((String op) => command.contains(op));
+
+    if (hasShellOperators) {
+      // Delegate to system shell for complex commands
+      if (io.Platform.isWindows) {
+        return <String>['cmd', '/c', command];
+      } else {
+        return <String>['sh', '-c', command];
+      }
+    }
+
+    // Parse simple commands with proper quote handling
+    return _parseSimpleCommand(command);
+  }
+
+  /// Parses a simple command (no shell operators) with proper quote handling.
+  List<String> _parseSimpleCommand(String command) {
+    final result = <String>[];
+    final currentArg = StringBuffer();
+    var inSingleQuote = false;
+    var inDoubleQuote = false;
+    var escaped = false;
+
+    for (var i = 0; i < command.length; i++) {
+      final String char = command[i];
+
+      if (escaped) {
+        currentArg.write(char);
+        escaped = false;
+        continue;
+      }
+
+      if (char == r'\' && !inSingleQuote) {
+        escaped = true;
+        continue;
+      }
+
+      if (char == "'" && !inDoubleQuote) {
+        inSingleQuote = !inSingleQuote;
+        continue;
+      }
+
+      if (char == '"' && !inSingleQuote) {
+        inDoubleQuote = !inDoubleQuote;
+        continue;
+      }
+
+      if (char == ' ' && !inSingleQuote && !inDoubleQuote) {
+        if (currentArg.isNotEmpty) {
+          result.add(currentArg.toString());
+          currentArg.clear();
+        }
+        continue;
+      }
+
+      currentArg.write(char);
+    }
+
+    if (currentArg.isNotEmpty) {
+      result.add(currentArg.toString());
+    }
+
+    return result;
+  }
+}

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -192,6 +192,36 @@ class FlutterManifest {
     }
   }
 
+  /// Returns the scripts defined in the `pubspec.yaml` file.
+  /// Returns null if no scripts are defined.
+  Map<String, String>? get scripts {
+    final Object? scriptsSection = _descriptor['scripts'];
+    if (scriptsSection == null) {
+      return null;
+    }
+    if (scriptsSection is! YamlMap) {
+      _logger.printError('Expected "scripts" to be a map, but got ${scriptsSection.runtimeType}.');
+      return null;
+    }
+    final scripts = <String, String>{};
+    for (final MapEntry<Object?, Object?> entry in scriptsSection.entries) {
+      if (entry.key is! String) {
+        _logger.printError(
+          'Expected script name to be a string, but got ${entry.key.runtimeType}.',
+        );
+        continue;
+      }
+      if (entry.value is! String) {
+        _logger.printError(
+          'Expected script command to be a string, but got ${entry.value.runtimeType}.',
+        );
+        continue;
+      }
+      scripts[entry.key! as String] = entry.value! as String;
+    }
+    return scripts.isEmpty ? null : scripts;
+  }
+
   bool get usesMaterialDesign {
     return _flutterDescriptor['uses-material-design'] as bool? ?? false;
   }

--- a/packages/flutter_tools/test/commands.shard/hermetic/exec_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/exec_test.dart
@@ -1,0 +1,505 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/exec.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/test_flutter_command_runner.dart';
+
+void main() {
+  group('ExecCommand', () {
+    late FileSystem fileSystem;
+    late BufferLogger logger;
+    late FakeProcessManager processManager;
+    late CommandRunner<void> runner;
+
+    setUp(() {
+      Cache.disableLocking();
+      fileSystem = MemoryFileSystem.test();
+      logger = BufferLogger.test();
+      processManager = FakeProcessManager.empty();
+      runner = createTestCommandRunner(ExecCommand());
+    });
+
+    testUsingContext(
+      'shows error when no script name provided',
+      () async {
+        await expectLater(
+          runner.run(<String>['exec']),
+          throwsToolExit(message: 'No script name provided'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'shows error when no pubspec.yaml exists',
+      () async {
+        await expectLater(
+          runner.run(<String>['exec', 'test']),
+          throwsToolExit(message: 'No scripts defined in pubspec.yaml'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'shows error when no scripts section in pubspec.yaml',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+
+        await expectLater(
+          runner.run(<String>['exec', 'test']),
+          throwsToolExit(message: 'No scripts defined in pubspec.yaml'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'shows error when script not found',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  build: flutter build apk
+''');
+
+        await expectLater(
+          runner.run(<String>['exec', 'test']),
+          throwsToolExit(message: 'Script "test" not found in pubspec.yaml'),
+        );
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'lists scripts when --list flag is used',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  test: dart test
+  build: flutter build apk
+  format: dart format .
+''');
+
+        await runner.run(<String>['exec', '--list']);
+
+        expect(logger.statusText, contains('Available scripts:'));
+        expect(logger.statusText, contains('test: dart test'));
+        expect(logger.statusText, contains('build: flutter build apk'));
+        expect(logger.statusText, contains('format: dart format .'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'shows message when no scripts defined and --list is used',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+''');
+
+        await runner.run(<String>['exec', '--list']);
+
+        expect(logger.statusText, contains('No scripts defined in pubspec.yaml'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script successfully',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  test: dart test
+''');
+
+        processManager.addCommand(
+          const FakeCommand(command: <String>['dart', 'test'], stdout: 'All tests passed!'),
+        );
+
+        await runner.run(<String>['exec', 'test']);
+
+        expect(logger.statusText, contains('Running script "test": dart test'));
+        expect(logger.statusText, contains('All tests passed!'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with multiple arguments',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  build: flutter build apk --release --dart-define-from-file=config.json
+''');
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>[
+              'flutter',
+              'build',
+              'apk',
+              '--release',
+              '--dart-define-from-file=config.json',
+            ],
+            stdout: 'Build completed successfully!',
+          ),
+        );
+
+        await runner.run(<String>['exec', 'build']);
+
+        expect(logger.statusText, contains('Running script "build"'));
+        expect(logger.statusText, contains('Build completed successfully!'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'handles script execution failure',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  test: dart test
+''');
+
+        processManager.addCommand(
+          const FakeCommand(command: <String>['dart', 'test'], exitCode: 1, stderr: 'Test failed!'),
+        );
+
+        await expectLater(
+          runner.run(<String>['exec', 'test']),
+          throwsToolExit(message: 'Script "test" failed with exit code 1'),
+        );
+
+        expect(logger.errorText, contains('Test failed!'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'handles invalid scripts section in pubspec.yaml',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts: "not a map"
+''');
+
+        await expectLater(
+          runner.run(<String>['exec', 'test']),
+          throwsToolExit(message: 'No scripts defined in pubspec.yaml'),
+        );
+
+        expect(logger.errorText, contains('Expected "scripts" to be a map'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'handles script with invalid command value',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  test: 123
+''');
+
+        await runner.run(<String>['exec', '--list']);
+
+        expect(logger.errorText, contains('Expected script command to be a string'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'handles script with invalid script name',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  123: dart test
+''');
+
+        await runner.run(<String>['exec', '--list']);
+
+        expect(logger.errorText, contains('Expected script name to be a string'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with quoted arguments correctly',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  greet: echo "Hello World"
+''');
+
+        processManager.addCommand(
+          const FakeCommand(command: <String>['echo', 'Hello World'], stdout: 'Hello World'),
+        );
+
+        await runner.run(<String>['exec', 'greet']);
+
+        expect(logger.statusText, contains('Running script "greet": echo "Hello World"'));
+        expect(logger.statusText, contains('Hello World'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with shell operators using sh -c',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  multi: echo "Hello" && echo "World"
+''');
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['sh', '-c', 'echo "Hello" && echo "World"'],
+            stdout: 'Hello\nWorld',
+          ),
+        );
+
+        await runner.run(<String>['exec', 'multi']);
+
+        expect(logger.statusText, contains('Running script "multi": echo "Hello" && echo "World"'));
+        expect(logger.statusText, contains('Hello\nWorld'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with pipe operators using sh -c',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  pipe: ls | grep test
+''');
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['sh', '-c', 'ls | grep test'],
+            stdout: 'test_file.dart',
+          ),
+        );
+
+        await runner.run(<String>['exec', 'pipe']);
+
+        expect(logger.statusText, contains('Running script "pipe": ls | grep test'));
+        expect(logger.statusText, contains('test_file.dart'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with mixed quotes and spaces',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  complex: flutter build --name "My App" --verbose
+''');
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['flutter', 'build', '--name', 'My App', '--verbose'],
+            stdout: 'Build completed',
+          ),
+        );
+
+        await runner.run(<String>['exec', 'complex']);
+
+        expect(logger.statusText, contains('Running script "complex"'));
+        expect(logger.statusText, contains('Build completed'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with single quotes',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  single: echo 'Hello Single Quote'
+''');
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['echo', 'Hello Single Quote'],
+            stdout: 'Hello Single Quote',
+          ),
+        );
+
+        await runner.run(<String>['exec', 'single']);
+
+        expect(logger.statusText, contains('Running script "single"'));
+        expect(logger.statusText, contains('Hello Single Quote'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+
+    testUsingContext(
+      'executes script with semicolon operator using sh -c',
+      () async {
+        fileSystem.file('pubspec.yaml').writeAsStringSync('''
+name: test_app
+dependencies:
+  flutter:
+    sdk: flutter
+scripts:
+  sequence: dart format .; dart analyze
+''');
+
+        processManager.addCommand(
+          const FakeCommand(
+            command: <String>['sh', '-c', 'dart format .; dart analyze'],
+            stdout: 'Formatted and analyzed',
+          ),
+        );
+
+        await runner.run(<String>['exec', 'sequence']);
+
+        expect(logger.statusText, contains('Running script "sequence"'));
+        expect(logger.statusText, contains('Formatted and analyzed'));
+      },
+      overrides: <Type, Generator>{
+        FileSystem: () => fileSystem,
+        ProcessManager: () => processManager,
+        Logger: () => logger,
+      },
+    );
+  });
+}


### PR DESCRIPTION
Add flutter exec command for running custom scripts

Currently,  Developers need to remember and type long, repetitive commands for common tasks like:
* flutter pub run build_runner build --delete-conflicting-files
* flutter build apk --release --dart-define-from-file=.env/prod.json
* dart format . && dart analyze && flutter test

or we may end up using tools like melos or create makefile.

This PR implemented a new flutter `exec` command that allows developers to define and run custom scripts from pubspec.yaml.

Example pubspec.yaml:
```yaml
name: app
dependencies:
...
scripts:
   generate: dart run build_runner build --delete-conflicting-files
   build:prod: flutter build apk --release --dart-define-from-file=.env/prod.json
   build:dev: flutter build apk --debug --dart-define-from-file=.env/dev.json
```

Example Usage:
```bash
flutter exec --list
flutter exec generate
flutter exec build:prod
flutter exec check
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
