### PR TITLE
Introduce the DisplayManager so that we send real display info down to the client

### DIFF
--- a/engine/src/flutter/shell/platform/windows/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/BUILD.gn
@@ -208,6 +208,7 @@ executable("flutter_windows_unittests") {
     "compositor_software_unittests.cc",
     "cursor_handler_unittests.cc",
     "direct_manipulation_unittests.cc",
+    "display_manager_unittests.cc",
     "dpi_utils_unittests.cc",
     "flutter_project_bundle_unittests.cc",
     "flutter_window_unittests.cc",

--- a/engine/src/flutter/shell/platform/windows/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/BUILD.gn
@@ -52,6 +52,8 @@ source_set("flutter_windows_source") {
     "cursor_handler.h",
     "direct_manipulation.cc",
     "direct_manipulation.h",
+    "display_manager.cc",
+    "display_manager.h",
     "dpi_utils.cc",
     "dpi_utils.h",
     "egl/context.cc",

--- a/engine/src/flutter/shell/platform/windows/display_manager.cc
+++ b/engine/src/flutter/shell/platform/windows/display_manager.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/windows/display_manager.h"
+#include "flutter/shell/platform/windows/dpi_utils.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
 #include <memory>
@@ -133,15 +134,7 @@ BOOL CALLBACK DisplayManager::MonitorEnumProc(HMONITOR hMonitor,
   display.refresh_rate = has_display_settings
                              ? static_cast<double>(dev_mode.dmDisplayFrequency)
                              : 0.0;
-
-  // Approximate device pixel ratio using system DPI
-  UINT dpi_x = 96;
-  HDC screen_dc = GetDC(nullptr);
-  if (screen_dc) {
-    dpi_x = GetDeviceCaps(screen_dc, LOGPIXELSX);
-    ReleaseDC(nullptr, screen_dc);
-  }
-  display.device_pixel_ratio = dpi_x / 96.0;
+  display.device_pixel_ratio = GetDpiForMonitor(hMonitor);
 
   data->displays.push_back(display);
   return TRUE;

--- a/engine/src/flutter/shell/platform/windows/display_manager.cc
+++ b/engine/src/flutter/shell/platform/windows/display_manager.cc
@@ -1,0 +1,141 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/display_manager.h"
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
+
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+DisplayManager::DisplayManager(FlutterWindowsEngine* engine) : engine_(engine) {
+  WNDCLASS window_class = RegisterWindowClass();
+  window_handle_ =
+      CreateWindowEx(0, window_class.lpszClassName, L"", 0, 0, 0, 0, 0,
+                     HWND_MESSAGE, nullptr, window_class.hInstance, nullptr);
+
+  if (window_handle_) {
+    SetWindowLongPtr(window_handle_, GWLP_USERDATA,
+                     reinterpret_cast<LONG_PTR>(this));
+  } else {
+    auto error = GetLastError();
+    LPWSTR message = nullptr;
+    size_t size = FormatMessageW(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+            FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPWSTR>(&message), 0, NULL);
+    OutputDebugString(message);
+    LocalFree(message);
+  }
+}
+
+DisplayManager::~DisplayManager() {
+  if (window_handle_) {
+    DestroyWindow(window_handle_);
+    window_handle_ = nullptr;
+  }
+  UnregisterClass(window_class_name_.c_str(), nullptr);
+}
+#include <iostream>
+std::vector<FlutterEngineDisplay> DisplayManager::displays() const {
+  std::vector<FlutterEngineDisplay> displays;
+  EnumDisplayMonitors(nullptr, nullptr, MonitorEnumProc,
+                      reinterpret_cast<LPARAM>(&displays));
+
+  if (displays.size() == 1) {
+    displays[0].single_display = true;
+    displays[0].display_id = 0;  // ignored when single_display is true
+  }
+
+  return displays;
+}
+
+WNDCLASS DisplayManager::RegisterWindowClass() {
+  window_class_name_ = L"FlutterDisplayManager";
+
+  WNDCLASS window_class{};
+  window_class.hCursor = nullptr;
+  window_class.lpszClassName = window_class_name_.c_str();
+  window_class.style = 0;
+  window_class.cbClsExtra = 0;
+  window_class.cbWndExtra = 0;
+  window_class.hInstance = GetModuleHandle(nullptr);
+  window_class.hIcon = nullptr;
+  window_class.hbrBackground = 0;
+  window_class.lpszMenuName = nullptr;
+  window_class.lpfnWndProc = WndProc;
+  RegisterClass(&window_class);
+  return window_class;
+}
+
+LRESULT
+DisplayManager::HandleMessage(UINT const message,
+                              WPARAM const wparam,
+                              LPARAM const lparam) noexcept {
+  switch (message) {
+    case WM_DISPLAYCHANGE:
+    case WM_DEVICECHANGE: {
+      if (engine_->running()) {
+        engine_->OnDisplaysChanged(displays());
+      }
+      break;
+    }
+  }
+  return DefWindowProcW(window_handle_, message, wparam, lparam);
+}
+
+LRESULT DisplayManager::WndProc(HWND const window,
+                                UINT const message,
+                                WPARAM const wparam,
+                                LPARAM const lparam) noexcept {
+  if (auto* that = reinterpret_cast<DisplayManager*>(
+          GetWindowLongPtr(window, GWLP_USERDATA))) {
+    return that->HandleMessage(message, wparam, lparam);
+  } else {
+    return DefWindowProc(window, message, wparam, lparam);
+  }
+}
+
+BOOL CALLBACK DisplayManager::MonitorEnumProc(HMONITOR hMonitor,
+                                              HDC,
+                                              LPRECT,
+                                              LPARAM lParam) {
+  auto displays = reinterpret_cast<std::vector<FlutterEngineDisplay>*>(lParam);
+
+  MONITORINFOEX monitor_info = {};
+  monitor_info.cbSize = sizeof(MONITORINFOEX);
+  if (!GetMonitorInfo(hMonitor, &monitor_info)) {
+    return TRUE;
+  }
+
+  // Get display settings
+  DEVMODE dev_mode = {};
+  dev_mode.dmSize = sizeof(DEVMODE);
+  bool has_display_settings = EnumDisplaySettings(
+      monitor_info.szDevice, ENUM_CURRENT_SETTINGS, &dev_mode);
+
+  FlutterEngineDisplay display;
+  display.struct_size = sizeof(FlutterEngineDisplay);
+  display.display_id = reinterpret_cast<FlutterEngineDisplayId>(hMonitor);
+  display.single_display = false;
+  display.width = monitor_info.rcMonitor.right - monitor_info.rcMonitor.left;
+  display.height = monitor_info.rcMonitor.bottom - monitor_info.rcMonitor.top;
+  display.refresh_rate = has_display_settings
+                             ? static_cast<double>(dev_mode.dmDisplayFrequency)
+                             : 0.0;
+
+  // Approximate device pixel ratio using system DPI
+  UINT dpi_x = 96;
+  HDC screen_dc = GetDC(nullptr);
+  if (screen_dc) {
+    dpi_x = GetDeviceCaps(screen_dc, LOGPIXELSX);
+    ReleaseDC(nullptr, screen_dc);
+  }
+  display.device_pixel_ratio = dpi_x / 96.0;
+
+  displays->push_back(display);
+  return TRUE;
+}
+
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/display_manager.cc
+++ b/engine/src/flutter/shell/platform/windows/display_manager.cc
@@ -55,7 +55,6 @@ std::vector<FlutterEngineDisplay> DisplayManager::displays() const {
 
   if (data.displays.size() == 1) {
     data.displays[0].single_display = true;
-    data.displays[0].display_id = 0;  // ignored when single_display is true
   }
 
   return data.displays;

--- a/engine/src/flutter/shell/platform/windows/display_manager.h
+++ b/engine/src/flutter/shell/platform/windows/display_manager.h
@@ -22,7 +22,8 @@ class DisplayManager {
   std::vector<FlutterEngineDisplay> displays() const;
 
  private:
-  WNDCLASS RegisterWindowClass();
+  WNDCLASS
+  RegisterWindowClass();
 
   LRESULT
   HandleMessage(UINT const message,

--- a/engine/src/flutter/shell/platform/windows/display_manager.h
+++ b/engine/src/flutter/shell/platform/windows/display_manager.h
@@ -21,6 +21,8 @@ class DisplayManager {
 
   std::vector<FlutterEngineDisplay> displays() const;
 
+  HWND get_window_handle() const { return window_handle_; }
+
  private:
   WNDCLASS
   RegisterWindowClass();

--- a/engine/src/flutter/shell/platform/windows/display_manager.h
+++ b/engine/src/flutter/shell/platform/windows/display_manager.h
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_DISPLAY_MANAGER_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_DISPLAY_MANAGER_H_
+
+#include <windows.h>
+#include <string>
+#include <vector>
+
+#include "flutter/shell/platform/embedder/embedder.h"
+
+namespace flutter {
+class FlutterWindowsEngine;
+
+class DisplayManager {
+ public:
+  DisplayManager(FlutterWindowsEngine* engine);
+  virtual ~DisplayManager();
+
+  std::vector<FlutterEngineDisplay> displays() const;
+
+ private:
+  WNDCLASS RegisterWindowClass();
+
+  LRESULT
+  HandleMessage(UINT const message,
+                WPARAM const wparam,
+                LPARAM const lparam) noexcept;
+
+  static LRESULT CALLBACK WndProc(HWND const window,
+                                  UINT const message,
+                                  WPARAM const wparam,
+                                  LPARAM const lparam) noexcept;
+
+  static BOOL CALLBACK MonitorEnumProc(HMONITOR hMonitor,
+                                       HDC,
+                                       LPRECT,
+                                       LPARAM lParam);
+
+  FlutterWindowsEngine* engine_;
+  HWND window_handle_;
+  std::wstring window_class_name_;
+};
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_DISPLAY_MANAGER_H_

--- a/engine/src/flutter/shell/platform/windows/display_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/display_manager_unittests.cc
@@ -74,7 +74,8 @@ TEST_F(DisplayManagerTest, CanGetSingleMonitorInfo) {
   auto const displays = manager.displays();
   EXPECT_THAT(displays.size(), ::testing::Eq(1));
   EXPECT_THAT(displays[0].single_display, ::testing::Eq(true));
-  EXPECT_THAT(displays[0].display_id, ::testing::Eq(0));
+  EXPECT_THAT(displays[0].display_id,
+              ::testing::Eq(reinterpret_cast<FlutterEngineDisplayId>(fake)));
   EXPECT_THAT(displays[0].width, ::testing::Eq(800));
   EXPECT_THAT(displays[0].height, ::testing::Eq(600));
   EXPECT_THAT(displays[0].refresh_rate, ::testing::Eq(0));

--- a/engine/src/flutter/shell/platform/windows/display_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/display_manager_unittests.cc
@@ -1,0 +1,128 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/display_manager.h"
+
+#include "flutter/shell/platform/windows/flutter_windows_engine.h"
+#include "flutter/shell/platform/windows/testing/mock_windows_proc_table.h"
+#include "flutter/shell/platform/windows/testing/windows_test.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+namespace {
+
+// Returns a Flutter project with the required path values to create
+// a test engine.
+FlutterProjectBundle GetTestProject() {
+  FlutterDesktopEngineProperties properties = {};
+  properties.assets_path = L"C:\\foo\\flutter_assets";
+  properties.icu_data_path = L"C:\\foo\\icudtl.dat";
+  properties.aot_library_path = L"C:\\foo\\aot.so";
+
+  return FlutterProjectBundle{properties};
+}
+
+class DisplayManagerTest : public WindowsTest {};
+
+class MockFlutterWindowsEngine : public FlutterWindowsEngine {
+ public:
+  explicit MockFlutterWindowsEngine(
+      std::shared_ptr<WindowsProcTable> windows_proc_table = nullptr)
+      : FlutterWindowsEngine(GetTestProject(), std::move(windows_proc_table)) {}
+  MOCK_METHOD(bool, running, (), (const));
+};
+}  // namespace
+
+TEST_F(DisplayManagerTest, CanGetSingleMonitorInfo) {
+  auto windows_proc_table = std::make_shared<MockWindowsProcTable>();
+  auto engine = MockFlutterWindowsEngine(windows_proc_table);
+  DisplayManager manager(&engine);
+
+  HMONITOR fake = reinterpret_cast<HMONITOR>(0x1234);
+  EXPECT_CALL(*windows_proc_table, EnumDisplayMonitors)
+      .WillOnce(::testing::Invoke(
+          [=](HDC, LPCRECT, MONITORENUMPROC callback, LPARAM dwData) -> BOOL {
+            callback(fake, nullptr, nullptr, dwData);
+            return TRUE;
+          }));
+  EXPECT_CALL(*windows_proc_table, GetMonitorInfo)
+      .WillOnce(::testing::Invoke([=](HMONITOR, LPMONITORINFO info) -> BOOL {
+        info->rcMonitor.right = 800;
+        info->rcMonitor.left = 0;
+        info->rcMonitor.bottom = 600;
+        info->rcMonitor.top = 0;
+        return TRUE;
+      }));
+  EXPECT_CALL(*windows_proc_table, EnumDisplaySettingsW)
+      .WillOnce(::testing::Return(FALSE));
+  auto const displays = manager.displays();
+  EXPECT_THAT(displays.size(), ::testing::Eq(1));
+  EXPECT_THAT(displays[0].single_display, ::testing::Eq(true));
+  EXPECT_THAT(displays[0].display_id, ::testing::Eq(0));
+  EXPECT_THAT(displays[0].width, ::testing::Eq(800));
+  EXPECT_THAT(displays[0].height, ::testing::Eq(600));
+  EXPECT_THAT(displays[0].refresh_rate, ::testing::Eq(0));
+}
+
+TEST_F(DisplayManagerTest, CanGetMultipleMonitorInfo) {
+  auto windows_proc_table = std::make_shared<MockWindowsProcTable>();
+  auto engine = MockFlutterWindowsEngine(windows_proc_table);
+  DisplayManager manager(&engine);
+
+  ::testing::InSequence seq;
+  HMONITOR first = reinterpret_cast<HMONITOR>(0x1234);
+  HMONITOR second = reinterpret_cast<HMONITOR>(0x1234);
+  EXPECT_CALL(*windows_proc_table, EnumDisplayMonitors)
+      .WillOnce(::testing::Invoke(
+          [=](HDC, LPCRECT, MONITORENUMPROC callback, LPARAM dwData) -> BOOL {
+            callback(first, nullptr, nullptr, dwData);
+            callback(second, nullptr, nullptr, dwData);
+            return TRUE;
+          }));
+
+  // First monitor
+  EXPECT_CALL(*windows_proc_table, GetMonitorInfo)
+      .WillOnce(::testing::Invoke([=](HMONITOR, LPMONITORINFO info) -> BOOL {
+        info->rcMonitor.right = 800;
+        info->rcMonitor.left = 0;
+        info->rcMonitor.bottom = 600;
+        info->rcMonitor.top = 0;
+        return TRUE;
+      }));
+  EXPECT_CALL(*windows_proc_table, EnumDisplaySettingsW)
+      .WillOnce(::testing::Return(FALSE));
+
+  // Second monitor
+  EXPECT_CALL(*windows_proc_table, GetMonitorInfo)
+      .WillOnce(::testing::Invoke([=](HMONITOR, LPMONITORINFO info) -> BOOL {
+        info->rcMonitor.right = 400;
+        info->rcMonitor.left = 0;
+        info->rcMonitor.bottom = 300;
+        info->rcMonitor.top = 0;
+        return TRUE;
+      }));
+  EXPECT_CALL(*windows_proc_table, EnumDisplaySettingsW)
+      .WillOnce(::testing::Return(FALSE));
+
+  auto const displays = manager.displays();
+  EXPECT_THAT(displays.size(), ::testing::Eq(2));
+  EXPECT_THAT(displays[0].single_display, ::testing::Eq(false));
+  EXPECT_THAT(displays[0].display_id,
+              ::testing::Eq(reinterpret_cast<FlutterEngineDisplayId>(first)));
+  EXPECT_THAT(displays[0].width, ::testing::Eq(800));
+  EXPECT_THAT(displays[0].height, ::testing::Eq(600));
+  EXPECT_THAT(displays[0].refresh_rate, ::testing::Eq(0));
+
+  EXPECT_THAT(displays[1].single_display, ::testing::Eq(false));
+  EXPECT_THAT(displays[1].display_id,
+              ::testing::Eq(reinterpret_cast<FlutterEngineDisplayId>(second)));
+  EXPECT_THAT(displays[1].width, ::testing::Eq(400));
+  EXPECT_THAT(displays[1].height, ::testing::Eq(300));
+  EXPECT_THAT(displays[1].refresh_rate, ::testing::Eq(0));
+}
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -27,6 +27,7 @@
 #include "flutter/shell/platform/windows/accessibility_plugin.h"
 #include "flutter/shell/platform/windows/compositor.h"
 #include "flutter/shell/platform/windows/cursor_handler.h"
+#include "flutter/shell/platform/windows/display_manager.h"
 #include "flutter/shell/platform/windows/egl/manager.h"
 #include "flutter/shell/platform/windows/egl/proc_table.h"
 #include "flutter/shell/platform/windows/flutter_desktop_messenger.h"
@@ -322,6 +323,10 @@ class FlutterWindowsEngine {
   // the window handle or nullptr if no such view could be found.
   FlutterWindowsView* GetViewFromTopLevelWindow(HWND hwnd) const;
 
+  // Called when the displays have changed.
+  void OnDisplaysChanged(
+      std::vector<FlutterEngineDisplay> const& displays) const;
+
  protected:
   // Creates the keyboard key handler.
   //
@@ -509,6 +514,8 @@ class FlutterWindowsEngine {
   std::shared_ptr<egl::ProcTable> gl_;
 
   std::unique_ptr<PlatformViewPlugin> platform_view_plugin_;
+
+  std::shared_ptr<DisplayManager> display_manager_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterWindowsEngine);
 };

--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine.h
@@ -324,7 +324,7 @@ class FlutterWindowsEngine {
   FlutterWindowsView* GetViewFromTopLevelWindow(HWND hwnd) const;
 
   // Called when the displays have changed.
-  void OnDisplaysChanged(
+  virtual void OnDisplaysChanged(
       std::vector<FlutterEngineDisplay> const& displays) const;
 
  protected:

--- a/engine/src/flutter/shell/platform/windows/testing/mock_windows_proc_table.h
+++ b/engine/src/flutter/shell/platform/windows/testing/mock_windows_proc_table.h
@@ -40,6 +40,20 @@ class MockWindowsProcTable : public WindowsProcTable {
               (const, override));
 
   MOCK_METHOD(HCURSOR, SetCursor, (HCURSOR cursor), (const, override));
+  MOCK_METHOD(BOOL,
+              EnumDisplayMonitors,
+              (HDC, LPCRECT, MONITORENUMPROC, LPARAM),
+              (const, override));
+
+  MOCK_METHOD(BOOL,
+              GetMonitorInfo,
+              (HMONITOR, LPMONITORINFO),
+              (const, override));
+
+  MOCK_METHOD(BOOL,
+              EnumDisplaySettingsW,
+              (LPCWSTR, DWORD, DEVMODEW*),
+              (const, override));
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(MockWindowsProcTable);

--- a/engine/src/flutter/shell/platform/windows/windows_proc_table.cc
+++ b/engine/src/flutter/shell/platform/windows/windows_proc_table.cc
@@ -120,4 +120,22 @@ BOOL WindowsProcTable::AdjustWindowRectExForDpi(LPRECT lpRect,
                                                  dwExStyle, dpi);
 }
 
+BOOL WindowsProcTable::EnumDisplayMonitors(HDC hdc,
+                                           LPCRECT lprcClip,
+                                           MONITORENUMPROC lpfnEnum,
+                                           LPARAM dwData) const {
+  return ::EnumDisplayMonitors(hdc, lprcClip, lpfnEnum, dwData);
+}
+
+BOOL WindowsProcTable::GetMonitorInfo(HMONITOR hMonitor,
+                                      LPMONITORINFO lpmi) const {
+  return ::GetMonitorInfo(hMonitor, lpmi);
+}
+
+BOOL WindowsProcTable::EnumDisplaySettingsW(LPCWSTR lpszDeviceName,
+                                            DWORD iModeNum,
+                                            DEVMODEW* lpDevMode) const {
+  return ::EnumDisplaySettingsW(lpszDeviceName, iModeNum, lpDevMode);
+}
+
 }  // namespace flutter

--- a/engine/src/flutter/shell/platform/windows/windows_proc_table.h
+++ b/engine/src/flutter/shell/platform/windows/windows_proc_table.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/native_library.h"
 
-namespace flutter {  // namespace
+namespace flutter {
 
 // Lookup table for Windows APIs that aren't available on all versions of
 // Windows, or for mocking Windows API calls.

--- a/engine/src/flutter/shell/platform/windows/windows_proc_table.h
+++ b/engine/src/flutter/shell/platform/windows/windows_proc_table.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/native_library.h"
 
-namespace flutter {
+namespace flutter {  // namespace
 
 // Lookup table for Windows APIs that aren't available on all versions of
 // Windows, or for mocking Windows API calls.
@@ -122,6 +122,29 @@ class WindowsProcTable {
                                         BOOL bMenu,
                                         DWORD dwExStyle,
                                         UINT dpi) const;
+
+  // Iterates over the list of available monitors and calls |lpfnEnum|.
+  //
+  // See:
+  // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaymonitors
+  virtual BOOL EnumDisplayMonitors(HDC hdc,
+                                   LPCRECT lprcClip,
+                                   MONITORENUMPROC lpfnEnum,
+                                   LPARAM dwData) const;
+
+  // Retrieve information about a display monitor.
+  //
+  // See:
+  // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmonitorinfoa
+  virtual BOOL GetMonitorInfo(HMONITOR hMonitor, LPMONITORINFO lpmi) const;
+
+  // Retrieve information about one of the graphics modes for a display device.
+  //
+  // See:
+  // https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaysettingsw
+  virtual BOOL EnumDisplaySettingsW(LPCWSTR lpszDeviceName,
+                                    DWORD iModeNum,
+                                    DEVMODEW* lpDevMode) const;
 
  private:
   using GetPointerType_ = BOOL __stdcall(UINT32 pointerId,


### PR DESCRIPTION
## What's new?
- Create a new class called `DisplayManager` which is responsible for retrieving display info on the win32 platform
- Use it to send that data down to the framework, including when that information changes
- Add methods to `WindowsProcTable` for test mocking purposes
- Wrote a bunch of unit tests :nerd_face: 

## Why?
The win32 platform is about to be interested in the displays that it has available, specifically when setting the fullscreen status of a window for windowing. Hence, we need to provide it with an accurate list of such things

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
