### PR TITLE
168625 make handle alignment for material design pixel perfect

### DIFF
--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -63,6 +63,7 @@ class CupertinoDesktopTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     return const SizedBox.shrink();

--- a/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/desktop_text_selection.dart
@@ -71,7 +71,11 @@ class CupertinoDesktopTextSelectionControls extends TextSelectionControls {
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return Offset.zero;
   }
 

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -156,7 +156,11 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     final Size handleSize = getHandleSize(textLineHeight);
 
     switch (type) {

--- a/packages/flutter/lib/src/cupertino/text_selection.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection.dart
@@ -114,6 +114,7 @@ class CupertinoTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     // iOS selection handles do not respond to taps.

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -64,6 +64,7 @@ class DesktopTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     return const SizedBox.shrink();

--- a/packages/flutter/lib/src/material/desktop_text_selection.dart
+++ b/packages/flutter/lib/src/material/desktop_text_selection.dart
@@ -72,7 +72,11 @@ class DesktopTextSelectionControls extends TextSelectionControls {
 
   /// Gets the position for the text selection handles, but desktop has none.
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return Offset.zero;
   }
 

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -111,7 +111,11 @@ class MaterialTextSelectionControls extends TextSelectionControls {
   ///
   /// See [TextSelectionControls.getHandleAnchor].
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return switch (type) {
       TextSelectionHandleType.collapsed => const Offset(_kHandleSize / 2, -4),
       TextSelectionHandleType.left => const Offset(_kHandleSize, 0),

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -15,6 +15,7 @@ import 'text_selection_toolbar_text_button.dart';
 import 'theme.dart';
 
 const double _kHandleSize = 22.0;
+const double _kDefaultCursorWidth = 2.0;
 
 // Padding between the toolbar and the anchor.
 const double _kToolbarContentDistanceBelow = _kHandleSize - 2.0;
@@ -91,8 +92,8 @@ class MaterialTextSelectionControls extends TextSelectionControls {
       ),
     );
 
-    // [handle] is a circle, with a rectangle in the top left quadrant of that
-    // circle (an onion pointing to 10:30). We rotate [handle] to point
+    // [handle] is a circle, with a square in the top left quadrant of that
+    // circle (an onion pointing to Northwest). We rotate [handle] to point
     // straight up or up-right depending on the handle type.
     return switch (type) {
       TextSelectionHandleType.left => Transform.rotate(
@@ -100,11 +101,20 @@ class MaterialTextSelectionControls extends TextSelectionControls {
         child: handle,
       ), // points up-right
       TextSelectionHandleType.right => handle, // points up-left
-      TextSelectionHandleType.collapsed => Transform.rotate(
-        angle: math.pi / 4.0,
-        child: handle,
+      TextSelectionHandleType.collapsed => Transform.translate(
+        offset: Offset((cursorWidth ?? _kDefaultCursorWidth) / 2, _getVerticalOffset()),
+        child: Transform.rotate(angle: math.pi / 4.0, child: handle),
       ), // points up
     };
+  }
+
+  /// When the handle is [TextSelectionHandleType.collapsed], it is rotated by
+  /// 45 degrees (π/4 radians). This rotation causes its vertex to protrude
+  /// beyond the handle's circular radius.
+  /// This protrusion length is calculated using the Pythagorean theorem.
+  double _getVerticalOffset() {
+    const double radius = _kHandleSize / 2;
+    return radius * (math.sqrt(2) - 1);
   }
 
   /// Gets anchor for material-style text selection handles.
@@ -117,7 +127,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
     bool isEditText = true,
   }) {
     return switch (type) {
-      TextSelectionHandleType.collapsed => const Offset(_kHandleSize / 2, -4),
+      TextSelectionHandleType.collapsed => Offset(_kHandleSize / 2, isEditText ? -4 : 0),
       TextSelectionHandleType.left => const Offset(_kHandleSize, 0),
       TextSelectionHandleType.right => Offset.zero,
     };

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -76,6 +76,7 @@ class MaterialTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     final ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2082,6 +2082,7 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay>
     final Offset handleAnchor = widget.selectionControls.getHandleAnchor(
       widget.type,
       widget.preferredLineHeight,
+      isEditText: false,
     );
 
     // Make sure a drag is eagerly accepted. This is used on iOS to match the

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -107,6 +107,7 @@ abstract class TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]);
 
@@ -299,6 +300,7 @@ class EmptyTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     return const SizedBox.shrink();
@@ -546,6 +548,7 @@ class TextSelectionOverlay {
         TextSelectionHandleType.left,
         TextSelectionHandleType.right,
       )
+      ..cursorWidth = renderObject.cursorWidth
       ..lineHeightAtStart = _getStartGlyphHeight()
       ..endHandleType = _chooseType(
         renderObject.textDirection,
@@ -1330,6 +1333,12 @@ class SelectionOverlay {
     markNeedsBuild();
   }
 
+  /// The width of the cursor.
+  ///
+  /// This value is used by [TextSelectionControls.buildHandle] for calculating
+  /// the handle offset when handle type is [TextSelectionTypeHandle.collapsed].
+  double cursorWidth = 2.0;
+
   /// The line height at the selection end.
   ///
   /// This value is used for calculating the size of the end selection handle.
@@ -1767,6 +1776,7 @@ class SelectionOverlay {
       handle = _SelectionHandleOverlay(
         type: _startHandleType,
         handleLayerLink: startHandleLayerLink,
+        cursorWidth: cursorWidth,
         onSelectionHandleTapped: onSelectionHandleTapped,
         onSelectionHandleDragStart: _handleStartHandleDragStart,
         onSelectionHandleDragUpdate: _handleStartHandleDragUpdate,
@@ -1795,6 +1805,7 @@ class SelectionOverlay {
       handle = _SelectionHandleOverlay(
         type: _endHandleType,
         handleLayerLink: endHandleLayerLink,
+        cursorWidth: cursorWidth,
         onSelectionHandleTapped: onSelectionHandleTapped,
         onSelectionHandleDragStart: _handleEndHandleDragStart,
         onSelectionHandleDragUpdate: _handleEndHandleDragUpdate,
@@ -1969,6 +1980,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
   const _SelectionHandleOverlay({
     required this.type,
     required this.handleLayerLink,
+    required this.cursorWidth,
     this.onSelectionHandleTapped,
     this.onSelectionHandleDragStart,
     this.onSelectionHandleDragUpdate,
@@ -1980,6 +1992,7 @@ class _SelectionHandleOverlay extends StatefulWidget {
   });
 
   final LayerLink handleLayerLink;
+  final double cursorWidth;
   final VoidCallback? onSelectionHandleTapped;
   final ValueChanged<DragStartDetails>? onSelectionHandleDragStart;
   final ValueChanged<DragUpdateDetails>? onSelectionHandleDragUpdate;
@@ -2118,6 +2131,7 @@ class _SelectionHandleOverlayState extends State<_SelectionHandleOverlay>
                   context,
                   widget.type,
                   widget.preferredLineHeight,
+                  widget.cursorWidth,
                   widget.onSelectionHandleTapped,
                 ),
               ),

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1344,7 +1344,7 @@ class SelectionOverlay {
   /// The width of the cursor.
   ///
   /// This value is used by [TextSelectionControls.buildHandle] for calculating
-  /// the handle offset when handle type is [TextSelectionTypeHandle.collapsed].
+  /// the handle offset when handle type is [TextSelectionHandleType.collapsed].
   double cursorWidth = 2.0;
 
   /// The line height at the selection end.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -114,7 +114,11 @@ abstract class TextSelectionControls {
   /// Get the anchor point of the handle relative to itself. The anchor point is
   /// the point that is aligned with a specific point in the text. A handle
   /// often visually "points to" that location.
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight);
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  });
 
   /// Builds a toolbar near a text selection.
   ///
@@ -307,7 +311,11 @@ class EmptyTextSelectionControls extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return Offset.zero;
   }
 }

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -36,6 +36,7 @@ class MockTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     throw UnimplementedError();

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -57,7 +57,11 @@ class MockTextSelectionControls extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17676,6 +17676,7 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     return const SizedBox();
@@ -17781,6 +17782,7 @@ class _CustomTextSelectionControls extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     return Container();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -17688,7 +17688,11 @@ class MockTextSelectionControls extends Fake implements TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return Offset.zero;
   }
 
@@ -17794,7 +17798,11 @@ class _CustomTextSelectionControls extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return Offset.zero;
   }
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -2131,7 +2131,11 @@ class TextSelectionControlsSpy extends TextSelectionControls {
   }
 
   @override
-  Offset getHandleAnchor(TextSelectionHandleType type, double textLineHeight) {
+  Offset getHandleAnchor(
+    TextSelectionHandleType type,
+    double textLineHeight, {
+    bool isEditText = true,
+  }) {
     return Offset.zero;
   }
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -2100,6 +2100,7 @@ class TextSelectionControlsSpy extends TextSelectionControls {
     BuildContext context,
     TextSelectionHandleType type,
     double textLineHeight, [
+    double? cursorWidth,
     VoidCallback? onTap,
   ]) {
     return ElevatedButton(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## PR description
This PR addresses the handle alignment issue when a textfield is selected and the cursor is visible (TextSelectionHandleType.collapsed). It aims to make the alignment pixel perfect.

| | Image | 
|:-----|:---:|
| Before | <img width="214" height="110" alt="before_1" src="https://github.com/user-attachments/assets/0a7be107-49a5-43a0-a250-f1bf9be55a5f" /> |
| After | <img width="214" height="110" alt="after_1" src="https://github.com/user-attachments/assets/063e9031-f7a9-46bb-beb7-5cf88fa26055" /> |

## Fix explanation
After some investigation, I came to the conclusion that the root cause of the handle misalignment is that the code ignores the variable cursor width.

This becomes more apparent from the, rather exaggerated, case below where the `cursorWidth` is given a value of 10 (obviously, we do not expect users to give such a value). 

**Before:**
<img width="194" height="107" alt="before_2" src="https://github.com/user-attachments/assets/82992a92-091a-4b2f-aaf6-5622a0abf597" />
**After:**
<img width="204" height="118" alt="after_2" src="https://github.com/user-attachments/assets/fa43bf90-a421-4d32-b711-e42ceaa2b300" />

The fix takes into account the width of the cursor value when offsetting the handle placement. 

## Issue fixed
[Flutter - Cursor Selection bubble alignment is not proper](https://github.com/flutter/flutter/issues/168625) 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.*

*All existing and new tests that were passing prior to the changes are still passing (48 tests were failing prior to any changes, and 48 tests still fail when `flutter test` is run).

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
