### PR TITLE
Add reason when failing with v1 embeddings

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -898,16 +898,16 @@ See the link below for more information:
       return;
     }
     // The v1 android embedding has been deleted.
-    throwToolExit('Build failed due to use of deleted Android v1 embedding.', exitCode: 1);
+    throwToolExit('Build failed due to use of deleted Android v1 embedding. Reason: ${result.reason}', exitCode: 1);
   }
 
   AndroidEmbeddingVersion getEmbeddingVersion() {
-    final AndroidEmbeddingVersion androidEmbeddingVersion = computeEmbeddingVersion().version;
-    if (androidEmbeddingVersion == AndroidEmbeddingVersion.v1) {
-      throwToolExit('Build failed due to use of deleted Android v1 embedding.', exitCode: 1);
+    final AndroidEmbeddingVersionResult result = computeEmbeddingVersion();
+    if (result.version == AndroidEmbeddingVersion.v1) {
+      throwToolExit('Build failed due to use of deleted Android v1 embedding. Reason: ${result.reason}', exitCode: 1);
     }
 
-    return androidEmbeddingVersion;
+    return result.version;
   }
 
   AndroidEmbeddingVersionResult computeEmbeddingVersion() {


### PR DESCRIPTION
When failing with `Build failed due to use of deleted Android v1 embedding.`, there are no reasons given. Finding the reason can be time consuming.

Just adding the `result.reason` to the error message.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
