### PR TITLE
Make sure that DataTable, DataColumn, DataRow, and DataCell don't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2315,6 +2315,19 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('DataTable renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox.shrink(
+          child: DataTable(
+            columns: const <DataColumn>[DataColumn(label: Text('X'))],
+            rows: const <DataRow>[],
+          ),
+        ),
+      ),
+    );
+  });
 }
 
 RenderParagraph _getTextRenderObject(WidgetTester tester, String text) {

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -2316,13 +2316,17 @@ void main() {
     semantics.dispose();
   });
 
-  testWidgets('DataTable renders at zero area', (WidgetTester tester) async {
+  testWidgets('DataTable, DataColumn, DataRow, and DataCell render at zero area', (
+    WidgetTester tester,
+  ) async {
     await tester.pumpWidget(
       MaterialApp(
         home: SizedBox.shrink(
           child: DataTable(
             columns: const <DataColumn>[DataColumn(label: Text('X'))],
-            rows: const <DataRow>[],
+            rows: const <DataRow>[
+              DataRow(cells: <DataCell>[DataCell(Text('X'))]),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the DataTable, DataColumn, DataRow, and DataCell UI controls.