### PR TITLE
Make sure that a DatePickerDialog doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -2750,6 +2750,16 @@ void main() {
       expect(lastDayText.data, equals('28'));
     });
   });
+
+  testWidgets('DatePickerDialog renders at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SizedBox.shrink(
+          child: DatePickerDialog(firstDate: firstDate, lastDate: lastDate),
+        ),
+      ),
+    );
+  });
 }
 
 class _RestorableDatePickerDialogTestWidget extends StatefulWidget {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the DatePickerDialog UI control.