### PR TITLE
Thread sub-builders for every engine-uploading builder

### DIFF
--- a/engine/src/flutter/ci/builders/linux_arm_host_engine.json
+++ b/engine/src/flutter/ci/builders/linux_arm_host_engine.json
@@ -8,6 +8,8 @@
         "definition files."
     ],
     "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
       "upload_content_hash": true
     },
     "builds": [

--- a/engine/src/flutter/ci/builders/linux_host_desktop_engine.json
+++ b/engine/src/flutter/ci/builders/linux_host_desktop_engine.json
@@ -8,6 +8,8 @@
         "definition files."
     ],
     "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
       "upload_content_hash": true
     },
     "builds": [

--- a/engine/src/flutter/ci/builders/linux_web_engine_build.json
+++ b/engine/src/flutter/ci/builders/linux_web_engine_build.json
@@ -8,6 +8,8 @@
       "definition files."
   ],
   "luci_flags": {
+    "delay_collect_builds": true,
+    "parallel_download_builds": true,
     "upload_content_hash": true
   },
   "builds": [

--- a/engine/src/flutter/ci/builders/mac_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/mac_android_aot_engine.json
@@ -8,6 +8,8 @@
         "definition files."
     ],
     "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
       "upload_content_hash": true
     },
     "builds": [

--- a/engine/src/flutter/ci/builders/windows_android_aot_engine.json
+++ b/engine/src/flutter/ci/builders/windows_android_aot_engine.json
@@ -1,5 +1,7 @@
 {
     "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
       "upload_content_hash": true
     },
     "builds": [

--- a/engine/src/flutter/ci/builders/windows_arm_host_engine.json
+++ b/engine/src/flutter/ci/builders/windows_arm_host_engine.json
@@ -1,6 +1,8 @@
 {
     "luci_flags": {
-        "upload_content_hash": true
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
+      "upload_content_hash": true
     },
     "builds": [
         {

--- a/engine/src/flutter/ci/builders/windows_host_engine.json
+++ b/engine/src/flutter/ci/builders/windows_host_engine.json
@@ -8,6 +8,8 @@
         "definition files."
     ],
     "luci_flags": {
+      "delay_collect_builds": true,
+      "parallel_download_builds": true,
       "upload_content_hash": true
     },
     "builds": [


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/173655.

We should consider making these flags either the default (opt-out to `false`) or evergreen (no opt-out).