### PR TITLE
Unmark `Linux android_java17_tool_integration_tests` as bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1534,7 +1534,6 @@ targets:
       - DEPS
 
   - name: Linux android_java17_tool_integration_tests
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
The only failures in the last 100 runs are those for which large swaths of the bots were failing:
https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.staging/Linux%20android_java17_tool_integration_tests?limit=100
<img width="1242" height="257" alt="Screenshot 2025-08-05 at 9 13 55 AM" src="https://github.com/user-attachments/assets/248de580-27ca-4704-9754-a109e961fb6f" />
