### PR TITLE
[3.36] Do not include `:unittests` unless `enable_unittests`

### DIFF
--- a/engine/src/flutter/BUILD.gn
+++ b/engine/src/flutter/BUILD.gn
@@ -78,10 +78,12 @@ group("flutter") {
 
   if (!is_qnx) {
     public_deps = [
-      ":unittests",
       "//flutter/shell/platform/embedder:flutter_engine",
       "//flutter/sky",
     ]
+    if (enable_unittests) {
+      public_deps += [ ":unittests" ]
+    }
   }
 
   # Ensure the example for a sample embedder compiles.


### PR DESCRIPTION
Same as https://github.com/flutter/flutter/pull/173734, but for the 3.36 branch.