### PR TITLE
Use LLDB as the default debugging method for iOS 17+ and Xcode 26+

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5483,6 +5483,7 @@ targets:
 
   - name: Mac_ios hot_mode_dev_cycle_ios_xcode_debug
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: false
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5481,6 +5481,15 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: hot_mode_dev_cycle_ios_simulator
 
+  - name: Mac_ios hot_mode_dev_cycle_ios_xcode_debug
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: hot_mode_dev_cycle_ios_xcode_debug
+
   - name: Mac_ios fullscreen_textfield_perf_ios__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -267,6 +267,7 @@
 /dev/devicelab/bin/tasks/hello_world_macos__compile.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/hello_world_win_desktop__compile.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_simulator.dart @louisehsu @flutter/tool
+/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart @vashworth @flutter/tool
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart @cbracken @flutter/tool
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/integration_ui_test_test_macos.dart @cbracken @flutter/desktop

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart
@@ -9,6 +9,7 @@ import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
 import 'package:path/path.dart' as path;
 
+/// This is a test to validate that Xcode debugging still works now that LLDB is the default.
 Future<void> main() async {
   await task(() async {
     deviceOperatingSystem = DeviceOperatingSystem.ios;

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart
@@ -1,0 +1,44 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main() async {
+  await task(() async {
+    deviceOperatingSystem = DeviceOperatingSystem.ios;
+    try {
+      await disableLLDBDebugging();
+      // This isn't actually a benchmark test, so do not use the returned `benchmarkScoreKeys` result.
+      await createHotModeTest()();
+      return TaskResult.success(null);
+    } finally {
+      await enableLLDBDebugging();
+    }
+  });
+}
+
+Future<void> disableLLDBDebugging() async {
+  final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+    'config',
+    '--no-enable-lldb-debugging',
+  ]);
+  if (configResult != 0) {
+    print('Failed to disable configuration, tasks may not run.');
+  }
+}
+
+Future<void> enableLLDBDebugging() async {
+  final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+    'config',
+    '--enable-lldb-debugging',
+  ], canFail: true);
+  if (configResult != 0) {
+    print('Failed to enable configuration.');
+  }
+}

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -1198,7 +1198,6 @@ class DebuggingOptions {
     String? route,
     Map<String, Object?> platformArgs, {
     DeviceConnectionInterface interfaceType = DeviceConnectionInterface.attached,
-    bool isCoreDevice = false,
   }) {
     return <String>[
       if (enableDartProfiling) '--enable-dart-profiling',
@@ -1212,13 +1211,7 @@ class DebuggingOptions {
       if (environmentType == EnvironmentType.simulator && dartFlags.isNotEmpty)
         '--dart-flags=$dartFlags',
       if (useTestFonts) '--use-test-fonts',
-      // Core Devices (iOS 17 devices) are debugged through Xcode so don't
-      // include these flags, which are used to check if the app was launched
-      // via Flutter CLI and `ios-deploy`.
-      if (debuggingEnabled && !isCoreDevice) ...<String>[
-        '--enable-checked-mode',
-        '--verify-entry-points',
-      ],
+      if (debuggingEnabled) ...<String>['--enable-checked-mode', '--verify-entry-points'],
       if (enableSoftwareRendering) '--enable-software-rendering',
       if (traceSystrace) '--trace-systrace',
       if (traceToFile != null) '--trace-to-file="$traceToFile"',

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -67,6 +67,9 @@ abstract class FeatureFlags {
   /// Whether desktop windowing is enabled.
   bool get isWindowingEnabled;
 
+  /// Whether physical iOS devices are debugging with LLDB.
+  bool get isLLDBDebuggingEnabled;
+
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -87,6 +90,7 @@ abstract class FeatureFlags {
     swiftPackageManager,
     omitLegacyVersionFile,
     windowingFeature,
+    lldbDebugging,
   ];
 
   /// All current Flutter feature flags that can be configured.
@@ -216,6 +220,18 @@ const windowingFeature = Feature(
   environmentOverride: 'FLUTTER_WINDOWING',
   runtimeId: 'windowing',
   master: FeatureChannelSetting(available: true),
+);
+
+/// Enable LLDB debugging for physical iOS devices. When LLDB debugging is off,
+/// Xcode debugging is used instead.
+const lldbDebugging = Feature(
+  name: 'support for debugging with LLDB for physical iOS devices',
+  extraHelpText: 'If LLDB debugging is off, Xcode debugging is used instead.',
+  configSetting: 'enable-lldb-debugging',
+  environmentOverride: 'FLUTTER_LLDB_DEBUGGING',
+  master: FeatureChannelSetting(available: true, enabledByDefault: true),
+  beta: FeatureChannelSetting(available: true, enabledByDefault: true),
+  stable: FeatureChannelSetting(available: true, enabledByDefault: true),
 );
 
 /// A [Feature] is a process for conditionally enabling tool features.

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -224,9 +224,14 @@ const windowingFeature = Feature(
 
 /// Enable LLDB debugging for physical iOS devices. When LLDB debugging is off,
 /// Xcode debugging is used instead.
+///
+/// Requires iOS 17+ and Xcode 26+. If those requirements are not met, the previous
+/// default debugging method is used instead.
 const lldbDebugging = Feature(
   name: 'support for debugging with LLDB for physical iOS devices',
-  extraHelpText: 'If LLDB debugging is off, Xcode debugging is used instead.',
+  extraHelpText:
+      'If LLDB debugging is off, Xcode debugging is used instead. '
+      'Only available for iOS 17 or newer devices. Requires Xcode 26 or greater.',
   configSetting: 'enable-lldb-debugging',
   environmentOverride: 'FLUTTER_LLDB_DEBUGGING',
   master: FeatureChannelSetting(available: true, enabledByDefault: true),

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -57,6 +57,9 @@ mixin FlutterFeatureFlagsIsEnabled implements FeatureFlags {
 
   @override
   bool get isWindowingEnabled => isEnabled(windowingFeature);
+
+  @override
+  bool get isLLDBDebuggingEnabled => isEnabled(lldbDebugging);
 }
 
 interface class FlutterFeatureFlags extends FeatureFlags with FlutterFeatureFlagsIsEnabled {

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -66,7 +66,7 @@ class IOSCoreDeviceLauncher {
     }
 
     // Launch app to device
-    final IOSCoreDeviceLaunchResult? launchResult = await _coreDeviceControl.launchAppInternal(
+    final IOSCoreDeviceLaunchResult? launchResult = await _coreDeviceControl.launchApp(
       deviceId: deviceId,
       bundleId: bundleId,
       launchArguments: launchArguments,
@@ -99,7 +99,7 @@ class IOSCoreDeviceLauncher {
     }
 
     // Launch app on device, but start it stopped so it will wait until the debugger is attached before starting.
-    final IOSCoreDeviceLaunchResult? launchResult = await _coreDeviceControl.launchAppInternal(
+    final IOSCoreDeviceLaunchResult? launchResult = await _coreDeviceControl.launchApp(
       deviceId: deviceId,
       bundleId: bundleId,
       launchArguments: launchArguments,
@@ -532,66 +532,12 @@ class IOSCoreDeviceControl {
     }
   }
 
-  Future<bool> launchApp({
-    required String deviceId,
-    required String bundleId,
-    List<String> launchArguments = const <String>[],
-  }) async {
-    if (!_xcode.isDevicectlInstalled) {
-      _logger.printError('devicectl is not installed.');
-      return false;
-    }
-
-    final Directory tempDirectory = _fileSystem.systemTempDirectory.createTempSync('core_devices.');
-    final File output = tempDirectory.childFile('launch_results.json');
-    output.createSync();
-
-    final command = <String>[
-      ..._xcode.xcrunCommand(),
-      'devicectl',
-      'device',
-      'process',
-      'launch',
-      '--device',
-      deviceId,
-      bundleId,
-      if (launchArguments.isNotEmpty) ...launchArguments,
-      '--json-output',
-      output.path,
-    ];
-
-    try {
-      await _processUtils.run(command, throwOnError: true);
-      final String stringOutput = output.readAsStringSync();
-
-      try {
-        final Object? decodeResult = (json.decode(stringOutput) as Map<String, Object?>)['info'];
-        if (decodeResult is Map<String, Object?> && decodeResult['outcome'] == 'success') {
-          return true;
-        }
-        _logger.printError('devicectl returned unexpected JSON response: $stringOutput');
-        return false;
-      } on FormatException {
-        // We failed to parse the devicectl output, or it returned junk.
-        _logger.printError('devicectl returned non-JSON response: $stringOutput');
-        return false;
-      }
-    } on ProcessException catch (err) {
-      _logger.printError('Error executing devicectl: $err');
-      return false;
-    } finally {
-      tempDirectory.deleteSync(recursive: true);
-    }
-  }
-
   /// Launches the app on the device.
   ///
   /// If [startStopped] is true, the app will be launched and paused, waiting
   /// for a debugger to attach.
-  // TODO(vashworth): Rename this method to launchApp and replace old version.
-  // See https://github.com/flutter/flutter/issues/173416.
   @visibleForTesting
-  Future<IOSCoreDeviceLaunchResult?> launchAppInternal({
+  Future<IOSCoreDeviceLaunchResult?> launchApp({
     required String deviceId,
     required String bundleId,
     List<String> launchArguments = const <String>[],

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -536,7 +536,6 @@ class IOSCoreDeviceControl {
   ///
   /// If [startStopped] is true, the app will be launched and paused, waiting
   /// for a debugger to attach.
-  @visibleForTesting
   Future<IOSCoreDeviceLaunchResult?> launchApp({
     required String deviceId,
     required String bundleId,

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1082,6 +1082,9 @@ class IOSDevice extends Device {
       return (false, deploymentMethod);
     }
 
+    // Core Devices (iOS 17 devices) are debugged through Xcode so don't
+    // include these flags, which are used to check if the app was launched
+    // via Flutter CLI and `ios-deploy`.
     final List<String> filteredLaunchArguments = launchArguments
         .where((String arg) => arg != '--enable-checked-mode' && arg != '--verify-entry-points')
         .toList();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../application_package.dart';
@@ -24,6 +25,7 @@ import '../darwin/darwin.dart';
 import '../device.dart';
 import '../device_port_forwarder.dart';
 import '../device_vm_service_discovery_for_attach.dart';
+import '../features.dart';
 import '../globals.dart' as globals;
 import '../macos/xcdevice.dart';
 import '../mdns_discovery.dart';
@@ -38,7 +40,6 @@ import 'iproxy.dart';
 import 'mac.dart';
 import 'xcode_build_settings.dart';
 import 'xcode_debug.dart';
-import 'xcodeproj.dart';
 
 const kJITCrashFailureMessage =
     'Crash occurred when compiling unknown function in unoptimized JIT mode in unknown pass';
@@ -58,6 +59,15 @@ In the meantime, we recommend these temporary workarounds:
 * If you must use a device updated to $deviceVersion, use Flutter's release or
   profile mode via --release or --profile flags.
 ════════════════════════════════════════════════════════════════════════════════''';
+
+enum IOSDeploymentMethod {
+  iosDeployLaunch,
+  iosDeployLaunchAndAttach,
+  coreDeviceWithoutDebugger,
+  coreDeviceWithLLDB,
+  coreDeviceWithXcode,
+  coreDeviceWithXcodeFallback,
+}
 
 class IOSDevices extends PollingDeviceDiscovery {
   IOSDevices({
@@ -284,6 +294,7 @@ class IOSDevice extends Device {
     required XcodeDebug xcodeDebug,
     required IProxy iProxy,
     required super.logger,
+    required Analytics analytics,
   }) : _sdkVersion = sdkVersion,
        _iosDeploy = iosDeploy,
        _iMobileDevice = iMobileDevice,
@@ -293,6 +304,7 @@ class IOSDevice extends Device {
        _iproxy = iProxy,
        _fileSystem = fileSystem,
        _logger = logger,
+       _analytics = analytics,
        _platform = platform,
        super(category: Category.mobile, platformType: PlatformType.ios, ephemeral: true) {
     if (!_platform.isMacOS) {
@@ -303,14 +315,12 @@ class IOSDevice extends Device {
 
   final String? _sdkVersion;
   final IOSDeploy _iosDeploy;
+  final Analytics _analytics;
   final FileSystem _fileSystem;
   final Logger _logger;
   final Platform _platform;
   final IMobileDevice _iMobileDevice;
   final IOSCoreDeviceControl _coreDeviceControl;
-
-  // TODO(vashworth): See https://github.com/flutter/flutter/issues/173416.
-  // ignore: unused_field
   final IOSCoreDeviceLauncher _coreDeviceLauncher;
   final XcodeDebug _xcodeDebug;
   final IProxy _iproxy;
@@ -492,7 +502,7 @@ class IOSDevice extends Device {
         _logger.printError('Could not build the precompiled application for the device.');
         await diagnoseXcodeBuildFailure(
           buildResult,
-          analytics: globals.analytics,
+          analytics: _analytics,
           fileSystem: globals.fs,
           logger: globals.logger,
           platform: FlutterDarwinPlatform.ios,
@@ -519,9 +529,10 @@ class IOSDevice extends Device {
       route,
       platformArgs,
       interfaceType: connectionInterface,
-      isCoreDevice: isCoreDevice,
     );
     Status startAppStatus = _logger.startProgress('Installing and launching...');
+
+    IOSDeploymentMethod? deploymentMethod;
     try {
       ProtocolDiscovery? vmServiceDiscovery;
       var installationResult = 1;
@@ -537,18 +548,21 @@ class IOSDevice extends Device {
       }
 
       if (isCoreDevice) {
-        installationResult =
-            await _startAppOnCoreDevice(
-              debuggingOptions: debuggingOptions,
-              package: package,
-              launchArguments: launchArguments,
-              mainPath: mainPath,
-              discoveryTimeout: discoveryTimeout,
-              shutdownHooks: shutdownHooks ?? globals.shutdownHooks,
-            )
-            ? 0
-            : 1;
+        final (
+          bool result,
+          IOSDeploymentMethod coreDeviceDeploymentMethod,
+        ) = await _startAppOnCoreDevice(
+          debuggingOptions: debuggingOptions,
+          package: package,
+          launchArguments: launchArguments,
+          mainPath: mainPath,
+          discoveryTimeout: discoveryTimeout,
+          shutdownHooks: shutdownHooks ?? globals.shutdownHooks,
+        );
+        installationResult = result ? 0 : 1;
+        deploymentMethod = coreDeviceDeploymentMethod;
       } else if (iosDeployDebugger == null) {
+        deploymentMethod = IOSDeploymentMethod.iosDeployLaunch;
         installationResult = await _iosDeploy.launchApp(
           deviceId: id,
           bundlePath: bundle.path,
@@ -558,15 +572,30 @@ class IOSDevice extends Device {
           uninstallFirst: debuggingOptions.uninstallFirst,
         );
       } else {
+        deploymentMethod = IOSDeploymentMethod.iosDeployLaunchAndAttach;
         installationResult = await iosDeployDebugger!.launchAndAttach() ? 0 : 1;
       }
       if (installationResult != 0) {
+        _analytics.send(
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: deploymentMethod.name,
+            result: 'launch failed',
+          ),
+        );
         _printInstallError(bundle);
         await dispose();
         return LaunchResult.failed();
       }
 
       if (!debuggingOptions.debuggingEnabled) {
+        _analytics.send(
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: deploymentMethod.name,
+            result: 'release success',
+          ),
+        );
         return LaunchResult.succeeded();
       }
 
@@ -587,13 +616,6 @@ class IOSDevice extends Device {
         _logger.printError(
           'The Dart VM Service was not discovered after $defaultTimeout seconds. This is taking much longer than expected...',
         );
-        if (isCoreDevice && debuggingOptions.debuggingEnabled) {
-          _logger.printError(
-            'Open the Xcode window the project is opened in to ensure the app '
-            'is running. If the app is not running, try selecting "Product > Run" '
-            'to fix the problem.',
-          );
-        }
         // If debugging with a wireless device and the timeout is reached, remind the
         // user to allow local network permissions.
         if (isWirelesslyConnected) {
@@ -632,6 +654,13 @@ class IOSDevice extends Device {
         if (serviceURL == null) {
           await iosDeployDebugger?.stopAndDumpBacktrace();
           await dispose();
+          _analytics.send(
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: deploymentMethod.name,
+              result: 'wireless debugging failed',
+            ),
+          );
           return LaunchResult.failed();
         }
 
@@ -688,13 +717,36 @@ class IOSDevice extends Device {
       if (localUri == null) {
         await iosDeployDebugger?.stopAndDumpBacktrace();
         await dispose();
+        _analytics.send(
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: deploymentMethod.name,
+            result: 'debugging failed',
+          ),
+        );
         return LaunchResult.failed();
       }
+      _analytics.send(
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: deploymentMethod.name,
+          result: 'debugging success',
+        ),
+      );
       return LaunchResult.succeeded(vmServiceUri: localUri);
     } on ProcessException catch (e) {
       await iosDeployDebugger?.stopAndDumpBacktrace();
       _logger.printError(e.message);
       await dispose();
+      if (deploymentMethod != null) {
+        _analytics.send(
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: deploymentMethod.name,
+            result: 'process exception',
+          ),
+        );
+      }
       return LaunchResult.failed();
     } finally {
       startAppStatus.stop();
@@ -891,7 +943,7 @@ class IOSDevice extends Device {
   ///
   /// Therefore, when starting an app on a CoreDevice, use `devicectl` when
   /// debugging is not enabled. Otherwise, use Xcode automation.
-  Future<bool> _startAppOnCoreDevice({
+  Future<(bool, IOSDeploymentMethod)> _startAppOnCoreDevice({
     required DebuggingOptions debuggingOptions,
     required IOSApp package,
     required List<String> launchArguments,
@@ -899,107 +951,74 @@ class IOSDevice extends Device {
     required ShutdownHooks shutdownHooks,
     @visibleForTesting Duration? discoveryTimeout,
   }) async {
+    // When starting the app in release mode, do not launch with a debugger.
     if (!debuggingOptions.debuggingEnabled) {
-      // Release mode
-
-      // Install app to device
-      final bool installSuccess = await _coreDeviceControl.installApp(
+      final bool launchSuccess = await _coreDeviceLauncher.launchAppWithoutDebugger(
         deviceId: id,
         bundlePath: package.deviceBundlePath,
+        bundleId: package.id,
+        launchArguments: launchArguments,
       );
-      if (!installSuccess) {
-        return installSuccess;
-      }
+      return (launchSuccess, IOSDeploymentMethod.coreDeviceWithoutDebugger);
+    }
 
-      // Launch app to device
-      final bool launchSuccess = await _coreDeviceControl.launchApp(
+    // Xcode 16 introduced a way to start and attach to a debugserver through LLDB.
+    // Use LLDB if available.
+    final Version? xcodeVersion = globals.xcode?.currentVersion;
+    final bool lldbEnabled = featureFlags.isLLDBDebuggingEnabled;
+    if (xcodeVersion != null && xcodeVersion.major >= 16 && lldbEnabled) {
+      final bool launchSuccess = await _coreDeviceLauncher.launchAppWithLLDBDebugger(
         deviceId: id,
+        bundlePath: package.deviceBundlePath,
         bundleId: package.id,
         launchArguments: launchArguments,
       );
 
-      return launchSuccess;
-    } else {
-      _logger.printStatus(
-        'You may be prompted to give access to control Xcode. Flutter uses Xcode '
-        'to run your app. If access is not allowed, you can change this through '
-        'your Settings > Privacy & Security > Automation.',
-      );
-      final launchTimeout = isWirelesslyConnected ? 45 : 30;
-      final timer = Timer(discoveryTimeout ?? Duration(seconds: launchTimeout), () {
-        _logger.printError(
-          'Xcode is taking longer than expected to start debugging the app. '
-          'Ensure the project is opened in Xcode.',
-        );
-      });
-
-      XcodeDebugProject debugProject;
-      final FlutterProject flutterProject = FlutterProject.current();
-
-      if (package is PrebuiltIOSApp) {
-        debugProject = await _xcodeDebug.createXcodeProjectWithCustomBundle(
-          package.deviceBundlePath,
-          templateRenderer: globals.templateRenderer,
-          verboseLogging: _logger.isVerbose,
-        );
-      } else if (package is BuildableIOSApp) {
-        // Before installing/launching/debugging with Xcode, update the build
-        // settings to use a custom configuration build directory so Xcode
-        // knows where to find the app bundle to launch.
-        final Directory bundle = _fileSystem.directory(package.deviceBundlePath);
-        await updateGeneratedXcodeProperties(
-          project: flutterProject,
-          buildInfo: debuggingOptions.buildInfo,
-          targetOverride: mainPath,
-          configurationBuildDir: bundle.parent.absolute.path,
-        );
-
-        final IosProject project = package.project;
-        final XcodeProjectInfo? projectInfo = await project.projectInfo();
-        if (projectInfo == null) {
-          globals.printError('Xcode project not found.');
-          return false;
-        }
-        if (project.xcodeWorkspace == null) {
-          globals.printError('Unable to get Xcode workspace.');
-          return false;
-        }
-        final String? scheme = projectInfo.schemeFor(debuggingOptions.buildInfo);
-        if (scheme == null) {
-          projectInfo.reportFlavorNotFoundAndExit();
-        }
-
-        _xcodeDebug.ensureXcodeDebuggerLaunchAction(project.xcodeProjectSchemeFile(scheme: scheme));
-
-        debugProject = XcodeDebugProject(
-          scheme: scheme,
-          xcodeProject: project.xcodeProject,
-          xcodeWorkspace: project.xcodeWorkspace!,
-          hostAppProjectName: project.hostAppProjectName,
-          expectedConfigurationBuildDir: bundle.parent.absolute.path,
-          verboseLogging: _logger.isVerbose,
-        );
+      // If it succeeds to launch with LLDB, return, otherwise continue on to
+      // try launching with Xcode.
+      if (launchSuccess) {
+        return (launchSuccess, IOSDeploymentMethod.coreDeviceWithLLDB);
       } else {
-        // This should not happen. Currently, only PrebuiltIOSApp and
-        // BuildableIOSApp extend from IOSApp.
-        _logger.printError('IOSApp type ${package.runtimeType} is not recognized.');
-        return false;
+        _analytics.send(
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithLLDB.name,
+            result: 'launch failed',
+          ),
+        );
       }
-
-      final bool debugSuccess = await _xcodeDebug.debugApp(
-        project: debugProject,
-        deviceId: id,
-        launchArguments: launchArguments,
-      );
-      timer.cancel();
-
-      // Kill Xcode on shutdown when running from CI
-      if (debuggingOptions.usingCISystem) {
-        shutdownHooks.addShutdownHook(() => _xcodeDebug.exit(force: true));
-      }
-
-      return debugSuccess;
     }
+
+    // If LLDB is not available or fails, fallback to using Xcode.
+    _logger.printStatus(
+      'You may be prompted to give access to control Xcode. Flutter uses Xcode '
+      'to run your app. If access is not allowed, you can change this through '
+      'your Settings > Privacy & Security > Automation.',
+    );
+    final launchTimeout = isWirelesslyConnected ? 45 : 30;
+    final timer = Timer(discoveryTimeout ?? Duration(seconds: launchTimeout), () {
+      _logger.printError(
+        'Xcode is taking longer than expected to start debugging the app. '
+        'If the issue persists, try closing Xcode and re-running your Flutter command.',
+      );
+    });
+
+    // Kill Xcode on shutdown when running from CI
+    if (debuggingOptions.usingCISystem) {
+      shutdownHooks.addShutdownHook(() => _xcodeDebug.exit(force: true));
+    }
+
+    final bool launchSuccess = await _coreDeviceLauncher.launchAppWithXcodeDebugger(
+      deviceId: id,
+      debuggingOptions: debuggingOptions,
+      package: package,
+      launchArguments: launchArguments,
+      mainPath: mainPath,
+      templateRenderer: globals.templateRenderer,
+    );
+
+    timer.cancel();
+    return (launchSuccess, IOSDeploymentMethod.coreDeviceWithXcode);
   }
 
   @override
@@ -1009,10 +1028,7 @@ class IOSDevice extends Device {
     if (deployDebugger != null && deployDebugger.debuggerAttached) {
       return deployDebugger.exit();
     }
-    if (_xcodeDebug.debugStarted) {
-      return _xcodeDebug.exit();
-    }
-    return false;
+    return _coreDeviceLauncher.stopApp(deviceId: id);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -986,10 +986,11 @@ class IOSDevice extends Device {
     IOSDeploymentMethod? deploymentMethod;
 
     // Xcode 16 introduced a way to start and attach to a debugserver through LLDB.
-    // Use LLDB if available.
+    // However, it doesn't work reliably until Xcode 26.
+    // Use LLDB if Xcode version is greater than 26 and the feature is enabled.
     final Version? xcodeVersion = globals.xcode?.currentVersion;
-    final bool lldbEnabled = featureFlags.isLLDBDebuggingEnabled;
-    if (xcodeVersion != null && xcodeVersion.major >= 16 && lldbEnabled) {
+    final bool lldbFeatureEnabled = featureFlags.isLLDBDebuggingEnabled;
+    if (xcodeVersion != null && xcodeVersion.major >= 26 && lldbFeatureEnabled) {
       final bool launchSuccess = await _coreDeviceLauncher.launchAppWithLLDBDebugger(
         deviceId: id,
         bundlePath: package.deviceBundlePath,

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -99,7 +99,7 @@ return False
       await _attachToAppProcess(appProcessId);
       await _resumeProcess();
     } on _LLDBError catch (e) {
-      _logger.printError('lldb failed with error: ${e.message}');
+      _logger.printTrace('lldb failed with error: ${e.message}');
       exit();
       return false;
     } finally {
@@ -115,7 +115,7 @@ return False
   /// to `stderr`, complete with an error and stop the process.
   Future<bool> _startLLDB(int appProcessId) async {
     if (_lldbProcess != null) {
-      _logger.printError(
+      _logger.printTrace(
         'An LLDB process is already running. It must be stopped before starting a new one.',
       );
       return false;
@@ -139,7 +139,7 @@ return False
           .transform<String>(utf8.decoder)
           .transform<String>(const LineSplitter())
           .listen((String line) {
-            _logger.printError('[lldb]: $line');
+            _logger.printTrace('[lldb]: $line');
             _monitorError(line);
           });
 
@@ -155,7 +155,7 @@ return False
             }),
       );
     } on ProcessException catch (exception) {
-      _logger.printError('Process exception running lldb:\n$exception');
+      _logger.printTrace('Process exception running lldb:\n$exception');
       return false;
     }
     return true;

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -602,6 +602,7 @@ class XCDevice {
           iProxy: _iProxy,
           fileSystem: globals.fs,
           logger: _logger,
+          analytics: globals.analytics,
           iosDeploy: _iosDeploy,
           iMobileDevice: _iMobileDevice,
           coreDeviceControl: _coreDeviceControl,

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -791,22 +791,6 @@ void main() {
       },
     );
 
-    testWithoutContext(
-      'Get launch arguments for physical CoreDevice with debugging enabled with no launch arguments',
-      () {
-        final original = DebuggingOptions.enabled(BuildInfo.debug);
-
-        final List<String> launchArguments = original.getIOSLaunchArguments(
-          EnvironmentType.physical,
-          null,
-          <String, Object?>{},
-          isCoreDevice: true,
-        );
-
-        expect(launchArguments.join(' '), <String>['--enable-dart-profiling'].join(' '));
-      },
-    );
-
     testWithoutContext('Get launch arguments for physical device with iPv4 network connection', () {
       final original = DebuggingOptions.enabled(BuildInfo.debug);
 

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -819,6 +819,9 @@ class FakeFlutterFeatures extends FeatureFlags {
   bool get isWindowingEnabled => _enabled;
 
   @override
+  bool get isLLDBDebuggingEnabled => _enabled;
+
+  @override
   final List<Feature> allFeatures;
 
   @override

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -28,6 +28,7 @@ import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/macos/xcdevice.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -79,6 +80,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -101,6 +103,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -125,6 +128,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -148,6 +152,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -171,6 +176,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -194,6 +200,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -217,6 +224,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -242,6 +250,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -267,6 +276,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -292,6 +302,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -317,6 +328,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -342,6 +354,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -363,6 +376,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -387,6 +401,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -412,6 +427,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -444,6 +460,7 @@ void main() {
               iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
               fileSystem: fileSystem,
               logger: logger,
+              analytics: FakeAnalytics(),
               platform: platform,
               iosDeploy: iosDeploy,
               iMobileDevice: iMobileDevice,
@@ -533,6 +550,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -609,6 +627,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -630,6 +649,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -939,6 +959,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -1108,3 +1129,5 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {
 class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {}
 
 class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+
+class FakeAnalytics extends Fake implements Analytics {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -380,6 +381,7 @@ IOSDevice setUpIOSDevice({
       artifacts: artifacts,
       cache: cache,
     ),
+    analytics: FakeAnalytics(),
     coreDeviceControl: FakeIOSCoreDeviceControl(),
     coreDeviceLauncher: FakeIOSCoreDeviceLauncher(),
     xcodeDebug: FakeXcodeDebug(),
@@ -412,3 +414,5 @@ class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
 }
 
 class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+
+class FakeAnalytics extends Fake implements Analytics {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -107,6 +108,7 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
       artifacts: Artifacts.test(),
       cache: Cache.test(processManager: processManager),
     ),
+    analytics: FakeAnalytics(),
     iMobileDevice: IMobileDevice.test(processManager: processManager),
     coreDeviceControl: FakeIOSCoreDeviceControl(),
     coreDeviceLauncher: FakeIOSCoreDeviceLauncher(),
@@ -129,3 +131,5 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {}
 class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {}
 
 class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+
+class FakeAnalytics extends Fake implements Analytics {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/device_port_forwarder.dart';
 import 'package:flutter_tools/src/ios/application_package.dart';
 import 'package:flutter_tools/src/ios/core_devices.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
@@ -32,6 +33,7 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart' hide FakeXcodeProjectInterpreter;
+import '../../src/fake_devices.dart';
 import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/package_config.dart';
@@ -591,7 +593,7 @@ void main() {
       );
 
       testUsingContext(
-        'fails when install or launch fails',
+        'fails when install fails',
         () async {
           final fakeExactAnalytics = FakeExactAnalytics();
           final IOSDevice iosDevice = setUpIOSDevice(
@@ -600,7 +602,7 @@ void main() {
             logger: logger,
             artifacts: artifacts,
             isCoreDevice: true,
-            coreDeviceControl: FakeIOSCoreDeviceControl(),
+            coreDeviceControl: FakeIOSCoreDeviceControl(installSuccess: false),
             coreDeviceLauncher: FakeIOSCoreDeviceLauncher(launchResult: false),
             analytics: fakeExactAnalytics,
           );
@@ -633,6 +635,52 @@ void main() {
               result: 'launch failed',
             ),
           ]);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: () => const ThrowingPub(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () => os,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+        },
+      );
+
+      testUsingContext(
+        'fails when launch fails',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(launchSuccess: false),
+          );
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+
+          final LaunchResult launchResult = await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+            platformArgs: <String, Object>{},
+          );
+
+          expect(fileSystem.directory('build/ios/iphoneos'), exists);
+          expect(launchResult.started, false);
+          expect(processManager, hasNoRemainingExpectations);
         },
         overrides: <Type, Generator>{
           ProcessManager: () => FakeProcessManager.any(),
@@ -682,6 +730,8 @@ void main() {
           expect(fileSystem.directory('build/ios/iphoneos'), exists);
           expect(launchResult.started, true);
           expect(processManager, hasNoRemainingExpectations);
+          expect(coreDeviceControl.argumentsUsedForLaunch, isNotNull);
+          expect(coreDeviceControl.argumentsUsedForLaunch, contains('--enable-dart-profiling'));
           expect(fakeExactAnalytics.sentEvents, [
             Event.appleUsageEvent(
               workflow: 'ios-physical-deployment',
@@ -696,6 +746,450 @@ void main() {
           FileSystem: () => fileSystem,
           Logger: () => logger,
           OperatingSystemUtils: () => os,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+        },
+      );
+    });
+
+    group('in debug mode', () {
+      testUsingContext(
+        'succeeds',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+            xcodeDebug: FakeXcodeDebug(
+              expectedProject: XcodeDebugProject(
+                scheme: 'Runner',
+                xcodeWorkspace: fileSystem.directory('/ios/Runner.xcworkspace'),
+                xcodeProject: fileSystem.directory('/ios/Runner.xcodeproj'),
+                hostAppProjectName: 'Runner',
+              ),
+              expectedDeviceId: '123',
+              expectedLaunchArguments: <String>['--enable-dart-profiling'],
+            ),
+          );
+
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+
+          final deviceLogReader = FakeDeviceLogReader();
+
+          iosDevice.portForwarder = const NoOpDevicePortForwarder();
+          iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          final LaunchResult launchResult = await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(
+                BuildMode.debug,
+                null,
+                buildName: '1.2.3',
+                buildNumber: '4',
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+            ),
+            platformArgs: <String, Object>{},
+          );
+
+          expect(logger.errorText, isEmpty);
+          expect(fileSystem.directory('build/ios/iphoneos'), exists);
+          expect(launchResult.started, true);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: () => const ThrowingPub(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () => os,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+        },
+      );
+
+      group('with flavor', () {
+        setUp(() {
+          projectInfo = XcodeProjectInfo(
+            <String>['Runner'],
+            <String>['Debug', 'Release', 'Debug-free', 'Release-free'],
+            <String>['Runner', 'free'],
+            logger,
+          );
+          fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(projectInfo: projectInfo);
+          xcode = Xcode.test(
+            processManager: FakeProcessManager.any(),
+            xcodeProjectInterpreter: fakeXcodeProjectInterpreter,
+          );
+        });
+
+        testUsingContext(
+          'succeeds',
+          () async {
+            const flavor = 'free';
+            final IOSDevice iosDevice = setUpIOSDevice(
+              fileSystem: fileSystem,
+              processManager: FakeProcessManager.any(),
+              logger: logger,
+              artifacts: artifacts,
+              isCoreDevice: true,
+              coreDeviceControl: FakeIOSCoreDeviceControl(),
+              xcodeDebug: FakeXcodeDebug(
+                expectedProject: XcodeDebugProject(
+                  scheme: flavor,
+                  xcodeWorkspace: fileSystem.directory('/ios/Runner.xcworkspace'),
+                  xcodeProject: fileSystem.directory('/ios/Runner.xcodeproj'),
+                  hostAppProjectName: 'Runner',
+                ),
+                expectedDeviceId: '123',
+                expectedLaunchArguments: <String>['--enable-dart-profiling'],
+                expectedSchemeFilePath:
+                    '/ios/Runner.xcodeproj/xcshareddata/xcschemes/$flavor.xcscheme',
+              ),
+            );
+
+            setUpIOSProject(fileSystem, scheme: flavor);
+            final FlutterProject flutterProject = FlutterProject.fromDirectory(
+              fileSystem.currentDirectory,
+            );
+            final buildableIOSApp = BuildableIOSApp(
+              flutterProject.ios,
+              'flutter',
+              'My Super Awesome App',
+            );
+            fileSystem
+                .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+                .createSync(recursive: true);
+
+            final deviceLogReader = FakeDeviceLogReader();
+
+            iosDevice.portForwarder = const NoOpDevicePortForwarder();
+            iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
+
+            // Start writing messages to the log reader.
+            Timer.run(() {
+              deviceLogReader.addLine('Foo');
+              deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+            });
+
+            final LaunchResult launchResult = await iosDevice.startApp(
+              buildableIOSApp,
+              debuggingOptions: DebuggingOptions.enabled(
+                const BuildInfo(
+                  BuildMode.debug,
+                  'free',
+                  buildName: '1.2.3',
+                  buildNumber: '4',
+                  treeShakeIcons: false,
+                  packageConfigPath: '.dart_tool/package_config.json',
+                ),
+              ),
+              platformArgs: <String, Object>{},
+            );
+
+            expect(logger.errorText, isEmpty);
+            expect(fileSystem.directory('build/ios/iphoneos'), exists);
+            expect(launchResult.started, true);
+            expect(processManager, hasNoRemainingExpectations);
+          },
+          overrides: <Type, Generator>{
+            ProcessManager: () => FakeProcessManager.any(),
+            Pub: () => const ThrowingPub(),
+            FileSystem: () => fileSystem,
+            Logger: () => logger,
+            OperatingSystemUtils: () => os,
+            Platform: () => macPlatform,
+            XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+            Xcode: () => xcode,
+          },
+        );
+      });
+
+      // testUsingContext(
+      //   'updates Generated.xcconfig before and after launch',
+      //   () async {
+      //     final debugStartedCompleter = Completer<void>();
+      //     final debugEndedCompleter = Completer<void>();
+      //     final IOSDevice iosDevice = setUpIOSDevice(
+      //       fileSystem: fileSystem,
+      //       processManager: FakeProcessManager.any(),
+      //       logger: logger,
+      //       artifacts: artifacts,
+      //       isCoreDevice: true,
+      //       coreDeviceControl: FakeIOSCoreDeviceControl(),
+      //       xcodeDebug: FakeXcodeDebug(
+      //         expectedProject: XcodeDebugProject(
+      //           scheme: 'Runner',
+      //           xcodeWorkspace: fileSystem.directory('/ios/Runner.xcworkspace'),
+      //           xcodeProject: fileSystem.directory('/ios/Runner.xcodeproj'),
+      //           hostAppProjectName: 'Runner',
+      //           expectedConfigurationBuildDir: '/build/ios/iphoneos',
+      //         ),
+      //         expectedDeviceId: '123',
+      //         expectedLaunchArguments: <String>['--enable-dart-profiling'],
+      //         debugStartedCompleter: debugStartedCompleter,
+      //         debugEndedCompleter: debugEndedCompleter,
+      //       ),
+      //     );
+
+      //     setUpIOSProject(fileSystem);
+      //     final FlutterProject flutterProject = FlutterProject.fromDirectory(
+      //       fileSystem.currentDirectory,
+      //     );
+      //     final buildableIOSApp = BuildableIOSApp(
+      //       flutterProject.ios,
+      //       'flutter',
+      //       'My Super Awesome App',
+      //     );
+      //     fileSystem
+      //         .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+      //         .createSync(recursive: true);
+
+      //     final deviceLogReader = FakeDeviceLogReader();
+
+      //     iosDevice.portForwarder = const NoOpDevicePortForwarder();
+      //     iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
+
+      //     // Start writing messages to the log reader.
+      //     Timer.run(() {
+      //       deviceLogReader.addLine('Foo');
+      //       deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+      //     });
+
+      //     final Future<LaunchResult> futureLaunchResult = iosDevice.startApp(
+      //       buildableIOSApp,
+      //       debuggingOptions: DebuggingOptions.enabled(
+      //         const BuildInfo(
+      //           BuildMode.debug,
+      //           null,
+      //           buildName: '1.2.3',
+      //           buildNumber: '4',
+      //           treeShakeIcons: false,
+      //           packageConfigPath: '.dart_tool/package_config.json',
+      //         ),
+      //       ),
+      //       platformArgs: <String, Object>{},
+      //     );
+
+      //     await debugStartedCompleter.future;
+
+      //     // Validate CoreDevice build settings were used
+      //     final File config = fileSystem.directory('ios').childFile('Flutter/Generated.xcconfig');
+      //     expect(config.existsSync(), isTrue);
+
+      //     String contents = config.readAsStringSync();
+      //     expect(contents, contains('CONFIGURATION_BUILD_DIR=/build/ios/iphoneos'));
+
+      //     debugEndedCompleter.complete();
+
+      //     await futureLaunchResult;
+
+      //     // Validate CoreDevice build settings were removed after launch
+      //     contents = config.readAsStringSync();
+      //     expect(contents.contains('CONFIGURATION_BUILD_DIR'), isFalse);
+      //   },
+      //   overrides: <Type, Generator>{
+      //     ProcessManager: () => FakeProcessManager.any(),
+      //     Pub: () => const ThrowingPub(),
+      //     FileSystem: () => fileSystem,
+      //     Logger: () => logger,
+      //     OperatingSystemUtils: () => os,
+      //     Platform: () => macPlatform,
+      //     XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+      //     Xcode: () => xcode,
+      //   },
+      // );
+
+      testUsingContext(
+        'fails when Xcode project is not found',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+          );
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+
+          final LaunchResult launchResult = await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(
+                BuildMode.debug,
+                null,
+                buildName: '1.2.3',
+                buildNumber: '4',
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+            ),
+            platformArgs: <String, Object>{},
+          );
+          expect(logger.errorText, contains('Xcode project not found'));
+          expect(fileSystem.directory('build/ios/iphoneos'), exists);
+          expect(launchResult.started, false);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: () => const ThrowingPub(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter(),
+          Xcode: () => xcode,
+        },
+      );
+
+      testUsingContext(
+        'fails when Xcode workspace is not found',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+          );
+          setUpIOSProject(fileSystem, createWorkspace: false);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+
+          final LaunchResult launchResult = await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(
+                BuildMode.debug,
+                null,
+                buildName: '1.2.3',
+                buildNumber: '4',
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+            ),
+            platformArgs: <String, Object>{},
+          );
+          expect(logger.errorText, contains('Unable to get Xcode workspace'));
+          expect(fileSystem.directory('build/ios/iphoneos'), exists);
+          expect(launchResult.started, false);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: () => const ThrowingPub(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () => os,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+        },
+      );
+
+      testUsingContext(
+        'fails when scheme is not found',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+          );
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+
+          final deviceLogReader = FakeDeviceLogReader();
+
+          iosDevice.portForwarder = const NoOpDevicePortForwarder();
+          iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          expect(
+            () async => iosDevice.startApp(
+              buildableIOSApp,
+              debuggingOptions: DebuggingOptions.enabled(
+                const BuildInfo(
+                  BuildMode.debug,
+                  'Flavor',
+                  buildName: '1.2.3',
+                  buildNumber: '4',
+                  treeShakeIcons: false,
+                  packageConfigPath: '.dart_tool/package_config.json',
+                ),
+              ),
+              platformArgs: <String, Object>{},
+            ),
+            throwsToolExit(),
+          );
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
@@ -867,7 +1361,34 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {
   }
 }
 
-class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {}
+class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
+  FakeIOSCoreDeviceControl({this.installSuccess = true, this.launchSuccess = true});
+
+  final bool installSuccess;
+  final bool launchSuccess;
+  List<String>? _launchArguments;
+
+  List<String>? get argumentsUsedForLaunch => _launchArguments;
+
+  @override
+  Future<bool> installApp({required String deviceId, required String bundlePath}) async {
+    return installSuccess;
+  }
+
+  @override
+  Future<IOSCoreDeviceLaunchResult?> launchApp({
+    required String deviceId,
+    required String bundleId,
+    List<String> launchArguments = const <String>[],
+    bool startStopped = false,
+  }) async {
+    _launchArguments = launchArguments;
+    final outcome = launchSuccess ? 'success' : 'failed';
+    return IOSCoreDeviceLaunchResult.fromJson(<String, Object?>{
+      'info': {'outcome': outcome},
+    });
+  }
+}
 
 const _validScheme = '''
 <?xml version="1.0" encoding="UTF-8"?>

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -529,7 +529,10 @@ void main() {
       projectInfo = XcodeProjectInfo(<String>['Runner'], <String>['Debug', 'Release'], <String>[
         'Runner',
       ], logger);
-      fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(projectInfo: projectInfo);
+      fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(
+        projectInfo: projectInfo,
+        xcodeVersion: Version(15, 0, 0),
+      );
       xcode = Xcode.test(
         processManager: FakeProcessManager.any(),
         xcodeProjectInterpreter: fakeXcodeProjectInterpreter,
@@ -929,100 +932,100 @@ void main() {
         );
       });
 
-      // testUsingContext(
-      //   'updates Generated.xcconfig before and after launch',
-      //   () async {
-      //     final debugStartedCompleter = Completer<void>();
-      //     final debugEndedCompleter = Completer<void>();
-      //     final IOSDevice iosDevice = setUpIOSDevice(
-      //       fileSystem: fileSystem,
-      //       processManager: FakeProcessManager.any(),
-      //       logger: logger,
-      //       artifacts: artifacts,
-      //       isCoreDevice: true,
-      //       coreDeviceControl: FakeIOSCoreDeviceControl(),
-      //       xcodeDebug: FakeXcodeDebug(
-      //         expectedProject: XcodeDebugProject(
-      //           scheme: 'Runner',
-      //           xcodeWorkspace: fileSystem.directory('/ios/Runner.xcworkspace'),
-      //           xcodeProject: fileSystem.directory('/ios/Runner.xcodeproj'),
-      //           hostAppProjectName: 'Runner',
-      //           expectedConfigurationBuildDir: '/build/ios/iphoneos',
-      //         ),
-      //         expectedDeviceId: '123',
-      //         expectedLaunchArguments: <String>['--enable-dart-profiling'],
-      //         debugStartedCompleter: debugStartedCompleter,
-      //         debugEndedCompleter: debugEndedCompleter,
-      //       ),
-      //     );
+      testUsingContext(
+        'updates Generated.xcconfig before and after launch',
+        () async {
+          final debugStartedCompleter = Completer<void>();
+          final debugEndedCompleter = Completer<void>();
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: FakeProcessManager.any(),
+            logger: logger,
+            artifacts: artifacts,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+            xcodeDebug: FakeXcodeDebug(
+              expectedProject: XcodeDebugProject(
+                scheme: 'Runner',
+                xcodeWorkspace: fileSystem.directory('/ios/Runner.xcworkspace'),
+                xcodeProject: fileSystem.directory('/ios/Runner.xcodeproj'),
+                hostAppProjectName: 'Runner',
+                expectedConfigurationBuildDir: '/build/ios/iphoneos',
+              ),
+              expectedDeviceId: '123',
+              expectedLaunchArguments: <String>['--enable-dart-profiling'],
+              debugStartedCompleter: debugStartedCompleter,
+              debugEndedCompleter: debugEndedCompleter,
+            ),
+          );
 
-      //     setUpIOSProject(fileSystem);
-      //     final FlutterProject flutterProject = FlutterProject.fromDirectory(
-      //       fileSystem.currentDirectory,
-      //     );
-      //     final buildableIOSApp = BuildableIOSApp(
-      //       flutterProject.ios,
-      //       'flutter',
-      //       'My Super Awesome App',
-      //     );
-      //     fileSystem
-      //         .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
-      //         .createSync(recursive: true);
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
 
-      //     final deviceLogReader = FakeDeviceLogReader();
+          final deviceLogReader = FakeDeviceLogReader();
 
-      //     iosDevice.portForwarder = const NoOpDevicePortForwarder();
-      //     iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
+          iosDevice.portForwarder = const NoOpDevicePortForwarder();
+          iosDevice.setLogReader(buildableIOSApp, deviceLogReader);
 
-      //     // Start writing messages to the log reader.
-      //     Timer.run(() {
-      //       deviceLogReader.addLine('Foo');
-      //       deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
-      //     });
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
 
-      //     final Future<LaunchResult> futureLaunchResult = iosDevice.startApp(
-      //       buildableIOSApp,
-      //       debuggingOptions: DebuggingOptions.enabled(
-      //         const BuildInfo(
-      //           BuildMode.debug,
-      //           null,
-      //           buildName: '1.2.3',
-      //           buildNumber: '4',
-      //           treeShakeIcons: false,
-      //           packageConfigPath: '.dart_tool/package_config.json',
-      //         ),
-      //       ),
-      //       platformArgs: <String, Object>{},
-      //     );
+          final Future<LaunchResult> futureLaunchResult = iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.enabled(
+              const BuildInfo(
+                BuildMode.debug,
+                null,
+                buildName: '1.2.3',
+                buildNumber: '4',
+                treeShakeIcons: false,
+                packageConfigPath: '.dart_tool/package_config.json',
+              ),
+            ),
+            platformArgs: <String, Object>{},
+          );
 
-      //     await debugStartedCompleter.future;
+          await debugStartedCompleter.future;
 
-      //     // Validate CoreDevice build settings were used
-      //     final File config = fileSystem.directory('ios').childFile('Flutter/Generated.xcconfig');
-      //     expect(config.existsSync(), isTrue);
+          // Validate CoreDevice build settings were used
+          final File config = fileSystem.directory('ios').childFile('Flutter/Generated.xcconfig');
+          expect(config.existsSync(), isTrue);
 
-      //     String contents = config.readAsStringSync();
-      //     expect(contents, contains('CONFIGURATION_BUILD_DIR=/build/ios/iphoneos'));
+          String contents = config.readAsStringSync();
+          expect(contents, contains('CONFIGURATION_BUILD_DIR=/build/ios/iphoneos'));
 
-      //     debugEndedCompleter.complete();
+          debugEndedCompleter.complete();
 
-      //     await futureLaunchResult;
+          await futureLaunchResult;
 
-      //     // Validate CoreDevice build settings were removed after launch
-      //     contents = config.readAsStringSync();
-      //     expect(contents.contains('CONFIGURATION_BUILD_DIR'), isFalse);
-      //   },
-      //   overrides: <Type, Generator>{
-      //     ProcessManager: () => FakeProcessManager.any(),
-      //     Pub: () => const ThrowingPub(),
-      //     FileSystem: () => fileSystem,
-      //     Logger: () => logger,
-      //     OperatingSystemUtils: () => os,
-      //     Platform: () => macPlatform,
-      //     XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
-      //     Xcode: () => xcode,
-      //   },
-      // );
+          // Validate CoreDevice build settings were removed after launch
+          contents = config.readAsStringSync();
+          expect(contents.contains('CONFIGURATION_BUILD_DIR'), isFalse);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => FakeProcessManager.any(),
+          Pub: () => const ThrowingPub(),
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () => os,
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+        },
+      );
 
       testUsingContext(
         'fails when Xcode project is not found',
@@ -1283,7 +1286,8 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
       'WRAPPER_NAME': 'My Super Awesome App.app',
       'DEVELOPMENT_TEAM': '3333CCCC33',
     },
-  });
+    Version? xcodeVersion,
+  }) : version = xcodeVersion ?? Version(1000, 0, 0);
 
   final Map<String, String> buildSettings;
   final XcodeProjectInfo? projectInfo;
@@ -1292,7 +1296,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   final isInstalled = true;
 
   @override
-  final version = Version(1000, 0, 0);
+  Version? version;
 
   @override
   String get versionText => version.toString();

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/template.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -24,8 +25,10 @@ import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/mdns_discovery.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -131,9 +134,11 @@ void main() {
     () async {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final processManager = FakeProcessManager.list(<FakeCommand>[attachDebuggerCommand()]);
+      final fakeAnalytics = FakeAnalytics();
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -162,6 +167,13 @@ void main() {
       expect(launchResult.started, true);
       expect(launchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), false);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -171,6 +183,7 @@ void main() {
       final logger = BufferLogger.test();
       final FileSystem fileSystem = MemoryFileSystem.test();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(stdout: 'PROCESS_EXITED'),
         attachDebuggerCommand(
@@ -183,6 +196,7 @@ void main() {
         processManager: processManager,
         fileSystem: fileSystem,
         logger: logger,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -202,7 +216,6 @@ void main() {
 
       expect(launchResult.started, false);
       expect(launchResult.hasVmService, false);
-
       final LaunchResult secondLaunchResult = await device.startApp(
         iosApp,
         prebuiltApplication: true,
@@ -214,6 +227,18 @@ void main() {
       expect(secondLaunchResult.started, true);
       expect(secondLaunchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), true);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'launch failed',
+        ),
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -222,10 +247,12 @@ void main() {
     () async {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final processManager = FakeProcessManager.list(<FakeCommand>[kLaunchDebugCommand]);
+      final fakeAnalytics = FakeAnalytics();
       final IOSDevice device = setUpIOSDevice(
         sdkVersion: '12.4.4',
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -254,6 +281,13 @@ void main() {
       expect(launchResult.started, true);
       expect(launchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), false);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -264,12 +298,14 @@ void main() {
       final logger = BufferLogger.test();
       final stdin = CompleterIOSink();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(stdin: stdin, completer: completer),
       ]);
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
         logger: logger,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
@@ -307,6 +343,13 @@ void main() {
       expect(utf8.decoder.convert(stdin.writes.first), contains('process interrupt'));
       completer.complete();
       expect(processManager, hasNoRemainingExpectations);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -317,12 +360,14 @@ void main() {
       final logger = BufferLogger.test();
       final stdin = CompleterIOSink();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(stdin: stdin, completer: completer, isWirelessDevice: true),
       ]);
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
         logger: logger,
         interfaceType: DeviceConnectionInterface.wireless,
       );
@@ -371,6 +416,13 @@ void main() {
         ),
       );
       completer.complete();
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery()},
@@ -382,6 +434,7 @@ void main() {
       final logger = BufferLogger.test();
       final FileSystem fileSystem = MemoryFileSystem.test();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(
           stdout:
@@ -399,6 +452,7 @@ void main() {
         processManager: processManager,
         fileSystem: fileSystem,
         logger: logger,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -425,6 +479,13 @@ void main() {
       expect(launchResult.started, true);
       expect(launchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), true);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -433,6 +494,7 @@ void main() {
     () async {
       final logger = BufferLogger.test();
       final FileSystem fileSystem = MemoryFileSystem.test();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(
           stdout:
@@ -442,6 +504,7 @@ void main() {
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
         logger: logger,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
@@ -464,13 +527,25 @@ void main() {
       expect(launchResult.started, false);
       expect(launchResult.hasVmService, false);
       expect(await device.stopApp(iosApp), false);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging failed',
+        ),
+      ]);
     },
   );
 
   testWithoutContext('IOSDevice.startApp succeeds in release mode', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final processManager = FakeProcessManager.list(<FakeCommand>[kLaunchReleaseCommand]);
-    final IOSDevice device = setUpIOSDevice(processManager: processManager, fileSystem: fileSystem);
+    final fakeAnalytics = FakeAnalytics();
+    final IOSDevice device = setUpIOSDevice(
+      processManager: processManager,
+      fileSystem: fileSystem,
+      analytics: fakeAnalytics,
+    );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
       bundleName: 'Runner',
@@ -489,10 +564,18 @@ void main() {
     expect(launchResult.hasVmService, false);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+        result: 'release success',
+      ),
+    ]);
   });
 
   testWithoutContext('IOSDevice.startApp forwards all supported debugging options', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    final fakeAnalytics = FakeAnalytics();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -546,6 +629,7 @@ void main() {
       sdkVersion: '13.3',
       processManager: processManager,
       fileSystem: fileSystem,
+      analytics: fakeAnalytics,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -594,10 +678,18 @@ void main() {
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+        result: 'debugging success',
+      ),
+    ]);
   });
 
   testWithoutContext('startApp using route', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    final fakeAnalytics = FakeAnalytics();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -633,6 +725,7 @@ void main() {
       sdkVersion: '13.3',
       processManager: processManager,
       fileSystem: fileSystem,
+      analytics: fakeAnalytics,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -661,10 +754,18 @@ void main() {
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+        result: 'debugging success',
+      ),
+    ]);
   });
 
   testWithoutContext('startApp using trace-startup', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    final fakeAnalytics = FakeAnalytics();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -700,6 +801,7 @@ void main() {
       sdkVersion: '13.3',
       processManager: processManager,
       fileSystem: fileSystem,
+      analytics: fakeAnalytics,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -727,33 +829,85 @@ void main() {
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+        result: 'debugging success',
+      ),
+    ]);
   });
 
   group('IOSDevice.startApp for CoreDevice', () {
     group('in debug mode', () {
-      testUsingContext('succeeds', () async {
+      testUsingContext(
+        'uses LLDB with Xcode 16+',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final deviceLogReader = FakeDeviceLogReader();
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(fakeLauncher.launchedWithLLDB, true);
+          expect(fakeLauncher.launchedWithXcode, false);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithLLDB.name,
+              result: 'debugging success',
+            ),
+          ]);
+        },
+        overrides: {
+          Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0)),
+          Analytics: () => FakeAnalytics(),
+        },
+      );
+
+      testUsingContext('uses Xcode if LLDB fails', () async {
         final FileSystem fileSystem = MemoryFileSystem.test();
         final processManager = FakeProcessManager.empty();
-
-        final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-            .childDirectory('flutter_empty_xcode.rand0');
         final Directory bundleLocation = fileSystem.currentDirectory;
+        final fakeAnalytics = FakeAnalytics();
+        final fakeLauncher = FakeIOSCoreDeviceLauncher(lldbLaunchResult: false);
         final IOSDevice device = setUpIOSDevice(
           processManager: processManager,
           fileSystem: fileSystem,
           isCoreDevice: true,
-          coreDeviceControl: FakeIOSCoreDeviceControl(),
-          xcodeDebug: FakeXcodeDebug(
-            expectedProject: XcodeDebugProject(
-              scheme: 'Runner',
-              xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-              xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-              hostAppProjectName: 'Runner',
-            ),
-            expectedDeviceId: '123',
-            expectedLaunchArguments: <String>['--enable-dart-profiling'],
-            expectedBundlePath: bundleLocation.path,
-          ),
+          coreDeviceLauncher: fakeLauncher,
+          analytics: fakeAnalytics,
         );
         final IOSApp iosApp = PrebuiltIOSApp(
           projectBundleId: 'app',
@@ -780,152 +934,196 @@ void main() {
         );
 
         expect(launchResult.started, true);
-      });
-
-      testUsingContext('prints warning message if it takes too long to start debugging', () async {
-        final FileSystem fileSystem = MemoryFileSystem.test();
-        final processManager = FakeProcessManager.empty();
-        final logger = BufferLogger.test();
-        final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-            .childDirectory('flutter_empty_xcode.rand0');
-        final Directory bundleLocation = fileSystem.currentDirectory;
-        final completer = Completer<void>();
-        final xcodeDebug = FakeXcodeDebug(
-          expectedProject: XcodeDebugProject(
-            scheme: 'Runner',
-            xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-            xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-            hostAppProjectName: 'Runner',
+        expect(fakeLauncher.launchedWithLLDB, true);
+        expect(fakeLauncher.launchedWithXcode, true);
+        expect(fakeAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithLLDB.name,
+            result: 'launch failed',
           ),
-          expectedDeviceId: '123',
-          expectedLaunchArguments: <String>['--enable-dart-profiling'],
-          expectedBundlePath: bundleLocation.path,
-          completer: completer,
-        );
-        final IOSDevice device = setUpIOSDevice(
-          processManager: processManager,
-          fileSystem: fileSystem,
-          logger: logger,
-          isCoreDevice: true,
-          coreDeviceControl: FakeIOSCoreDeviceControl(),
-          xcodeDebug: xcodeDebug,
-        );
-        final IOSApp iosApp = PrebuiltIOSApp(
-          projectBundleId: 'app',
-          bundleName: 'Runner',
-          uncompressedBundle: bundleLocation,
-          applicationPackage: bundleLocation,
-        );
-        final deviceLogReader = FakeDeviceLogReader();
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+            result: 'debugging success',
+          ),
+        ]);
+      }, overrides: {Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0))});
 
-        device.portForwarder = const NoOpDevicePortForwarder();
-        device.setLogReader(iosApp, deviceLogReader);
+      testUsingContext(
+        'uses Xcode if less than Xcode 16',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher(lldbLaunchResult: false);
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final deviceLogReader = FakeDeviceLogReader();
 
-        // Start writing messages to the log reader.
-        Timer.run(() {
-          deviceLogReader.addLine('Foo');
-          deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
-        });
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
 
-        FakeAsync().run((FakeAsync fakeAsync) {
-          device.startApp(
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          final LaunchResult launchResult = await device.startApp(
             iosApp,
             prebuiltApplication: true,
             debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
             platformArgs: <String, dynamic>{},
           );
 
-          fakeAsync.flushTimers();
-          expect(
-            logger.errorText,
-            contains(
-              'Xcode is taking longer than expected to start debugging the app. Ensure the project is opened in Xcode.',
+          expect(launchResult.started, true);
+          expect(fakeLauncher.launchedWithLLDB, false);
+          expect(fakeLauncher.launchedWithXcode, true);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
             ),
+          ]);
+        },
+        overrides: {Xcode: () => FakeXcode(currentVersion: Version(15, 0, 0))},
+      );
+
+      testUsingContext(
+        'using Xcode prints warning message if it takes too long to start debugging',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          final logger = BufferLogger.test();
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final xcodeDebugCompleter = Completer<void>();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher(lldbLaunchResult: false);
+          fakeLauncher.xcodeCompleter = xcodeDebugCompleter;
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            logger: logger,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
           );
-          completer.complete();
-        });
-      });
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final deviceLogReader = FakeDeviceLogReader();
 
-      testUsingContext('succeeds with shutdown hook added when running from CI', () async {
-        final FileSystem fileSystem = MemoryFileSystem.test();
-        final processManager = FakeProcessManager.empty();
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
 
-        final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-            .childDirectory('flutter_empty_xcode.rand0');
-        final Directory bundleLocation = fileSystem.currentDirectory;
-        final IOSDevice device = setUpIOSDevice(
-          processManager: processManager,
-          fileSystem: fileSystem,
-          isCoreDevice: true,
-          coreDeviceControl: FakeIOSCoreDeviceControl(),
-          xcodeDebug: FakeXcodeDebug(
-            expectedProject: XcodeDebugProject(
-              scheme: 'Runner',
-              xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-              xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-              hostAppProjectName: 'Runner',
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          FakeAsync().run((FakeAsync fakeAsync) {
+            device.startApp(
+              iosApp,
+              prebuiltApplication: true,
+              debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+              platformArgs: <String, dynamic>{},
+            );
+
+            fakeAsync.flushTimers();
+            expect(
+              logger.errorText,
+              contains(
+                'Xcode is taking longer than expected to start debugging the app. If the issue persists, try closing Xcode and re-running your Flutter command.',
+              ),
+            );
+            xcodeDebugCompleter.complete();
+          });
+        },
+        overrides: {Xcode: () => FakeXcode(currentVersion: Version(15, 0, 0))},
+      );
+
+      testUsingContext(
+        'using Xcode succeeds with shutdown hook added when running from CI',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            analytics: fakeAnalytics,
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final deviceLogReader = FakeDeviceLogReader();
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          final shutDownHooks = FakeShutDownHooks();
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, usingCISystem: true),
+            platformArgs: <String, dynamic>{},
+            shutdownHooks: shutDownHooks,
+          );
+
+          expect(launchResult.started, true);
+          expect(shutDownHooks.hooks.length, 1);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
             ),
-            expectedDeviceId: '123',
-            expectedLaunchArguments: <String>['--enable-dart-profiling'],
-            expectedBundlePath: bundleLocation.path,
-          ),
-        );
-        final IOSApp iosApp = PrebuiltIOSApp(
-          projectBundleId: 'app',
-          bundleName: 'Runner',
-          uncompressedBundle: bundleLocation,
-          applicationPackage: bundleLocation,
-        );
-        final deviceLogReader = FakeDeviceLogReader();
-
-        device.portForwarder = const NoOpDevicePortForwarder();
-        device.setLogReader(iosApp, deviceLogReader);
-
-        // Start writing messages to the log reader.
-        Timer.run(() {
-          deviceLogReader.addLine('Foo');
-          deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
-        });
-
-        final shutDownHooks = FakeShutDownHooks();
-
-        final LaunchResult launchResult = await device.startApp(
-          iosApp,
-          prebuiltApplication: true,
-          debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug, usingCISystem: true),
-          platformArgs: <String, dynamic>{},
-          shutdownHooks: shutDownHooks,
-        );
-
-        expect(launchResult.started, true);
-        expect(shutDownHooks.hooks.length, 1);
-      });
+          ]);
+        },
+      );
 
       testUsingContext(
         'IOSDevice.startApp attaches in debug mode via mDNS when device logging fails',
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
-
-          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-              .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
           final IOSDevice device = setUpIOSDevice(
             processManager: processManager,
             fileSystem: fileSystem,
             isCoreDevice: true,
-            coreDeviceControl: FakeIOSCoreDeviceControl(),
-            xcodeDebug: FakeXcodeDebug(
-              expectedProject: XcodeDebugProject(
-                scheme: 'Runner',
-                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-                hostAppProjectName: 'Runner',
-              ),
-              expectedDeviceId: '123',
-              expectedLaunchArguments: <String>['--enable-dart-profiling'],
-              expectedBundlePath: bundleLocation.path,
-            ),
+            analytics: fakeAnalytics,
           );
           final IOSApp iosApp = PrebuiltIOSApp(
             projectBundleId: 'app',
@@ -947,7 +1145,13 @@ void main() {
 
           expect(launchResult.started, true);
           expect(launchResult.hasVmService, true);
-          expect(await device.stopApp(iosApp), true);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
+            ),
+          ]);
         },
         // If mDNS is not the only method of discovery, it shouldn't throw on error.
         overrides: <Type, Generator>{
@@ -965,26 +1169,13 @@ void main() {
         testUsingContext('when mDNS fails', () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
-
-          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-              .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
           final IOSDevice device = setUpIOSDevice(
             processManager: processManager,
             fileSystem: fileSystem,
             isCoreDevice: true,
-            coreDeviceControl: FakeIOSCoreDeviceControl(),
-            xcodeDebug: FakeXcodeDebug(
-              expectedProject: XcodeDebugProject(
-                scheme: 'Runner',
-                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-                hostAppProjectName: 'Runner',
-              ),
-              expectedDeviceId: '123',
-              expectedLaunchArguments: <String>['--enable-dart-profiling'],
-              expectedBundlePath: bundleLocation.path,
-            ),
+            analytics: fakeAnalytics,
           );
           final IOSApp iosApp = PrebuiltIOSApp(
             projectBundleId: 'app',
@@ -1016,7 +1207,13 @@ void main() {
 
           expect(launchResult.started, true);
           expect(launchResult.hasVmService, true);
-          expect(await device.stopApp(iosApp), true);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
+            ),
+          ]);
         }, overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => mdnsDiscovery});
       });
 
@@ -1028,30 +1225,17 @@ void main() {
 
           const pathToFlutterLogs = '/path/to/flutter/logs';
           const pathToHome = '/path/to/home';
-
-          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-              .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
           final IOSDevice device = setUpIOSDevice(
             processManager: processManager,
             fileSystem: fileSystem,
             isCoreDevice: true,
-            coreDeviceControl: FakeIOSCoreDeviceControl(),
-            xcodeDebug: FakeXcodeDebug(
-              expectedProject: XcodeDebugProject(
-                scheme: 'Runner',
-                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-                hostAppProjectName: 'Runner',
-              ),
-              expectedDeviceId: '123',
-              expectedLaunchArguments: <String>['--enable-dart-profiling'],
-              expectedBundlePath: bundleLocation.path,
-            ),
             platform: FakePlatform(
               operatingSystem: 'macos',
               environment: <String, String>{'HOME': pathToHome},
             ),
+            analytics: fakeAnalytics,
           );
 
           final IOSApp iosApp = PrebuiltIOSApp(
@@ -1091,6 +1275,13 @@ void main() {
                     .existsSync(),
                 true,
               );
+              expect(fakeAnalytics.sentEvents, [
+                Event.appleUsageEvent(
+                  workflow: 'ios-physical-deployment',
+                  parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+                  result: 'debugging failed',
+                ),
+              ]);
               completer.complete();
             });
             time.elapse(const Duration(minutes: 15));
@@ -1108,27 +1299,12 @@ void main() {
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
-
-          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
-              .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
           final IOSDevice device = setUpIOSDevice(
             sdkVersion: '18.4',
             processManager: processManager,
             fileSystem: fileSystem,
             isCoreDevice: true,
-            coreDeviceControl: FakeIOSCoreDeviceControl(),
-            xcodeDebug: FakeXcodeDebug(
-              expectedProject: XcodeDebugProject(
-                scheme: 'Runner',
-                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
-                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
-                hostAppProjectName: 'Runner',
-              ),
-              expectedDeviceId: '123',
-              expectedLaunchArguments: <String>['--enable-dart-profiling'],
-              expectedBundlePath: bundleLocation.path,
-            ),
           );
           final IOSApp iosApp = PrebuiltIOSApp(
             projectBundleId: 'app',
@@ -1184,6 +1360,8 @@ IOSDevice setUpIOSDevice({
   DeviceConnectionInterface interfaceType = DeviceConnectionInterface.attached,
   bool isCoreDevice = false,
   IOSCoreDeviceControl? coreDeviceControl,
+  IOSCoreDeviceLauncher? coreDeviceLauncher,
+  Analytics? analytics,
   FakeXcodeDebug? xcodeDebug,
   FakePlatform? platform,
 }) {
@@ -1214,6 +1392,7 @@ IOSDevice setUpIOSDevice({
           artifacts: artifacts,
           cache: cache,
         ),
+    analytics: analytics ?? FakeAnalytics(),
     iMobileDevice: IMobileDevice(
       logger: logger,
       processManager: processManager ?? FakeProcessManager.any(),
@@ -1221,7 +1400,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     coreDeviceControl: coreDeviceControl ?? FakeIOSCoreDeviceControl(),
-    coreDeviceLauncher: FakeIOSCoreDeviceLauncher(),
+    coreDeviceLauncher: coreDeviceLauncher ?? FakeIOSCoreDeviceLauncher(),
     xcodeDebug: xcodeDebug ?? FakeXcodeDebug(),
     cpuArchitecture: DarwinArch.arm64,
     connectionInterface: interfaceType,
@@ -1275,64 +1454,6 @@ class FakeMDnsVmServiceDiscovery extends Fake implements MDnsVmServiceDiscovery 
 }
 
 class FakeXcodeDebug extends Fake implements XcodeDebug {
-  FakeXcodeDebug({
-    this.debugSuccess = true,
-    this.expectedProject,
-    this.expectedDeviceId,
-    this.expectedLaunchArguments,
-    this.expectedBundlePath,
-    this.completer,
-  });
-
-  final bool debugSuccess;
-  final XcodeDebugProject? expectedProject;
-  final String? expectedDeviceId;
-  final List<String>? expectedLaunchArguments;
-  final String? expectedBundlePath;
-  final Completer<void>? completer;
-
-  @override
-  var debugStarted = false;
-
-  @override
-  Future<XcodeDebugProject> createXcodeProjectWithCustomBundle(
-    String deviceBundlePath, {
-    required TemplateRenderer templateRenderer,
-    Directory? projectDestination,
-    bool verboseLogging = false,
-  }) async {
-    if (expectedBundlePath != null) {
-      expect(expectedBundlePath, deviceBundlePath);
-    }
-    return expectedProject!;
-  }
-
-  @override
-  Future<bool> debugApp({
-    required XcodeDebugProject project,
-    required String deviceId,
-    required List<String> launchArguments,
-  }) async {
-    if (expectedProject != null) {
-      expect(project.scheme, expectedProject!.scheme);
-      expect(project.xcodeWorkspace.path, expectedProject!.xcodeWorkspace.path);
-      expect(project.xcodeProject.path, expectedProject!.xcodeProject.path);
-      expect(project.isTemporaryProject, expectedProject!.isTemporaryProject);
-    }
-    if (expectedDeviceId != null) {
-      expect(deviceId, expectedDeviceId);
-    }
-    if (expectedLaunchArguments != null) {
-      expect(expectedLaunchArguments, launchArguments);
-    }
-    debugStarted = debugSuccess;
-
-    if (completer != null) {
-      await completer!.future;
-    }
-    return debugSuccess;
-  }
-
   @override
   Future<bool> exit({bool force = false, bool skipDelay = false}) async {
     return true;
@@ -1349,4 +1470,61 @@ class FakeShutDownHooks extends Fake implements ShutdownHooks {
   }
 }
 
-class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+class FakeXcode extends Fake implements Xcode {
+  FakeXcode({this.currentVersion});
+
+  @override
+  Version? currentVersion;
+}
+
+class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
+  FakeIOSCoreDeviceLauncher({this.lldbLaunchResult = true, this.xcodeLaunchResult = true});
+  bool lldbLaunchResult;
+  bool xcodeLaunchResult;
+  var launchedWithLLDB = false;
+  var launchedWithXcode = false;
+
+  Completer<void>? xcodeCompleter;
+
+  @override
+  Future<bool> launchAppWithLLDBDebugger({
+    required String deviceId,
+    required String bundlePath,
+    required String bundleId,
+    required List<String> launchArguments,
+  }) async {
+    launchedWithLLDB = true;
+    return lldbLaunchResult;
+  }
+
+  @override
+  Future<bool> launchAppWithXcodeDebugger({
+    required String deviceId,
+    required DebuggingOptions debuggingOptions,
+    required IOSApp package,
+    required List<String> launchArguments,
+    required TemplateRenderer templateRenderer,
+    String? mainPath,
+    Duration? discoveryTimeout,
+  }) async {
+    if (xcodeCompleter != null) {
+      await xcodeCompleter!.future;
+    }
+    launchedWithXcode = true;
+    return xcodeLaunchResult;
+  }
+
+  @override
+  Future<bool> stopApp({required String deviceId, int? processId}) async {
+    return false;
+  }
+}
+
+class FakeAnalytics extends Fake implements Analytics {
+  final sentEvents = <Event>[];
+
+  @override
+  void send(Event event) {
+    sentEvents.add(event);
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -958,7 +958,7 @@ void main() {
           ),
           Event.appleUsageEvent(
             workflow: 'ios-physical-deployment',
-            parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+            parameter: IOSDeploymentMethod.coreDeviceWithXcodeFallback.name,
             result: 'debugging success',
           ),
         ]);

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -842,7 +842,7 @@ void main() {
   group('IOSDevice.startApp for CoreDevice', () {
     group('in debug mode', () {
       testUsingContext(
-        'uses LLDB with Xcode 16+',
+        'uses LLDB with Xcode 26+',
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
@@ -892,7 +892,7 @@ void main() {
           ]);
         },
         overrides: {
-          Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0)),
+          Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0)),
           Analytics: () => FakeAnalytics(),
         },
       );
@@ -962,10 +962,10 @@ void main() {
             result: 'debugging success',
           ),
         ]);
-      }, overrides: {Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0))});
+      }, overrides: {Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0))});
 
       testUsingContext(
-        'uses Xcode if less than Xcode 16',
+        'uses Xcode if less than Xcode 26',
         () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
@@ -1027,7 +1027,7 @@ void main() {
             ),
           ]);
         },
-        overrides: {Xcode: () => FakeXcode(currentVersion: Version(15, 0, 0))},
+        overrides: {Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0))},
       );
 
       testUsingContext('succeeds', () async {

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(lldb.isRunning, isFalse);
     expect(lldb.appProcessId, isNull);
     expect(processManager.hasRemainingExpectations, isFalse);
-    expect(logger.errorText, contains('Process exception running lldb'));
+    expect(logger.traceText, contains('Process exception running lldb'));
   });
 
   testWithoutContext('attachAndStart returns true on success', () async {
@@ -174,7 +174,7 @@ Target 0: (Runner) stopped.
     expect(lldb.appProcessId, isNull);
     expect(expectedInputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
-    expect(logger.errorText, contains(errorText));
+    expect(logger.traceText, contains(errorText));
   });
 
   testWithoutContext('attachAndStart returns false when stderr not during log waiter', () async {
@@ -220,7 +220,7 @@ Target 0: (Runner) stopped.
     expect(lldb.appProcessId, isNull);
     expect(expectedInputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
-    expect(logger.errorText, contains(errorText));
+    expect(logger.traceText, contains(errorText));
   });
 
   testWithoutContext('attachAndStart prints warning if takes too long', () async {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -503,6 +503,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isSwiftPackageManagerEnabled = false,
     this.isOmitLegacyVersionFileEnabled = false,
     this.isWindowingEnabled = false,
+    this.isLLDBDebuggingEnabled = false,
   });
 
   @override
@@ -545,6 +546,9 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isWindowingEnabled;
 
   @override
+  final bool isLLDBDebuggingEnabled;
+
+  @override
   bool isEnabled(Feature feature) {
     return switch (feature) {
       flutterWebFeature => isWebEnabled,
@@ -557,8 +561,10 @@ class TestFeatureFlags implements FeatureFlags {
       flutterCustomDevicesFeature => areCustomDevicesEnabled,
       cliAnimation => isCliAnimationEnabled,
       nativeAssets => isNativeAssetsEnabled,
+      swiftPackageManager => isSwiftPackageManagerEnabled,
       omitLegacyVersionFile => isOmitLegacyVersionFileEnabled,
       windowingFeature => isWindowingEnabled,
+      lldbDebugging => isLLDBDebuggingEnabled,
       _ => false,
     };
   }
@@ -578,6 +584,7 @@ class TestFeatureFlags implements FeatureFlags {
     swiftPackageManager,
     omitLegacyVersionFile,
     windowingFeature,
+    lldbDebugging,
   ];
 
   @override


### PR DESCRIPTION
This PR introduces a new feature flag called `lldb-debugging`, which is turned on by default. When this feature is turned on, if deploying to a physical iOS 17+ device with Xcode 26+, it will use a mixture of `devicectl` and `lldb` to install, launch, and debug the app.

If LLDB fails, it will fallback to use Xcode automation. If LLDB times out, it will warn the user they may want to disable it. If LLDB is disabled, it will use Xcode automation.

This PR also adds analytics to track what deployment method is used and if it's successful.

Part 2 and 3 of https://github.com/flutter/flutter/issues/173416.

Fixes https://github.com/flutter/flutter/issues/144218. Fixes https://github.com/flutter/flutter/issues/133465.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
