### PR TITLE
Remove a couple of asserts from display_list_unittest

### DIFF
--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5251,7 +5251,6 @@ TEST_F(DisplayListTest, ClipRectRRectPathPromoteToClipRect) {
   DlRoundRect clip_rrect = DlRoundRect::MakeRect(clip_rect);
   DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
   DlPath clip_path = DlPath::MakeRoundRect(clip_rrect);
-  ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, DlClipOp::kIntersect, false);
@@ -5272,7 +5271,6 @@ TEST_F(DisplayListTest, ClipOvalRRectPathPromoteToClipOval) {
   DlRoundRect clip_rrect = DlRoundRect::MakeOval(clip_rect);
   DlRect draw_rect = clip_rect.Expand(2.0f, 2.0f);
   DlPath clip_path = DlPath::MakeRoundRect(clip_rrect);
-  ASSERT_TRUE(clip_path.IsRoundRect());
 
   DisplayListBuilder builder;
   builder.ClipPath(clip_path, DlClipOp::kIntersect, false);


### PR DESCRIPTION
Skia is updating some of the semantics around SkPath simple shape inference [1].  Specifically, degenerate rounded rects are to be reflected as simple rects instead of rrects.

The display list assertions should be sufficient for these tests.

This PR unblocks the Skia-side change.

[1] https://skia-review.googlesource.com/c/skia/+/1031900


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

