### PR TITLE
Does the copy task actualy do anything

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -58,7 +58,7 @@ class FlutterPlugin : Plugin<Project> {
             resolveFlutterSdkProperty(flutterRootSystemVal)
                 ?: throw GradleException(
                     "Flutter SDK not found. Define location with flutter.sdk in the " +
-                        "local.properties file or with a FLUTTER_ROOT environment variable."
+                        "local.properties file or with a FLUTTER_ROOT environment variable.",
                 )
 
         flutterRoot = project.file(flutterRootPath)
@@ -113,8 +113,8 @@ class FlutterPlugin : Plugin<Project> {
                     "src",
                     "main",
                     "scripts",
-                    "native_plugin_loader.gradle.kts"
-                )
+                    "native_plugin_loader.gradle.kts",
+                ),
             )
         }
 
@@ -226,7 +226,7 @@ class FlutterPlugin : Plugin<Project> {
                     project.logger.error(
                         "Warning: Flutter was unable to detect project Gradle, Java, " +
                             "AGP, and KGP versions. Skipping dependency version checking. Error was: " +
-                            e
+                            e,
                     )
                 } else {
                     // If usesUnsupportedDependencyVersions is set, the exception was thrown by us
@@ -244,7 +244,7 @@ class FlutterPlugin : Plugin<Project> {
                     "packages",
                     "flutter_tools",
                     "gradle",
-                    "flutter_proguard_rules.pro"
+                    "flutter_proguard_rules.pro",
                 ).toString()
         // TODO(gmackall): reconsider getting the android extension every time
         FlutterPluginUtils.getAndroidExtension(project).buildTypes {
@@ -273,7 +273,7 @@ class FlutterPlugin : Plugin<Project> {
                             .getAndroidExtension(project)
                             .getDefaultProguardFile("proguard-android-optimize.txt"),
                         flutterProguardRules,
-                        "proguard-rules.pro"
+                        "proguard-rules.pro",
                     )
                 }
             }
@@ -308,7 +308,7 @@ class FlutterPlugin : Plugin<Project> {
             project!!,
             buildType,
             getPluginHandler(project!!),
-            engineVersion!!
+            engineVersion!!,
         )
     }
 
@@ -323,7 +323,7 @@ class FlutterPlugin : Plugin<Project> {
         }
         return project?.findProperty(propertyName) as? String ?: localProperties!!.getProperty(
             propertyName,
-            defaultValue
+            defaultValue,
         )
     }
 
@@ -374,7 +374,7 @@ class FlutterPlugin : Plugin<Project> {
                 val assembleTask = variant.assembleProvider.get()
                 if (!FlutterPluginUtils.shouldConfigureFlutterTask(
                         projectToAddTasksTo,
-                        assembleTask
+                        assembleTask,
                     )
                 ) {
                     return@configureEach
@@ -436,8 +436,8 @@ class FlutterPlugin : Plugin<Project> {
                                     "${
                                         projectToAddTasksTo.layout.buildDirectory.dir("outputs/flutter-apk")
                                             .get()
-                                    }"
-                                )
+                                    }",
+                                ),
                             )
                             rename { "$filename.apk" }
                         }
@@ -457,7 +457,7 @@ class FlutterPlugin : Plugin<Project> {
             getPluginHandler(projectToAddTasksTo).configurePlugins(engineVersion!!)
             FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(
                 projectToAddTasksTo,
-                getPluginHandler(projectToAddTasksTo).getPluginList()
+                getPluginHandler(projectToAddTasksTo).getPluginList(),
             )
             return
         }
@@ -465,7 +465,7 @@ class FlutterPlugin : Plugin<Project> {
         val hostAppProjectName: String? =
             if (projectToAddTasksTo.rootProject.hasProperty("flutter.hostAppProjectName")) {
                 projectToAddTasksTo.rootProject.property(
-                    "flutter.hostAppProjectName"
+                    "flutter.hostAppProjectName",
                 ) as? String
             } else {
                 "app"
@@ -520,7 +520,7 @@ class FlutterPlugin : Plugin<Project> {
                     copyFlutterAssetsTask = copyFlutterAssetsTask ?: addFlutterDeps(
                         libraryVariant,
                         flutterPlugin,
-                        targetPlatforms
+                        targetPlatforms,
                     )
                     // TODO(gmackall): Migrate to AGPs variant api.
                     //    https://github.com/flutter/flutter/issues/166550
@@ -536,7 +536,7 @@ class FlutterPlugin : Plugin<Project> {
         getPluginHandler(projectToAddTasksTo).configurePlugins(engineVersion!!)
         FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(
             projectToAddTasksTo,
-            getPluginHandler(projectToAddTasksTo).getPluginList()
+            getPluginHandler(projectToAddTasksTo).getPluginList(),
         )
     }
 
@@ -564,7 +564,7 @@ class FlutterPlugin : Plugin<Project> {
          */
         private fun findTaskOrNull(
             project: Project,
-            taskName: String
+            taskName: String,
         ): Task? =
             try {
                 project.tasks.named(taskName).get()
@@ -577,7 +577,7 @@ class FlutterPlugin : Plugin<Project> {
         private fun addFlutterDeps(
             @Suppress("DEPRECATION") variant: com.android.build.gradle.api.BaseVariant,
             flutterPlugin: FlutterPlugin,
-            targetPlatforms: List<String>
+            targetPlatforms: List<String>,
         ): Task {
             // Shorthand
             val project: Project = flutterPlugin.project!!
@@ -640,12 +640,12 @@ class FlutterPlugin : Plugin<Project> {
             val packageAssets: Task? =
                 findTaskOrNull(
                     project,
-                    "package${FlutterPluginUtils.capitalize(variant.name)}Assets"
+                    "package${FlutterPluginUtils.capitalize(variant.name)}Assets",
                 )
             val cleanPackageAssets: Task? =
                 findTaskOrNull(
                     project,
-                    "cleanPackage${FlutterPluginUtils.capitalize(variant.name)}Assets"
+                    "cleanPackage${FlutterPluginUtils.capitalize(variant.name)}Assets",
                 )
 
             val isUsedAsSubproject: Boolean =
@@ -658,8 +658,8 @@ class FlutterPlugin : Plugin<Project> {
                     listOf(
                         "compile",
                         FLUTTER_BUILD_PREFIX,
-                        variant.name
-                    )
+                        variant.name,
+                    ),
                 )
             // The task provider below will shadow a lot of the variable names, so provide this reference
             // to access them within that scope.
@@ -689,7 +689,7 @@ class FlutterPlugin : Plugin<Project> {
                     sourceDir = FlutterPluginUtils.getFlutterSourceDirectory(project)
                     intermediateDir =
                         project.file(
-                            project.layout.buildDirectory.dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/${variant.name}/")
+                            project.layout.buildDirectory.dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/${variant.name}/"),
                         )
                     frontendServerStarterPath = frontendServerStarterPathValue
                     extraFrontEndOptions = extraFrontEndOptionsValue
@@ -712,7 +712,7 @@ class FlutterPlugin : Plugin<Project> {
             val packJniLibsTaskProvider: TaskProvider<Jar> =
                 project.tasks.register(
                     "packJniLibs${FLUTTER_BUILD_PREFIX}${FlutterPluginUtils.capitalize(variant.name)}",
-                    Jar::class.java
+                    Jar::class.java,
                 ) {
                     destinationDirectory.set(libJar.parentFile)
                     archiveFileName.set(libJar.name)
@@ -801,7 +801,7 @@ class FlutterPlugin : Plugin<Project> {
                 listOf(
                     "compress${FlutterPluginUtils.capitalize(variant.name)}Assets",
                     "bundle${FlutterPluginUtils.capitalize(variant.name)}Aar",
-                    "bundle${FlutterPluginUtils.capitalize(variant.name)}LocalLintAar"
+                    "bundle${FlutterPluginUtils.capitalize(variant.name)}LocalLintAar",
                 )
             tasksToCheck.forEach { taskTocheck ->
                 try {
@@ -829,7 +829,7 @@ class FlutterPlugin : Plugin<Project> {
 
     private fun maybeAddAndroidStudioNativeConfiguration(
         plugins: PluginContainer,
-        dependencies: DependencyHandler
+        dependencies: DependencyHandler,
     ) {
         if (shouldAddAndroidStudioNativeConfiguration(plugins)) {
             dependencies.add("compileOnly", "io.flutter:flutter_embedding_debug:$engineVersion")

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -704,10 +704,10 @@ class FlutterPlugin : Plugin<Project> {
                     validateDeferredComponents = validateDeferredComponentsValue
                     flavor = flavorValue
                 }
-            val compileTask: FlutterTask = compileTaskProvider.get()
+            val flutterCompileTask: FlutterTask = compileTaskProvider.get()
             val libJar: File =
                 project.file(
-                    project.layout.buildDirectory.dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/${variant.name}/libs.jar")
+                    project.layout.buildDirectory.dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/${variant.name}/libs.jar"),
                 )
             val packJniLibsTaskProvider: TaskProvider<Jar> =
                 project.tasks.register(
@@ -716,10 +716,10 @@ class FlutterPlugin : Plugin<Project> {
                 ) {
                     destinationDirectory.set(libJar.parentFile)
                     archiveFileName.set(libJar.name)
-                    dependsOn(compileTask)
+                    dependsOn(flutterCompileTask)
                     targetPlatforms.forEach { targetPlatform ->
                         val abi: String? = FlutterPluginConstants.PLATFORM_ARCH_MAP[targetPlatform]
-                        from("${compileTask.intermediateDir}/$abi") {
+                        from("${flutterCompileTask.intermediateDir}/$abi") {
                             include("*.so")
                             // Move `app.so` to `lib/<abi>/libapp.so`
                             rename { filename: String -> "lib/$abi/lib$filename" }

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -749,33 +749,33 @@ class FlutterPlugin : Plugin<Project> {
                     "copyFlutterAssets${FlutterPluginUtils.capitalize(variant.name)}",
                     Copy::class.java
                 ) {
-                    dependsOn(compileTask)
-                    with(compileTask.assets)
+//                    dependsOn(compileTask)
+//                    with(compileTask.assets)
                     filePermissions {
                         user {
                             read = true
                             write = true
                         }
                     }
-                    if (isUsedAsSubproject) {
-                        // TODO(gmackall): above is always false, can delete
-                        dependsOn(packageAssets)
-                        dependsOn(cleanPackageAssets)
-                        into(packageAssets!!.outputs)
-                    }
-                    val mergeAssets =
-                        try {
-                            variant.mergeAssetsProvider.get()
-                        } catch (e: IllegalStateException) {
-                            // TODO(gmackall): Migrate to AGPs variant api.
-                            //    https://github.com/flutter/flutter/issues/166550
-                            @Suppress("DEPRECATION")
-                            variant.mergeAssets
-                        }
-                    dependsOn(mergeAssets)
-                    dependsOn("clean${FlutterPluginUtils.capitalize(mergeAssets.name)}")
-                    mergeAssets.mustRunAfter("clean${FlutterPluginUtils.capitalize(mergeAssets.name)}")
-                    into(mergeAssets.outputDir)
+//                    if (isUsedAsSubproject) {
+//                        // TODO(gmackall): above is always false, can delete
+//                        dependsOn(packageAssets)
+//                        dependsOn(cleanPackageAssets)
+//                        into(packageAssets!!.outputs)
+//                    }
+//                    val mergeAssets =
+//                        try {
+//                            variant.mergeAssetsProvider.get()
+//                        } catch (e: IllegalStateException) {
+//                            // TODO(gmackall): Migrate to AGPs variant api.
+//                            //    https://github.com/flutter/flutter/issues/166550
+//                            @Suppress("DEPRECATION")
+//                            variant.mergeAssets
+//                        }
+//                    dependsOn(mergeAssets)
+//                    dependsOn("clean${FlutterPluginUtils.capitalize(mergeAssets.name)}")
+//                    mergeAssets.mustRunAfter("clean${FlutterPluginUtils.capitalize(mergeAssets.name)}")
+//                    into(mergeAssets.outputDir)
                 }
             val copyFlutterAssetsTask: Task = copyFlutterAssetsTaskProvider.get()
             if (!isUsedAsSubproject) {

--- a/packages/flutter_tools/gradle/src/main/kotlin/tasks/FlutterTask.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/tasks/FlutterTask.kt
@@ -25,11 +25,13 @@ abstract class FlutterTask : BaseFlutterTask() {
     val outputDirectory: File?
         get() = FlutterTaskHelper.getOutputDirectory(flutterTask = this)
 
-    @get:Internal
+    // Warning assetsDirectory assets appear to return different contents.
+    @get:OutputDirectory
     val assetsDirectory: String
         get() = FlutterTaskHelper.getAssetsDirectory(flutterTask = this)
 
-    @get:Internal
+    // Warning assetsDirectory assets appear to return different contents.
+    @get:OutputFiles
     val assets: CopySpec
         get() = FlutterTaskHelper.getAssets(project, flutterTask = this)
 


### PR DESCRIPTION
Reading the copyFlutterAssets gradle task there is a lot of configuration but surprisingly little copying of flutter assets. 
This pr deletes most of what the task does in an effort to determine if the task is useful and/or if we have integration tests that cover flutter assets inclusion. 

Related to #166550
From: packages/devicelab/ 
`../../bin/cache/dart-sdk/bin/dart bin/test_runner.dart test -t module_host_with_custom_build_test`
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
