### PR TITLE
Fix SegmentedButton segment loses focus when unselected

### DIFF
--- a/examples/api/test/material/toggle_buttons/toggle_buttons.1_test.dart
+++ b/examples/api/test/material/toggle_buttons/toggle_buttons.1_test.dart
@@ -12,7 +12,7 @@ void main() {
     Finder findButton(String text) {
       return find.descendant(
         of: find.byType(ToggleButtons),
-        matching: find.widgetWithText(TextButton, text),
+        matching: find.ancestor(of: find.text(text), matching: find.bySubtype<TextButton>()),
       );
     }
 
@@ -75,7 +75,7 @@ void main() {
     Finder findButton(String text) {
       return find.descendant(
         of: find.byType(SegmentedButton<example.ShirtSize>),
-        matching: find.widgetWithText(TextButton, text),
+        matching: find.ancestor(of: find.text(text), matching: find.bySubtype<TextButton>()),
       );
     }
 

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -570,44 +570,23 @@ class SegmentedButtonState<T> extends State<SegmentedButton<T>> {
       );
       controller.update(WidgetState.selected, segmentSelected);
 
-      final Widget button = icon != null
-          ? TextButton.icon(
-              style: segmentStyle,
-              statesController: controller,
-              onHover: (bool hovering) {
-                setState(() {
-                  _hovering = hovering;
-                });
-              },
-              onFocusChange: (bool focused) {
-                setState(() {
-                  _focused = focused;
-                });
-              },
-              onPressed: (_enabled && segment.enabled)
-                  ? () => _handleOnPressed(segment.value)
-                  : null,
-              icon: icon,
-              label: label,
-            )
-          : TextButton(
-              style: segmentStyle,
-              statesController: controller,
-              onHover: (bool hovering) {
-                setState(() {
-                  _hovering = hovering;
-                });
-              },
-              onFocusChange: (bool focused) {
-                setState(() {
-                  _focused = focused;
-                });
-              },
-              onPressed: (_enabled && segment.enabled)
-                  ? () => _handleOnPressed(segment.value)
-                  : null,
-              child: label,
-            );
+      final Widget button = TextButton.icon(
+        style: segmentStyle,
+        statesController: controller,
+        onHover: (bool hovering) {
+          setState(() {
+            _hovering = hovering;
+          });
+        },
+        onFocusChange: (bool focused) {
+          setState(() {
+            _focused = focused;
+          });
+        },
+        onPressed: (_enabled && segment.enabled) ? () => _handleOnPressed(segment.value) : null,
+        icon: icon,
+        label: label,
+      );
 
       final Widget buttonWithTooltip = segment.tooltip != null
           ? Tooltip(message: segment.tooltip, child: button)

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -101,7 +101,7 @@ class TextButton extends ButtonStyleButton {
   /// The icon and label are arranged in a row and padded by 8 logical pixels
   /// at the ends, with an 8 pixel gap in between.
   ///
-  /// If [icon] is null, will create a [TextButton] instead.
+  /// [icon] can be null, this is useful when the icon visibility is conditional.
   ///
   /// {@macro flutter.material.ButtonStyleButton.iconAlignment}
   ///
@@ -120,21 +120,6 @@ class TextButton extends ButtonStyleButton {
     required Widget label,
     IconAlignment? iconAlignment,
   }) {
-    if (icon == null) {
-      return TextButton(
-        key: key,
-        onPressed: onPressed,
-        onLongPress: onLongPress,
-        onHover: onHover,
-        onFocusChange: onFocusChange,
-        style: style,
-        focusNode: focusNode,
-        autofocus: autofocus ?? false,
-        clipBehavior: clipBehavior ?? Clip.none,
-        statesController: statesController,
-        child: label,
-      );
-    }
     return _TextButtonWithIcon(
       key: key,
       onPressed: onPressed,
@@ -464,10 +449,11 @@ class _TextButtonWithIcon extends TextButton {
     bool? autofocus,
     super.clipBehavior,
     super.statesController,
-    required Widget icon,
+    Widget? icon,
     required Widget label,
     IconAlignment? iconAlignment,
-  }) : super(
+  }) : hasIcon = icon != null,
+       super(
          autofocus: autofocus ?? false,
          child: _TextButtonWithIconChild(
            icon: icon,
@@ -476,6 +462,8 @@ class _TextButtonWithIcon extends TextButton {
            iconAlignment: iconAlignment,
          ),
        );
+
+  final bool hasIcon;
 
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
@@ -486,7 +474,9 @@ class _TextButtonWithIcon extends TextButton {
     final double effectiveTextScale =
         MediaQuery.textScalerOf(context).scale(defaultFontSize) / 14.0;
     final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
-      useMaterial3 ? const EdgeInsetsDirectional.fromSTEB(12, 8, 16, 8) : const EdgeInsets.all(8),
+      useMaterial3
+          ? EdgeInsetsDirectional.fromSTEB(12, 8, hasIcon ? 16 : 12, 8)
+          : const EdgeInsets.all(8),
       const EdgeInsets.symmetric(horizontal: 4),
       const EdgeInsets.symmetric(horizontal: 4),
       effectiveTextScale,
@@ -506,12 +496,15 @@ class _TextButtonWithIconChild extends StatelessWidget {
   });
 
   final Widget label;
-  final Widget icon;
+  final Widget? icon;
   final ButtonStyle? buttonStyle;
   final IconAlignment? iconAlignment;
 
   @override
   Widget build(BuildContext context) {
+    if (icon == null) {
+      return label;
+    }
     final double defaultFontSize =
         buttonStyle?.textStyle?.resolve(const <MaterialState>{})?.fontSize ?? 14.0;
     final double scale =
@@ -526,8 +519,8 @@ class _TextButtonWithIconChild extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       spacing: lerpDouble(8, 4, scale)!,
       children: effectiveIconAlignment == IconAlignment.start
-          ? <Widget>[icon, Flexible(child: label)]
-          : <Widget>[Flexible(child: label), icon],
+          ? <Widget>[icon!, Flexible(child: label)]
+          : <Widget>[Flexible(child: label), icon!],
     );
   }
 }

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2651,4 +2651,31 @@ void main() {
     expect(textColor(tester, buttonText), hoveredColor);
     expect(iconStyle(tester, buttonIcon).color, hoveredColor);
   });
+
+  testWidgets('TextButton.icon does not lose focus when icon is nullified', (
+    WidgetTester tester,
+  ) async {
+    Widget buildTextButton({required Widget? icon}) {
+      return MaterialApp(
+        home: Center(
+          child: TextButton.icon(onPressed: () {}, icon: icon, label: const Text('button')),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildTextButton(icon: const Icon(Icons.abc)));
+
+    FocusNode getButtonFocusNode() {
+      return Focus.of(tester.element(find.text('button')));
+    }
+
+    getButtonFocusNode().requestFocus();
+    await tester.pumpAndSettle();
+    expect(getButtonFocusNode().hasFocus, true);
+
+    await tester.pumpWidget(buildTextButton(icon: null));
+
+    // The button should still be focused.
+    expect(getButtonFocusNode().hasFocus, true);
+  });
 }


### PR DESCRIPTION
## Description

This PR fixes SegmentedButton focus traversal.

# Before

When a focused segment (with no icon) is selected or unselected, the focus moves to another segment.

[Capture vidéo du 2025-08-11 15-28-03.webm](https://github.com/user-attachments/assets/11c29194-6b96-4ea4-9245-dcbd36dc424f)

In this recording, tab key is used to set the focus on 'Month' segment, then enter is used to select the segment. The focus move unexpectedly to 'Week' segment.

# After

When a focused segment (with no icon) is selected or unselected, the focus stays on this same segment and the InkWell animations are correctly painted.

[Capture vidéo du 2025-08-11 15-27-30.webm](https://github.com/user-attachments/assets/e09056d0-b572-462b-8ad8-c23eddcc4bfd)


<details><summary>Code sample for recordings</summary>

```dart
import 'package:flutter/material.dart';

/// Flutter code sample for [SegmentedButton].

void main() {
  runApp(const SegmentedButtonApp());
}

class SegmentedButtonApp extends StatelessWidget {
  const SegmentedButtonApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      home: Scaffold(body: Center(child: SingleChoice())),
    );
  }
}

enum Calendar { day, week, month, year }

class SingleChoice extends StatefulWidget {
  const SingleChoice({super.key});

  @override
  State<SingleChoice> createState() => _SingleChoiceState();
}

class _SingleChoiceState extends State<SingleChoice> {
  Calendar calendarView = Calendar.day;

  @override
  Widget build(BuildContext context) {
    return SegmentedButton<Calendar>(
      segments: const <ButtonSegment<Calendar>>[
        ButtonSegment<Calendar>(value: Calendar.day, label: Text('Day')),
        ButtonSegment<Calendar>(value: Calendar.week, label: Text('Week')),
        ButtonSegment<Calendar>(value: Calendar.month, label: Text('Month')),
        ButtonSegment<Calendar>(value: Calendar.year, label: Text('Year')),
      ],
      selected: <Calendar>{calendarView},
      onSelectionChanged: (Set<Calendar> newSelection) {
        setState(() {
          // By default there is only a single segment that can be
          // selected at one time, so its value is always the first
          // item in the selected set.
          calendarView = newSelection.first;
        });
      },
    );
  }
}

``` 
</details> 

## Related Issue

Fixes [SegmentedButton keyboard navigation incorrectly moves focus on click](https://github.com/flutter/flutter/issues/161922)


## Implementation choice

The root of this issue is TextButton.icon which creates a different widget tree depending on the icon.
For use cases where the icon appears/disappears regularly (`SegmentedButton` for instance) it breaks focus traversal and `InkWell` rendering.
The proposed solution is to maintain the same widget tree when possible.
I did not split the PR in two (first a fix for TextButton, then one for SegmentedButton) in order to give the whole picture.
If this proposed solution is ok, I will file similar PRs for the other buttons with .icon constructor.

## Tests

Adds 2 tests.
