### PR TITLE
Make sure that a DateRangePickerDialog doesn't crash in 0x0 environments

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2395,8 +2395,10 @@ class _MonthItemGridDelegate extends SliverGridDelegate {
 
   @override
   SliverGridLayout getLayout(SliverConstraints constraints) {
-    final double tileWidth =
-        (constraints.crossAxisExtent - 2 * _horizontalPadding) / DateTime.daysPerWeek;
+    final double tileWidth = math.max(
+      (constraints.crossAxisExtent - 2 * _horizontalPadding) / DateTime.daysPerWeek,
+      0.0,
+    );
     return _MonthSliverGridLayout(
       crossAxisCount: DateTime.daysPerWeek + 2,
       dayChildWidth: tileWidth,

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1978,7 +1978,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.getSize(find.byType(DateRangePickerDialog)).isEmpty, isTrue);
+    expect(tester.getSize(find.byType(DateRangePickerDialog)), Size.zero);
   });
 }
 

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1967,6 +1967,19 @@ void main() {
       expect(getDayCount(secondMonthItem), 21);
     });
   });
+
+  testWidgets('DateRangePickerDialog does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: DateRangePickerDialog(firstDate: firstDate, lastDate: lastDate),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(DateRangePickerDialog)).isEmpty, isTrue);
+  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the DateRangePickerDialog UI control.