### PR TITLE
Add onHover callback support for TableRowInkWell

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1276,6 +1276,7 @@ class TableRowInkWell extends InkResponse {
     super.onDoubleTap,
     super.onLongPress,
     super.onHighlightChanged,
+    super.onHover,
     super.onSecondaryTap,
     super.onSecondaryTapDown,
     super.overlayColor,

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -148,6 +148,7 @@ class DataRow {
     this.selected = false,
     this.onSelectChanged,
     this.onLongPress,
+    this.onHover,
     this.color,
     this.mouseCursor,
     required this.cells,
@@ -160,6 +161,7 @@ class DataRow {
     this.selected = false,
     this.onSelectChanged,
     this.onLongPress,
+    this.onHover,
     this.color,
     this.mouseCursor,
     required this.cells,
@@ -199,6 +201,11 @@ class DataRow {
   /// that callback behavior overrides the gesture behavior of the row for
   /// that particular cell.
   final GestureLongPressCallback? onLongPress;
+
+  /// Called if the row is hovered.
+  ///
+  /// If non-null, hovering the row will invoke this callback.
+  final ValueChanged<bool>? onHover;
 
   /// Whether the row is selected.
   ///
@@ -951,6 +958,7 @@ class DataTable extends StatelessWidget {
     required GestureTapCancelCallback? onTapCancel,
     required MaterialStateProperty<Color?>? overlayColor,
     required GestureLongPressCallback? onRowLongPress,
+    required ValueChanged<bool>? onRowHover,
     required MouseCursor? mouseCursor,
   }) {
     final ThemeData themeData = Theme.of(context);
@@ -1007,10 +1015,11 @@ class DataTable extends StatelessWidget {
         overlayColor: overlayColor,
         child: label,
       );
-    } else if (onSelectChanged != null || onRowLongPress != null) {
+    } else if (onSelectChanged != null || onRowLongPress != null || onRowHover != null) {
       label = TableRowInkWell(
         onTap: onSelectChanged,
         onLongPress: onRowLongPress,
+	onHover: onRowHover,
         overlayColor: overlayColor,
         mouseCursor: mouseCursor,
         child: label,
@@ -1223,6 +1232,7 @@ class DataTable extends StatelessWidget {
               : () => row.onSelectChanged?.call(!row.selected),
           overlayColor: row.color ?? effectiveDataRowColor,
           onRowLongPress: row.onLongPress,
+	  onRowHover: row.onHover,
           mouseCursor:
               row.mouseCursor?.resolve(states) ?? dataTableTheme.dataRowCursor?.resolve(states),
         );

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -1019,7 +1019,7 @@ class DataTable extends StatelessWidget {
       label = TableRowInkWell(
         onTap: onSelectChanged,
         onLongPress: onRowLongPress,
-	onHover: onRowHover,
+        onHover: onRowHover,
         overlayColor: overlayColor,
         mouseCursor: mouseCursor,
         child: label,
@@ -1232,7 +1232,7 @@ class DataTable extends StatelessWidget {
               : () => row.onSelectChanged?.call(!row.selected),
           overlayColor: row.color ?? effectiveDataRowColor,
           onRowLongPress: row.onLongPress,
-	  onRowHover: row.onHover,
+          onRowHover: row.onHover,
           mouseCursor:
               row.mouseCursor?.resolve(states) ?? dataTableTheme.dataRowCursor?.resolve(states),
         );

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -202,7 +202,7 @@ class DataRow {
   /// that particular cell.
   final GestureLongPressCallback? onLongPress;
 
-  /// Called if the row is hovered.
+  /// Called when a pointer enters or exits the row.
   ///
   /// The boolean value passed to the callback is true if a pointer has entered the row and false
   /// when a pointer has exited the row.

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -204,7 +204,8 @@ class DataRow {
 
   /// Called if the row is hovered.
   ///
-  /// If non-null, hovering the row will invoke this callback.
+  /// The boolean value passed to the callback is true if a pointer has entered the row and false
+  /// when a pointer has exited the row.
   final ValueChanged<bool>? onHover;
 
   /// Whether the row is selected.

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -96,7 +96,7 @@ void main() {
     expect(log, <String>['onLongPress: Cupcake']);
     log.clear();
 
-    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     await gesture.addPointer(location: Offset.zero);
     addTearDown(gesture.removePointer);
     await tester.pump();
@@ -137,7 +137,7 @@ void main() {
     expect(log, <String>['cell-tapDown: 375', 'cell-tapCancel: 375', 'cell-longPress: 375']);
     log.clear();
 
-    TestGesture gesture = await tester.startGesture(tester.getRect(find.text('375')).center);
+    gesture = await tester.startGesture(tester.getRect(find.text('375')).center);
     await tester.pump(const Duration(milliseconds: 100));
     // onTapDown callback is registered.
     expect(log, equals(<String>['cell-tapDown: 375']));

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -47,11 +47,11 @@ void main() {
             onLongPress: () {
               log.add('onLongPress: ${dessert.name}');
             },
-	    onHover: (bool hovering) {
-	      if (hovering) {
-		log.add('onHover: ${dessert.name}');
-	      }
-	    },
+            onHover: (bool hovering) {
+              if (hovering) {
+                log.add('onHover: ${dessert.name}');
+              }
+            },
             cells: <DataCell>[
               DataCell(Text(dessert.name)),
               DataCell(

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -47,8 +47,10 @@ void main() {
             onLongPress: () {
               log.add('onLongPress: ${dessert.name}');
             },
-	    onHover: () {
-	      log.add('onHover: ${dessert.name}');
+	    onHover: (bool hovering) {
+	      if (hovering) {
+		log.add('onHover: ${dessert.name}');
+	      }
 	    },
             cells: <DataCell>[
               DataCell(Text(dessert.name)),

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -47,6 +47,9 @@ void main() {
             onLongPress: () {
               log.add('onLongPress: ${dessert.name}');
             },
+	    onHover: () {
+	      log.add('onHover: ${dessert.name}');
+	    },
             cells: <DataCell>[
               DataCell(Text(dessert.name)),
               DataCell(
@@ -89,6 +92,15 @@ void main() {
     await tester.longPress(find.text('Cupcake'));
 
     expect(log, <String>['onLongPress: Cupcake']);
+    log.clear();
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    await gesture.moveTo(tester.getCenter(find.text('Cupcake')));
+
+    expect(log, <String>['onHover: Cupcake']);
     log.clear();
 
     await tester.tap(find.text('Calories'));


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

- Add `onHover` parameter to `TableRowInkWell`
- Add corresponding tests

Issue: https://github.com/flutter/flutter/issues/173370

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
