### PR TITLE
[ Widget Preview ] Move `--dtd-url` from a global flag to a `widget-preview start` option

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -139,6 +139,12 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
             'Serve the widget preview environment using the web-server device instead of the '
             'browser.',
       )
+      ..addOption(
+        kDtdUri,
+        help:
+            'The address of an existing Dart Tooling Daemon instance to be used by the Flutter CLI.',
+        hide: !verbose,
+      )
       ..addFlag(
         kLaunchPreviewer,
         defaultsTo: true,
@@ -156,6 +162,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
       );
   }
 
+  static const kDtdUri = 'dtd-uri';
   static const kWidgetPreviewScaffoldName = 'widget_preview_scaffold';
   static const kLaunchPreviewer = 'launch-previewer';
   static const kHeadless = 'headless';
@@ -342,7 +349,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   ///
   /// If --dtd-uri is not provided, a DTD instance managed by the tool will be started.
   Future<void> configureDtd() async {
-    final String? existingDtdUriStr = stringArg(FlutterGlobalOptions.kDtdUrl, global: true);
+    final String? existingDtdUriStr = stringArg(kDtdUri);
     Uri? existingDtdUri;
     try {
       if (existingDtdUriStr != null) {

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -25,7 +25,6 @@ import '../isolated/resident_web_runner.dart';
 import '../project.dart';
 import '../resident_runner.dart';
 import '../runner/flutter_command.dart';
-import '../runner/flutter_command_runner.dart';
 import '../web/web_device.dart';
 import '../widget_preview/analytics.dart';
 import '../widget_preview/dependency_graph.dart';

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -140,7 +140,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
             'browser.',
       )
       ..addOption(
-        kDtdUri,
+        kDtdUrl,
         help:
             'The address of an existing Dart Tooling Daemon instance to be used by the Flutter CLI.',
         hide: !verbose,
@@ -162,7 +162,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
       );
   }
 
-  static const kDtdUri = 'dtd-uri';
+  static const kDtdUrl = 'dtd-url';
   static const kWidgetPreviewScaffoldName = 'widget_preview_scaffold';
   static const kLaunchPreviewer = 'launch-previewer';
   static const kHeadless = 'headless';
@@ -349,7 +349,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   ///
   /// If --dtd-uri is not provided, a DTD instance managed by the tool will be started.
   Future<void> configureDtd() async {
-    final String? existingDtdUriStr = stringArg(kDtdUri);
+    final String? existingDtdUriStr = stringArg(kDtdUrl);
     Uri? existingDtdUri;
     try {
       if (existingDtdUriStr != null) {

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -151,12 +151,6 @@ class FlutterCommandRunner extends CommandRunner<void> {
       hide: !verboseHelp,
       help: 'Path to your "package_config.json" file.',
     );
-    argParser.addOption(
-      FlutterGlobalOptions.kDtdUrl,
-      help:
-          'The address of an existing Dart Tooling Daemon instance to be used by the Flutter CLI.',
-      hide: !verboseHelp,
-    );
     argParser.addFlag(
       FlutterGlobalOptions.kPrintDtd,
       negatable: false,

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -36,7 +36,6 @@ abstract final class FlutterGlobalOptions {
   static const kMachineFlag = 'machine';
   static const kPackagesOption = 'packages';
   static const kPrefixedErrorsFlag = 'prefixed-errors';
-  static const kDtdUrl = 'dtd-url';
   static const kPrintDtd = 'print-dtd';
   static const kQuietFlag = 'quiet';
   static const kShowTestDeviceFlag = 'show-test-device';

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -74,7 +74,7 @@ void main() {
       '--verbose',
       '--${WidgetPreviewStartCommand.kHeadless}',
       if (useWebServer) '--${WidgetPreviewStartCommand.kWebServer}',
-      if (dtdUri != null) '--${FlutterGlobalOptions.kDtdUrl}=$dtdUri',
+      if (dtdUri != null) '--${WidgetPreviewStartCommand.kDtdUri}=$dtdUri',
     ], workingDirectory: tempDir.path);
 
     final completer = Completer<void>();

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -74,7 +74,7 @@ void main() {
       '--verbose',
       '--${WidgetPreviewStartCommand.kHeadless}',
       if (useWebServer) '--${WidgetPreviewStartCommand.kWebServer}',
-      if (dtdUri != null) '--${WidgetPreviewStartCommand.kDtdUri}=$dtdUri',
+      if (dtdUri != null) '--${WidgetPreviewStartCommand.kDtdUrl}=$dtdUri',
     ], workingDirectory: tempDir.path);
 
     final completer = Completer<void>();

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/commands/widget_preview.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import 'package:flutter_tools/src/widget_preview/dtd_services.dart';
 import 'package:process/process.dart';
 


### PR DESCRIPTION
`--dtd-url` is only used by widget previews and has no current usage, so this is a safe change.