### PR TITLE
[CP beta] Use LLDB as the default debugging method for iOS 17+ and Xcode 26+ (#173443)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -5481,6 +5481,16 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: hot_mode_dev_cycle_ios_simulator
 
+  - name: Mac_ios hot_mode_dev_cycle_ios_xcode_debug
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: hot_mode_dev_cycle_ios_xcode_debug
+
   - name: Mac_ios fullscreen_textfield_perf_ios__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -267,6 +267,7 @@
 /dev/devicelab/bin/tasks/hello_world_macos__compile.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/hello_world_win_desktop__compile.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_simulator.dart @louisehsu @flutter/tool
+/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart @vashworth @flutter/tool
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_macos_target__benchmark.dart @cbracken @flutter/tool
 /dev/devicelab/bin/tasks/hot_mode_dev_cycle_win_target__benchmark.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/integration_ui_test_test_macos.dart @cbracken @flutter/desktop

--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_xcode_debug.dart
@@ -1,0 +1,45 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/tasks/hot_mode_tests.dart';
+import 'package:path/path.dart' as path;
+
+/// This is a test to validate that Xcode debugging still works now that LLDB is the default.
+Future<void> main() async {
+  await task(() async {
+    deviceOperatingSystem = DeviceOperatingSystem.ios;
+    try {
+      await disableLLDBDebugging();
+      // This isn't actually a benchmark test, so do not use the returned `benchmarkScoreKeys` result.
+      await createHotModeTest()();
+      return TaskResult.success(null);
+    } finally {
+      await enableLLDBDebugging();
+    }
+  });
+}
+
+Future<void> disableLLDBDebugging() async {
+  final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+    'config',
+    '--no-enable-lldb-debugging',
+  ]);
+  if (configResult != 0) {
+    print('Failed to disable configuration, tasks may not run.');
+  }
+}
+
+Future<void> enableLLDBDebugging() async {
+  final int configResult = await exec(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+    'config',
+    '--enable-lldb-debugging',
+  ], canFail: true);
+  if (configResult != 0) {
+    print('Failed to enable configuration.');
+  }
+}

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -1198,7 +1198,6 @@ class DebuggingOptions {
     String? route,
     Map<String, Object?> platformArgs, {
     DeviceConnectionInterface interfaceType = DeviceConnectionInterface.attached,
-    bool isCoreDevice = false,
   }) {
     return <String>[
       if (enableDartProfiling) '--enable-dart-profiling',
@@ -1212,13 +1211,7 @@ class DebuggingOptions {
       if (environmentType == EnvironmentType.simulator && dartFlags.isNotEmpty)
         '--dart-flags=$dartFlags',
       if (useTestFonts) '--use-test-fonts',
-      // Core Devices (iOS 17 devices) are debugged through Xcode so don't
-      // include these flags, which are used to check if the app was launched
-      // via Flutter CLI and `ios-deploy`.
-      if (debuggingEnabled && !isCoreDevice) ...<String>[
-        '--enable-checked-mode',
-        '--verify-entry-points',
-      ],
+      if (debuggingEnabled) ...<String>['--enable-checked-mode', '--verify-entry-points'],
       if (enableSoftwareRendering) '--enable-software-rendering',
       if (traceSystrace) '--trace-systrace',
       if (traceToFile != null) '--trace-to-file="$traceToFile"',

--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -67,6 +67,9 @@ abstract class FeatureFlags {
   /// Whether desktop windowing is enabled.
   bool get isWindowingEnabled;
 
+  /// Whether physical iOS devices are debugging with LLDB.
+  bool get isLLDBDebuggingEnabled;
+
   /// Whether a particular feature is enabled for the current channel.
   ///
   /// Prefer using one of the specific getters above instead of this API.
@@ -87,6 +90,7 @@ abstract class FeatureFlags {
     swiftPackageManager,
     omitLegacyVersionFile,
     windowingFeature,
+    lldbDebugging,
   ];
 
   /// All current Flutter feature flags that can be configured.
@@ -216,6 +220,23 @@ const windowingFeature = Feature(
   environmentOverride: 'FLUTTER_WINDOWING',
   runtimeId: 'windowing',
   master: FeatureChannelSetting(available: true),
+);
+
+/// Enable LLDB debugging for physical iOS devices. When LLDB debugging is off,
+/// Xcode debugging is used instead.
+///
+/// Requires iOS 17+ and Xcode 26+. If those requirements are not met, the previous
+/// default debugging method is used instead.
+const lldbDebugging = Feature(
+  name: 'support for debugging with LLDB for physical iOS devices',
+  extraHelpText:
+      'If LLDB debugging is off, Xcode debugging is used instead. '
+      'Only available for iOS 17 or newer devices. Requires Xcode 26 or greater.',
+  configSetting: 'enable-lldb-debugging',
+  environmentOverride: 'FLUTTER_LLDB_DEBUGGING',
+  master: FeatureChannelSetting(available: true, enabledByDefault: true),
+  beta: FeatureChannelSetting(available: true, enabledByDefault: true),
+  stable: FeatureChannelSetting(available: true, enabledByDefault: true),
 );
 
 /// A [Feature] is a process for conditionally enabling tool features.

--- a/packages/flutter_tools/lib/src/flutter_features.dart
+++ b/packages/flutter_tools/lib/src/flutter_features.dart
@@ -57,6 +57,9 @@ mixin FlutterFeatureFlagsIsEnabled implements FeatureFlags {
 
   @override
   bool get isWindowingEnabled => isEnabled(windowingFeature);
+
+  @override
+  bool get isLLDBDebuggingEnabled => isEnabled(lldbDebugging);
 }
 
 interface class FlutterFeatureFlags extends FeatureFlags with FlutterFeatureFlagsIsEnabled {

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -99,7 +99,7 @@ return False
       await _attachToAppProcess(appProcessId);
       await _resumeProcess();
     } on _LLDBError catch (e) {
-      _logger.printError('lldb failed with error: ${e.message}');
+      _logger.printTrace('lldb failed with error: ${e.message}');
       exit();
       return false;
     } finally {
@@ -115,7 +115,7 @@ return False
   /// to `stderr`, complete with an error and stop the process.
   Future<bool> _startLLDB(int appProcessId) async {
     if (_lldbProcess != null) {
-      _logger.printError(
+      _logger.printTrace(
         'An LLDB process is already running. It must be stopped before starting a new one.',
       );
       return false;
@@ -139,7 +139,7 @@ return False
           .transform<String>(utf8.decoder)
           .transform<String>(const LineSplitter())
           .listen((String line) {
-            _logger.printError('[lldb]: $line');
+            _logger.printTrace('[lldb]: $line');
             _monitorError(line);
           });
 
@@ -155,7 +155,7 @@ return False
             }),
       );
     } on ProcessException catch (exception) {
-      _logger.printError('Process exception running lldb:\n$exception');
+      _logger.printTrace('Process exception running lldb:\n$exception');
       return false;
     }
     return true;

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -602,6 +602,7 @@ class XCDevice {
           iProxy: _iProxy,
           fileSystem: globals.fs,
           logger: _logger,
+          analytics: globals.analytics,
           iosDeploy: _iosDeploy,
           iMobileDevice: _iMobileDevice,
           coreDeviceControl: _coreDeviceControl,

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -791,22 +791,6 @@ void main() {
       },
     );
 
-    testWithoutContext(
-      'Get launch arguments for physical CoreDevice with debugging enabled with no launch arguments',
-      () {
-        final original = DebuggingOptions.enabled(BuildInfo.debug);
-
-        final List<String> launchArguments = original.getIOSLaunchArguments(
-          EnvironmentType.physical,
-          null,
-          <String, Object?>{},
-          isCoreDevice: true,
-        );
-
-        expect(launchArguments.join(' '), <String>['--enable-dart-profiling'].join(' '));
-      },
-    );
-
     testWithoutContext('Get launch arguments for physical device with iPv4 network connection', () {
       final original = DebuggingOptions.enabled(BuildInfo.debug);
 

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -819,6 +819,9 @@ class FakeFlutterFeatures extends FeatureFlags {
   bool get isWindowingEnabled => _enabled;
 
   @override
+  bool get isLLDBDebuggingEnabled => _enabled;
+
+  @override
   final List<Feature> allFeatures;
 
   @override

--- a/packages/flutter_tools/test/general.shard/ios/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/devices_test.dart
@@ -28,6 +28,7 @@ import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/macos/xcdevice.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -79,6 +80,7 @@ void main() {
         logger: logger,
         platform: macPlatform,
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -101,6 +103,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -125,6 +128,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -148,6 +152,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -171,6 +176,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -194,6 +200,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -217,6 +224,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -242,6 +250,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -267,6 +276,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -292,6 +302,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -317,6 +328,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -342,6 +354,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -363,6 +376,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -387,6 +401,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -412,6 +427,7 @@ void main() {
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         fileSystem: fileSystem,
         logger: logger,
+        analytics: FakeAnalytics(),
         platform: macPlatform,
         iosDeploy: iosDeploy,
         iMobileDevice: iMobileDevice,
@@ -444,6 +460,7 @@ void main() {
               iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
               fileSystem: fileSystem,
               logger: logger,
+              analytics: FakeAnalytics(),
               platform: platform,
               iosDeploy: iosDeploy,
               iMobileDevice: iMobileDevice,
@@ -533,6 +550,7 @@ void main() {
           iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
           fileSystem: fileSystem,
           logger: logger,
+          analytics: FakeAnalytics(),
           platform: macPlatform,
           iosDeploy: iosDeploy,
           iMobileDevice: iMobileDevice,
@@ -609,6 +627,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -630,6 +649,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -939,6 +959,7 @@ void main() {
         cpuArchitecture: DarwinArch.arm64,
         iProxy: IProxy.test(logger: logger, processManager: FakeProcessManager.any()),
         iosDeploy: iosDeploy,
+        analytics: FakeAnalytics(),
         iMobileDevice: iMobileDevice,
         coreDeviceControl: coreDeviceControl,
         coreDeviceLauncher: coreDeviceLauncher,
@@ -1108,3 +1129,5 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {
 class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {}
 
 class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+
+class FakeAnalytics extends Fake implements Analytics {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_install_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/fake_process_manager.dart';
@@ -380,6 +381,7 @@ IOSDevice setUpIOSDevice({
       artifacts: artifacts,
       cache: cache,
     ),
+    analytics: FakeAnalytics(),
     coreDeviceControl: FakeIOSCoreDeviceControl(),
     coreDeviceLauncher: FakeIOSCoreDeviceLauncher(),
     xcodeDebug: FakeXcodeDebug(),
@@ -412,3 +414,5 @@ class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
 }
 
 class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+
+class FakeAnalytics extends Fake implements Analytics {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -107,6 +108,7 @@ IOSDevice setUpIOSDevice(FileSystem fileSystem) {
       artifacts: Artifacts.test(),
       cache: Cache.test(processManager: processManager),
     ),
+    analytics: FakeAnalytics(),
     iMobileDevice: IMobileDevice.test(processManager: processManager),
     coreDeviceControl: FakeIOSCoreDeviceControl(),
     coreDeviceLauncher: FakeIOSCoreDeviceLauncher(),
@@ -129,3 +131,5 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {}
 class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {}
 
 class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+
+class FakeAnalytics extends Fake implements Analytics {}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -219,11 +219,13 @@ void main() {
     testUsingContext(
       'with buildable app',
       () async {
+        final fakeExactAnalytics = FakeExactAnalytics();
         final IOSDevice iosDevice = setUpIOSDevice(
           fileSystem: fileSystem,
           processManager: processManager,
           logger: logger,
           artifacts: artifacts,
+          analytics: fakeExactAnalytics,
         );
         setUpIOSProject(fileSystem);
         final FlutterProject flutterProject = FlutterProject.fromDirectory(
@@ -279,6 +281,13 @@ void main() {
         expect(fileSystem.directory('build/ios/iphoneos'), exists);
         expect(launchResult.started, true);
         expect(processManager, hasNoRemainingExpectations);
+        expect(fakeExactAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+            result: 'release success',
+          ),
+        ]);
       },
       overrides: <Type, Generator>{
         ProcessManager: () => processManager,
@@ -296,11 +305,13 @@ void main() {
       'ONLY_ACTIVE_ARCH is NO if different host and target architectures',
       () async {
         // Host architecture is x64, target architecture is arm64.
+        final fakeExactAnalytics = FakeExactAnalytics();
         final IOSDevice iosDevice = setUpIOSDevice(
           fileSystem: fileSystem,
           processManager: processManager,
           logger: logger,
           artifacts: artifacts,
+          analytics: fakeExactAnalytics,
         );
         setUpIOSProject(fileSystem);
         final FlutterProject flutterProject = FlutterProject.fromDirectory(
@@ -385,6 +396,13 @@ void main() {
         expect(fileSystem.directory('build/ios/iphoneos'), exists);
         expect(launchResult.started, true);
         expect(processManager, hasNoRemainingExpectations);
+        expect(fakeExactAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+            result: 'release success',
+          ),
+        ]);
       },
       overrides: <Type, Generator>{
         ProcessManager: () => processManager,
@@ -401,11 +419,13 @@ void main() {
     testUsingContext(
       'with concurrent build failures',
       () async {
+        final fakeExactAnalytics = FakeExactAnalytics();
         final IOSDevice iosDevice = setUpIOSDevice(
           fileSystem: fileSystem,
           processManager: processManager,
           logger: logger,
           artifacts: artifacts,
+          analytics: fakeExactAnalytics,
         );
         setUpIOSProject(fileSystem);
         final FlutterProject flutterProject = FlutterProject.fromDirectory(
@@ -464,6 +484,13 @@ void main() {
               );
               expect(launchResult.started, true);
               expect(processManager, hasNoRemainingExpectations);
+              expect(fakeExactAnalytics.sentEvents, [
+                Event.appleUsageEvent(
+                  workflow: 'ios-physical-deployment',
+                  parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+                  result: 'release success',
+                ),
+              ]);
             }),
           ),
         );
@@ -502,7 +529,10 @@ void main() {
       projectInfo = XcodeProjectInfo(<String>['Runner'], <String>['Debug', 'Release'], <String>[
         'Runner',
       ], logger);
-      fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(projectInfo: projectInfo);
+      fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(
+        projectInfo: projectInfo,
+        xcodeVersion: Version(15, 0, 0),
+      );
       xcode = Xcode.test(
         processManager: FakeProcessManager.any(),
         xcodeProjectInterpreter: fakeXcodeProjectInterpreter,
@@ -513,6 +543,7 @@ void main() {
       testUsingContext(
         'succeeds when install and launch succeed',
         () async {
+          final fakeExactAnalytics = FakeExactAnalytics();
           final IOSDevice iosDevice = setUpIOSDevice(
             fileSystem: fileSystem,
             processManager: FakeProcessManager.any(),
@@ -520,6 +551,7 @@ void main() {
             artifacts: artifacts,
             isCoreDevice: true,
             coreDeviceControl: FakeIOSCoreDeviceControl(),
+            analytics: fakeExactAnalytics,
           );
           setUpIOSProject(fileSystem);
           final FlutterProject flutterProject = FlutterProject.fromDirectory(
@@ -543,6 +575,13 @@ void main() {
           expect(fileSystem.directory('build/ios/iphoneos'), exists);
           expect(launchResult.started, true);
           expect(processManager, hasNoRemainingExpectations);
+          expect(fakeExactAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithoutDebugger.name,
+              result: 'release success',
+            ),
+          ]);
         },
         overrides: <Type, Generator>{
           ProcessManager: () => FakeProcessManager.any(),
@@ -559,6 +598,7 @@ void main() {
       testUsingContext(
         'fails when install fails',
         () async {
+          final fakeExactAnalytics = FakeExactAnalytics();
           final IOSDevice iosDevice = setUpIOSDevice(
             fileSystem: fileSystem,
             processManager: FakeProcessManager.any(),
@@ -566,6 +606,8 @@ void main() {
             artifacts: artifacts,
             isCoreDevice: true,
             coreDeviceControl: FakeIOSCoreDeviceControl(installSuccess: false),
+            coreDeviceLauncher: FakeIOSCoreDeviceLauncher(launchResult: false),
+            analytics: fakeExactAnalytics,
           );
           setUpIOSProject(fileSystem);
           final FlutterProject flutterProject = FlutterProject.fromDirectory(
@@ -589,6 +631,13 @@ void main() {
           expect(fileSystem.directory('build/ios/iphoneos'), exists);
           expect(launchResult.started, false);
           expect(processManager, hasNoRemainingExpectations);
+          expect(fakeExactAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithoutDebugger.name,
+              result: 'launch failed',
+            ),
+          ]);
         },
         overrides: <Type, Generator>{
           ProcessManager: () => FakeProcessManager.any(),
@@ -652,6 +701,7 @@ void main() {
         'ensure arguments passed to launch',
         () async {
           final coreDeviceControl = FakeIOSCoreDeviceControl();
+          final fakeExactAnalytics = FakeExactAnalytics();
           final IOSDevice iosDevice = setUpIOSDevice(
             fileSystem: fileSystem,
             processManager: FakeProcessManager.any(),
@@ -659,6 +709,7 @@ void main() {
             artifacts: artifacts,
             isCoreDevice: true,
             coreDeviceControl: coreDeviceControl,
+            analytics: fakeExactAnalytics,
           );
           setUpIOSProject(fileSystem);
           final FlutterProject flutterProject = FlutterProject.fromDirectory(
@@ -684,6 +735,13 @@ void main() {
           expect(processManager, hasNoRemainingExpectations);
           expect(coreDeviceControl.argumentsUsedForLaunch, isNotNull);
           expect(coreDeviceControl.argumentsUsedForLaunch, contains('--enable-dart-profiling'));
+          expect(fakeExactAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithoutDebugger.name,
+              result: 'release success',
+            ),
+          ]);
         },
         overrides: <Type, Generator>{
           ProcessManager: () => FakeProcessManager.any(),
@@ -1177,6 +1235,7 @@ IOSDevice setUpIOSDevice({
   IOSCoreDeviceLauncher? coreDeviceLauncher,
   FakeXcodeDebug? xcodeDebug,
   DarwinArch cpuArchitecture = DarwinArch.arm64,
+  FakeExactAnalytics? analytics,
 }) {
   artifacts ??= Artifacts.test();
   final cache = Cache.test(
@@ -1200,6 +1259,7 @@ IOSDevice setUpIOSDevice({
       artifacts: artifacts,
       cache: cache,
     ),
+    analytics: analytics ?? FakeExactAnalytics(),
     iMobileDevice: IMobileDevice(
       logger: logger,
       processManager: processManager ?? FakeProcessManager.any(),
@@ -1226,7 +1286,8 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
       'WRAPPER_NAME': 'My Super Awesome App.app',
       'DEVELOPMENT_TEAM': '3333CCCC33',
     },
-  });
+    Version? xcodeVersion,
+  }) : version = xcodeVersion ?? Version(1000, 0, 0);
 
   final Map<String, String> buildSettings;
   final XcodeProjectInfo? projectInfo;
@@ -1235,7 +1296,7 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
   final isInstalled = true;
 
   @override
-  final version = Version(1000, 0, 0);
+  Version? version;
 
   @override
   String get versionText => version.toString();
@@ -1319,13 +1380,17 @@ class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
   }
 
   @override
-  Future<bool> launchApp({
+  Future<IOSCoreDeviceLaunchResult?> launchApp({
     required String deviceId,
     required String bundleId,
     List<String> launchArguments = const <String>[],
+    bool startStopped = false,
   }) async {
     _launchArguments = launchArguments;
-    return launchSuccess;
+    final outcome = launchSuccess ? 'success' : 'failed';
+    return IOSCoreDeviceLaunchResult.fromJson(<String, Object?>{
+      'info': {'outcome': outcome},
+    });
   }
 }
 
@@ -1395,4 +1460,36 @@ const _validScheme = '''
 </Scheme>
 ''';
 
-class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
+  FakeIOSCoreDeviceLauncher({this.launchResult = true});
+  bool launchResult;
+
+  @override
+  Future<bool> launchAppWithoutDebugger({
+    required String deviceId,
+    required String bundlePath,
+    required String bundleId,
+    required List<String> launchArguments,
+  }) async {
+    return launchResult;
+  }
+
+  @override
+  Future<bool> launchAppWithLLDBDebugger({
+    required String deviceId,
+    required String bundlePath,
+    required String bundleId,
+    required List<String> launchArguments,
+  }) async {
+    return true;
+  }
+}
+
+class FakeExactAnalytics extends Fake implements Analytics {
+  final sentEvents = <Event>[];
+
+  @override
+  void send(Event event) {
+    sentEvents.add(event);
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/template.dart';
+import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -24,8 +25,10 @@ import 'package:flutter_tools/src/ios/ios_deploy.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/ios/xcode_debug.dart';
+import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/mdns_discovery.dart';
 import 'package:test/fake.dart';
+import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -131,9 +134,11 @@ void main() {
     () async {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final processManager = FakeProcessManager.list(<FakeCommand>[attachDebuggerCommand()]);
+      final fakeAnalytics = FakeAnalytics();
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -162,6 +167,13 @@ void main() {
       expect(launchResult.started, true);
       expect(launchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), false);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -171,6 +183,7 @@ void main() {
       final logger = BufferLogger.test();
       final FileSystem fileSystem = MemoryFileSystem.test();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(stdout: 'PROCESS_EXITED'),
         attachDebuggerCommand(
@@ -183,6 +196,7 @@ void main() {
         processManager: processManager,
         fileSystem: fileSystem,
         logger: logger,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -214,6 +228,18 @@ void main() {
       expect(secondLaunchResult.started, true);
       expect(secondLaunchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), true);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'launch failed',
+        ),
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -222,10 +248,12 @@ void main() {
     () async {
       final FileSystem fileSystem = MemoryFileSystem.test();
       final processManager = FakeProcessManager.list(<FakeCommand>[kLaunchDebugCommand]);
+      final fakeAnalytics = FakeAnalytics();
       final IOSDevice device = setUpIOSDevice(
         sdkVersion: '12.4.4',
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -254,6 +282,13 @@ void main() {
       expect(launchResult.started, true);
       expect(launchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), false);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -264,12 +299,14 @@ void main() {
       final logger = BufferLogger.test();
       final stdin = CompleterIOSink();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(stdin: stdin, completer: completer),
       ]);
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
         logger: logger,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
@@ -307,6 +344,13 @@ void main() {
       expect(utf8.decoder.convert(stdin.writes.first), contains('process interrupt'));
       completer.complete();
       expect(processManager, hasNoRemainingExpectations);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -317,12 +361,14 @@ void main() {
       final logger = BufferLogger.test();
       final stdin = CompleterIOSink();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(stdin: stdin, completer: completer, isWirelessDevice: true),
       ]);
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
         logger: logger,
         interfaceType: DeviceConnectionInterface.wireless,
       );
@@ -371,6 +417,13 @@ void main() {
         ),
       );
       completer.complete();
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
       expect(processManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => FakeMDnsVmServiceDiscovery()},
@@ -382,6 +435,7 @@ void main() {
       final logger = BufferLogger.test();
       final FileSystem fileSystem = MemoryFileSystem.test();
       final completer = Completer<void>();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(
           stdout:
@@ -399,6 +453,7 @@ void main() {
         processManager: processManager,
         fileSystem: fileSystem,
         logger: logger,
+        analytics: fakeAnalytics,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
         projectBundleId: 'app',
@@ -425,6 +480,13 @@ void main() {
       expect(launchResult.started, true);
       expect(launchResult.hasVmService, true);
       expect(await device.stopApp(iosApp), true);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging success',
+        ),
+      ]);
     },
   );
 
@@ -433,6 +495,7 @@ void main() {
     () async {
       final logger = BufferLogger.test();
       final FileSystem fileSystem = MemoryFileSystem.test();
+      final fakeAnalytics = FakeAnalytics();
       final processManager = FakeProcessManager.list(<FakeCommand>[
         attachDebuggerCommand(
           stdout:
@@ -442,6 +505,7 @@ void main() {
       final IOSDevice device = setUpIOSDevice(
         processManager: processManager,
         fileSystem: fileSystem,
+        analytics: fakeAnalytics,
         logger: logger,
       );
       final IOSApp iosApp = PrebuiltIOSApp(
@@ -464,13 +528,25 @@ void main() {
       expect(launchResult.started, false);
       expect(launchResult.hasVmService, false);
       expect(await device.stopApp(iosApp), false);
+      expect(fakeAnalytics.sentEvents, [
+        Event.appleUsageEvent(
+          workflow: 'ios-physical-deployment',
+          parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+          result: 'debugging failed',
+        ),
+      ]);
     },
   );
 
   testWithoutContext('IOSDevice.startApp succeeds in release mode', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final processManager = FakeProcessManager.list(<FakeCommand>[kLaunchReleaseCommand]);
-    final IOSDevice device = setUpIOSDevice(processManager: processManager, fileSystem: fileSystem);
+    final fakeAnalytics = FakeAnalytics();
+    final IOSDevice device = setUpIOSDevice(
+      processManager: processManager,
+      fileSystem: fileSystem,
+      analytics: fakeAnalytics,
+    );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
       bundleName: 'Runner',
@@ -489,10 +565,18 @@ void main() {
     expect(launchResult.hasVmService, false);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunch.name,
+        result: 'release success',
+      ),
+    ]);
   });
 
   testWithoutContext('IOSDevice.startApp forwards all supported debugging options', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    final fakeAnalytics = FakeAnalytics();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -546,6 +630,7 @@ void main() {
       sdkVersion: '13.3',
       processManager: processManager,
       fileSystem: fileSystem,
+      analytics: fakeAnalytics,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -594,10 +679,18 @@ void main() {
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+        result: 'debugging success',
+      ),
+    ]);
   });
 
   testWithoutContext('startApp using route', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    final fakeAnalytics = FakeAnalytics();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -633,6 +726,7 @@ void main() {
       sdkVersion: '13.3',
       processManager: processManager,
       fileSystem: fileSystem,
+      analytics: fakeAnalytics,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -661,10 +755,18 @@ void main() {
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+        result: 'debugging success',
+      ),
+    ]);
   });
 
   testWithoutContext('startApp using trace-startup', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
+    final fakeAnalytics = FakeAnalytics();
     final processManager = FakeProcessManager.list(<FakeCommand>[
       FakeCommand(
         command: <String>[
@@ -700,6 +802,7 @@ void main() {
       sdkVersion: '13.3',
       processManager: processManager,
       fileSystem: fileSystem,
+      analytics: fakeAnalytics,
     );
     final IOSApp iosApp = PrebuiltIOSApp(
       projectBundleId: 'app',
@@ -727,17 +830,81 @@ void main() {
     expect(launchResult.started, true);
     expect(await device.stopApp(iosApp), false);
     expect(processManager, hasNoRemainingExpectations);
+    expect(fakeAnalytics.sentEvents, [
+      Event.appleUsageEvent(
+        workflow: 'ios-physical-deployment',
+        parameter: IOSDeploymentMethod.iosDeployLaunchAndAttach.name,
+        result: 'debugging success',
+      ),
+    ]);
   });
 
   group('IOSDevice.startApp for CoreDevice', () {
     group('in debug mode', () {
-      testUsingContext('succeeds', () async {
+      testUsingContext(
+        'uses LLDB with Xcode 26+',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final deviceLogReader = FakeDeviceLogReader();
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(fakeLauncher.launchedWithLLDB, true);
+          expect(fakeLauncher.launchedWithXcode, false);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithLLDB.name,
+              result: 'debugging success',
+            ),
+          ]);
+        },
+        overrides: {
+          Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0)),
+          Analytics: () => FakeAnalytics(),
+        },
+      );
+
+      testUsingContext('uses Xcode if LLDB fails', () async {
         final FileSystem fileSystem = MemoryFileSystem.test();
         final processManager = FakeProcessManager.empty();
-
         final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
             .childDirectory('flutter_empty_xcode.rand0');
         final Directory bundleLocation = fileSystem.currentDirectory;
+        final fakeAnalytics = FakeAnalytics();
+        final fakeLauncher = FakeIOSCoreDeviceLauncher(lldbLaunchResult: false);
         final IOSDevice device = setUpIOSDevice(
           processManager: processManager,
           fileSystem: fileSystem,
@@ -754,6 +921,8 @@ void main() {
             expectedLaunchArguments: <String>['--enable-dart-profiling'],
             expectedBundlePath: bundleLocation.path,
           ),
+          coreDeviceLauncher: fakeLauncher,
+          analytics: fakeAnalytics,
         );
         final IOSApp iosApp = PrebuiltIOSApp(
           projectBundleId: 'app',
@@ -780,6 +949,144 @@ void main() {
         );
 
         expect(launchResult.started, true);
+        expect(fakeLauncher.launchedWithLLDB, true);
+        expect(fakeAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithLLDB.name,
+            result: 'launch failed',
+          ),
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithXcodeFallback.name,
+            result: 'debugging success',
+          ),
+        ]);
+      }, overrides: {Xcode: () => FakeXcode(currentVersion: Version(26, 0, 0))});
+
+      testUsingContext(
+        'uses Xcode if less than Xcode 26',
+        () async {
+          final FileSystem fileSystem = MemoryFileSystem.test();
+          final processManager = FakeProcessManager.empty();
+          final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
+              .childDirectory('flutter_empty_xcode.rand0');
+          final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
+          final fakeLauncher = FakeIOSCoreDeviceLauncher();
+          final IOSDevice device = setUpIOSDevice(
+            processManager: processManager,
+            fileSystem: fileSystem,
+            isCoreDevice: true,
+            coreDeviceControl: FakeIOSCoreDeviceControl(),
+            xcodeDebug: FakeXcodeDebug(
+              expectedProject: XcodeDebugProject(
+                scheme: 'Runner',
+                xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
+                xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
+                hostAppProjectName: 'Runner',
+              ),
+              expectedDeviceId: '123',
+              expectedLaunchArguments: <String>['--enable-dart-profiling'],
+              expectedBundlePath: bundleLocation.path,
+            ),
+            coreDeviceLauncher: fakeLauncher,
+            analytics: fakeAnalytics,
+          );
+          final IOSApp iosApp = PrebuiltIOSApp(
+            projectBundleId: 'app',
+            bundleName: 'Runner',
+            uncompressedBundle: bundleLocation,
+            applicationPackage: bundleLocation,
+          );
+          final deviceLogReader = FakeDeviceLogReader();
+
+          device.portForwarder = const NoOpDevicePortForwarder();
+          device.setLogReader(iosApp, deviceLogReader);
+
+          // Start writing messages to the log reader.
+          Timer.run(() {
+            deviceLogReader.addLine('Foo');
+            deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+          });
+
+          final LaunchResult launchResult = await device.startApp(
+            iosApp,
+            prebuiltApplication: true,
+            debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+            platformArgs: <String, dynamic>{},
+          );
+
+          expect(launchResult.started, true);
+          expect(fakeLauncher.launchedWithLLDB, false);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
+            ),
+          ]);
+        },
+        overrides: {Xcode: () => FakeXcode(currentVersion: Version(16, 0, 0))},
+      );
+
+      testUsingContext('succeeds', () async {
+        final FileSystem fileSystem = MemoryFileSystem.test();
+        final processManager = FakeProcessManager.empty();
+        final fakeAnalytics = FakeAnalytics();
+        final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
+            .childDirectory('flutter_empty_xcode.rand0');
+        final Directory bundleLocation = fileSystem.currentDirectory;
+        final IOSDevice device = setUpIOSDevice(
+          processManager: processManager,
+          fileSystem: fileSystem,
+          isCoreDevice: true,
+          coreDeviceControl: FakeIOSCoreDeviceControl(),
+          xcodeDebug: FakeXcodeDebug(
+            expectedProject: XcodeDebugProject(
+              scheme: 'Runner',
+              xcodeWorkspace: temporaryXcodeProjectDirectory.childDirectory('Runner.xcworkspace'),
+              xcodeProject: temporaryXcodeProjectDirectory.childDirectory('Runner.xcodeproj'),
+              hostAppProjectName: 'Runner',
+            ),
+            expectedDeviceId: '123',
+            expectedLaunchArguments: <String>['--enable-dart-profiling'],
+            expectedBundlePath: bundleLocation.path,
+          ),
+          analytics: fakeAnalytics,
+        );
+        final IOSApp iosApp = PrebuiltIOSApp(
+          projectBundleId: 'app',
+          bundleName: 'Runner',
+          uncompressedBundle: bundleLocation,
+          applicationPackage: bundleLocation,
+        );
+        final deviceLogReader = FakeDeviceLogReader();
+
+        device.portForwarder = const NoOpDevicePortForwarder();
+        device.setLogReader(iosApp, deviceLogReader);
+
+        // Start writing messages to the log reader.
+        Timer.run(() {
+          deviceLogReader.addLine('Foo');
+          deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
+        });
+
+        final LaunchResult launchResult = await device.startApp(
+          iosApp,
+          prebuiltApplication: true,
+          debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+          platformArgs: <String, dynamic>{},
+        );
+
+        expect(launchResult.started, true);
+        expect(fakeAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+            result: 'debugging success',
+          ),
+        ]);
       });
 
       testUsingContext('prints warning message if it takes too long to start debugging', () async {
@@ -839,7 +1146,8 @@ void main() {
           expect(
             logger.errorText,
             contains(
-              'Xcode is taking longer than expected to start debugging the app. Ensure the project is opened in Xcode.',
+              'Xcode is taking longer than expected to start debugging the app. '
+              'If the issue persists, try closing Xcode and re-running your Flutter command.',
             ),
           );
           completer.complete();
@@ -853,6 +1161,7 @@ void main() {
         final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
             .childDirectory('flutter_empty_xcode.rand0');
         final Directory bundleLocation = fileSystem.currentDirectory;
+        final fakeAnalytics = FakeAnalytics();
         final IOSDevice device = setUpIOSDevice(
           processManager: processManager,
           fileSystem: fileSystem,
@@ -869,6 +1178,7 @@ void main() {
             expectedLaunchArguments: <String>['--enable-dart-profiling'],
             expectedBundlePath: bundleLocation.path,
           ),
+          analytics: fakeAnalytics,
         );
         final IOSApp iosApp = PrebuiltIOSApp(
           projectBundleId: 'app',
@@ -899,6 +1209,13 @@ void main() {
 
         expect(launchResult.started, true);
         expect(shutDownHooks.hooks.length, 1);
+        expect(fakeAnalytics.sentEvents, [
+          Event.appleUsageEvent(
+            workflow: 'ios-physical-deployment',
+            parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+            result: 'debugging success',
+          ),
+        ]);
       });
 
       testUsingContext(
@@ -910,10 +1227,12 @@ void main() {
           final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
               .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
           final IOSDevice device = setUpIOSDevice(
             processManager: processManager,
             fileSystem: fileSystem,
             isCoreDevice: true,
+            analytics: fakeAnalytics,
             coreDeviceControl: FakeIOSCoreDeviceControl(),
             xcodeDebug: FakeXcodeDebug(
               expectedProject: XcodeDebugProject(
@@ -948,6 +1267,13 @@ void main() {
           expect(launchResult.started, true);
           expect(launchResult.hasVmService, true);
           expect(await device.stopApp(iosApp), true);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
+            ),
+          ]);
         },
         // If mDNS is not the only method of discovery, it shouldn't throw on error.
         overrides: <Type, Generator>{
@@ -965,7 +1291,7 @@ void main() {
         testUsingContext('when mDNS fails', () async {
           final FileSystem fileSystem = MemoryFileSystem.test();
           final processManager = FakeProcessManager.empty();
-
+          final fakeAnalytics = FakeAnalytics();
           final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
               .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
@@ -985,6 +1311,7 @@ void main() {
               expectedLaunchArguments: <String>['--enable-dart-profiling'],
               expectedBundlePath: bundleLocation.path,
             ),
+            analytics: fakeAnalytics,
           );
           final IOSApp iosApp = PrebuiltIOSApp(
             projectBundleId: 'app',
@@ -1017,6 +1344,13 @@ void main() {
           expect(launchResult.started, true);
           expect(launchResult.hasVmService, true);
           expect(await device.stopApp(iosApp), true);
+          expect(fakeAnalytics.sentEvents, [
+            Event.appleUsageEvent(
+              workflow: 'ios-physical-deployment',
+              parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+              result: 'debugging success',
+            ),
+          ]);
         }, overrides: <Type, Generator>{MDnsVmServiceDiscovery: () => mdnsDiscovery});
       });
 
@@ -1032,6 +1366,7 @@ void main() {
           final Directory temporaryXcodeProjectDirectory = fileSystem.systemTempDirectory
               .childDirectory('flutter_empty_xcode.rand0');
           final Directory bundleLocation = fileSystem.currentDirectory;
+          final fakeAnalytics = FakeAnalytics();
           final IOSDevice device = setUpIOSDevice(
             processManager: processManager,
             fileSystem: fileSystem,
@@ -1052,6 +1387,7 @@ void main() {
               operatingSystem: 'macos',
               environment: <String, String>{'HOME': pathToHome},
             ),
+            analytics: fakeAnalytics,
           );
 
           final IOSApp iosApp = PrebuiltIOSApp(
@@ -1091,6 +1427,13 @@ void main() {
                     .existsSync(),
                 true,
               );
+              expect(fakeAnalytics.sentEvents, [
+                Event.appleUsageEvent(
+                  workflow: 'ios-physical-deployment',
+                  parameter: IOSDeploymentMethod.coreDeviceWithXcode.name,
+                  result: 'debugging failed',
+                ),
+              ]);
               completer.complete();
             });
             time.elapse(const Duration(minutes: 15));
@@ -1184,6 +1527,8 @@ IOSDevice setUpIOSDevice({
   DeviceConnectionInterface interfaceType = DeviceConnectionInterface.attached,
   bool isCoreDevice = false,
   IOSCoreDeviceControl? coreDeviceControl,
+  IOSCoreDeviceLauncher? coreDeviceLauncher,
+  Analytics? analytics,
   FakeXcodeDebug? xcodeDebug,
   FakePlatform? platform,
 }) {
@@ -1214,6 +1559,7 @@ IOSDevice setUpIOSDevice({
           artifacts: artifacts,
           cache: cache,
         ),
+    analytics: analytics ?? FakeAnalytics(),
     iMobileDevice: IMobileDevice(
       logger: logger,
       processManager: processManager ?? FakeProcessManager.any(),
@@ -1221,7 +1567,7 @@ IOSDevice setUpIOSDevice({
       cache: cache,
     ),
     coreDeviceControl: coreDeviceControl ?? FakeIOSCoreDeviceControl(),
-    coreDeviceLauncher: FakeIOSCoreDeviceLauncher(),
+    coreDeviceLauncher: coreDeviceLauncher ?? FakeIOSCoreDeviceLauncher(),
     xcodeDebug: xcodeDebug ?? FakeXcodeDebug(),
     cpuArchitecture: DarwinArch.arm64,
     connectionInterface: interfaceType,
@@ -1349,4 +1695,61 @@ class FakeShutDownHooks extends Fake implements ShutdownHooks {
   }
 }
 
-class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {}
+class FakeXcode extends Fake implements Xcode {
+  FakeXcode({this.currentVersion});
+
+  @override
+  Version? currentVersion;
+}
+
+class FakeIOSCoreDeviceLauncher extends Fake implements IOSCoreDeviceLauncher {
+  FakeIOSCoreDeviceLauncher({this.lldbLaunchResult = true, this.xcodeLaunchResult = true});
+  bool lldbLaunchResult;
+  bool xcodeLaunchResult;
+  var launchedWithLLDB = false;
+  var launchedWithXcode = false;
+
+  Completer<void>? xcodeCompleter;
+
+  @override
+  Future<bool> launchAppWithLLDBDebugger({
+    required String deviceId,
+    required String bundlePath,
+    required String bundleId,
+    required List<String> launchArguments,
+  }) async {
+    launchedWithLLDB = true;
+    return lldbLaunchResult;
+  }
+
+  @override
+  Future<bool> launchAppWithXcodeDebugger({
+    required String deviceId,
+    required DebuggingOptions debuggingOptions,
+    required IOSApp package,
+    required List<String> launchArguments,
+    required TemplateRenderer templateRenderer,
+    String? mainPath,
+    Duration? discoveryTimeout,
+  }) async {
+    if (xcodeCompleter != null) {
+      await xcodeCompleter!.future;
+    }
+    launchedWithXcode = true;
+    return xcodeLaunchResult;
+  }
+
+  @override
+  Future<bool> stopApp({required String deviceId, int? processId}) async {
+    return false;
+  }
+}
+
+class FakeAnalytics extends Fake implements Analytics {
+  final sentEvents = <Event>[];
+
+  @override
+  void send(Event event) {
+    sentEvents.add(event);
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/lldb_test.dart
@@ -43,7 +43,7 @@ void main() {
     expect(lldb.isRunning, isFalse);
     expect(lldb.appProcessId, isNull);
     expect(processManager.hasRemainingExpectations, isFalse);
-    expect(logger.errorText, contains('Process exception running lldb'));
+    expect(logger.traceText, contains('Process exception running lldb'));
   });
 
   testWithoutContext('attachAndStart returns true on success', () async {
@@ -174,7 +174,7 @@ Target 0: (Runner) stopped.
     expect(lldb.appProcessId, isNull);
     expect(expectedInputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
-    expect(logger.errorText, contains(errorText));
+    expect(logger.traceText, contains(errorText));
   });
 
   testWithoutContext('attachAndStart returns false when stderr not during log waiter', () async {
@@ -220,7 +220,7 @@ Target 0: (Runner) stopped.
     expect(lldb.appProcessId, isNull);
     expect(expectedInputs, isEmpty);
     expect(processManager.hasRemainingExpectations, isFalse);
-    expect(logger.errorText, contains(errorText));
+    expect(logger.traceText, contains(errorText));
   });
 
   testWithoutContext('attachAndStart prints warning if takes too long', () async {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -503,6 +503,7 @@ class TestFeatureFlags implements FeatureFlags {
     this.isSwiftPackageManagerEnabled = false,
     this.isOmitLegacyVersionFileEnabled = false,
     this.isWindowingEnabled = false,
+    this.isLLDBDebuggingEnabled = false,
   });
 
   @override
@@ -545,6 +546,9 @@ class TestFeatureFlags implements FeatureFlags {
   final bool isWindowingEnabled;
 
   @override
+  final bool isLLDBDebuggingEnabled;
+
+  @override
   bool isEnabled(Feature feature) {
     return switch (feature) {
       flutterWebFeature => isWebEnabled,
@@ -557,8 +561,10 @@ class TestFeatureFlags implements FeatureFlags {
       flutterCustomDevicesFeature => areCustomDevicesEnabled,
       cliAnimation => isCliAnimationEnabled,
       nativeAssets => isNativeAssetsEnabled,
+      swiftPackageManager => isSwiftPackageManagerEnabled,
       omitLegacyVersionFile => isOmitLegacyVersionFileEnabled,
       windowingFeature => isWindowingEnabled,
+      lldbDebugging => isLLDBDebuggingEnabled,
       _ => false,
     };
   }
@@ -578,6 +584,7 @@ class TestFeatureFlags implements FeatureFlags {
     swiftPackageManager,
     omitLegacyVersionFile,
     windowingFeature,
+    lldbDebugging,
   ];
 
   @override


### PR DESCRIPTION
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
Part 2 of https://github.com/flutter/flutter/issues/144218

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

Use LLDB and devicectl for deploying to physical iOS devices when using Xcode 26. This will allow Xcode 26 to `flutter run` twice in a row.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

Flutter developers running Xcode 26 can `flutter run` to a tethered iOS device once. However subsequent `flutter run` attempts are likely to fail. 

### Workaround:
Is there a workaround for this issue?

Quitting and reopening Xcode.

### Risk:
What is the risk level of this cherry-pick?

  - [ ] Low
  - [x] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Create a flutter project and run `flutter run` twice in a row with a physical iOS 17+ device and Xcode 26.
