### PR TITLE
Fix null value reference in `flutter logs` path

### DIFF
--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -116,10 +116,10 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
 
     if (androidProject.isUsingGradle && androidProject.isSupportedVersion) {
       Directory apkDirectory = getApkDirectory(androidProject.parent);
-      if (androidProject.parent.isModule) {
+      if (androidProject.parent.isModule && buildInfo != null) {
         // Module builds output the apk in a subdirectory that corresponds
         // to the buildmode of the apk.
-        apkDirectory = apkDirectory.childDirectory(buildInfo!.mode.cliName);
+        apkDirectory = apkDirectory.childDirectory(buildInfo.mode.cliName);
       }
       apkFile = apkDirectory.childFile(filename);
       if (apkFile.existsSync()) {

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -57,6 +57,68 @@ void main() {
           .createSync(recursive: true);
     });
 
+    testUsingContext('does not throw and exception when build info is null', () async {
+      const aaptPath = 'aaptPath';
+      final File apkFile = globals.fs.file('app.apk');
+      final sdkVersion = FakeAndroidSdkVersion();
+      sdkVersion.aaptPath = aaptPath;
+      sdk.latestVersion = sdkVersion;
+      sdk.platformToolsAvailable = true;
+      sdk.licensesAvailable = false;
+
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[aaptPath, 'dump', 'xmltree', apkFile.path, 'AndroidManifest.xml'],
+          stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity,
+        ),
+      );
+
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[
+            aaptPath,
+            'dump',
+            'xmltree',
+            fs.path.join('module_project', 'build', 'host', 'outputs', 'apk', 'app.apk'),
+            'AndroidManifest.xml',
+          ],
+          stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity,
+        ),
+      );
+
+      await ApplicationPackageFactory.instance!.getPackageForPlatform(
+        TargetPlatform.android_arm,
+        applicationBinary: apkFile,
+      );
+      final logger = BufferLogger.test();
+      final FlutterProject project = await aModuleProject();
+      project.android.hostAppGradleRoot.childFile('build.gradle').createSync(recursive: true);
+      final File appGradle = project.android.hostAppGradleRoot.childFile(
+        fs.path.join('app', 'build.gradle'),
+      );
+      appGradle.createSync(recursive: true);
+      appGradle.writeAsStringSync("def flutterPluginVersion = 'managed'");
+      final File apkDebugFile = project.directory
+          .childDirectory('build')
+          .childDirectory('host')
+          .childDirectory('outputs')
+          .childDirectory('apk')
+          .childFile('app.apk');
+      apkDebugFile.createSync(recursive: true);
+      final AndroidApk? androidApk = await AndroidApk.fromAndroidProject(
+        project.android,
+        androidSdk: sdk,
+        processManager: fakeProcessManager,
+        userMessages: UserMessages(),
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        logger: logger,
+        fileSystem: fs,
+        // ignore: avoid_redundant_argument_values
+        buildInfo: null,
+      );
+      expect(androidApk, isNotNull);
+    }, overrides: overrides);
+
     testUsingContext('correct debug filename in module projects', () async {
       const aaptPath = 'aaptPath';
       final File apkFile = globals.fs.file('app-debug.apk');
@@ -210,75 +272,6 @@ void main() {
 
       expect(androidApk, isNull);
       expect(fakeProcessManager, hasNoRemainingExpectations);
-    });
-
-    testWithoutContext('returns null when failed to extract manifest', () async {
-      const aaptPath = 'aaptPath';
-      final File apkFile = globals.fs.file('app-debug.apk');
-      final sdkVersion = FakeAndroidSdkVersion();
-      sdkVersion.aaptPath = aaptPath;
-      sdk.latestVersion = sdkVersion;
-      sdk.platformToolsAvailable = true;
-      sdk.licensesAvailable = false;
-
-      fakeProcessManager.addCommand(
-        FakeCommand(
-          command: <String>[aaptPath, 'dump', 'xmltree', apkFile.path, 'AndroidManifest.xml'],
-          stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity,
-        ),
-      );
-
-      fakeProcessManager.addCommand(
-        FakeCommand(
-          command: <String>[
-            aaptPath,
-            'dump',
-            'xmltree',
-            fs.path.join(
-              'module_project',
-              'build',
-              'host',
-              'outputs',
-              'apk',
-              'debug',
-              'app-debug.apk',
-            ),
-            'AndroidManifest.xml',
-          ],
-          stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity,
-        ),
-      );
-
-      await ApplicationPackageFactory.instance!.getPackageForPlatform(
-        TargetPlatform.android_arm,
-        applicationBinary: apkFile,
-      );
-      final logger = BufferLogger.test();
-      final FlutterProject project = await aModuleProject();
-      project.android.hostAppGradleRoot.childFile('build.gradle').createSync(recursive: true);
-      final File appGradle = project.android.hostAppGradleRoot.childFile(
-        fs.path.join('app', 'build.gradle'),
-      );
-      appGradle.createSync(recursive: true);
-      appGradle.writeAsStringSync("def flutterPluginVersion = 'managed'");
-      final File apkDebugFile = project.directory
-          .childDirectory('build')
-          .childDirectory('host')
-          .childDirectory('outputs')
-          .childDirectory('apk')
-          .childDirectory('debug')
-          .childFile('app-debug.apk');
-      apkDebugFile.createSync(recursive: true);
-      final AndroidApk? androidApk = await AndroidApk.fromAndroidProject(
-        project.android,
-        androidSdk: sdk,
-        processManager: fakeProcessManager,
-        userMessages: UserMessages(),
-        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
-        logger: logger,
-        fileSystem: fs,
-      );
-      expect(androidApk, isNotNull);
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -211,6 +211,75 @@ void main() {
       expect(androidApk, isNull);
       expect(fakeProcessManager, hasNoRemainingExpectations);
     });
+
+    testWithoutContext('returns null when failed to extract manifest', () async {
+      const aaptPath = 'aaptPath';
+      final File apkFile = globals.fs.file('app-debug.apk');
+      final sdkVersion = FakeAndroidSdkVersion();
+      sdkVersion.aaptPath = aaptPath;
+      sdk.latestVersion = sdkVersion;
+      sdk.platformToolsAvailable = true;
+      sdk.licensesAvailable = false;
+
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[aaptPath, 'dump', 'xmltree', apkFile.path, 'AndroidManifest.xml'],
+          stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity,
+        ),
+      );
+
+      fakeProcessManager.addCommand(
+        FakeCommand(
+          command: <String>[
+            aaptPath,
+            'dump',
+            'xmltree',
+            fs.path.join(
+              'module_project',
+              'build',
+              'host',
+              'outputs',
+              'apk',
+              'debug',
+              'app-debug.apk',
+            ),
+            'AndroidManifest.xml',
+          ],
+          stdout: _aaptDataWithDefaultEnabledAndMainLauncherActivity,
+        ),
+      );
+
+      await ApplicationPackageFactory.instance!.getPackageForPlatform(
+        TargetPlatform.android_arm,
+        applicationBinary: apkFile,
+      );
+      final logger = BufferLogger.test();
+      final FlutterProject project = await aModuleProject();
+      project.android.hostAppGradleRoot.childFile('build.gradle').createSync(recursive: true);
+      final File appGradle = project.android.hostAppGradleRoot.childFile(
+        fs.path.join('app', 'build.gradle'),
+      );
+      appGradle.createSync(recursive: true);
+      appGradle.writeAsStringSync("def flutterPluginVersion = 'managed'");
+      final File apkDebugFile = project.directory
+          .childDirectory('build')
+          .childDirectory('host')
+          .childDirectory('outputs')
+          .childDirectory('apk')
+          .childDirectory('debug')
+          .childFile('app-debug.apk');
+      apkDebugFile.createSync(recursive: true);
+      final AndroidApk? androidApk = await AndroidApk.fromAndroidProject(
+        project.android,
+        androidSdk: sdk,
+        processManager: fakeProcessManager,
+        userMessages: UserMessages(),
+        processUtils: ProcessUtils(processManager: fakeProcessManager, logger: logger),
+        logger: logger,
+        fileSystem: fs,
+      );
+      expect(androidApk, isNotNull);
+    });
   });
 
   group('ApkManifestData', () {


### PR DESCRIPTION
The `flutter logs` path for a module does not pass the buildInfo to the `fromAndroidProject` function.  This will cause an exception to be thrown when `buildInfo!` is invoked.  Instead, just allow the buildInfo to be null and check for the manifest with the code that already exists.

Fixes: #172884

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.