### PR TITLE
Make sure that a TableRowInkWell doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1905,6 +1905,22 @@ void main() {
       expect(secondaryTapped, isTrue);
       expect(secondaryTappedDown, isTrue);
     });
+
+    testWidgets('TableRowInkWell renders at zero area', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: SizedBox.shrink(
+              child: Table(
+                children: const <TableRow>[
+                  TableRow(children: <Widget>[TableRowInkWell(child: Text('X'))]),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    });
   });
 
   testWidgets('Heading cell cursor resolves MaterialStateMouseCursor correctly', (


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the TableRowInkWell UI control.