### PR TITLE
Return result of setting OpenGL contexts back to Flutter

### DIFF
--- a/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_compositor_opengl.cc
@@ -113,7 +113,12 @@ static gchar* get_program_log(GLuint program) {
 }
 
 static void setup_shader(FlCompositorOpenGL* self) {
-  fl_opengl_manager_make_current(self->opengl_manager);
+  if (!fl_opengl_manager_make_current(self->opengl_manager)) {
+    g_warning(
+        "Failed to setup compositor shaders, unable to make OpenGL context "
+        "current");
+    return;
+  }
 
   GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
   glShaderSource(vertex_shader, 1, &vertex_shader_src, nullptr);
@@ -167,7 +172,12 @@ static void setup_shader(FlCompositorOpenGL* self) {
 }
 
 static void cleanup_shader(FlCompositorOpenGL* self) {
-  fl_opengl_manager_make_current(self->opengl_manager);
+  if (!fl_opengl_manager_make_current(self->opengl_manager)) {
+    g_warning(
+        "Failed to cleanup compositor shaders, unable to make OpenGL context "
+        "current");
+    return;
+  }
 
   if (self->program != 0) {
     glDeleteProgram(self->program);

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -251,7 +251,9 @@ static bool create_opengl_backing_store(
     FlEngine* self,
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* backing_store_out) {
-  fl_opengl_manager_make_current(self->opengl_manager);
+  if (!fl_opengl_manager_make_current(self->opengl_manager)) {
+    return false;
+  }
 
   GLint sized_format = GL_RGBA8;
   GLint general_format = GL_RGBA;
@@ -285,7 +287,9 @@ static bool create_opengl_backing_store(
 static bool collect_opengl_backing_store(
     FlEngine* self,
     const FlutterBackingStore* backing_store) {
-  fl_opengl_manager_make_current(self->opengl_manager);
+  if (!fl_opengl_manager_make_current(self->opengl_manager)) {
+    return false;
+  }
 
   // OpenGL context is required when destroying #FlFramebuffer.
   g_object_unref(backing_store->open_gl.framebuffer.user_data);

--- a/engine/src/flutter/shell/platform/linux/fl_engine.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_engine.cc
@@ -381,14 +381,12 @@ static void* fl_engine_gl_proc_resolver(void* user_data, const char* name) {
 
 static bool fl_engine_gl_make_current(void* user_data) {
   FlEngine* self = static_cast<FlEngine*>(user_data);
-  fl_opengl_manager_make_current(self->opengl_manager);
-  return true;
+  return fl_opengl_manager_make_current(self->opengl_manager);
 }
 
 static bool fl_engine_gl_clear_current(void* user_data) {
   FlEngine* self = static_cast<FlEngine*>(user_data);
-  fl_opengl_manager_clear_current(self->opengl_manager);
-  return true;
+  return fl_opengl_manager_clear_current(self->opengl_manager);
 }
 
 static uint32_t fl_engine_gl_get_fbo(void* user_data) {
@@ -398,8 +396,7 @@ static uint32_t fl_engine_gl_get_fbo(void* user_data) {
 
 static bool fl_engine_gl_make_resource_current(void* user_data) {
   FlEngine* self = static_cast<FlEngine*>(user_data);
-  fl_opengl_manager_make_resource_current(self->opengl_manager);
-  return true;
+  return fl_opengl_manager_make_resource_current(self->opengl_manager);
 }
 
 // Called by the engine to retrieve an external texture.

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.cc
@@ -73,16 +73,17 @@ FlOpenGLManager* fl_opengl_manager_new() {
   return self;
 }
 
-void fl_opengl_manager_make_current(FlOpenGLManager* self) {
-  eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                 self->render_context);
+gboolean fl_opengl_manager_make_current(FlOpenGLManager* self) {
+  return eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        self->render_context) == EGL_TRUE;
 }
 
-void fl_opengl_manager_make_resource_current(FlOpenGLManager* self) {
-  eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                 self->resource_context);
+gboolean fl_opengl_manager_make_resource_current(FlOpenGLManager* self) {
+  return eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        self->resource_context) == EGL_TRUE;
 }
 
-void fl_opengl_manager_clear_current(FlOpenGLManager* self) {
-  eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+gboolean fl_opengl_manager_clear_current(FlOpenGLManager* self) {
+  return eglMakeCurrent(self->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        EGL_NO_CONTEXT) == EGL_TRUE;
 }

--- a/engine/src/flutter/shell/platform/linux/fl_opengl_manager.h
+++ b/engine/src/flutter/shell/platform/linux/fl_opengl_manager.h
@@ -29,24 +29,30 @@ FlOpenGLManager* fl_opengl_manager_new();
  * @manager: an #FlOpenGLManager.
  *
  * Makes the rendering context current.
+ *
+ * Returns: %TRUE if the context made current.
  */
-void fl_opengl_manager_make_current(FlOpenGLManager* manager);
+gboolean fl_opengl_manager_make_current(FlOpenGLManager* manager);
 
 /**
  * fl_opengl_manager_make_resource_current:
  * @manager: an #FlOpenGLManager.
  *
  * Makes the resource rendering context current.
+ *
+ * Returns: %TRUE if the context made current.
  */
-void fl_opengl_manager_make_resource_current(FlOpenGLManager* manager);
+gboolean fl_opengl_manager_make_resource_current(FlOpenGLManager* manager);
 
 /**
  * fl_opengl_manager_clear_current:
  * @manager: an #FlOpenGLManager.
  *
  * Clears the current rendering context.
+ *
+ * Returns: %TRUE if the context cleared.
  */
-void fl_opengl_manager_clear_current(FlOpenGLManager* manager);
+gboolean fl_opengl_manager_clear_current(FlOpenGLManager* manager);
 
 G_END_DECLS
 


### PR DESCRIPTION
Also check when using them internally that they have worked.
