### PR TITLE
add `--variance host_debug_unopt_arm64` for apple chip simulator

### DIFF
--- a/engine/src/flutter/docs/testing/Testing-the-engine.md
+++ b/engine/src/flutter/docs/testing/Testing-the-engine.md
@@ -186,7 +186,7 @@ testing/run_tests.py --type=objc
 
 to easily build and run the XCTests.
 
-- Add the `--variant host_debug_unopt_arm64` argument when using an arm64 Mac targeting either simulators or devices.
+- Add the `--variant host_debug_unopt_arm64` argument when using an arm64 Mac targeting either simulators or physical devices.
 - Add the `--ios-variant ios_debug_sim_unopt_arm64` argument when using an arm64 Mac simulator (built with `--simulator-cpu=arm64`).
 
 This script only has a limited amount of smartness. If you've never built the engine before, it'll build the test and classes under test with a reasonable default configuration. If you've built the engine before, it'll re-build the engine with the same GN flags. You may want to double check your GN flags ([See compiling for ios from macos](../contributing/Compiling-the-engine.md#compiling-for-ios-from-macos)) if you haven't built the engine for a while.

--- a/engine/src/flutter/docs/testing/Testing-the-engine.md
+++ b/engine/src/flutter/docs/testing/Testing-the-engine.md
@@ -31,7 +31,7 @@ from the `flutter` directory, after building the engine variant to test
 an Apple Silicon Mac), run:
 
 ```sh
-testing/run_tests.py --type=engine --variant=host_debug_unopt_arm64 
+testing/run_tests.py --type=engine --variant=host_debug_unopt_arm64
 ```
 
 Behind the scenes, those tests in the same directory are built together as a

--- a/engine/src/flutter/docs/testing/Testing-the-engine.md
+++ b/engine/src/flutter/docs/testing/Testing-the-engine.md
@@ -186,7 +186,7 @@ testing/run_tests.py --type=objc
 
 to easily build and run the XCTests.
 
-- Add the `--variant host_debug_unopt_arm64` argument when using an arm64 Mac targeting either simulators or devices. 
+- Add the `--variant host_debug_unopt_arm64` argument when using an arm64 Mac targeting either simulators or devices.
 - Add the `--ios-variant ios_debug_sim_unopt_arm64` argument when using an arm64 Mac simulator (built with `--simulator-cpu=arm64`).
 
 This script only has a limited amount of smartness. If you've never built the engine before, it'll build the test and classes under test with a reasonable default configuration. If you've built the engine before, it'll re-build the engine with the same GN flags. You may want to double check your GN flags ([See compiling for ios from macos](../contributing/Compiling-the-engine.md#compiling-for-ios-from-macos)) if you haven't built the engine for a while.

--- a/engine/src/flutter/docs/testing/Testing-the-engine.md
+++ b/engine/src/flutter/docs/testing/Testing-the-engine.md
@@ -31,7 +31,7 @@ from the `flutter` directory, after building the engine variant to test
 an Apple Silicon Mac), run:
 
 ```sh
-testing/run_tests.py --type=engine --variant=host_debug_unopt_arm64
+testing/run_tests.py --type=engine --variant=host_debug_unopt_arm64 
 ```
 
 Behind the scenes, those tests in the same directory are built together as a
@@ -186,6 +186,7 @@ testing/run_tests.py --type=objc
 
 to easily build and run the XCTests.
 
+- Add the `--variant host_debug_unopt_arm64` argument when using an arm64 Mac targeting either simulators or devices. 
 - Add the `--ios-variant ios_debug_sim_unopt_arm64` argument when using an arm64 Mac simulator (built with `--simulator-cpu=arm64`).
 
 This script only has a limited amount of smartness. If you've never built the engine before, it'll build the test and classes under test with a reasonable default configuration. If you've built the engine before, it'll re-build the engine with the same GN flags. You may want to double check your GN flags ([See compiling for ios from macos](../contributing/Compiling-the-engine.md#compiling-for-ios-from-macos)) if you haven't built the engine for a while.


### PR DESCRIPTION
For run_tests.py, the host default is `host_debug_unopt`, but when running tests on apple chip simulator, we should set it to `host_debug_unopt_arm64`

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
