### PR TITLE
[ios][tools]do not log "bonjour not found" at all (unless verbose)

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -104,7 +104,14 @@ class Context {
 
   /// Run given command in a synchronous subprocess.
   ///
-  /// Will throw [Exception] if the exit code is not 0.
+  /// @param bin The command to run.
+  /// @param args Args to pass into the command.
+  /// @param verbose Verbose mode.
+  /// @param allowFail If set, will not throw exceptions or result in xcode failure.
+  /// @param skipErrorLog If set, will skip stderr in non-verbose mode, and pipe
+  ///     stderr to stdout in verbose mode.
+  /// @param workingDirectory The current working directory to run the command.
+  /// @throws [Exception] if the exit code is not 0.
   ProcessResult runSync(
     String bin,
     List<String> args, {

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -102,16 +102,16 @@ class Context {
 
   Directory directoryFromPath(String path) => Directory(path);
 
-  /// Run given command in a synchronous subprocess.
+  /// Run given command ([bin]) in a synchronous subprocess.
   ///
-  /// @param bin The command to run.
-  /// @param args Args to pass into the command.
-  /// @param verbose Verbose mode.
-  /// @param allowFail If set, will not throw exceptions or result in xcode failure.
-  /// @param skipErrorLog If set, will skip stderr in non-verbose mode, and pipe
-  ///     stderr to stdout in verbose mode.
-  /// @param workingDirectory The current working directory to run the command.
-  /// @throws [Exception] if the exit code is not 0.
+  /// If [allowFail] is true, an exception will not be thrown even if the process returns a
+  /// non-zero exit code. Also, `error:` will not be prefixed to the output to prevent Xcode
+  /// complication failures.
+  ///
+  /// If [skipErrorLog] is true, `stderr` from the process will not be output unless in [verbose]
+  /// mode. If in [verbose], pipes `stderr` to `stdout`.
+  ///
+  /// Will throw [Exception] if the exit code is not 0.
   ProcessResult runSync(
     String bin,
     List<String> args, {

--- a/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
@@ -394,6 +394,9 @@ void main() {
       final Directory buildDir = fileSystem.directory('/path/to/builds')
         ..createSync(recursive: true);
       final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+      const plutilErrorMessage =
+          'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
+
       final context = TestContext(
         <String>['test_vm_service_bonjour_service'],
         <String, String>{
@@ -413,7 +416,7 @@ void main() {
               infoPlist.path,
             ],
             exitCode: 1,
-            stderr: 'No value at that key path or invalid key path: NSBonjourServices',
+            stderr: plutilErrorMessage,
           ),
           FakeCommand(
             command: <String>[
@@ -439,74 +442,76 @@ void main() {
         ],
         fileSystem: fileSystem,
       )..run();
-      expect(context.stderr, isNot(contains('error: ')));
+      expect(context.stderr, isNot(startsWith('error: ')));
+      expect(context.stderr, isNot(contains(plutilErrorMessage)));
+      expect(context.stdout, isNot(contains(plutilErrorMessage)));
     });
 
-    test(
-      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation',
-      () {
-        final Directory buildDir = fileSystem.directory('/path/to/builds')
-          ..createSync(recursive: true);
-        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-        final context = TestContext(
-          <String>['test_vm_service_bonjour_service'],
-          <String, String>{
-            'CONFIGURATION': 'Debug',
-            'BUILT_PRODUCTS_DIR': buildDir.path,
-            'INFOPLIST_PATH': 'Info.plist',
-          },
-          commands: <FakeCommand>[
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSBonjourServices',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-insert',
-                'NSBonjourServices.0',
-                '-string',
-                '_dartVmService._tcp',
-                infoPlist.path,
-              ],
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSLocalNetworkUsageDescription',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-              exitCode: 1,
-              stderr:
-                  'No value at that key path or invalid key path: NSLocalNetworkUsageDescription',
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-insert',
-                'NSLocalNetworkUsageDescription',
-                '-string',
-                'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
-                infoPlist.path,
-              ],
-            ),
-          ],
-          fileSystem: fileSystem,
-        )..run();
-        expect(context.stderr, isNot(contains('error: ')));
-      },
-    );
+    test('Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation', () {
+      final Directory buildDir = fileSystem.directory('/path/to/builds')
+        ..createSync(recursive: true);
+      final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+      const plutilErrorMessage =
+          'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
+      final context = TestContext(
+        <String>['test_vm_service_bonjour_service'],
+        <String, String>{
+          'CONFIGURATION': 'Debug',
+          'BUILT_PRODUCTS_DIR': buildDir.path,
+          'INFOPLIST_PATH': 'Info.plist',
+        },
+        commands: <FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-extract',
+              'NSBonjourServices',
+              'xml1',
+              '-o',
+              '-',
+              infoPlist.path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-insert',
+              'NSBonjourServices.0',
+              '-string',
+              '_dartVmService._tcp',
+              infoPlist.path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-extract',
+              'NSLocalNetworkUsageDescription',
+              'xml1',
+              '-o',
+              '-',
+              infoPlist.path,
+            ],
+            exitCode: 1,
+            stderr: plutilErrorMessage,
+          ),
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-insert',
+              'NSLocalNetworkUsageDescription',
+              '-string',
+              'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
+              infoPlist.path,
+            ],
+          ),
+        ],
+        fileSystem: fileSystem,
+      )..run();
+      expect(context.stderr, isNot(startsWith('error: ')));
+      expect(context.stderr, isNot(contains(plutilErrorMessage)));
+      expect(context.stdout, isNot(contains(plutilErrorMessage)));
+    });
   });
 
   for (final platform in platforms) {

--- a/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
@@ -390,128 +390,265 @@ void main() {
       );
     });
 
-    test('Missing NSBonjourServices key in Info.plist should not fail Xcode compilation', () {
-      final Directory buildDir = fileSystem.directory('/path/to/builds')
-        ..createSync(recursive: true);
-      final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-      const plutilErrorMessage =
-          'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
+    test(
+      'Missing NSBonjourServices key in Info.plist should not fail Xcode compilation, and no plutil error in stdout without verbose mode',
+      () {
+        final Directory buildDir = fileSystem.directory('/path/to/builds')
+          ..createSync(recursive: true);
+        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+        const plutilErrorMessage =
+            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
 
-      final context = TestContext(
-        <String>['test_vm_service_bonjour_service'],
-        <String, String>{
-          'CONFIGURATION': 'Debug',
-          'BUILT_PRODUCTS_DIR': buildDir.path,
-          'INFOPLIST_PATH': 'Info.plist',
-        },
-        commands: <FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-extract',
-              'NSBonjourServices',
-              'xml1',
-              '-o',
-              '-',
-              infoPlist.path,
-            ],
-            exitCode: 1,
-            stderr: plutilErrorMessage,
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-insert',
-              'NSBonjourServices',
-              '-json',
-              '["_dartVmService._tcp"]',
-              infoPlist.path,
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-extract',
-              'NSLocalNetworkUsageDescription',
-              'xml1',
-              '-o',
-              '-',
-              infoPlist.path,
-            ],
-          ),
-        ],
-        fileSystem: fileSystem,
-      )..run();
-      expect(context.stderr, isNot(startsWith('error: ')));
-      expect(context.stderr, isNot(contains(plutilErrorMessage)));
-      expect(context.stdout, isNot(contains(plutilErrorMessage)));
-    });
+        final context = TestContext(
+          <String>['test_vm_service_bonjour_service'],
+          <String, String>{
+            'CONFIGURATION': 'Debug',
+            'BUILT_PRODUCTS_DIR': buildDir.path,
+            'INFOPLIST_PATH': 'Info.plist',
+          },
+          commands: <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSBonjourServices',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+              exitCode: 1,
+              stderr: plutilErrorMessage,
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSBonjourServices',
+                '-json',
+                '["_dartVmService._tcp"]',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSLocalNetworkUsageDescription',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+            ),
+          ],
+          fileSystem: fileSystem,
+        )..run();
+        expect(context.stderr, isNot(startsWith('error: ')));
+        expect(context.stderr, isNot(contains(plutilErrorMessage)));
+        expect(context.stdout, isNot(contains(plutilErrorMessage)));
+      },
+    );
 
-    test('Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation', () {
-      final Directory buildDir = fileSystem.directory('/path/to/builds')
-        ..createSync(recursive: true);
-      final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-      const plutilErrorMessage =
-          'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
-      final context = TestContext(
-        <String>['test_vm_service_bonjour_service'],
-        <String, String>{
-          'CONFIGURATION': 'Debug',
-          'BUILT_PRODUCTS_DIR': buildDir.path,
-          'INFOPLIST_PATH': 'Info.plist',
-        },
-        commands: <FakeCommand>[
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-extract',
-              'NSBonjourServices',
-              'xml1',
-              '-o',
-              '-',
-              infoPlist.path,
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-insert',
-              'NSBonjourServices.0',
-              '-string',
-              '_dartVmService._tcp',
-              infoPlist.path,
-            ],
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-extract',
-              'NSLocalNetworkUsageDescription',
-              'xml1',
-              '-o',
-              '-',
-              infoPlist.path,
-            ],
-            exitCode: 1,
-            stderr: plutilErrorMessage,
-          ),
-          FakeCommand(
-            command: <String>[
-              'plutil',
-              '-insert',
-              'NSLocalNetworkUsageDescription',
-              '-string',
-              'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
-              infoPlist.path,
-            ],
-          ),
-        ],
-        fileSystem: fileSystem,
-      )..run();
-      expect(context.stderr, isNot(startsWith('error: ')));
-      expect(context.stderr, isNot(contains(plutilErrorMessage)));
-      expect(context.stdout, isNot(contains(plutilErrorMessage)));
-    });
+    test(
+      'Missing NSBonjourServices key in Info.plist should not fail Xcode compilation, and has plutil error in stdout under verbose mode',
+      () {
+        final Directory buildDir = fileSystem.directory('/path/to/builds')
+          ..createSync(recursive: true);
+        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+        const plutilErrorMessage =
+            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
+
+        final context = TestContext(
+          <String>['test_vm_service_bonjour_service'],
+          <String, String>{
+            'CONFIGURATION': 'Debug',
+            'BUILT_PRODUCTS_DIR': buildDir.path,
+            'INFOPLIST_PATH': 'Info.plist',
+            'VERBOSE_SCRIPT_LOGGING': 'YES',
+          },
+          commands: <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSBonjourServices',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+              exitCode: 1,
+              stderr: plutilErrorMessage,
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSBonjourServices',
+                '-json',
+                '["_dartVmService._tcp"]',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSLocalNetworkUsageDescription',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+            ),
+          ],
+          fileSystem: fileSystem,
+        )..run();
+        expect(context.stderr, isNot(startsWith('error: ')));
+        expect(context.stderr, isNot(contains(plutilErrorMessage)));
+        expect(context.stdout, contains(plutilErrorMessage));
+      },
+    );
+
+    test(
+      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation, and no plutil error in stdout without verbose mode',
+      () {
+        final Directory buildDir = fileSystem.directory('/path/to/builds')
+          ..createSync(recursive: true);
+        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+        const plutilErrorMessage =
+            'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
+        final context = TestContext(
+          <String>['test_vm_service_bonjour_service'],
+          <String, String>{
+            'CONFIGURATION': 'Debug',
+            'BUILT_PRODUCTS_DIR': buildDir.path,
+            'INFOPLIST_PATH': 'Info.plist',
+          },
+          commands: <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSBonjourServices',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSBonjourServices.0',
+                '-string',
+                '_dartVmService._tcp',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSLocalNetworkUsageDescription',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+              exitCode: 1,
+              stderr: plutilErrorMessage,
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSLocalNetworkUsageDescription',
+                '-string',
+                'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
+                infoPlist.path,
+              ],
+            ),
+          ],
+          fileSystem: fileSystem,
+        )..run();
+        expect(context.stderr, isNot(startsWith('error: ')));
+        expect(context.stderr, isNot(contains(plutilErrorMessage)));
+        expect(context.stdout, isNot(contains(plutilErrorMessage)));
+      },
+    );
+
+    test(
+      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation, and has plutil error in stdout under verbose mode',
+      () {
+        final Directory buildDir = fileSystem.directory('/path/to/builds')
+          ..createSync(recursive: true);
+        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+        const plutilErrorMessage =
+            'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
+        final context = TestContext(
+          <String>['test_vm_service_bonjour_service'],
+          <String, String>{
+            'CONFIGURATION': 'Debug',
+            'BUILT_PRODUCTS_DIR': buildDir.path,
+            'INFOPLIST_PATH': 'Info.plist',
+            'VERBOSE_SCRIPT_LOGGING': 'YES',
+          },
+          commands: <FakeCommand>[
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSBonjourServices',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSBonjourServices.0',
+                '-string',
+                '_dartVmService._tcp',
+                infoPlist.path,
+              ],
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-extract',
+                'NSLocalNetworkUsageDescription',
+                'xml1',
+                '-o',
+                '-',
+                infoPlist.path,
+              ],
+              exitCode: 1,
+              stderr: plutilErrorMessage,
+            ),
+            FakeCommand(
+              command: <String>[
+                'plutil',
+                '-insert',
+                'NSLocalNetworkUsageDescription',
+                '-string',
+                'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
+                infoPlist.path,
+              ],
+            ),
+          ],
+          fileSystem: fileSystem,
+        )..run();
+        expect(context.stderr, isNot(startsWith('error: ')));
+        expect(context.stderr, isNot(contains(plutilErrorMessage)));
+        expect(context.stdout, contains(plutilErrorMessage));
+      },
+    );
   });
 
   for (final platform in platforms) {

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -151,14 +151,16 @@ void main() {
         expect(actualInfoPlist, contains('NSLocalNetworkUsageDescription'));
 
         expect(result.stderr, isNot(startsWith('error:')));
+        const plutilErrorMessage =
+            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
+        expect(result.stderr, isNot(contains(plutilErrorMessage)));
+        expect(result.stdout, isNot(contains(plutilErrorMessage)));
         expect(result, const ProcessResultMatcher());
       });
     }
 
-    test(
-      'adds to existing Bonjour services, does not override network usage description',
-      () async {
-        infoPlist.writeAsStringSync('''
+    test('adds to existing Bonjour services, does not override network usage description', () async {
+      infoPlist.writeAsStringSync('''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -172,17 +174,17 @@ void main() {
 </dict>
 </plist>''');
 
-        final ProcessResult result = await Process.run(
-          xcodeBackendPath,
-          <String>['test_vm_service_bonjour_service'],
-          environment: <String, String>{
-            'CONFIGURATION': 'Debug',
-            'BUILT_PRODUCTS_DIR': buildDirectory.path,
-            'INFOPLIST_PATH': 'Info.plist',
-          },
-        );
+      final ProcessResult result = await Process.run(
+        xcodeBackendPath,
+        <String>['test_vm_service_bonjour_service'],
+        environment: <String, String>{
+          'CONFIGURATION': 'Debug',
+          'BUILT_PRODUCTS_DIR': buildDirectory.path,
+          'INFOPLIST_PATH': 'Info.plist',
+        },
+      );
 
-        expect(infoPlist.readAsStringSync(), '''
+      expect(infoPlist.readAsStringSync(), '''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -198,10 +200,13 @@ void main() {
 </plist>
 ''');
 
-        expect(result.stderr, isNot(startsWith('error:')));
-        expect(result, const ProcessResultMatcher());
-      },
-    );
+      const plutilErrorMessage =
+          'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
+      expect(result.stderr, isNot(startsWith('error:')));
+      expect(result.stderr, isNot(contains(plutilErrorMessage)));
+      expect(result.stdout, isNot(contains(plutilErrorMessage)));
+      expect(result, const ProcessResultMatcher());
+    });
 
     test('does not add bonjour settings when port publication is disabled', () async {
       infoPlist.writeAsStringSync('''


### PR DESCRIPTION
The previous PR https://github.com/flutter/flutter/pull/172913 avoids compilation error by not having the "error: " prefix. However, it's still very confusing to have "key not found" printed out in the terminal (either stderr or stdout), despite that it doesn't cause compilation error anymore. 

This PR introduces a new flag "skipErrorLog" which skips logging the `stderr` if set to true. We set it for plist extraction, because "not having bonjour key" should be one of the expected "normal" states

<s> We don't want to pipe it to `stdout` either, because it would be confusing too. I figured people would still file issue if they see it in terminal, even if it's a completely normal state. But not a strong opinion, so let me know if you disagree. </s>

However, under verbose mode, we would pipe it to `stdout`. This will be consistent with our previous behavior before macOS 26.

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/172627

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
