### PR TITLE
Update CanRenderTiledTexture unit tests

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -156,20 +156,17 @@ void CanRenderTiledTexture(AiksTest* aiks_test,
 
   {
     // Should not change the image. Tests the Convex short-cut code.
-    DlPath circle = DlPath::MakeCircle(DlPoint(150, 450), 150);
 
-    // Unfortunately, the circle path can be simplified...
-    EXPECT_TRUE(circle.IsOval(nullptr));
-    // At least it's convex, though...
-    EXPECT_TRUE(circle.IsConvex());
-
-    // Let's make a copy that doesn't remember that it's just a circle...
-    DlPathBuilder path_builder;
-    // This moveTo confuses addPath into appending rather than replacing,
-    // which prevents it from noticing that it's just a circle...
-    path_builder.MoveTo({10, 10});
-    path_builder.AddPath(circle);
-    DlPath path = path_builder.TakePath();
+    // To avoid simplification, construct an explicit circle using conics.
+    const float circle_weight = 0.707106781f;
+    const DlPath path = DlPathBuilder()
+        .MoveTo({150, 300})
+        .ConicCurveTo({300, 300}, {300, 450}, circle_weight)
+        .ConicCurveTo({300, 600}, {150, 600}, circle_weight)
+        .ConicCurveTo({  0, 600}, {  0, 450}, circle_weight)
+        .ConicCurveTo({  0, 300}, {150, 300}, circle_weight)
+        .Close()
+        .TakePath();
 
     // Make sure path cannot be simplified...
     EXPECT_FALSE(path.IsRect(nullptr));

--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -158,15 +158,15 @@ void CanRenderTiledTexture(AiksTest* aiks_test,
     // Should not change the image. Tests the Convex short-cut code.
 
     // To avoid simplification, construct an explicit circle using conics.
-    constexpr float kConicWeight = 0.707106781f; // sqrt(2)/2
+    constexpr float kConicWeight = 0.707106781f;  // sqrt(2)/2
     const DlPath path = DlPathBuilder()
-        .MoveTo({150, 300})
-        .ConicCurveTo({300, 300}, {300, 450}, kConicWeight)
-        .ConicCurveTo({300, 600}, {150, 600}, kConicWeight)
-        .ConicCurveTo({  0, 600}, {  0, 450}, kConicWeight)
-        .ConicCurveTo({  0, 300}, {150, 300}, kConicWeight)
-        .Close()
-        .TakePath();
+                            .MoveTo({150, 300})
+                            .ConicCurveTo({300, 300}, {300, 450}, kConicWeight)
+                            .ConicCurveTo({300, 600}, {150, 600}, kConicWeight)
+                            .ConicCurveTo({0, 600}, {0, 450}, kConicWeight)
+                            .ConicCurveTo({0, 300}, {150, 300}, kConicWeight)
+                            .Close()
+                            .TakePath();
 
     // Make sure path cannot be simplified...
     EXPECT_FALSE(path.IsRect(nullptr));

--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -158,13 +158,13 @@ void CanRenderTiledTexture(AiksTest* aiks_test,
     // Should not change the image. Tests the Convex short-cut code.
 
     // To avoid simplification, construct an explicit circle using conics.
-    const float circle_weight = 0.707106781f;
+    constexpr float kConicWeight = 0.707106781f; // sqrt(2)/2
     const DlPath path = DlPathBuilder()
         .MoveTo({150, 300})
-        .ConicCurveTo({300, 300}, {300, 450}, circle_weight)
-        .ConicCurveTo({300, 600}, {150, 600}, circle_weight)
-        .ConicCurveTo({  0, 600}, {  0, 450}, circle_weight)
-        .ConicCurveTo({  0, 300}, {150, 300}, circle_weight)
+        .ConicCurveTo({300, 300}, {300, 450}, kConicWeight)
+        .ConicCurveTo({300, 600}, {150, 600}, kConicWeight)
+        .ConicCurveTo({  0, 600}, {  0, 450}, kConicWeight)
+        .ConicCurveTo({  0, 300}, {150, 300}, kConicWeight)
         .Close()
         .TakePath();
 


### PR DESCRIPTION
The current version relies on a Skia quirk where leading moveTos defeat the simple shape detection in SkPath::addPath().

Skia is updating its behavior to make shape detection more robust, and that breaks the assertion EXPECT_FALSE(path.IsOval(nullptr)).

To address, construct an equivalent circle using four conic verbs, which will not be identified as a simple shape.  This
preserves all related assertions in the unit test.

This unblocks some Skia shape detection improvements.
