### PR TITLE
Do not include `:unittests` unless `enable_unittests`

### DIFF
--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -78,10 +78,12 @@ group("flutter") {
 
   if (!is_qnx) {
     public_deps = [
-      ":unittests",
       "//flutter/shell/platform/embedder:flutter_engine",
       "//flutter/sky",
     ]
+    if (enable_unittests) {
+      public_deps += [ ":unittests" ]
+    }
   }
 
   # Ensure the example for a sample embedder compiles.


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/173728.

This will need to be cherrypicked into both 3.35 and 3.36.