### PR TITLE
[ Widget Preview ] Cleanup for experimental release

### DIFF
--- a/packages/flutter/lib/src/widget_previews/widget_previews.dart
+++ b/packages/flutter/lib/src/widget_previews/widget_previews.dart
@@ -63,7 +63,7 @@ typedef PreviewLocalizations = PreviewLocalizationsData Function();
 /// be constant and non-private.
 ///
 /// See also:
-///   - [docs.flutter.dev/development/tools/widget-previews](https://docs.flutter.dev/development/tools/widget-previews)
+///   - [flutter.dev/to/widget-previews](flutter.dev/to/widget-previews)
 ///     for details on getting started with widget previews.
 final class Preview {
   /// Annotation used to mark functions that return widget previews.

--- a/packages/flutter/lib/src/widget_previews/widget_previews.dart
+++ b/packages/flutter/lib/src/widget_previews/widget_previews.dart
@@ -61,7 +61,10 @@ typedef PreviewLocalizations = PreviewLocalizationsData Function();
 ///
 /// **Important Note:** all values provided to the `@Preview()` annotation must
 /// be constant and non-private.
-// TODO(bkonyi): link to actual documentation when available.
+///
+/// See also:
+///   - [docs.flutter.dev/development/tools/widget-previews](https://docs.flutter.dev/development/tools/widget-previews)
+///     for details on getting started with widget previews.
 final class Preview {
   /// Annotation used to mark functions that return widget previews.
   const Preview({
@@ -254,6 +257,8 @@ base class PreviewLocalizationsData {
 
 /// A collection of [ThemeData] and [CupertinoThemeData] instances for use in
 /// widget previews.
+///
+/// NOTE: this interface is not stable and **will change**.
 base class PreviewThemeData {
   /// Creates a collection of [ThemeData] and [CupertinoThemeData] instances
   /// for use in widget previews.

--- a/packages/flutter/lib/src/widget_previews/widget_previews.dart
+++ b/packages/flutter/lib/src/widget_previews/widget_previews.dart
@@ -63,7 +63,7 @@ typedef PreviewLocalizations = PreviewLocalizationsData Function();
 /// be constant and non-private.
 ///
 /// See also:
-///   - [flutter.dev/to/widget-previews](flutter.dev/to/widget-previews)
+///   - [flutter.dev/to/widget-previews](https://flutter.dev/to/widget-previews)
 ///     for details on getting started with widget previews.
 final class Preview {
   /// Annotation used to mark functions that return widget previews.

--- a/packages/flutter/lib/widget_previews.dart
+++ b/packages/flutter/lib/widget_previews.dart
@@ -5,6 +5,9 @@
 /// The Flutter widget preview annotations and data classes.
 ///
 /// To use, import `package:flutter/widget_previews.dart`.
+///
+/// See [docs.flutter.dev/development/tools/widget-previews](https://docs.flutter.dev/development/tools/widget-previews)
+/// for more details on getting started with widget previews.
 library widget_previews;
 
 export 'src/widget_previews/widget_previews.dart';

--- a/packages/flutter/lib/widget_previews.dart
+++ b/packages/flutter/lib/widget_previews.dart
@@ -6,7 +6,7 @@
 ///
 /// To use, import `package:flutter/widget_previews.dart`.
 ///
-/// See [docs.flutter.dev/development/tools/widget-previews](https://docs.flutter.dev/development/tools/widget-previews)
+/// See [flutter.dev/to/widget-previews](https://flutter.dev/to/widget-previews)
 /// for more details on getting started with widget previews.
 library widget_previews;
 

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -79,11 +79,6 @@ class WidgetPreviewCommand extends FlutterCommand {
   @override
   String get category => FlutterCommandCategory.tools;
 
-  // TODO(bkonyi): show when --verbose is not provided when this feature is
-  // ready to ship.
-  @override
-  bool get hidden => true;
-
   @override
   Future<FlutterCommandResult> runCommand() async => FlutterCommandResult.fail();
 }

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -114,9 +114,7 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
 class NoPreviewsDetectedWidget extends StatelessWidget {
   const NoPreviewsDetectedWidget({super.key});
 
-  static Uri documentationUrl = Uri.https(
-    'docs.flutter.dev/development/tools/widget-previews',
-  );
+  static Uri documentationUrl = Uri.https('flutter.dev/to/widget-previews');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -114,11 +114,8 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
 class NoPreviewsDetectedWidget extends StatelessWidget {
   const NoPreviewsDetectedWidget({super.key});
 
-  // TODO(bkonyi): update with actual documentation on flutter.dev.
   static Uri documentationUrl = Uri.https(
-    'github.com',
-    'flutter/flutter/blob/master/packages/flutter/'
-        'lib/src/widget_previews/widget_previews.dart',
+    'docs.flutter.dev/development/tools/widget-previews',
   );
 
   @override
@@ -726,6 +723,7 @@ class PreviewAssetBundle extends PlatformAssetBundle {
     // actually located in the parent project, meaning their paths did not need
     // to be modified.
     if (key == 'AssetManifest.bin' ||
+        key == 'AssetManifest.bin.json' ||
         key == 'FontManifest.json' ||
         key.startsWith(_kPackagesPrefix) ||
         packageName == null) {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -114,7 +114,7 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
 class NoPreviewsDetectedWidget extends StatelessWidget {
   const NoPreviewsDetectedWidget({super.key});
 
-  static Uri documentationUrl = Uri.https('flutter.dev/to/widget-previews');
+  static Uri documentationUrl = Uri.https('flutter.dev', 'to/widget-previews');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -114,9 +114,7 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
 class NoPreviewsDetectedWidget extends StatelessWidget {
   const NoPreviewsDetectedWidget({super.key});
 
-  static Uri documentationUrl = Uri.https(
-    'docs.flutter.dev/development/tools/widget-previews',
-  );
+  static Uri documentationUrl = Uri.https('flutter.dev/to/widget-previews');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -114,11 +114,8 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
 class NoPreviewsDetectedWidget extends StatelessWidget {
   const NoPreviewsDetectedWidget({super.key});
 
-  // TODO(bkonyi): update with actual documentation on flutter.dev.
   static Uri documentationUrl = Uri.https(
-    'github.com',
-    'flutter/flutter/blob/master/packages/flutter/'
-        'lib/src/widget_previews/widget_previews.dart',
+    'docs.flutter.dev/development/tools/widget-previews',
   );
 
   @override
@@ -726,6 +723,7 @@ class PreviewAssetBundle extends PlatformAssetBundle {
     // actually located in the parent project, meaning their paths did not need
     // to be modified.
     if (key == 'AssetManifest.bin' ||
+        key == 'AssetManifest.bin.json' ||
         key == 'FontManifest.json' ||
         key.startsWith(_kPackagesPrefix) ||
         packageName == null) {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -114,7 +114,7 @@ class _WidgetPreviewErrorWidget extends StatelessWidget {
 class NoPreviewsDetectedWidget extends StatelessWidget {
   const NoPreviewsDetectedWidget({super.key});
 
-  static Uri documentationUrl = Uri.https('flutter.dev/to/widget-previews');
+  static Uri documentationUrl = Uri.https('flutter.dev', 'to/widget-previews');
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Widget previews are being released as an experimental feature in the next stable release.

This change has some minor last minute changes to prepare for release:
  - Makes `flutter widget-preview` visible
  - Adds documentation links to docs.flutter.dev (not yet staged)
  - Fixes minor bug with asset loading due to `AssetManifest.bin.json` not being accounted for in the asset path mapping logic