### PR TITLE
[beta] Cherry pick fix GTK redraw call being called from non-GTK thread

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_view.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_view.cc
@@ -95,11 +95,16 @@ G_DEFINE_TYPE_WITH_CODE(
         G_IMPLEMENT_INTERFACE(fl_plugin_registry_get_type(),
                               fl_view_plugin_registry_iface_init))
 
-// Emit the first frame signal in the main thread.
-static gboolean first_frame_idle_cb(gpointer user_data) {
+// Redraw the view from the GTK thread.
+static gboolean redraw_cb(gpointer user_data) {
   FlView* self = FL_VIEW(user_data);
 
-  g_signal_emit(self, fl_view_signals[SIGNAL_FIRST_FRAME], 0);
+  gtk_widget_queue_draw(GTK_WIDGET(self->render_area));
+
+  if (!self->have_first_frame) {
+    self->have_first_frame = TRUE;
+    g_signal_emit(self, fl_view_signals[SIGNAL_FIRST_FRAME], 0);
+  }
 
   return FALSE;
 }
@@ -256,14 +261,8 @@ static void fl_view_present_layers(FlRenderable* renderable,
 
   fl_compositor_present_layers(self->compositor, layers, layers_count);
 
-  gtk_widget_queue_draw(self->render_area);
-
-  if (!self->have_first_frame) {
-    self->have_first_frame = TRUE;
-    // This is not the main thread, so the signal needs to be done via an idle
-    // callback.
-    g_idle_add(first_frame_idle_cb, self);
-  }
+  // Perform the redraw in the GTK thead.
+  g_idle_add(redraw_cb, self);
 }
 
 // Implements FlPluginRegistry::get_registrar_for_plugin.


### PR DESCRIPTION
Cherry pick of https://github.com/flutter/flutter/pull/173602

Impacted users: All Linux users of Flutter
Impact Description: Due to calling gtk_window_redraw on a Flutter thread a lock up may occur. The Flutter app will then become unresponsive.
Workaround: No workaround
Risk: Low - fix is to run the GTK call on the GTK thread which is what the correct behaviour should be.
Test coverage: Rendering covered by existing tests, use of thread not explicitly tested, but https://github.com/flutter/flutter/issues/173660 opened to add this in future.
Validation Steps: Run test program in https://github.com/flutter/flutter/issues/173447 which generates many frames and maximizes the chance of a lock up.