### PR TITLE
Release thread-local resources when submitting a Flutter GPU command buffer

### DIFF
--- a/engine/src/flutter/lib/gpu/command_buffer.cc
+++ b/engine/src/flutter/lib/gpu/command_buffer.cc
@@ -53,9 +53,9 @@ bool CommandBuffer::Submit(
             encodable->EncodeCommands();
           }
 
-          context->GetCommandQueue()
-              ->Submit({command_buffer}, completion_callback)
-              .ok();
+          context->GetCommandQueue()->Submit({command_buffer},
+                                             completion_callback);
+          context->DisposeThreadLocalCachedResources();
         }));
     return true;
   }
@@ -64,9 +64,10 @@ bool CommandBuffer::Submit(
     encodable->EncodeCommands();
   }
 
-  return context_->GetCommandQueue()
-      ->Submit({command_buffer_}, completion_callback)
-      .ok();
+  auto status = context_->GetCommandQueue()->Submit({command_buffer_},
+                                                    completion_callback);
+  context_->DisposeThreadLocalCachedResources();
+  return status.ok();
 }
 
 }  // namespace gpu


### PR DESCRIPTION
Impeller back ends may hold resources (such as Vulkan command pools) in thread-local storage so they can be reused during a series of operations. These resources must be freed when they are no longer useful.

Fixes https://github.com/flutter/flutter/issues/172068