### PR TITLE
Make sure that a ChoiceChip doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/choice_chip_test.dart
+++ b/packages/flutter/test/material/choice_chip_test.dart
@@ -848,4 +848,18 @@ void main() {
       SystemMouseCursors.forbidden,
     );
   });
+
+  testWidgets('ChoiceChip renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: Scaffold(body: ChoiceChip(label: Text('X'), selected: true)),
+          ),
+        ),
+      ),
+    );
+    final Finder xText = find.text('X');
+    expect(tester.getSize(xText).isEmpty, isTrue);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the ChoiceChip UI control.