### PR TITLE
Make sure that a RawChip doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -6374,6 +6374,20 @@ void main() {
       handle.dispose();
     },
   );
+
+  testWidgets('RawChip renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: Scaffold(body: RawChip(label: Text('X'))),
+          ),
+        ),
+      ),
+    );
+    final Finder xText = find.text('X');
+    expect(tester.getSize(xText).isEmpty, isTrue);
+  });
 }
 
 class _MaterialStateOutlinedBorder extends StadiumBorder implements MaterialStateOutlinedBorder {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the RawChip UI control.