### PR TITLE
Fix #173302: Announce selected state for AM/PM buttons on iOS

### DIFF
--- a/examples/api/test/material/time_picker/show_time_picker.0_test.dart
+++ b/examples/api/test/material/time_picker/show_time_picker.0_test.dart
@@ -63,3 +63,47 @@ void main() {
     expect(find.text('OK'), findsOneWidget);
   });
 }
+
+testWidgets('AM/PM buttons have correct selected semantics on iOS', (WidgetTester tester) async {
+  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Builder(
+        builder: (BuildContext context) {
+          return TextButton(
+            onPressed: () {
+              showTimePicker(
+                context: context,
+                initialTime: const TimeOfDay(hour: 14, minute: 0),
+              );
+            },
+            child: const Text('Open Picker'),
+          );
+        },
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('Open Picker'));
+  await tester.pumpAndSettle();
+
+  final Finder pmButtonSemantics = find.descendant(
+    of: find.widgetWithText(InkWell, 'PM'),
+    matching: find.byWidgetPredicate(
+      (Widget widget) => widget is Semantics && widget.properties.selected == true,
+    ),
+  );
+
+  final Finder amButtonSemantics = find.descendant(
+    of: find.widgetWithText(InkWell, 'AM'),
+    matching: find.byWidgetPredicate(
+      (Widget widget) => widget is Semantics && widget.properties.selected == false,
+    ),
+  );
+
+  expect(pmButtonSemantics, findsOneWidget, reason: 'The selected PM button should have Semantics with selected: true');
+  expect(amButtonSemantics, findsOneWidget, reason: 'The unselected AM button should have Semantics with selected: false');
+
+  debugDefaultTargetPlatformOverride = null;
+});

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -737,7 +737,8 @@ class _AmPmButton extends StatelessWidget {
       child: InkWell(
         onTap: onPressed,
         child: Semantics(
-          checked: selected,
+          selected: Theme.of(context).platform == TargetPlatform.iOS ? selected : null,
+          checked: Theme.of(context).platform == TargetPlatform.iOS ? null : selected,
           inMutuallyExclusiveGroup: true,
           button: true,
           child: Center(


### PR DESCRIPTION
On iOS, VoiceOver did not announce the selected state for the AM/PM buttons in the TimePicker. This change makes sure the `selected` semantic property is set based on the current platform, allowing VoiceOver to correctly announce the state.

Fixes #173302

## Pre-launch Checklist

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x ] I signed the [CLA].
- [x ] I listed at least one issue that this PR fixes in the description above.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x ] All existing and new tests are passing.
