### PR TITLE
[ Tool ] Fix crash from possible DDS startup race

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -370,7 +370,6 @@ known, it can be explicitly provided to attach via the command-line, e.g.
               return runner.attach(
                 connectionInfoCompleter: connectionInfoCompleter,
                 appStartedCompleter: appStartedCompleter,
-                allowExistingDdsInstance: true,
               );
             },
             device,
@@ -411,10 +410,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
                   ..setupTerminal();
           }),
         );
-        result = await runner.attach(
-          appStartedCompleter: onAppStart,
-          allowExistingDdsInstance: true,
-        );
+        result = await runner.attach(appStartedCompleter: onAppStart);
         if (result != 0) {
           throwToolExit(null, exitCode: result);
         }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -787,7 +787,6 @@ Please provide a valid TCP port (an integer between 0 and 65535, inclusive).
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
     Future<ConnectionResult?>? connectDebug,
-    bool allowExistingDdsInstance = false,
     bool needsFullRestart = true,
   }) async {
     if (_chromiumLauncher != null) {

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -273,8 +273,8 @@ class FlutterDevice {
           // This first try block is meant to catch errors that occur during DDS startup
           // (e.g., failure to bind to a port, failure to connect to the VM service,
           // attaching to a VM service with existing clients, etc.).
-          const kMaxRetries = 3;
-          var retries = 0;
+          const kMaxAttempts = 3;
+          var attempts = 0;
           while (true) {
             try {
               await device!.dds.startDartDevelopmentServiceFromDebuggingOptions(
@@ -297,15 +297,15 @@ class FlutterDevice {
               // an existingDdsInstanceError if the failure to start was due to a startup race.
               //
               // See https://github.com/flutter/flutter/issues/169265 for details.
-              ++retries;
-              if (retries >= kMaxRetries) {
+              ++attempts;
+              if (attempts >= kMaxAttempts) {
                 handleError(e, st);
                 return;
               }
               // Exponential backoff.
-              final int backoffPeriod = pow(2, retries).toInt() * 100;
+              final int backoffPeriod = (1 << attempts) * 100;
               globals.printTrace(
-                'Failed to start DDS (attempt $retries of $kMaxRetries). '
+                'Failed to start DDS (attempt $attempts of $kMaxAttempts). '
                 'Retrying in ${backoffPeriod}ms...',
               );
               await Future<void>.delayed(Duration(milliseconds: backoffPeriod));

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1168,7 +1168,6 @@ abstract class ResidentRunner extends ResidentHandlers {
   Future<int?> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    bool allowExistingDdsInstance = false,
     bool needsFullRestart = true,
   });
 
@@ -1321,7 +1320,6 @@ abstract class ResidentRunner extends ResidentHandlers {
     ReloadSources? reloadSources,
     Restart? restart,
     CompileExpression? compileExpression,
-    required bool allowExistingDdsInstance,
   }) async {
     if (!debuggingOptions.debuggingEnabled) {
       throw Exception('The service protocol is not enabled.');

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -255,28 +255,63 @@ class FlutterDevice {
             }
           }
 
-          // First check if the VM service is actually listening on vmServiceUri as
-          // this may not be the case when scraping logcat for URIs. If this URI is
-          // from an old application instance, we shouldn't try and start DDS.
-          try {
-            service = await connectToVmService(vmServiceUri!, logger: globals.logger);
-            await service.dispose();
-          } on Exception catch (exception) {
-            globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $exception');
-            if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
-              completer.completeError('failed to connect to $vmServiceUri $exception');
+          const kMaxAttempts = 3;
+          for (var attempts = 1; attempts <= kMaxAttempts; ++attempts) {
+            void handleVmServiceCheckException(Exception e) {
+              globals.printTrace('Fail to connect to service protocol: $vmServiceUri: $e');
+              if (!completer.isCompleted && !_isListeningForVmServiceUri!) {
+                completer.completeError('failed to connect to $vmServiceUri $e');
+              }
             }
-            return;
+
+            // First check if the VM service is actually listening on vmServiceUri as
+            // this may not be the case when scraping logcat for URIs. If this URI is
+            // from an old application instance, we shouldn't try and start DDS.
+            try {
+              service = await connectToVmService(vmServiceUri!, logger: globals.logger);
+              await service.dispose();
+            } on vm_service.RPCError catch (e, st) {
+              if (!e.isConnectionDisposedException) {
+                handleVmServiceCheckException(e);
+                return;
+              }
+              // It's possible (but unlikely) that two DDS instances can try and start at the same
+              // time (e.g., a "flutter run" is initiated while an existing "flutter attach" is
+              // waiting for a target to attach to). This can lead to the initial VM service connection
+              // failing for one of the processes when the VM service disconnects it after the other
+              // instance successfully invoked the "_yieldControlToDDS" RPC.
+              //
+              // To handle this, we retry connecting to the VM service, which should successfully
+              // be redirected to the DDS instance.
+              //
+              // See https://github.com/flutter/flutter/issues/169265 for details.
+              if (attempts == kMaxAttempts) {
+                globals.printTrace(
+                  'Failed to make initial connection to VM Service (attempt $attempts of $kMaxAttempts).',
+                );
+                handleError(e, st);
+                return;
+              }
+              // Exponential backoff.
+              final int backoffPeriod = (1 << (attempts - 1)) * 100;
+              globals.printTrace(
+                'Failed to make initial connection to VM Service (attempt $attempts of $kMaxAttempts). '
+                'Retrying in ${backoffPeriod}ms...',
+              );
+              await Future<void>.delayed(Duration(milliseconds: backoffPeriod));
+            } on Exception catch (e) {
+              handleVmServiceCheckException(e);
+              return;
+            }
           }
 
-          const kMaxAttempts = 3;
           for (var attempts = 1; attempts <= kMaxAttempts; ++attempts) {
             // This try block is meant to catch errors that occur during DDS startup
             // (e.g., failure to bind to a port, failure to connect to the VM service,
             // attaching to a VM service with existing clients, etc.).
             try {
               await device!.dds.startDartDevelopmentServiceFromDebuggingOptions(
-                vmServiceUri,
+                vmServiceUri!,
                 debuggingOptions: debuggingOptions,
               );
               break;

--- a/packages/flutter_tools/lib/src/run_cold.dart
+++ b/packages/flutter_tools/lib/src/run_cold.dart
@@ -67,7 +67,7 @@ class ColdRunner extends ResidentRunner {
     // Connect to the VM Service.
     if (debuggingEnabled) {
       try {
-        await connectToServiceProtocol(allowExistingDdsInstance: false);
+        await connectToServiceProtocol();
       } on Exception catch (exception) {
         globals.printError(exception.toString());
         appFailedToStart();
@@ -138,12 +138,11 @@ class ColdRunner extends ResidentRunner {
   Future<int> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    bool allowExistingDdsInstance = false,
     bool needsFullRestart = true,
   }) async {
     _didAttach = true;
     try {
-      await connectToServiceProtocol(allowExistingDdsInstance: allowExistingDdsInstance);
+      await connectToServiceProtocol();
     } on Exception catch (error) {
       globals.printError('Error connecting to the service protocol: $error');
       return 2;

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -233,14 +233,12 @@ class HotRunner extends ResidentRunner {
   Future<int> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    bool allowExistingDdsInstance = false,
     bool needsFullRestart = true,
   }) async {
     stopAppDuringCleanup = false;
     return _attach(
       connectionInfoCompleter: connectionInfoCompleter,
       appStartedCompleter: appStartedCompleter,
-      allowExistingDdsInstance: allowExistingDdsInstance,
       needsFullRestart: needsFullRestart,
     );
   }
@@ -248,7 +246,6 @@ class HotRunner extends ResidentRunner {
   Future<int> _attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    bool allowExistingDdsInstance = false,
     bool needsFullRestart = true,
   }) async {
     try {
@@ -256,7 +253,6 @@ class HotRunner extends ResidentRunner {
         reloadSources: _reloadSourcesService,
         restart: _restartService,
         compileExpression: _compileExpressionService,
-        allowExistingDdsInstance: allowExistingDdsInstance,
       );
       // Catches all exceptions, non-Exception objects are rethrown.
     } catch (error) {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -326,6 +326,9 @@ Future<vm_service.VmService> setUpVmService({
   try {
     await Future.wait(registrationRequests);
   } on vm_service.RPCError catch (e) {
+    if (e.isConnectionDisposedException) {
+      rethrow;
+    }
     throwToolExit('Failed to register service methods on attached VM Service: $e');
   }
   return vmService;
@@ -483,9 +486,7 @@ class FlutterVmService {
     try {
       return await service.getVM();
     } on vm_service.RPCError catch (err) {
-      if (err.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
-          err.code == vm_service.RPCErrorKind.kConnectionDisposed.code ||
-          err.message.contains('Service connection disposed')) {
+      if (err.isConnectionDisposedException) {
         globals.printTrace('VmService.getVm call failed: $err');
         return null;
       }
@@ -505,9 +506,7 @@ class FlutterVmService {
       // and should begin to shutdown due to the service connection closing.
       // Swallow the exception here and let the shutdown logic elsewhere deal
       // with cleaning up.
-      if (e.code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
-          e.code == vm_service.RPCErrorKind.kConnectionDisposed.code ||
-          e.message.contains('Service connection disposed')) {
+      if (e.isConnectionDisposedException) {
         return null;
       }
       rethrow;
@@ -773,10 +772,8 @@ class FlutterVmService {
     } on vm_service.RPCError catch (err) {
       // If an application is not using the framework or the VM service
       // disappears while handling a request, return null.
-      if ((err.code == vm_service.RPCErrorKind.kMethodNotFound.code) ||
-          (err.code == vm_service.RPCErrorKind.kServiceDisappeared.code) ||
-          (err.code == vm_service.RPCErrorKind.kConnectionDisposed.code) ||
-          (err.message.contains('Service connection disposed'))) {
+      if (err.code == vm_service.RPCErrorKind.kMethodNotFound.code ||
+          err.isConnectionDisposedException) {
         return null;
       }
       rethrow;
@@ -1009,4 +1006,11 @@ String processVmServiceMessage(vm_service.Event event) {
     return message.substring(0, message.length - 1);
   }
   return message;
+}
+
+extension RPCErrorExtension on vm_service.RPCError {
+  bool get isConnectionDisposedException =>
+      code == vm_service.RPCErrorKind.kServiceDisappeared.code ||
+      code == vm_service.RPCErrorKind.kConnectionDisposed.code ||
+      message.contains('Service connection disposed');
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -135,7 +135,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -212,7 +211,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async {
                 appStartedCompleter?.complete();
@@ -294,7 +292,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -370,7 +367,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -451,7 +447,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -537,7 +532,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -636,7 +630,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -829,7 +822,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -937,7 +929,6 @@ void main() {
               (
                 Completer<DebugConnectionInfo>? connectionInfoCompleter,
                 Completer<void>? appStartedCompleter,
-                bool allowExistingDdsInstance,
                 bool enableDevTools,
               ) async => 0;
           hotRunner.exited = false;
@@ -1327,7 +1318,6 @@ void main() {
             (
               Completer<DebugConnectionInfo>? connectionInfoCompleter,
               Completer<void>? appStartedCompleter,
-              bool allowExistingDdsInstance,
               bool enableDevTools,
             ) async {
               await null;
@@ -1375,7 +1365,6 @@ void main() {
             (
               Completer<DebugConnectionInfo>? connectionInfoCompleter,
               Completer<void>? appStartedCompleter,
-              bool allowExistingDdsInstance,
               bool enableDevTools,
             ) async {
               await null;
@@ -1423,7 +1412,6 @@ void main() {
             (
               Completer<DebugConnectionInfo>? connectionInfoCompleter,
               Completer<void>? appStartedCompleter,
-              bool allowExistingDdsInstance,
               bool enableDevTools,
             ) async {
               await null;
@@ -1472,7 +1460,6 @@ void main() {
             (
               Completer<DebugConnectionInfo>? connectionInfoCompleter,
               Completer<void>? appStartedCompleter,
-              bool allowExistingDdsInstance,
               bool enableDevTools,
             ) async {
               await null;
@@ -1557,7 +1544,7 @@ void main() {
 }
 
 class FakeHotRunner extends Fake implements HotRunner {
-  late Future<int> Function(Completer<DebugConnectionInfo>?, Completer<void>?, bool, bool) onAttach;
+  late Future<int> Function(Completer<DebugConnectionInfo>?, Completer<void>?, bool) onAttach;
 
   @override
   var exited = false;
@@ -1569,16 +1556,10 @@ class FakeHotRunner extends Fake implements HotRunner {
   Future<int> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    bool allowExistingDdsInstance = false,
     bool enableDevTools = false,
     bool needsFullRestart = true,
   }) {
-    return onAttach(
-      connectionInfoCompleter,
-      appStartedCompleter,
-      allowExistingDdsInstance,
-      enableDevTools,
-    );
+    return onAttach(connectionInfoCompleter, appStartedCompleter, enableDevTools);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -242,7 +242,6 @@ class TestFlutterDevice extends FlutterDevice {
     PrintStructuredErrorLogMethod? printStructuredErrorLogMethod,
     required DebuggingOptions debuggingOptions,
     int? hostVmServicePort,
-    required bool allowExistingDdsInstance,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/hot_shared.dart
+++ b/packages/flutter_tools/test/general.shard/hot_shared.dart
@@ -164,7 +164,6 @@ class TestFlutterDevice extends FlutterDevice {
     int? hostVmServicePort,
     bool? ipv6 = false,
     bool enableDevTools = false,
-    bool allowExistingDdsInstance = false,
   }) async {
     throw exception;
   }

--- a/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_helpers.dart
@@ -232,7 +232,6 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
     required DebuggingOptions debuggingOptions,
     int? hostVmServicePort,
     bool? ipv6 = false,
-    bool allowExistingDdsInstance = false,
   }) async {}
 
   @override
@@ -281,7 +280,6 @@ class FakeDelegateFlutterDevice extends FlutterDevice {
     required DebuggingOptions debuggingOptions,
     int? hostVmServicePort,
     bool? ipv6 = false,
-    bool allowExistingDdsInstance = false,
   }) async {}
 
   final DevFS fakeDevFS;

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2021,10 +2021,7 @@ flutter:
         unawaited(
           runZonedGuarded(
             () => flutterDevice
-                .connect(
-                  allowExistingDdsInstance: true,
-                  debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
-                )
+                .connect(debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug))
                 .then((_) => done.complete()),
             (_, _) => done.complete(),
           ),
@@ -2077,7 +2074,6 @@ flutter:
             };
         final flutterDevice = TestFlutterDevice(device, vmServiceUris: Stream<Uri>.value(testUri));
         await flutterDevice.connect(
-          allowExistingDdsInstance: true,
           debuggingOptions: DebuggingOptions.enabled(
             BuildInfo.debug,
             disableServiceAuthCodes: true,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -2227,7 +2227,6 @@ class FakeFlutterDevice extends Fake implements FlutterDevice {
     int? hostVmServicePort,
     bool? ipv6 = false,
     bool enableDevTools = false,
-    bool allowExistingDdsInstance = false,
   }) async {}
 
   @override

--- a/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
+++ b/packages/flutter_tools/test/general.shard/terminal_handler_test.dart
@@ -1415,7 +1415,6 @@ class TestRunner extends Fake implements ResidentRunner {
   Future<int?> attach({
     Completer<DebugConnectionInfo>? connectionInfoCompleter,
     Completer<void>? appStartedCompleter,
-    bool allowExistingDdsInstance = false,
     bool enableDevTools = false,
     bool needsFullRestart = true,
   }) async => null;

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -649,16 +649,18 @@ final class FlutterRunTestDriver extends FlutterTestDriver {
           timeout: appStartTimeout,
         );
 
-        if (withDebugger) {
+        if (withDebugger || attachPort != null) {
           final Map<String, Object?> debugPort = await _waitFor(
             event: 'app.debugPort',
             timeout: appStartTimeout,
           );
           final wsUriString = (debugPort['params']! as Map<String, Object?>)['wsUri']! as String;
           _vmServiceWsUri = Uri.parse(wsUriString);
-          await connectToVmService(pauseOnExceptions: pauseOnExceptions);
-          if (!startPaused) {
-            await resume();
+          if (withDebugger) {
+            await connectToVmService(pauseOnExceptions: pauseOnExceptions);
+            if (!startPaused) {
+              await resume();
+            }
           }
         }
 

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -186,7 +186,7 @@ abstract final class FlutterTestDriver {
     String extension, {
     Map<String, Object?> args = const <String, Object>{},
   }) async {
-    final int? port = _vmServiceWsUri != null ? vmServicePort : _attachPort;
+    final int port = _attachPort ?? vmServicePort!;
     final VmService vmService = await vmServiceConnectUri('ws://localhost:$port/ws');
     final Isolate isolate = await waitForExtension(vmService, extension);
     return vmService.callServiceExtension(extension, isolateId: isolate.id, args: args);


### PR DESCRIPTION
It's possible (but unlikely) that two DDS instances can try and start at the same time (e.g., a "flutter run" is initiated while an existing "flutter attach" is waiting for a target to attach to). This can lead to DDS failing to initialize for one of the processes when the VM service disconnects it after the other process successfully invokes the "_yieldControlToDDS" RPC.

This change adds some retry logic to avoid crashing in this scenario.

Fixes https://github.com/flutter/flutter/issues/169265