### PR TITLE
Adds deprecation for impeller opt out on android

### DIFF
--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -474,12 +474,17 @@ Shell::Shell(DartVMRef vm,
   FML_CHECK(!settings.enable_software_rendering || !settings.enable_impeller)
       << "Software rendering is incompatible with Impeller.";
   if (!settings.enable_impeller && settings.warn_on_impeller_opt_out) {
-    FML_LOG(IMPORTANT)
-        << "[Action Required] The application opted out of Impeller by either "
-           "using the --no-enable-impeller flag or FLTEnableImpeller=false "
-           "plist flag. This option is going to go away in an upcoming Flutter "
-           "release. Remove the explicit opt-out. If you need to opt-out, "
-           "report a bug describing the issue.";
+    FML_LOG(IMPORTANT) <<  //
+        R"warn([Action Required]: Impeller opt-out deprecated.
+    The application opted out of Impeller by either using: the
+    `--no-enable-impeller` flag, `FLTEnableImpeller` plist flag, or the
+    `io.flutter.embedding.android.EnableImpeller` `AndroidManifest.xml` entry.
+    These options are going to go away in an upcoming Flutter release. Remove
+    the explicit opt-out. If you need to opt-out, please report a bug describing
+    the issue.
+
+    https://github.com/flutter/flutter/issues/new?template=02_bug.yml
+)warn";
   }
   FML_CHECK(vm_) << "Must have access to VM to create a shell.";
   FML_DCHECK(task_runners_.IsValid());

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -476,8 +476,8 @@ Shell::Shell(DartVMRef vm,
   if (!settings.enable_impeller && settings.warn_on_impeller_opt_out) {
     FML_LOG(IMPORTANT) <<  //
         R"warn([Action Required]: Impeller opt-out deprecated.
-    The application opted out of Impeller by either using: the
-    `--no-enable-impeller` flag, `FLTEnableImpeller` plist flag, or the
+    The application opted out of Impeller by either using the
+    `--no-enable-impeller` flag or the
     `io.flutter.embedding.android.EnableImpeller` `AndroidManifest.xml` entry.
     These options are going to go away in an upcoming Flutter release. Remove
     the explicit opt-out. If you need to opt-out, please report a bug describing

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -4831,9 +4831,9 @@ TEST_F(ShellTest, WillLogWarningWhenImpellerIsOptedOut) {
   std::ostringstream stream;
   fml::LogMessage::CaptureNextLog(&stream);
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
-  ASSERT_TRUE(stream.str().find(
-                  "[Action Required]: Impeller opt-out deprecated.") !=
-              std::string::npos);
+  ASSERT_TRUE(
+      stream.str().find("[Action Required]: Impeller opt-out deprecated.") !=
+      std::string::npos);
   ASSERT_TRUE(shell);
   DestroyShell(std::move(shell), task_runners);
 }

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -4832,7 +4832,7 @@ TEST_F(ShellTest, WillLogWarningWhenImpellerIsOptedOut) {
   fml::LogMessage::CaptureNextLog(&stream);
   std::unique_ptr<Shell> shell = CreateShell(settings, task_runners);
   ASSERT_TRUE(stream.str().find(
-                  "[Action Required] The application opted out of Impeller") !=
+                  "[Action Required]: Impeller opt-out deprecated.") !=
               std::string::npos);
   ASSERT_TRUE(shell);
   DestroyShell(std::move(shell), task_runners);

--- a/engine/src/flutter/shell/platform/android/flutter_main.cc
+++ b/engine/src/flutter/shell/platform/android/flutter_main.cc
@@ -124,6 +124,7 @@ void FlutterMain::Init(JNIEnv* env,
   AndroidRenderingAPI android_rendering_api =
       SelectedRenderingAPI(settings, api_level);
 
+  settings.warn_on_impeller_opt_out = true;
 #if !SLIMPELLER
   switch (android_rendering_api) {
     case AndroidRenderingAPI::kSoftware:


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/173122

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
