### PR TITLE
Fix Slider value indicator shape is broken if label is multiple-line text in Material 3

### DIFF
--- a/packages/flutter/lib/src/material/slider_parts.dart
+++ b/packages/flutter/lib/src/material/slider_parts.dart
@@ -18,6 +18,8 @@ import 'slider_theme.dart';
 import 'slider_value_indicator_shape.dart';
 import 'theme.dart';
 
+const String _kEllipsis = '\u2026';
+
 /// Base class for [Slider] tick mark shapes.
 ///
 /// Create a subclass of this if you would like a custom slider tick mark shape.
@@ -874,36 +876,16 @@ class _ValueIndicatorTextProcessor {
       return;
     }
 
-    // Text exceeds maxLines, create painter with ellipsis.
-    final String labelText = _originalPainter.text?.toPlainText() ?? '';
-    _textPainter = _createTextPainterWithEllipsis(
-      originalPainter: _originalPainter,
-      originalText: labelText,
+    // If text exceeds maxLines, create painter with ellipsis
+    // using TextPainter's built-in API.
+    _textPainter = TextPainter(
+      text: _originalPainter.text,
+      textDirection: _originalPainter.textDirection,
+      textScaleFactor: textScaleFactor,
       maxLines: maxLines,
-      textScaleFactor: textScaleFactor,
-    );
-    _createdNewPainter = true;
-  }
-
-  /// Creates a TextPainter with ellipsis when text exceeds maxLines.
-  // TODO(huycozy): Use TextPainter built-in API for ellipsis.
-  //  See https://github.com/flutter/flutter/issues/175251
-  //  Blocked by https://github.com/flutter/flutter/issues/50168
-  TextPainter _createTextPainterWithEllipsis({
-    required TextPainter originalPainter,
-    required String originalText,
-    required int maxLines,
-    required double textScaleFactor,
-  }) {
-    final List<String> lines = originalText.split('\n');
-    final List<String> visibleLines = lines.take(maxLines - 1).toList();
-    visibleLines.add('${lines[maxLines - 1]}...');
-
-    return TextPainter(
-      text: TextSpan(text: visibleLines.join('\n'), style: originalPainter.text?.style),
-      textDirection: originalPainter.textDirection,
-      textScaleFactor: textScaleFactor,
+      ellipsis: _kEllipsis,
     )..layout();
+    _createdNewPainter = true;
   }
 
   /// Disposes resources if a new TextPainter was created.

--- a/packages/flutter/lib/src/material/slider_parts.dart
+++ b/packages/flutter/lib/src/material/slider_parts.dart
@@ -869,23 +869,26 @@ abstract class _ValueIndicatorTextProcessor {
       return originalPainter;
     }
 
-    final TextPainter truncatedPainter = TextPainter(
-      text: originalPainter.text,
-      textDirection: originalPainter.textDirection,
-      textScaleFactor: textScaleFactor,
-      maxLines: multilineConfig.maxLines,
-    )..layout();
+    // Use computeLineMetrics to check if truncation is needed.
+    final int actualLines = originalPainter.computeLineMetrics().length;
+    final int maxLines = multilineConfig.maxLines!;
 
-    if (!truncatedPainter.didExceedMaxLines) {
-      return truncatedPainter;
+    if (actualLines <= maxLines) {
+      // Text fits within maxLines, create a simple TextPainter with maxLines constraint.
+      return TextPainter(
+        text: originalPainter.text,
+        textDirection: originalPainter.textDirection,
+        textScaleFactor: textScaleFactor,
+        maxLines: maxLines,
+      )..layout();
     }
 
-    truncatedPainter.dispose();
+    // Text exceeds maxLines, create painter with ellipsis.
     final String labelText = originalPainter.text?.toPlainText() ?? '';
     return _createTextPainterWithEllipsis(
       originalPainter: originalPainter,
       originalText: labelText,
-      maxLines: multilineConfig.maxLines!,
+      maxLines: maxLines,
       textScaleFactor: textScaleFactor,
     );
   }

--- a/packages/flutter/lib/src/material/slider_parts.dart
+++ b/packages/flutter/lib/src/material/slider_parts.dart
@@ -886,6 +886,9 @@ class _ValueIndicatorTextProcessor {
   }
 
   /// Creates a TextPainter with ellipsis when text exceeds maxLines.
+  // TODO(huycozy): Use TextPainter built-in API for ellipsis.
+  //  See https://github.com/flutter/flutter/issues/175251
+  //  Blocked by https://github.com/flutter/flutter/issues/50168
   TextPainter _createTextPainterWithEllipsis({
     required TextPainter originalPainter,
     required String originalText,

--- a/packages/flutter/lib/src/material/slider_parts.dart
+++ b/packages/flutter/lib/src/material/slider_parts.dart
@@ -868,10 +868,10 @@ class _DropSliderValueIndicatorPathPainter {
   Size getPreferredSize(TextPainter labelPainter, double textScaleFactor) {
     // For getPreferredSize, assuming multiline support for sizing estimation.
     // The actual rendering decision is made in the paint method based on theme.
-    final bool hasMultipleLines = labelPainter.text?.toPlainText().contains('\n') ?? false;
+    final bool hasNewline = labelPainter.text?.toPlainText().contains('\n') ?? false;
     final double width =
         math.max(_minLabelWidth, labelPainter.width) + _labelPadding * 2 * textScaleFactor;
-    if (hasMultipleLines) {
+    if (hasNewline) {
       final double height = math.max(
         _preferredHeight,
         labelPainter.height + (_labelPadding * 2 * textScaleFactor),
@@ -987,10 +987,10 @@ class _DropSliderValueIndicatorPathPainter {
       scale: scale,
     );
 
-    final bool hasMultipleLines = multilineConfig.enabled && (labelText.contains('\n'));
+    final bool hasNewline = multilineConfig.enabled && (labelText.contains('\n'));
 
     final Rect upperRect;
-    if (hasMultipleLines) {
+    if (hasNewline) {
       // For multiline text, the rectangle should be positioned to accommodate
       // the text with proper padding.
       final double rectHeight = finalLabelPainter.height + (_labelPadding * 2);
@@ -1018,7 +1018,7 @@ class _DropSliderValueIndicatorPathPainter {
     canvas.scale(scale, scale);
 
     final Path path;
-    if (hasMultipleLines) {
+    if (hasNewline) {
       // For multiline text, create a single continuous path for the
       // drop/triangle shape.
       path = Path();
@@ -1098,7 +1098,7 @@ class _DropSliderValueIndicatorPathPainter {
     canvas.drawPath(path, fillPaint);
 
     // The label text is centered within the value indicator.
-    if (hasMultipleLines) {
+    if (hasNewline) {
       // Center multiline text within the rectangle.
       final Offset labelOffset = Offset(
         upperRect.left + (upperRect.width - finalLabelPainter.width) / 2,
@@ -1483,16 +1483,15 @@ class _RoundedRectSliderValueIndicatorPathPainter {
   /// A default extra padding for rounded corners when the label is multiline.
   ///
   /// This constant is to prevent text from appearing to "spill out" of the rounded corners.
-
   static const double _multilineCornerPadding = 8.0;
 
   Size getPreferredSize(TextPainter labelPainter, double textScaleFactor) {
     // For getPreferredSize, assuming multiline support for sizing estimation.
     // The actual rendering decision is made in the paint method based on theme.
-    final bool hasMultipleLines = labelPainter.text?.toPlainText().contains('\n') ?? false;
+    final bool hasNewline = labelPainter.text?.toPlainText().contains('\n') ?? false;
     final double width =
         math.max(_minLabelWidth, labelPainter.width) + _labelPadding * 2 * textScaleFactor;
-    if (hasMultipleLines) {
+    if (hasNewline) {
       final double height = math.max(
         _preferredHeight,
         labelPainter.height + (_labelPadding * 2 * textScaleFactor) + _multilineCornerPadding,
@@ -1601,9 +1600,9 @@ class _RoundedRectSliderValueIndicatorPathPainter {
       scale: scale,
     );
 
-    final bool hasMultipleLines = multilineConfig.enabled && labelText.contains('\n');
+    final bool hasNewline = multilineConfig.enabled && labelText.contains('\n');
     final double cornerPadding = multilineConfig.cornerPadding ?? _multilineCornerPadding;
-    final double rectHeight = hasMultipleLines
+    final double rectHeight = hasNewline
         ? math.max(_preferredHeight, finalLabelPainter.height + (_labelPadding * 2) + cornerPadding)
         : _preferredHeight * textScaleFactor;
 

--- a/packages/flutter/lib/src/material/slider_parts.dart
+++ b/packages/flutter/lib/src/material/slider_parts.dart
@@ -851,17 +851,14 @@ class _ValueIndicatorTextProcessor {
   }
 
   final TextPainter _originalPainter;
-  late final TextPainter _textPainter;
-  bool _createdNewPainter = false;
 
   /// Gets the TextPainter to use for rendering.
   /// This will be either the original painter or a new one with multiline processing applied.
-  TextPainter get textPainter => _textPainter;
+  TextPainter get textPainter => _originalPainter;
 
   void _processText(ValueIndicatorMultilineConfig multilineConfig, double textScaleFactor) {
     if (!multilineConfig.enabled || multilineConfig.maxLines == null) {
-      _textPainter = _originalPainter;
-      _createdNewPainter = false;
+      // No multiline processing is needed if multiline is disabled or maxLines is null.
       return;
     }
 
@@ -871,29 +868,14 @@ class _ValueIndicatorTextProcessor {
 
     if (actualLines <= maxLines) {
       // Text fits within maxLines, just return the original painter.
-      _textPainter = _originalPainter;
-      _createdNewPainter = false;
       return;
     }
 
-    // If text exceeds maxLines, create painter with ellipsis
+    // If text exceeds maxLines, update old painter with maxLines and ellipsis
     // using TextPainter's built-in API.
-    _textPainter = TextPainter(
-      text: _originalPainter.text,
-      textDirection: _originalPainter.textDirection,
-      textScaleFactor: textScaleFactor,
-      maxLines: maxLines,
-      ellipsis: _kEllipsis,
-    )..layout();
-    _createdNewPainter = true;
-  }
-
-  /// Disposes resources if a new TextPainter was created.
-  /// Safe to call multiple times.
-  void dispose() {
-    if (_createdNewPainter && _textPainter != _originalPainter) {
-      _textPainter.dispose();
-    }
+    _originalPainter.ellipsis = _kEllipsis;
+    _originalPainter.maxLines = maxLines;
+    _originalPainter.layout();
   }
 }
 
@@ -1153,9 +1135,6 @@ class _DropSliderValueIndicatorPathPainter {
       finalLabelPainter.paint(canvas, labelOffset);
     }
     canvas.restore();
-
-    // Dispose the processor, which handles TextPainter lifecycle automatically.
-    processor.dispose();
   }
 }
 
@@ -1667,9 +1646,6 @@ class _RoundedRectSliderValueIndicatorPathPainter {
     );
     finalLabelPainter.paint(canvas, labelOffset);
     canvas.restore();
-
-    // Dispose the processor, which handles TextPainter lifecycle automatically.
-    processor.dispose();
   }
 }
 

--- a/packages/flutter/lib/src/material/slider_parts.dart
+++ b/packages/flutter/lib/src/material/slider_parts.dart
@@ -836,8 +836,6 @@ class DropSliderValueIndicatorShape extends SliderComponentShape {
 
 /// Utility class for processing multiline text in value indicators.
 abstract class _ValueIndicatorTextProcessor {
-  const _ValueIndicatorTextProcessor._();
-
   /// Creates a TextPainter with ellipsis when text exceeds maxLines.
   static TextPainter _createTextPainterWithEllipsis({
     required TextPainter originalPainter,
@@ -1513,7 +1511,7 @@ class _RoundedRectSliderValueIndicatorPathPainter {
   /// A default extra padding for rounded corners when the label is multiline.
   ///
   /// This constant is to prevent text from appearing to "spill out" of the rounded corners.
-  static const double _multilineCornerPadding = 8.0;
+  static const EdgeInsets _multilineCornerPadding = EdgeInsets.all(8.0);
 
   Size getPreferredSize(TextPainter labelPainter, double textScaleFactor) {
     // For getPreferredSize, assuming multiline support for sizing estimation.
@@ -1524,7 +1522,9 @@ class _RoundedRectSliderValueIndicatorPathPainter {
     if (hasNewline) {
       final double height = math.max(
         _preferredHeight,
-        labelPainter.height + (_labelPadding * 2 * textScaleFactor) + _multilineCornerPadding,
+        labelPainter.height +
+            (_labelPadding * 2 * textScaleFactor) +
+            _multilineCornerPadding.vertical,
       );
       return Size(width, height);
     } else {
@@ -1615,12 +1615,10 @@ class _RoundedRectSliderValueIndicatorPathPainter {
     );
     final String labelText = labelPainter.text?.toPlainText() ?? '';
     final bool hasNewline = multilineConfig.enabled && labelText.contains('\n');
-    final double cornerPadding = multilineConfig.cornerPadding ?? _multilineCornerPadding;
-    // Apply cornerPadding more effectively by distributing it between width and height.
-    // The w/h ratio(6/4) provides better visual balance,
-    // since horizontal size is often longer than vertical size as usual.
-    final double effectiveCornerPaddingWidth = hasNewline ? cornerPadding * 0.6 : 0.0;
-    final double effectiveCornerPaddingHeight = hasNewline ? cornerPadding * 0.4 : 0.0;
+    final EdgeInsetsGeometry cornerPadding =
+        multilineConfig.cornerPadding ?? _multilineCornerPadding;
+    final double effectiveCornerPaddingWidth = hasNewline ? cornerPadding.horizontal : 0.0;
+    final double effectiveCornerPaddingHeight = hasNewline ? cornerPadding.vertical : 0.0;
 
     final double adjustedRectangleWidth = rectangleWidth + effectiveCornerPaddingWidth;
     final double rectHeight = hasNewline

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1197,7 +1197,7 @@ class ValueIndicatorMultilineConfig with Diagnosticable {
   /// Maximum number of lines to display in the value indicator.
   ///
   /// If null, there is no limit on the number of lines.
-  /// If specified, text beyond this limit will be truncated.
+  /// If specified, text beyond this limit will be ellipsized.
   final int? maxLines;
 
   /// Additional padding for rounded corners in multiline mode.

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -314,6 +314,7 @@ class SliderThemeData with Diagnosticable {
       'This feature was deprecated after v3.27.0-0.2.pre.',
     )
     this.year2023,
+    this.valueIndicatorMultilineConfig,
   });
 
   /// Generates a SliderThemeData from three main colors.
@@ -655,6 +656,16 @@ class SliderThemeData with Diagnosticable {
   )
   final bool? year2023;
 
+  /// Configuration for value indicator multiline behavior.
+  ///
+  /// Controls how multiline text is handled in slider value indicators.
+  /// When null, multiline support is enabled with default settings.
+  ///
+  /// See also:
+  ///
+  ///  * [ValueIndicatorMultilineConfig], which defines the configuration options.
+  final ValueIndicatorMultilineConfig? valueIndicatorMultilineConfig;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   SliderThemeData copyWith({
@@ -694,6 +705,7 @@ class SliderThemeData with Diagnosticable {
     WidgetStateProperty<Size?>? thumbSize,
     double? trackGap,
     bool? year2023,
+    ValueIndicatorMultilineConfig? valueIndicatorMultilineConfig,
   }) {
     return SliderThemeData(
       trackHeight: trackHeight ?? this.trackHeight,
@@ -734,6 +746,8 @@ class SliderThemeData with Diagnosticable {
       thumbSize: thumbSize ?? this.thumbSize,
       trackGap: trackGap ?? this.trackGap,
       year2023: year2023 ?? this.year2023,
+      valueIndicatorMultilineConfig:
+          valueIndicatorMultilineConfig ?? this.valueIndicatorMultilineConfig,
     );
   }
 
@@ -817,6 +831,11 @@ class SliderThemeData with Diagnosticable {
       thumbSize: WidgetStateProperty.lerp<Size?>(a.thumbSize, b.thumbSize, t, Size.lerp),
       trackGap: lerpDouble(a.trackGap, b.trackGap, t),
       year2023: t < 0.5 ? a.year2023 : b.year2023,
+      valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig.lerp(
+        a.valueIndicatorMultilineConfig,
+        b.valueIndicatorMultilineConfig,
+        t,
+      ),
     );
   }
 
@@ -858,6 +877,7 @@ class SliderThemeData with Diagnosticable {
       thumbSize,
       trackGap,
       year2023,
+      valueIndicatorMultilineConfig,
     ),
   );
 
@@ -905,7 +925,8 @@ class SliderThemeData with Diagnosticable {
         other.padding == padding &&
         other.thumbSize == thumbSize &&
         other.trackGap == trackGap &&
-        other.year2023 == year2023;
+        other.year2023 == year2023 &&
+        other.valueIndicatorMultilineConfig == valueIndicatorMultilineConfig;
   }
 
   @override
@@ -1140,6 +1161,113 @@ class SliderThemeData with Diagnosticable {
     properties.add(
       DiagnosticsProperty<bool>('year2023', year2023, defaultValue: defaultData.year2023),
     );
+    properties.add(
+      DiagnosticsProperty<ValueIndicatorMultilineConfig?>(
+        'valueIndicatorMultilineConfig',
+        valueIndicatorMultilineConfig,
+        defaultValue: defaultData.valueIndicatorMultilineConfig,
+      ),
+    );
+  }
+}
+
+/// Configuration for value indicator multiline behavior.
+///
+/// Used with [SliderThemeData.valueIndicatorMultilineConfig] to control
+/// how multiline text is handled in slider value indicators.
+///
+/// See also:
+///
+///  * [SliderThemeData], which uses this to configure multiline behavior.
+///  * [Slider.label], which can contain newline characters for multiline text.
+@immutable
+class ValueIndicatorMultilineConfig with Diagnosticable {
+  /// Creates a configuration for multiline value indicators.
+  const ValueIndicatorMultilineConfig({this.enabled = true, this.maxLines, this.cornerPadding});
+
+  /// Whether multiline value indicators are enabled.
+  ///
+  /// When true, value indicators will dynamically size to accommodate
+  /// multiline text (text containing '\n' characters). When false,
+  /// all text will be treated as single-line for backward compatibility.
+  ///
+  /// Defaults to true.
+  final bool enabled;
+
+  /// Maximum number of lines to display in the value indicator.
+  ///
+  /// If null, there is no limit on the number of lines.
+  /// If specified, text beyond this limit will be truncated.
+  final int? maxLines;
+
+  /// Additional padding for rounded corners in multiline mode.
+  ///
+  /// This padding is added beyond the standard label padding to prevent
+  /// text from appearing to "spill out" of rounded corners when using
+  /// [RoundedRectSliderValueIndicatorShape] (Material 3, when [ThemeData.useMaterial3]
+  /// is true or [SliderThemeData.valueIndicatorShape] is explicitly set).
+  ///
+  /// This property is ignored by [DropSliderValueIndicatorShape] (Material 2)
+  /// as it uses a different geometry that doesn't require corner padding.
+  ///
+  /// If null, uses a default padding of 8.0 logical pixels for rounded rect shapes.
+  final double? cornerPadding;
+
+  /// Creates a copy of this configuration with the given fields replaced
+  /// with new values.
+  ValueIndicatorMultilineConfig copyWith({bool? enabled, int? maxLines, double? cornerPadding}) {
+    return ValueIndicatorMultilineConfig(
+      enabled: enabled ?? this.enabled,
+      maxLines: maxLines ?? this.maxLines,
+      cornerPadding: cornerPadding ?? this.cornerPadding,
+    );
+  }
+
+  /// Linearly interpolate between two multiline configurations.
+  static ValueIndicatorMultilineConfig? lerp(
+    ValueIndicatorMultilineConfig? a,
+    ValueIndicatorMultilineConfig? b,
+    double t,
+  ) {
+    if (identical(a, b)) {
+      return a;
+    }
+    if (a == null) {
+      return b;
+    }
+    if (b == null) {
+      return a;
+    }
+    return ValueIndicatorMultilineConfig(
+      enabled: t < 0.5 ? a.enabled : b.enabled,
+      maxLines: t < 0.5 ? a.maxLines : b.maxLines,
+      cornerPadding: lerpDouble(a.cornerPadding, b.cornerPadding, t),
+    );
+  }
+
+  @override
+  int get hashCode => Object.hash(enabled, maxLines, cornerPadding);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ValueIndicatorMultilineConfig &&
+        other.enabled == enabled &&
+        other.maxLines == maxLines &&
+        other.cornerPadding == cornerPadding;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<bool>('enabled', enabled));
+    properties.add(IntProperty('maxLines', maxLines));
+    properties.add(DoubleProperty('cornerPadding', cornerPadding));
   }
 }
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -1210,12 +1210,16 @@ class ValueIndicatorMultilineConfig with Diagnosticable {
   /// This property is ignored by [DropSliderValueIndicatorShape] (Material 2)
   /// as it uses a different geometry that doesn't require corner padding.
   ///
-  /// If null, uses a default padding of 8.0 logical pixels for rounded rect shapes.
-  final double? cornerPadding;
+  /// If null, uses a default padding of [EdgeInsets.all(8.0)] for rounded rect shapes.
+  final EdgeInsetsGeometry? cornerPadding;
 
   /// Creates a copy of this configuration with the given fields replaced
   /// with new values.
-  ValueIndicatorMultilineConfig copyWith({bool? enabled, int? maxLines, double? cornerPadding}) {
+  ValueIndicatorMultilineConfig copyWith({
+    bool? enabled,
+    int? maxLines,
+    EdgeInsetsGeometry? cornerPadding,
+  }) {
     return ValueIndicatorMultilineConfig(
       enabled: enabled ?? this.enabled,
       maxLines: maxLines ?? this.maxLines,
@@ -1241,7 +1245,7 @@ class ValueIndicatorMultilineConfig with Diagnosticable {
     return ValueIndicatorMultilineConfig(
       enabled: t < 0.5 ? a.enabled : b.enabled,
       maxLines: t < 0.5 ? a.maxLines : b.maxLines,
-      cornerPadding: lerpDouble(a.cornerPadding, b.cornerPadding, t),
+      cornerPadding: EdgeInsetsGeometry.lerp(a.cornerPadding, b.cornerPadding, t),
     );
   }
 
@@ -1267,7 +1271,7 @@ class ValueIndicatorMultilineConfig with Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<bool>('enabled', enabled));
     properties.add(IntProperty('maxLines', maxLines));
-    properties.add(DoubleProperty('cornerPadding', cornerPadding));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('cornerPadding', cornerPadding));
   }
 }
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -5727,7 +5727,7 @@ void main() {
       const String labelText = 'First line\nSecond line\nThird line\nFourth line\nFifth line';
 
       // First test without cornerPadding to get baseline overlay size.
-      // without additional padding - text might spill out at corners.
+      // Without additional padding - text might spill out at corners.
       const ValueIndicatorMultilineConfig configNoPadding = ValueIndicatorMultilineConfig(
         cornerPadding: 0.0,
       );
@@ -5769,7 +5769,6 @@ void main() {
       expect(paddingSize.height, greaterThanOrEqualTo(noPaddingSize.height));
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
 
     testWidgets('ValueIndicatorMultilineConfig.cornerPadding is ignored  when year2023 is true', (
@@ -5817,7 +5816,6 @@ void main() {
       expect(largePaddingSize.height, equals(defaultPaddingSize.height));
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
 
     testWidgets('text is truncated when label exceeds maxLines with year2023 false', (
@@ -5876,7 +5874,6 @@ void main() {
       expect(limitedHeight, lessThan(unlimitedHeight));
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
 
     testWidgets('text is truncated when label exceeds maxLines with year2023 true', (
@@ -5934,7 +5931,6 @@ void main() {
       expect(limitedHeight, lessThan(unlimitedHeight));
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
 
     testWidgets('multiline text gets ellipsis at the tail when exceeding maxLines', (
@@ -5961,7 +5957,6 @@ void main() {
       expect(capturedTexts.first.split('\n').length, lessThanOrEqualTo(2));
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
 
     testWidgets('text with fewer line than maxLines should not throw any crash', (
@@ -5988,7 +5983,6 @@ void main() {
       expect(tester.takeException(), isNull);
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
 
     testWidgets('text with fewer lines than maxLines preserves original text', (
@@ -6015,7 +6009,6 @@ void main() {
       expect(capturedTexts.first, equals('Line 1\nLine 2'));
 
       await gesture.up();
-      await tester.pumpAndSettle();
     });
   });
 }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -132,8 +132,8 @@ class LoggingValueIndicatorShape extends SliderComponentShape {
 }
 
 // A value indicator shape that captures the final processed text painter size for testing.
-class HeightCapturingValueIndicatorShape extends SliderComponentShape {
-  HeightCapturingValueIndicatorShape(this.capturedSizes);
+class _HeightCapturingValueIndicatorShape extends SliderComponentShape {
+  _HeightCapturingValueIndicatorShape(this.capturedSizes);
   final List<Size> capturedSizes;
 
   @override
@@ -158,7 +158,7 @@ class HeightCapturingValueIndicatorShape extends SliderComponentShape {
     required double textScaleFactor,
     required Size sizeWithOverflow,
   }) {
-    // Apply the same multiline logic as the real implementation
+    // Apply the same multiline logic as the real implementation.
     final ValueIndicatorMultilineConfig? multilineConfig =
         sliderTheme.valueIndicatorMultilineConfig;
     TextPainter finalLabelPainter = labelPainter;
@@ -181,8 +181,8 @@ class HeightCapturingValueIndicatorShape extends SliderComponentShape {
 }
 
 // A test value indicator shape that captures the final rendered text for testing ellipsis behavior.
-class TestEllipsisValueIndicatorShape extends SliderComponentShape {
-  TestEllipsisValueIndicatorShape(this.capturedTexts);
+class _TestEllipsisValueIndicatorShape extends SliderComponentShape {
+  _TestEllipsisValueIndicatorShape(this.capturedTexts);
   final List<String> capturedTexts;
 
   @override
@@ -5621,7 +5621,7 @@ void main() {
       const ValueIndicatorMultilineConfig customConfig = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 3,
-        cornerPadding: 12.0,
+        cornerPadding: EdgeInsets.all(12.0),
       );
 
       await tester.pumpWidget(
@@ -5645,7 +5645,7 @@ void main() {
       expect(sliderTheme.valueIndicatorMultilineConfig, equals(customConfig));
       expect(sliderTheme.valueIndicatorMultilineConfig!.enabled, false);
       expect(sliderTheme.valueIndicatorMultilineConfig!.maxLines, 3);
-      expect(sliderTheme.valueIndicatorMultilineConfig!.cornerPadding, 12.0);
+      expect(sliderTheme.valueIndicatorMultilineConfig!.cornerPadding, const EdgeInsets.all(12.0));
     });
 
     testWidgets('SliderTheme.copyWith can update valueIndicatorMultilineConfig', (
@@ -5653,13 +5653,13 @@ void main() {
     ) async {
       const ValueIndicatorMultilineConfig originalConfig = ValueIndicatorMultilineConfig(
         maxLines: 2,
-        cornerPadding: 8.0,
+        cornerPadding: EdgeInsets.all(8.0),
       );
 
       const ValueIndicatorMultilineConfig updatedConfig = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 5,
-        cornerPadding: 16.0,
+        cornerPadding: EdgeInsets.all(16.0),
       );
 
       await tester.pumpWidget(
@@ -5686,7 +5686,7 @@ void main() {
       expect(sliderTheme.valueIndicatorMultilineConfig, equals(updatedConfig));
       expect(sliderTheme.valueIndicatorMultilineConfig!.enabled, false);
       expect(sliderTheme.valueIndicatorMultilineConfig!.maxLines, 5);
-      expect(sliderTheme.valueIndicatorMultilineConfig!.cornerPadding, 16.0);
+      expect(sliderTheme.valueIndicatorMultilineConfig!.cornerPadding, const EdgeInsets.all(16.0));
     });
 
     // Common widget builder for testing value indicator multiline config.
@@ -5729,7 +5729,7 @@ void main() {
       // First test without cornerPadding to get baseline overlay size.
       // Without additional padding - text might spill out at corners.
       const ValueIndicatorMultilineConfig configNoPadding = ValueIndicatorMultilineConfig(
-        cornerPadding: 0.0,
+        cornerPadding: EdgeInsets.zero,
       );
 
       await tester.pumpWidget(
@@ -5748,7 +5748,7 @@ void main() {
 
       // Now test with additional cornerPadding to prevent text spill out.
       const ValueIndicatorMultilineConfig configWithPadding = ValueIndicatorMultilineConfig(
-        cornerPadding: 24.0,
+        cornerPadding: EdgeInsets.all(24.0),
       );
 
       await tester.pumpWidget(
@@ -5762,7 +5762,7 @@ void main() {
       final Size paddingSize = paddingBox.size;
 
       // Verify that value indicator renders properly with cornerPadding applied.
-      expect(paddingBox, paints..rrect()); // RoundedRectSliderValueIndicatorShape uses rrect
+      expect(paddingBox, paints..rrect()); // RoundedRectSliderValueIndicatorShape uses rrect.
 
       // With cornerPadding, the overlay should be larger than the non - additional padding size.
       expect(paddingSize.width, greaterThanOrEqualTo(noPaddingSize.width));
@@ -5795,7 +5795,9 @@ void main() {
 
       // Now test with large cornerPadding.
       const ValueIndicatorMultilineConfig configLargePadding = ValueIndicatorMultilineConfig(
-        cornerPadding: 50.0, // A big enough padding that would affect the rounded rect size.
+        cornerPadding: EdgeInsets.all(
+          50.0,
+        ), // A big enough padding that would affect the rounded rect size.
       );
 
       await tester.pumpWidget(
@@ -5826,9 +5828,8 @@ void main() {
 
       // First test with unlimited maxLines.
       final List<Size> unlimitedSizes = <Size>[];
-      final HeightCapturingValueIndicatorShape unlimitedShape = HeightCapturingValueIndicatorShape(
-        unlimitedSizes,
-      );
+      final _HeightCapturingValueIndicatorShape unlimitedShape =
+          _HeightCapturingValueIndicatorShape(unlimitedSizes);
 
       await tester.pumpWidget(
         buildSliderWithConfig(
@@ -5851,7 +5852,7 @@ void main() {
 
       // Now test with limited maxLines = 2.
       final List<Size> limitedSizes = <Size>[];
-      final HeightCapturingValueIndicatorShape limitedShape = HeightCapturingValueIndicatorShape(
+      final _HeightCapturingValueIndicatorShape limitedShape = _HeightCapturingValueIndicatorShape(
         limitedSizes,
       );
 
@@ -5883,9 +5884,8 @@ void main() {
 
       // First test with unlimited maxLines.
       final List<Size> unlimitedSizes = <Size>[];
-      final HeightCapturingValueIndicatorShape unlimitedShape = HeightCapturingValueIndicatorShape(
-        unlimitedSizes,
-      );
+      final _HeightCapturingValueIndicatorShape unlimitedShape =
+          _HeightCapturingValueIndicatorShape(unlimitedSizes);
 
       await tester.pumpWidget(
         buildSliderWithConfig(
@@ -5908,7 +5908,7 @@ void main() {
 
       // Now test with limited maxLines = 3.
       final List<Size> limitedSizes = <Size>[];
-      final HeightCapturingValueIndicatorShape limitedShape = HeightCapturingValueIndicatorShape(
+      final _HeightCapturingValueIndicatorShape limitedShape = _HeightCapturingValueIndicatorShape(
         limitedSizes,
       );
 
@@ -5937,7 +5937,9 @@ void main() {
       WidgetTester tester,
     ) async {
       final List<String> capturedTexts = <String>[];
-      final TestEllipsisValueIndicatorShape shape = TestEllipsisValueIndicatorShape(capturedTexts);
+      final _TestEllipsisValueIndicatorShape shape = _TestEllipsisValueIndicatorShape(
+        capturedTexts,
+      );
 
       await tester.pumpWidget(
         buildSliderWithConfig(
@@ -5963,7 +5965,9 @@ void main() {
       WidgetTester tester,
     ) async {
       final List<String> capturedTexts = <String>[];
-      final TestEllipsisValueIndicatorShape shape = TestEllipsisValueIndicatorShape(capturedTexts);
+      final _TestEllipsisValueIndicatorShape shape = _TestEllipsisValueIndicatorShape(
+        capturedTexts,
+      );
 
       await tester.pumpWidget(
         buildSliderWithConfig(
@@ -5989,12 +5993,14 @@ void main() {
       WidgetTester tester,
     ) async {
       final List<String> capturedTexts = <String>[];
-      final TestEllipsisValueIndicatorShape shape = TestEllipsisValueIndicatorShape(capturedTexts);
+      final _TestEllipsisValueIndicatorShape shape = _TestEllipsisValueIndicatorShape(
+        capturedTexts,
+      );
 
       await tester.pumpWidget(
         buildSliderWithConfig(
           config: const ValueIndicatorMultilineConfig(maxLines: 5),
-          year2023: false,
+          year2023: true,
           label: 'Line 1\nLine 2',
           valueIndicatorShape: shape,
         ),

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -3653,55 +3653,55 @@ void main() {
       const ValueIndicatorMultilineConfig config = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 3,
-        cornerPadding: 12.0,
+        cornerPadding: EdgeInsets.all(12.0),
       );
       expect(config.enabled, false);
       expect(config.maxLines, 3);
-      expect(config.cornerPadding, 12.0);
+      expect(config.cornerPadding, const EdgeInsets.all(12.0));
     });
 
     test('ValueIndicatorMultilineConfig copyWith', () {
       const ValueIndicatorMultilineConfig original = ValueIndicatorMultilineConfig(
         maxLines: 2,
-        cornerPadding: 8.0,
+        cornerPadding: EdgeInsets.all(8.0),
       );
 
       // Test copying with no changes.
       final ValueIndicatorMultilineConfig copy1 = original.copyWith();
       expect(copy1.enabled, true);
       expect(copy1.maxLines, 2);
-      expect(copy1.cornerPadding, 8.0);
+      expect(copy1.cornerPadding, const EdgeInsets.all(8.0));
 
       // Test copying with changes.
       final ValueIndicatorMultilineConfig copy2 = original.copyWith(
         enabled: false,
         maxLines: 5,
-        cornerPadding: 16.0,
+        cornerPadding: const EdgeInsets.all(16.0),
       );
       expect(copy2.enabled, false);
       expect(copy2.maxLines, 5);
-      expect(copy2.cornerPadding, 16.0);
+      expect(copy2.cornerPadding, const EdgeInsets.all(16.0));
 
       // Test copying with partial changes.
       final ValueIndicatorMultilineConfig copy3 = original.copyWith(maxLines: 4);
       expect(copy3.enabled, true);
       expect(copy3.maxLines, 4);
-      expect(copy3.cornerPadding, 8.0);
+      expect(copy3.cornerPadding, const EdgeInsets.all(8.0));
     });
 
     test('ValueIndicatorMultilineConfig equality', () {
       const ValueIndicatorMultilineConfig config1 = ValueIndicatorMultilineConfig(
         maxLines: 2,
-        cornerPadding: 8.0,
+        cornerPadding: EdgeInsets.all(8.0),
       );
       const ValueIndicatorMultilineConfig config2 = ValueIndicatorMultilineConfig(
         maxLines: 2,
-        cornerPadding: 8.0,
+        cornerPadding: EdgeInsets.all(8.0),
       );
       const ValueIndicatorMultilineConfig config3 = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 2,
-        cornerPadding: 8.0,
+        cornerPadding: EdgeInsets.all(8.0),
       );
 
       // Test equality with same values.
@@ -3714,12 +3714,12 @@ void main() {
     test('ValueIndicatorMultilineConfig lerp', () {
       const ValueIndicatorMultilineConfig a = ValueIndicatorMultilineConfig(
         maxLines: 2,
-        cornerPadding: 8.0,
+        cornerPadding: EdgeInsets.all(8.0),
       );
       const ValueIndicatorMultilineConfig b = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 4,
-        cornerPadding: 16.0,
+        cornerPadding: EdgeInsets.all(16.0),
       );
 
       final ValueIndicatorMultilineConfig? lerp0 = ValueIndicatorMultilineConfig.lerp(a, b, 0.0);
@@ -3731,12 +3731,20 @@ void main() {
       final ValueIndicatorMultilineConfig? lerp05 = ValueIndicatorMultilineConfig.lerp(a, b, 0.5);
       expect(lerp05!.enabled, false);
       expect(lerp05.maxLines, 4);
-      expect(lerp05.cornerPadding, 12.0); // = (8.0 + (16.0 - 8.0) * 0.5)
+      expect(lerp05.cornerPadding, const EdgeInsets.all(12.0)); // = (8.0 + (16.0 - 8.0) * 0.5)
 
       final ValueIndicatorMultilineConfig? lerp03 = ValueIndicatorMultilineConfig.lerp(a, b, 0.3);
       expect(lerp03!.enabled, true);
       expect(lerp03.maxLines, 2);
-      expect(lerp03.cornerPadding, closeTo(10.4, 0.01)); // = (8.0 + (16.0 - 8.0) * 0.3)
+
+      // = (8.0 + (16.0 - 8.0) * 0.3) = 10.4
+      // It's expected to equal EdgeInsets.all(10.4) directly but will encounter floating-point issue.
+      // So, do check the values for all sides are close to 10.4, not strict EdgeInsets object equality.
+      final EdgeInsets e = lerp03.cornerPadding! as EdgeInsets;
+      expect(e.left, moreOrLessEquals(10.4));
+      expect(e.top, moreOrLessEquals(10.4));
+      expect(e.right, moreOrLessEquals(10.4));
+      expect(e.bottom, moreOrLessEquals(10.4));
 
       expect(ValueIndicatorMultilineConfig.lerp(null, null, 0.5), null);
       expect(ValueIndicatorMultilineConfig.lerp(a, null, 0.5), a);
@@ -3748,7 +3756,7 @@ void main() {
       const ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 3,
-        cornerPadding: 12.0,
+        cornerPadding: EdgeInsets.all(12.0),
       ).debugFillProperties(builder);
 
       final List<String> description = builder.properties
@@ -3756,14 +3764,18 @@ void main() {
           .map((DiagnosticsNode node) => node.toString())
           .toList();
 
-      expect(description, <String>['enabled: false', 'maxLines: 3', 'cornerPadding: 12.0']);
+      expect(description, <String>[
+        'enabled: false',
+        'maxLines: 3',
+        'cornerPadding: EdgeInsets.all(12.0)',
+      ]);
     });
 
     testWidgets('ValueIndicatorMultilineConfig in SliderThemeData', (WidgetTester tester) async {
       const ValueIndicatorMultilineConfig config = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 2,
-        cornerPadding: 10.0,
+        cornerPadding: EdgeInsets.all(10.0),
       );
 
       const SliderThemeData theme = SliderThemeData(valueIndicatorMultilineConfig: config);
@@ -3784,12 +3796,12 @@ void main() {
     ) async {
       const ValueIndicatorMultilineConfig configA = ValueIndicatorMultilineConfig(
         maxLines: 1,
-        cornerPadding: 4.0,
+        cornerPadding: EdgeInsets.all(4.0),
       );
       const ValueIndicatorMultilineConfig configB = ValueIndicatorMultilineConfig(
         enabled: false,
         maxLines: 3,
-        cornerPadding: 12.0,
+        cornerPadding: EdgeInsets.all(12.0),
       );
 
       const SliderThemeData themeA = SliderThemeData(valueIndicatorMultilineConfig: configA);
@@ -3798,7 +3810,7 @@ void main() {
       final SliderThemeData lerpedTheme = SliderThemeData.lerp(themeA, themeB, 0.5);
       expect(lerpedTheme.valueIndicatorMultilineConfig!.enabled, false);
       expect(lerpedTheme.valueIndicatorMultilineConfig!.maxLines, 3);
-      expect(lerpedTheme.valueIndicatorMultilineConfig!.cornerPadding, 8.0);
+      expect(lerpedTheme.valueIndicatorMultilineConfig!.cornerPadding, const EdgeInsets.all(8.0));
     });
 
     testWidgets('SliderThemeData debugFillProperties includes ValueIndicatorMultilineConfig', (
@@ -3810,7 +3822,7 @@ void main() {
         valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(
           enabled: false,
           maxLines: 2,
-          cornerPadding: 8.0,
+          cornerPadding: EdgeInsets.all(8.0),
         ),
       ).debugFillProperties(builder);
 
@@ -3824,7 +3836,7 @@ void main() {
         description.any(
           (String desc) =>
               desc.startsWith('valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig#') &&
-              desc.contains('enabled: false, maxLines: 2, cornerPadding: 8.0'),
+              desc.contains('enabled: false, maxLines: 2, cornerPadding: EdgeInsets.all(8.0)'),
         ),
         true,
       );

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -3640,6 +3640,196 @@ void main() {
       }
     });
   });
+
+  group('ValueIndicatorMultilineConfig', () {
+    test('ValueIndicatorMultilineConfig defaults', () {
+      const ValueIndicatorMultilineConfig config = ValueIndicatorMultilineConfig();
+      expect(config.enabled, true);
+      expect(config.maxLines, null);
+      expect(config.cornerPadding, null);
+    });
+
+    test('ValueIndicatorMultilineConfig with custom values', () {
+      const ValueIndicatorMultilineConfig config = ValueIndicatorMultilineConfig(
+        enabled: false,
+        maxLines: 3,
+        cornerPadding: 12.0,
+      );
+      expect(config.enabled, false);
+      expect(config.maxLines, 3);
+      expect(config.cornerPadding, 12.0);
+    });
+
+    test('ValueIndicatorMultilineConfig copyWith', () {
+      const ValueIndicatorMultilineConfig original = ValueIndicatorMultilineConfig(
+        maxLines: 2,
+        cornerPadding: 8.0,
+      );
+
+      // Test copying with no changes.
+      final ValueIndicatorMultilineConfig copy1 = original.copyWith();
+      expect(copy1.enabled, true);
+      expect(copy1.maxLines, 2);
+      expect(copy1.cornerPadding, 8.0);
+
+      // Test copying with changes.
+      final ValueIndicatorMultilineConfig copy2 = original.copyWith(
+        enabled: false,
+        maxLines: 5,
+        cornerPadding: 16.0,
+      );
+      expect(copy2.enabled, false);
+      expect(copy2.maxLines, 5);
+      expect(copy2.cornerPadding, 16.0);
+
+      // Test copying with partial changes.
+      final ValueIndicatorMultilineConfig copy3 = original.copyWith(maxLines: 4);
+      expect(copy3.enabled, true);
+      expect(copy3.maxLines, 4);
+      expect(copy3.cornerPadding, 8.0);
+    });
+
+    test('ValueIndicatorMultilineConfig equality', () {
+      const ValueIndicatorMultilineConfig config1 = ValueIndicatorMultilineConfig(
+        maxLines: 2,
+        cornerPadding: 8.0,
+      );
+      const ValueIndicatorMultilineConfig config2 = ValueIndicatorMultilineConfig(
+        maxLines: 2,
+        cornerPadding: 8.0,
+      );
+      const ValueIndicatorMultilineConfig config3 = ValueIndicatorMultilineConfig(
+        enabled: false,
+        maxLines: 2,
+        cornerPadding: 8.0,
+      );
+
+      // Test equality with same values.
+      expect(config1, config2);
+      expect(config1 == config3, false);
+      expect(config1.hashCode, config2.hashCode);
+      expect(config1.hashCode == config3.hashCode, false);
+    });
+
+    test('ValueIndicatorMultilineConfig lerp', () {
+      const ValueIndicatorMultilineConfig a = ValueIndicatorMultilineConfig(
+        maxLines: 2,
+        cornerPadding: 8.0,
+      );
+      const ValueIndicatorMultilineConfig b = ValueIndicatorMultilineConfig(
+        enabled: false,
+        maxLines: 4,
+        cornerPadding: 16.0,
+      );
+
+      final ValueIndicatorMultilineConfig? lerp0 = ValueIndicatorMultilineConfig.lerp(a, b, 0.0);
+      expect(lerp0, a);
+
+      final ValueIndicatorMultilineConfig? lerp1 = ValueIndicatorMultilineConfig.lerp(a, b, 1.0);
+      expect(lerp1, b);
+
+      final ValueIndicatorMultilineConfig? lerp05 = ValueIndicatorMultilineConfig.lerp(a, b, 0.5);
+      expect(lerp05!.enabled, false);
+      expect(lerp05.maxLines, 4);
+      expect(lerp05.cornerPadding, 12.0); // = (8.0 + (16.0 - 8.0) * 0.5)
+
+      final ValueIndicatorMultilineConfig? lerp03 = ValueIndicatorMultilineConfig.lerp(a, b, 0.3);
+      expect(lerp03!.enabled, true);
+      expect(lerp03.maxLines, 2);
+      expect(lerp03.cornerPadding, closeTo(10.4, 0.01)); // = (8.0 + (16.0 - 8.0) * 0.3)
+
+      expect(ValueIndicatorMultilineConfig.lerp(null, null, 0.5), null);
+      expect(ValueIndicatorMultilineConfig.lerp(a, null, 0.5), a);
+      expect(ValueIndicatorMultilineConfig.lerp(null, b, 0.5), b);
+    });
+
+    testWidgets('ValueIndicatorMultilineConfig debugFillProperties', (WidgetTester tester) async {
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+      const ValueIndicatorMultilineConfig(
+        enabled: false,
+        maxLines: 3,
+        cornerPadding: 12.0,
+      ).debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description, <String>['enabled: false', 'maxLines: 3', 'cornerPadding: 12.0']);
+    });
+
+    testWidgets('ValueIndicatorMultilineConfig in SliderThemeData', (WidgetTester tester) async {
+      const ValueIndicatorMultilineConfig config = ValueIndicatorMultilineConfig(
+        enabled: false,
+        maxLines: 2,
+        cornerPadding: 10.0,
+      );
+
+      const SliderThemeData theme = SliderThemeData(valueIndicatorMultilineConfig: config);
+
+      expect(theme.valueIndicatorMultilineConfig, config);
+
+      final SliderThemeData copiedTheme = theme.copyWith(
+        valueIndicatorMultilineConfig: const ValueIndicatorMultilineConfig(maxLines: 5),
+      );
+
+      expect(copiedTheme.valueIndicatorMultilineConfig!.enabled, true);
+      expect(copiedTheme.valueIndicatorMultilineConfig!.maxLines, 5);
+      expect(copiedTheme.valueIndicatorMultilineConfig!.cornerPadding, null);
+    });
+
+    testWidgets('SliderThemeData lerp with ValueIndicatorMultilineConfig', (
+      WidgetTester tester,
+    ) async {
+      const ValueIndicatorMultilineConfig configA = ValueIndicatorMultilineConfig(
+        maxLines: 1,
+        cornerPadding: 4.0,
+      );
+      const ValueIndicatorMultilineConfig configB = ValueIndicatorMultilineConfig(
+        enabled: false,
+        maxLines: 3,
+        cornerPadding: 12.0,
+      );
+
+      const SliderThemeData themeA = SliderThemeData(valueIndicatorMultilineConfig: configA);
+      const SliderThemeData themeB = SliderThemeData(valueIndicatorMultilineConfig: configB);
+
+      final SliderThemeData lerpedTheme = SliderThemeData.lerp(themeA, themeB, 0.5);
+      expect(lerpedTheme.valueIndicatorMultilineConfig!.enabled, false);
+      expect(lerpedTheme.valueIndicatorMultilineConfig!.maxLines, 3);
+      expect(lerpedTheme.valueIndicatorMultilineConfig!.cornerPadding, 8.0);
+    });
+
+    testWidgets('SliderThemeData debugFillProperties includes ValueIndicatorMultilineConfig', (
+      WidgetTester tester,
+    ) async {
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+      const SliderThemeData(
+        trackHeight: 5.0,
+        valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(
+          enabled: false,
+          maxLines: 2,
+          cornerPadding: 8.0,
+        ),
+      ).debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description, contains('trackHeight: 5.0'));
+      expect(
+        description.any(
+          (String desc) =>
+              desc.startsWith('valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig#') &&
+              desc.contains('enabled: false, maxLines: 2, cornerPadding: 8.0'),
+        ),
+        true,
+      );
+    });
+  });
 }
 
 class RoundedRectSliderTrackShapeWithCustomAdditionalActiveTrackHeight

--- a/packages/flutter/test/material/value_indicating_slider_test.dart
+++ b/packages/flutter/test/material/value_indicating_slider_test.dart
@@ -202,13 +202,20 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: Center(
-              child: Slider(
-                value: 2,
-                year2023: false,
-                divisions: 4,
-                max: 5,
-                label: multilineLabel,
-                onChanged: (double newValue) {},
+              child: Theme(
+                data: ThemeData(
+                  sliderTheme: const SliderThemeData(
+                    valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(cornerPadding: 40),
+                  ),
+                ),
+                child: Slider(
+                  value: 2,
+                  year2023: false,
+                  divisions: 4,
+                  max: 5,
+                  label: multilineLabel,
+                  onChanged: (double newValue) {},
+                ),
               ),
             ),
           ),

--- a/packages/flutter/test/material/value_indicating_slider_test.dart
+++ b/packages/flutter/test/material/value_indicating_slider_test.dart
@@ -145,6 +145,103 @@ void main() {
     );
   });
 
+  testWidgets(
+    'DropSliderValueIndicatorShape should surround entire multiline label (year2023: true)',
+    (WidgetTester tester) async {
+      const String multilineLabel = 'First line\nSecond line\nThird line\nFourth line\nFifth line';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Slider(
+                value: 2,
+                year2023: true,
+                divisions: 4,
+                max: 5,
+                label: multilineLabel,
+                onChanged: (double newValue) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.press(find.byType(Slider));
+      await tester.pumpAndSettle();
+
+      // Check the golden file.
+      await expectLater(
+        find.byType(MaterialApp),
+        matchesGoldenFile('slider_drop_shape_multiline_label.png'),
+      );
+
+      // Find the Overlay where the value indicator is drawn.
+      final RenderBox overlayBox = tester.renderObject(find.byType(Overlay));
+      final Size overlaySize = overlayBox.size;
+
+      // Use TextPainter to measure the label's size as it would be rendered.
+      final TextPainter textPainter = TextPainter(
+        text: const TextSpan(text: multilineLabel, style: TextStyle(fontSize: 14.0)),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      final Size labelSize = textPainter.size;
+      textPainter.dispose(); // Dispose the TextPainter to prevent memory leaks
+
+      // The overlay of the value indicator should be at least as large as the label, plus some padding.
+      // The DropSliderValueIndicatorShape uses 16.0 padding on each side by default.
+      const double indicatorPadding = 16.0 * 2;
+      expect(overlaySize.height, greaterThanOrEqualTo(labelSize.height + indicatorPadding));
+      expect(overlaySize.width, greaterThanOrEqualTo(labelSize.width + indicatorPadding));
+    },
+  );
+
+  testWidgets(
+    'RoundedRectSliderValueIndicatorShape should surround entire multiline label (year2023: false)',
+    (WidgetTester tester) async {
+      const String multilineLabel = 'First line\nSecond line\nThird line\nFourth line\nFifth line';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: Slider(
+                value: 2,
+                year2023: false,
+                divisions: 4,
+                max: 5,
+                label: multilineLabel,
+                onChanged: (double newValue) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.press(find.byType(Slider));
+      await tester.pumpAndSettle();
+      // Check the golden file.
+      await expectLater(
+        find.byType(MaterialApp),
+        matchesGoldenFile('slider_roundedrect_shape_multiline_label.png'),
+      );
+
+      // Find the Overlay where the value indicator is drawn.
+      final RenderBox overlayBox = tester.renderObject(find.byType(Overlay));
+      final Size overlaySize = overlayBox.size;
+
+      // Use TextPainter to measure the label's size as it would be rendered.
+      final TextPainter textPainter = TextPainter(
+        text: const TextSpan(text: multilineLabel, style: TextStyle(fontSize: 14.0)),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      final Size labelSize = textPainter.size;
+      textPainter.dispose(); // Dispose the TextPainter to prevent memory leaks
+
+      // The overlay of the value indicator should be at least as large as the label, plus some padding.
+      // The RoundedRectSliderValueIndicatorShape uses 16.0 padding on each side by default.
+      const double indicatorPadding = 16.0 * 2;
+      expect(overlaySize.height, greaterThanOrEqualTo(labelSize.height + indicatorPadding));
+      expect(overlaySize.width, greaterThanOrEqualTo(labelSize.width + indicatorPadding));
+    },
+  );
+
   group('Material 2', () {
     // These tests are only relevant for Material 2. Once Material 2
     // support is deprecated and the APIs are removed, these tests

--- a/packages/flutter/test/material/value_indicating_slider_test.dart
+++ b/packages/flutter/test/material/value_indicating_slider_test.dart
@@ -205,7 +205,9 @@ void main() {
               child: Theme(
                 data: ThemeData(
                   sliderTheme: const SliderThemeData(
-                    valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(cornerPadding: 40),
+                    valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(
+                      cornerPadding: EdgeInsets.all(16),
+                    ),
                   ),
                 ),
                 child: Slider(


### PR DESCRIPTION
- Fix https://github.com/flutter/flutter/issues/170204

#### Demo (after the fix):

<details open>
<summary>Screenshots</summary>

- year2023 true:

| multiline | multiline with maxLines limitation |
| --------------- | --------------- |
<img width="400" src="https://github.com/user-attachments/assets/396b9bb8-8e8f-4617-af2a-ac1cef00924e"/> | <img width="400" src="https://github.com/user-attachments/assets/51c3f211-50e0-499d-9c6a-dfc3c2a52889"/>

- year2023 false:

| multiline | multiline with maxLines limitation |
| --------------- | --------------- |
<img width="400" src="https://github.com/user-attachments/assets/3f541d49-7b03-42e3-95c7-0bbef4356d5d"> | <img width="400" src="https://github.com/user-attachments/assets/37e49e20-d33a-440a-b9d2-0e0e8fbdebc8">

</details>

<details open>
<summary>video</summary>

https://github.com/user-attachments/assets/3b00fb58-f575-464a-ae3b-3d6da93ec10d

</details>

<details>
<summary>Sample code</summary>

```dart
import 'package:flutter/material.dart';

void main() => runApp(const SliderExampleApp());

class SliderExampleApp extends StatelessWidget {
  const SliderExampleApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: SliderExample(),
    );
  }
}

class SliderExample extends StatefulWidget {
  const SliderExample({super.key});

  @override
  State<SliderExample> createState() => _SliderExampleState();
}

class _SliderExampleState extends State<SliderExample> {
  double _currentDiscreteSliderValue = 2;
  double _currentDiscreteSliderValue2 = 2;
  double _currentDiscreteSliderValue3 = 2;
  double _currentDiscreteSliderValue4 = 2;
  double _currentDiscreteSliderValue5 = 2;
  double _currentDiscreteSliderValue6 = 2;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      backgroundColor: Colors.grey,
      appBar: AppBar(title: const Text('Slider')),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          crossAxisAlignment: CrossAxisAlignment.start,
          children: <Widget>[
            Text('year2023: true or null'),
            Text('.   Oneline'),
            Slider(
              value: _currentDiscreteSliderValue2,
              max: 5,
              divisions: 4,
              label: _currentDiscreteSliderValue2.toString(),
              onChanged: (double value) {
                setState(() {
                  _currentDiscreteSliderValue2 = value;
                });
              },
            ),
            Text('.   Multiline'),
            Slider(
              value: _currentDiscreteSliderValue,
              max: 5,
              divisions: 4,
              label:
                  "${_currentDiscreteSliderValue.toString()}\nFirst Line\nSecond line\nThird line\nFourth line\nFifth line",
              onChanged: (double value) {
                setState(() {
                  _currentDiscreteSliderValue = value;
                });
              },
            ),
            Text('.   Multiline with maxLines'),
            Theme(
              data: ThemeData(
                sliderTheme: SliderThemeData(
                  valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(
                    maxLines: 3,
                    cornerPadding: 64,
                  ),
                ),
              ),
              child: Slider(
                value: _currentDiscreteSliderValue5,
                max: 5,
                divisions: 4,
                label:
                    "${_currentDiscreteSliderValue5.toString()}\nFirst Line\nSecond line\nThird line\nFourth line\nFifth line",
                onChanged: (double value) {
                  setState(() {
                    _currentDiscreteSliderValue5 = value;
                  });
                },
              ),
            ),
            Text('year2023: false'),
            Text('.   Oneline'),
            Slider(
              value: _currentDiscreteSliderValue4,
              max: 5,
              year2023: false,
              divisions: 4,
              label: _currentDiscreteSliderValue4.toString(),
              onChanged: (double value) {
                setState(() {
                  _currentDiscreteSliderValue4 = value;
                });
              },
            ),
            Text('.   Multiline'),
            Slider(
              value: _currentDiscreteSliderValue3,
              max: 5,
              year2023: false,
              divisions: 4,
              label:
                  "${_currentDiscreteSliderValue3.toString()}\nFirst Line\nSecond line\nThird line\nFourth line\nFifth line",
              onChanged: (double value) {
                setState(() {
                  _currentDiscreteSliderValue3 = value;
                });
              },
            ),
            Text('.   Multiline with maxLines'),
            Theme(
              data: ThemeData(
                sliderTheme: SliderThemeData(
                  valueIndicatorMultilineConfig: ValueIndicatorMultilineConfig(
                    maxLines: 3,
                    cornerPadding: 64,
                  ),
                ),
              ),
              child: Slider(
                value: _currentDiscreteSliderValue6,
                max: 5,
                year2023: false,
                divisions: 4,
                label:
                    "${_currentDiscreteSliderValue6.toString()}\nFirst Line\nSecond line\nThird line\nFourth line\nFifth line",
                onChanged: (double value) {
                  setState(() {
                    _currentDiscreteSliderValue6 = value;
                  });
                },
              ),
            ),
          ],
        ),
      ),
    );
  }
}

```
</details>

#### Description
In this PR:
    - Address the issue reported where the value indicator shape does not fully surround the label when multiline text is set. The fix is applied for both cases when `year2023` flag is true or false (corresponding to `DropSliderValueIndicatorShape` or `RoundedRectSliderValueIndicatorShape`).
    - Add some tests.
    - Enable support for an optional configuration of multiline label for the slider value indicator: introduce `ValueIndicatorMultilineConfig` in `SliderThemeData` with 3 properties: `enabled`, `maxLines`, and `cornerPadding`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
