### PR TITLE
Considers large title height in CupertinoNavigationBar's preferred size

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -644,7 +644,11 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   @override
   Size get preferredSize {
     final double heightForDrawer = bottom?.preferredSize.height ?? 0.0;
-    return Size.fromHeight(_kNavBarPersistentHeight + heightForDrawer);
+
+    final double effectiveLargeHeight =
+        largeTitle != null ? _kNavBarLargeTitleHeightExtension : 0.0;
+
+    return Size.fromHeight(_kNavBarPersistentHeight + heightForDrawer + effectiveLargeHeight);
   }
 
   @override

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -645,8 +645,9 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   Size get preferredSize {
     final double bottomHeight = bottom?.preferredSize.height ?? 0.0;
 
-    final double effectiveLargeHeight =
-        largeTitle != null ? _kNavBarLargeTitleHeightExtension : 0.0;
+    final double effectiveLargeHeight = largeTitle != null
+        ? _kNavBarLargeTitleHeightExtension
+        : 0.0;
 
     return Size.fromHeight(_kNavBarPersistentHeight + bottomHeight + effectiveLargeHeight);
   }

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -643,12 +643,12 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
 
   @override
   Size get preferredSize {
-    final double heightForDrawer = bottom?.preferredSize.height ?? 0.0;
+    final double bottomHeight = bottom?.preferredSize.height ?? 0.0;
 
     final double effectiveLargeHeight =
         largeTitle != null ? _kNavBarLargeTitleHeightExtension : 0.0;
 
-    return Size.fromHeight(_kNavBarPersistentHeight + heightForDrawer + effectiveLargeHeight);
+    return Size.fromHeight(_kNavBarPersistentHeight + bottomHeight + effectiveLargeHeight);
   }
 
   @override

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -2745,6 +2745,122 @@ void main() {
     expect(navBar.preferredSize.height, persistentHeight + bottomHeight);
   });
 
+  testWidgets('CupertinoNavigationBar has correct height', (WidgetTester tester) async {
+    const double persistentHeight = 44.0;
+
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar(middle: Text('Middle')),
+          child: Placeholder(),
+        ),
+      ),
+    );
+
+    final Finder navBarFinder = find.byType(CupertinoNavigationBar);
+    expect(navBarFinder, findsOneWidget);
+
+    final RenderBox navBarBox = tester.renderObject(navBarFinder);
+    final CupertinoNavigationBar navBar = tester.widget<CupertinoNavigationBar>(navBarFinder);
+
+    // preferredSize should only include persistent height when no large title.
+    expect(navBar.preferredSize.height, persistentHeight);
+    // The box size height should match the preferred size height.
+    expect(navBarBox.size.height, persistentHeight);
+  });
+
+  testWidgets('CupertinoNavigationBar with bottom widget has correct height', (
+    WidgetTester tester,
+  ) async {
+    const double persistentHeight = 44.0;
+    const double bottomHeight = 20.0;
+
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar(
+            middle: Text('Middle'),
+            bottom: PreferredSize(
+              preferredSize: Size.fromHeight(bottomHeight),
+              child: Placeholder(),
+            ),
+          ),
+          child: Placeholder(),
+        ),
+      ),
+    );
+
+    final Finder navBarFinder = find.byType(CupertinoNavigationBar);
+    expect(navBarFinder, findsOneWidget);
+
+    final RenderBox navBarBox = tester.renderObject(navBarFinder);
+    final CupertinoNavigationBar navBar = tester.widget<CupertinoNavigationBar>(navBarFinder);
+
+    // preferredSize should include persistent height and bottom height
+    expect(navBar.preferredSize.height, persistentHeight + bottomHeight);
+    // The box size height should match the preferred size height.
+    expect(navBarBox.size.height, persistentHeight + bottomHeight);
+  });
+
+  testWidgets('CupertinoNavigationBar.large has correct height', (WidgetTester tester) async {
+    const double persistentHeight = 44.0;
+    const double largeTitleExtension = 52.0;
+
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar.large(largeTitle: Text('Large Title')),
+          child: Placeholder(),
+        ),
+      ),
+    );
+
+    final Finder navBarFinder = find.byType(CupertinoNavigationBar);
+    expect(navBarFinder, findsOneWidget);
+
+    final RenderBox navBarBox = tester.renderObject(navBarFinder);
+    final CupertinoNavigationBar navBar = tester.widget<CupertinoNavigationBar>(navBarFinder);
+
+    // preferredSize should include both persistent height and large title extension
+    expect(navBar.preferredSize.height, persistentHeight + largeTitleExtension);
+    // The box size height should match the preferred size height.
+    expect(navBarBox.size.height, persistentHeight + largeTitleExtension);
+  });
+
+  testWidgets('CupertinoNavigationBar.large with bottom widget has correct height', (
+    WidgetTester tester,
+  ) async {
+    const double persistentHeight = 44.0;
+    const double largeTitleExtension = 52.0;
+    const double bottomHeight = 20.0;
+
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoPageScaffold(
+          navigationBar: CupertinoNavigationBar.large(
+            largeTitle: Text('Large Title'),
+            bottom: PreferredSize(
+              preferredSize: Size.fromHeight(bottomHeight),
+              child: Placeholder(),
+            ),
+          ),
+          child: Placeholder(),
+        ),
+      ),
+    );
+
+    final Finder navBarFinder = find.byType(CupertinoNavigationBar);
+    expect(navBarFinder, findsOneWidget);
+
+    final RenderBox navBarBox = tester.renderObject(navBarFinder);
+    final CupertinoNavigationBar navBar = tester.widget<CupertinoNavigationBar>(navBarFinder);
+
+    // preferredSize should include persistent height, large title extension, and bottom height
+    expect(navBar.preferredSize.height, persistentHeight + largeTitleExtension + bottomHeight);
+    // The box size height should match the preferred size height.
+    expect(navBarBox.size.height, persistentHeight + largeTitleExtension + bottomHeight);
+  });
+
   testWidgets('CupertinoSliverNavigationBar.search field collapses nav bar on tap', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes #173721 

The `CupertinoNavigationBar` was not considering large title height extension.

I added 4 tests to ensure correct heights for possible variants :

- _CupertinoNavigationBar has correct height_
- _CupertinoNavigationBar with bottom widget has correct height_
- _CupertinoNavigationBar.large has correct height_
- _CupertinoNavigationBar.large with bottom widget has correct height_

| Master branch | PR |
|--------|--------|
| <img width="645" height="1398" alt="Simulator Screenshot - iPhone 16 Plus - 2025-07-07 at 11 18 50" src="https://github.com/user-attachments/assets/abcd3c3b-bb38-410b-abf4-48372af9029e" /> | <img width="645" height="1398" alt="Simulator Screenshot - iPhone 16 Plus - 2025-07-07 at 11 19 00" src="https://github.com/user-attachments/assets/1d7e1fc4-74f2-431f-9f8e-7fdff03df6fe" /> | 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
