### PR TITLE
Remove jetifier usages from framework and engine

### DIFF
--- a/dev/benchmarks/multiple_flutters/android/gradle.properties
+++ b/dev/benchmarks/multiple_flutters/android/gradle.properties
@@ -15,7 +15,5 @@ org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official

--- a/dev/integration_tests/deferred_components_test/android/gradle.properties
+++ b/dev/integration_tests/deferred_components_test/android/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
 android.enableR8=true
 android.experimental.enableNewResourceShrinker=true

--- a/dev/integration_tests/pure_android_host_apps/android_custom_host_app/gradle.properties
+++ b/dev/integration_tests/pure_android_host_apps/android_custom_host_app/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
 flutter.hostAppProjectName=SampleApp

--- a/dev/integration_tests/release_smoke_test/android/gradle.properties
+++ b/dev/integration_tests/release_smoke_test/android/gradle.properties
@@ -1,5 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/engine/src/flutter/shell/platform/android/gradle.properties
+++ b/engine/src/flutter/shell/platform/android/gradle.properties
@@ -2,4 +2,3 @@
 #
 # See ./README.md for details.
 android.useAndroidX=true
-android.enableJetifier=true

--- a/examples/layers/android/gradle.properties
+++ b/examples/layers/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
@@ -98,7 +98,6 @@ void main() {
     gradleProperties.writeAsStringSync('''
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
 android.enableR8=true''');
 
     // Run flutter build apk using AGP 3.3.0

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_project.dart
@@ -226,7 +226,6 @@ flutter.versionCode=22
   String get androidGradleProperties => '''
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
-android.enableJetifier=true
 ''';
 
   @override

--- a/packages/integration_test/example/android/gradle.properties
+++ b/packages/integration_test/example/android/gradle.properties
@@ -1,7 +1,6 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 
 android.useAndroidX=true
-android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false


### PR DESCRIPTION
Justification this is safe: 
useAndroidX which I left in this pr was added in 2018 and is one of 2 flags that control what compile behavior is used as android migrated from the support library to androidx. 
We (flutter android) believe we have migrated all support library usages to android x. 
Android Studio does not automatically insert the Jetifier flag in newly created projects, suggesting a move towards less reliance on it.

I think even if plugins were using the support libraries this pr would not break them because the targets being modified are tests in this repo and the engine build which only uses androidx dependencies. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

