### PR TITLE
Fix drawerScrimColor transition.

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -649,10 +649,9 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
   final GlobalKey _gestureDetectorKey = GlobalKey();
 
   ColorTween _buildScrimColorTween() {
-    return ColorTween(
-      begin: Colors.transparent,
-      end: widget.scrimColor ?? DrawerTheme.of(context).scrimColor ?? Colors.black54,
-    );
+    final Color effectiveScrimColor =
+        widget.scrimColor ?? DrawerTheme.of(context).scrimColor ?? Colors.black54;
+    return ColorTween(begin: effectiveScrimColor.withValues(alpha: 0), end: effectiveScrimColor);
   }
 
   AlignmentDirectional get _drawerOuterAlignment => switch (widget.alignment) {

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -505,18 +505,8 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
 
   @protected
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _scrimColorTween = _buildScrimColorTween();
-  }
-
-  @protected
-  @override
   void didUpdateWidget(DrawerController oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.scrimColor != oldWidget.scrimColor) {
-      _scrimColorTween = _buildScrimColorTween();
-    }
 
     if (_controller.status.isAnimating) {
       return; // Don't snap the drawer open or shut while the user is dragging.
@@ -645,14 +635,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
     widget.drawerCallback?.call(false);
   }
 
-  late ColorTween _scrimColorTween;
   final GlobalKey _gestureDetectorKey = GlobalKey();
-
-  ColorTween _buildScrimColorTween() {
-    final Color effectiveScrimColor =
-        widget.scrimColor ?? DrawerTheme.of(context).scrimColor ?? Colors.black54;
-    return ColorTween(begin: effectiveScrimColor.withValues(alpha: 0), end: effectiveScrimColor);
-  }
 
   AlignmentDirectional get _drawerOuterAlignment => switch (widget.alignment) {
     DrawerAlignment.start => AlignmentDirectional.centerStart,
@@ -713,14 +696,15 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
           platformHasBackButton = false;
       }
 
-      Widget drawerScrim = const LimitedBox(
-        maxWidth: 0.0,
-        maxHeight: 0.0,
-        child: SizedBox.expand(),
+      final Color scrimColor =
+          widget.scrimColor ?? DrawerTheme.of(context).scrimColor ?? Colors.black54;
+      final Color effectiveScrimColor = scrimColor.withValues(
+        alpha: scrimColor.a * _controller.value,
       );
-      if (_scrimColorTween.evaluate(_controller) case final Color color) {
-        drawerScrim = ColoredBox(color: color, child: drawerScrim);
-      }
+      final Widget drawerScrim = ColoredBox(
+        color: effectiveScrimColor,
+        child: const LimitedBox(maxWidth: 0.0, maxHeight: 0.0, child: SizedBox.expand()),
+      );
 
       final Widget child = _DrawerControllerScope(
         controller: widget,

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -187,9 +187,12 @@ void main() {
 
     await tester.pumpWidget(buildFrame());
     scaffoldKey.currentState!.openDrawer();
-    await tester.pumpAndSettle();
-
+    await tester.pump();
     ColoredBox scrim = getScrim() as ColoredBox;
+    expect(scrim.color, isSameColorAs(Colors.black54.withValues(alpha: 0)));
+
+    await tester.pumpAndSettle();
+    scrim = getScrim() as ColoredBox;
     expect(scrim.color, Colors.black54);
 
     await tester.tap(find.byType(Drawer));
@@ -200,8 +203,11 @@ void main() {
 
     await tester.pumpWidget(buildFrame(drawerScrimColor: const Color(0xFF323232)));
     scaffoldKey.currentState!.openDrawer();
-    await tester.pumpAndSettle();
+    await tester.pump();
+    scrim = getScrim() as ColoredBox;
+    expect(scrim.color, isSameColorAs(const Color(0xFF323232).withValues(alpha: 0)));
 
+    await tester.pumpAndSettle();
     scrim = getScrim() as ColoredBox;
     expect(scrim.color, const Color(0xFF323232));
 

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -183,37 +183,28 @@ void main() {
       );
     }
 
+    Future<void> checkScrim(Color color) async {
+      scaffoldKey.currentState!.openDrawer();
+      await tester.pump();
+      ColoredBox scrim = getScrim() as ColoredBox;
+      expect(scrim.color, isSameColorAs(color.withValues(alpha: 0)));
+
+      await tester.pumpAndSettle();
+      scrim = getScrim() as ColoredBox;
+      expect(scrim.color, isSameColorAs(color));
+
+      await tester.tap(find.byType(Drawer));
+      await tester.pumpAndSettle();
+      expect(find.byType(Drawer), findsNothing);
+    }
+
     // Default drawerScrimColor
-
     await tester.pumpWidget(buildFrame());
-    scaffoldKey.currentState!.openDrawer();
-    await tester.pump();
-    ColoredBox scrim = getScrim() as ColoredBox;
-    expect(scrim.color, isSameColorAs(Colors.black54.withValues(alpha: 0)));
-
-    await tester.pumpAndSettle();
-    scrim = getScrim() as ColoredBox;
-    expect(scrim.color, Colors.black54);
-
-    await tester.tap(find.byType(Drawer));
-    await tester.pumpAndSettle();
-    expect(find.byType(Drawer), findsNothing);
+    await checkScrim(Colors.black54);
 
     // Specific drawerScrimColor
-
     await tester.pumpWidget(buildFrame(drawerScrimColor: const Color(0xFF323232)));
-    scaffoldKey.currentState!.openDrawer();
-    await tester.pump();
-    scrim = getScrim() as ColoredBox;
-    expect(scrim.color, isSameColorAs(const Color(0xFF323232).withValues(alpha: 0)));
-
-    await tester.pumpAndSettle();
-    scrim = getScrim() as ColoredBox;
-    expect(scrim.color, const Color(0xFF323232));
-
-    await tester.tap(find.byType(Drawer));
-    await tester.pumpAndSettle();
-    expect(find.byType(Drawer), findsNothing);
+    await checkScrim(const Color(0xFF323232));
   });
 
   testWidgets('Open/close drawers by flinging', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/173112

### Description
- Fixes `drawerScrimColor` transition issue caused by `Colors.transparent` usage in color interpolation

| BEFORE | AFTER |
| - | - |
| <video alt="before" src="https://github.com/user-attachments/assets/67d4295e-667e-4f73-b5e0-7841d29f8f57" /> | <video alt="after" src="https://github.com/user-attachments/assets/0f3cacc1-55bd-4c00-8ebe-a5d06ebb7663" /> |

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
