### PR TITLE
Enhance FilledButton and Theme Data's documentation to clarify platform-specific visual density behavior

### DIFF
--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -61,6 +61,14 @@ enum _FilledButtonVariant { filled, tonal }
 /// ** See code in examples/api/lib/material/filled_button/filled_button.0.dart **
 /// {@end-tool}
 ///
+/// ## Visual density effects
+///
+/// The button's appearance is affected by the [VisualDensity] from the enclosing
+/// [Theme] or from its [style]. Visual density adjusts the [ButtonStyle.padding]
+/// and [ButtonStyle.minimumSize] to accommodate different UI densities across platforms.
+/// See [VisualDensity] for more details on how it affects component layout and
+/// the platform-specific defaults.
+///
 /// See also:
 ///
 ///  * [ElevatedButton], a filled button whose material elevates when pressed.

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -3153,6 +3153,10 @@ class _FifoCache<K, V> {
 /// the Material Design specification. It does not affect text sizes, icon
 /// sizes, or padding values.
 ///
+/// The default visual density varies by platform: mobile platforms (Android, iOS,
+/// Fuchsia) use [VisualDensity.standard], while desktop platforms (macOS, Windows,
+/// Linux) use [VisualDensity.compact]. See [defaultDensityForPlatform] for more details.
+///
 /// For example, for buttons, it affects the spacing around the child of the
 /// button. For lists, it affects the distance between baselines of entries in
 /// the list. For chips, it only affects the vertical size, not the horizontal
@@ -3163,6 +3167,7 @@ class _FifoCache<K, V> {
 ///  * [Checkbox]
 ///  * [Chip]
 ///  * [ElevatedButton]
+///  * [FilledButton]
 ///  * [IconButton]
 ///  * [InputDecorator] (which gives density support to [TextField], etc.)
 ///  * [ListTile]
@@ -3240,8 +3245,8 @@ class VisualDensity with Diagnosticable {
 
   /// Returns a [VisualDensity] that is adaptive based on the given [platform].
   ///
-  /// For desktop platforms, this returns [compact], and for other platforms, it
-  /// returns a default-constructed [VisualDensity].
+  /// For mobile platforms (Android, iOS, Fuchsia), this returns [VisualDensity.standard],
+  /// and for desktop platforms (macOS, Windows, Linux), it returns [VisualDensity.compact].
   ///
   /// See also:
   ///


### PR DESCRIPTION
- Fix https://github.com/flutter/flutter/issues/155768
- Description: The issue is not a bug but WAI, it's due to visual density not being the same on each platform by default (see my full explanation at [here](https://github.com/flutter/flutter/issues/155768#issuecomment-3178302255)), see:

https://github.com/flutter/flutter/blob/f22787193bcca7c1455f29e1ed4fd15215a736d5/packages/flutter/lib/src/material/theme_data.dart#L3250-L3255

 - This is LOCs where visual density impacts the padding:

https://github.com/flutter/flutter/blob/a04fb324be734cf18811c30c06baf9bf07b3bab3/packages/flutter/lib/src/material/button_style_button.dart#L501-L505



In this PR:
- Add `Visual density effects` section to FilledButton documentation to avoid confusion for users
- Improve the documentation for `VisualDensity.defaultDensityForPlatform` by including detailed information about the specific density for each platform.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
