### PR TITLE
Impeller: Convert GLProc name field and GLErrorToString to std::string_view

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.cc
@@ -15,7 +15,7 @@
 
 namespace impeller {
 
-const char* GLErrorToString(GLenum value) {
+std::string_view GLErrorToString(GLenum value) {
   switch (value) {
     case GL_NO_ERROR:
       return "GL_NO_ERROR";
@@ -89,7 +89,7 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
   }
 
 #define IMPELLER_PROC(proc_ivar)                                \
-  if (auto fn_ptr = resolver(proc_ivar.name)) {                 \
+  if (auto fn_ptr = resolver(proc_ivar.name.data())) {          \
     proc_ivar.function =                                        \
         reinterpret_cast<decltype(proc_ivar.function)>(fn_ptr); \
     proc_ivar.error_fn = error_fn;                              \
@@ -115,7 +115,7 @@ ProcTableGLES::ProcTableGLES(  // NOLINT(google-readability-function-size)
 #undef IMPELLER_PROC
 
 #define IMPELLER_PROC(proc_ivar)                                \
-  if (auto fn_ptr = resolver(proc_ivar.name)) {                 \
+  if (auto fn_ptr = resolver(proc_ivar.name.data())) {          \
     proc_ivar.function =                                        \
         reinterpret_cast<decltype(proc_ivar.function)>(fn_ptr); \
     proc_ivar.error_fn = error_fn;                              \

--- a/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/proc_table_gles.h
@@ -7,6 +7,7 @@
 
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
@@ -19,16 +20,17 @@
 
 namespace impeller {
 
-const char* GLErrorToString(GLenum value);
+std::string_view GLErrorToString(GLenum value);
 bool GLErrorIsFatal(GLenum value);
 
 struct AutoErrorCheck {
   const PFNGLGETERRORPROC error_fn;
 
-  // TODO(135922) Change to string_view.
-  const char* name;
+  /// Name of the GL call being wrapped.
+  /// should not be stored beyond the caller's lifetime.
+  std::string_view name;
 
-  AutoErrorCheck(PFNGLGETERRORPROC error, const char* name)
+  AutoErrorCheck(PFNGLGETERRORPROC error, std::string_view name)
       : error_fn(error), name(name) {}
 
   ~AutoErrorCheck() {
@@ -80,8 +82,7 @@ struct GLProc {
   //----------------------------------------------------------------------------
   /// The name of the GL function.
   ///
-  // TODO(135922) Change to string_view.
-  const char* name = nullptr;
+  std::string_view name = {};
 
   //----------------------------------------------------------------------------
   /// The pointer to the GL function.

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/proc_table_gles_unittests.cc
@@ -33,5 +33,47 @@ TEST(ProcTableGLES, ResolvesCorrectClearDepthProcOnDesktopGL) {
   FOR_EACH_IMPELLER_ES_ONLY_PROC(EXPECT_UNAVAILABLE);
 }
 
+TEST(GLErrorToString, ReturnsCorrectStringForKnownErrors) {
+  EXPECT_EQ(GLErrorToString(GL_NO_ERROR), "GL_NO_ERROR");
+  EXPECT_EQ(GLErrorToString(GL_INVALID_ENUM), "GL_INVALID_ENUM");
+  EXPECT_EQ(GLErrorToString(GL_INVALID_VALUE), "GL_INVALID_VALUE");
+  EXPECT_EQ(GLErrorToString(GL_INVALID_OPERATION), "GL_INVALID_OPERATION");
+  EXPECT_EQ(GLErrorToString(GL_INVALID_FRAMEBUFFER_OPERATION),
+            "GL_INVALID_FRAMEBUFFER_OPERATION");
+  EXPECT_EQ(GLErrorToString(GL_FRAMEBUFFER_COMPLETE),
+            "GL_FRAMEBUFFER_COMPLETE");
+  EXPECT_EQ(GLErrorToString(GL_OUT_OF_MEMORY), "GL_OUT_OF_MEMORY");
+}
+
+TEST(GLErrorToString, ReturnsUnknownForInvalidError) {
+  // Test with an invalid error code
+  GLenum invalid_error = 0x9999;
+  EXPECT_EQ(GLErrorToString(invalid_error), "Unknown.");
+}
+
+TEST(GLErrorToString, ReturnValueIsValidStringView) {
+  // Test that the returned string_view is valid and non-empty
+  auto result = GLErrorToString(GL_NO_ERROR);
+  EXPECT_FALSE(result.empty());
+  EXPECT_NE(result.data(), nullptr);
+
+  // Test that we can compare with string literals
+  EXPECT_TRUE(result == "GL_NO_ERROR");
+}
+
+TEST(GLProc, NameFieldWorksWithStringView) {
+  GLProc<void()> proc;
+
+  // Test setting name with string literal
+  const char* literal = "glTestFunction";
+  proc.name = literal;
+
+  EXPECT_EQ(proc.name, "glTestFunction");
+  EXPECT_FALSE(proc.name.empty());
+
+  // Test that the string_view properly references the original data
+  EXPECT_EQ(proc.name.data(), literal);
+}
+
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/toolkit/glvk/proc_table.cc
+++ b/engine/src/flutter/impeller/toolkit/glvk/proc_table.cc
@@ -20,7 +20,7 @@ ProcTable::ProcTable(const Resolver& resolver) {
   }
 
 #define GLVK_PROC(proc_ivar)                                    \
-  if (auto fn_ptr = resolver(proc_ivar.name)) {                 \
+  if (auto fn_ptr = resolver(proc_ivar.name.data())) {          \
     proc_ivar.function =                                        \
         reinterpret_cast<decltype(proc_ivar.function)>(fn_ptr); \
     proc_ivar.error_fn = error_fn;                              \


### PR DESCRIPTION
This PR improves the OpenGL error handling and procedure table interface in the Impeller renderer by changing `const char*` to `std::string_view` for better memory safety.

### Testing:

Added unit tests to cover `GLErrorToString` return values and `string_view` behavior

### Issues Fixed #135922

This PR addresses technical debt by improving string handling in the OpenGL backend, and type safety without breaking existing functionality.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.