### PR TITLE
[web] Cleanup usages of deprecated `routeUpdated` message

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -625,11 +625,6 @@ final class EngineFlutterWindow extends EngineFlutterView implements ui.Singleto
           await _useSingleEntryBrowserHistory();
           return true;
         // the following cases assert that arguments are not null
-        case 'routeUpdated': // deprecated
-          assert(arguments != null);
-          await _useSingleEntryBrowserHistory();
-          browserHistory.setRouteName(arguments!.tryString('routeName'));
-          return true;
         case 'routeInformationUpdated':
           assert(arguments != null);
           final String? uriString = arguments!.tryString('uri');

--- a/engine/src/flutter/lib/web_ui/test/engine/history_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/history_test.dart
@@ -186,7 +186,7 @@ void testMain() {
       expect(strategy.history, hasLength(2));
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-      await routeUpdated('/page1');
+      await routeInformationUpdated('/page1', null);
       // The number of entries shouldn't change.
       expect(strategy.history, hasLength(2));
       expect(strategy.currentEntryIndex, 1);
@@ -204,7 +204,7 @@ void testMain() {
       expect(spy.messages[0].methodName, 'popRoute');
       expect(spy.messages[0].methodArguments, isNull);
       // The framework responds by updating to the most current route name.
-      await routeUpdated('/home');
+      await routeInformationUpdated('/home', null);
       // We still have 2 entries.
       expect(strategy.history, hasLength(2));
       expect(strategy.currentEntryIndex, 1);
@@ -219,8 +219,8 @@ void testMain() {
       );
       await implicitView.debugInitializeHistory(strategy, useSingle: true);
 
-      await routeUpdated('/page1');
-      await routeUpdated('/page2');
+      await routeInformationUpdated('/page1', null);
+      await routeInformationUpdated('/page2', null);
 
       // Make sure we are on page2.
       expect(strategy.history, hasLength(2));
@@ -237,7 +237,7 @@ void testMain() {
       expect(spy.messages[0].methodArguments, isNull);
       spy.messages.clear();
       // 2. The framework sends a `routePopped` platform message.
-      await routeUpdated('/page1');
+      await routeInformationUpdated('/page1', null);
       // 3. The history state should reflect that /page1 is currently active.
       expect(strategy.history, hasLength(2));
       expect(strategy.currentEntryIndex, 1);
@@ -253,7 +253,7 @@ void testMain() {
       expect(spy.messages[0].methodArguments, isNull);
       spy.messages.clear();
       // 2. The framework sends a `routePopped` platform message.
-      await routeUpdated('/home');
+      await routeInformationUpdated('/home', null);
       // 3. The history state should reflect that /page1 is currently active.
       expect(strategy.history, hasLength(2));
       expect(strategy.currentEntryIndex, 1);
@@ -296,7 +296,7 @@ void testMain() {
       expect(spy.messages[0].methodArguments, '/page3');
       spy.messages.clear();
       // 2. The framework sends a `routeUpdated` platform message.
-      await routeUpdated('/page3');
+      await routeInformationUpdated('/page3', null);
       // 3. The history state should reflect that /page3 is currently active.
       expect(strategy.history, hasLength(3));
       expect(strategy.currentEntryIndex, 1);
@@ -312,7 +312,7 @@ void testMain() {
       expect(spy.messages[0].methodArguments, isNull);
       spy.messages.clear();
       // 2. The framework sends a `routeUpdated` platform message.
-      await routeUpdated('/home');
+      await routeInformationUpdated('/home', null);
       // 3. The history state should reflect that /home is currently active.
       expect(strategy.history, hasLength(2));
       expect(strategy.currentEntryIndex, 1);
@@ -351,7 +351,7 @@ void testMain() {
       await implicitView.debugInitializeHistory(strategy, useSingle: true);
 
       // Go to a named route.
-      await routeUpdated('/named-route');
+      await routeInformationUpdated('/named-route', null);
       expect(strategy.currentEntry.url, '/named-route');
 
       // Now, push a nameless route. The url shouldn't change.
@@ -759,16 +759,6 @@ void testMain() {
       expect(location.getBaseHref(), isNotNull);
     });
   });
-}
-
-Future<void> routeUpdated(String routeName) {
-  final Completer<void> completer = Completer<void>();
-  EnginePlatformDispatcher.instance.sendPlatformMessage(
-    'flutter/navigation',
-    codec.encodeMethodCall(MethodCall('routeUpdated', <String, dynamic>{'routeName': routeName})),
-    (_) => completer.complete(),
-  );
-  return completer.future;
 }
 
 Future<void> routeInformationUpdated(String location, dynamic state) {

--- a/engine/src/flutter/lib/web_ui/test/engine/navigation_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/navigation_test.dart
@@ -29,7 +29,7 @@ void testMain() {
       ui.PlatformDispatcher.instance.sendPlatformMessage(
         'flutter/navigation',
         codec.encodeMethodCall(
-          const MethodCall('routeUpdated', <String, dynamic>{'routeName': '/foo'}),
+          const MethodCall('routeInformationUpdated', <String, dynamic>{'location': '/foo'}),
         ),
         (ByteData? response) => completer.complete(response),
       );
@@ -53,7 +53,7 @@ void testMain() {
       ui.PlatformDispatcher.instance.sendPlatformMessage(
         'flutter/navigation',
         codec.encodeMethodCall(
-          const MethodCall('routeUpdated', <String, dynamic>{'routeName': '/foo'}),
+          const MethodCall('routeInformationUpdated', <String, dynamic>{'location': '/foo'}),
         ),
         (_) => completer.complete(),
       );


### PR DESCRIPTION
This is a follow up to https://github.com/flutter/flutter/pull/173652

Closes https://github.com/flutter/flutter/issues/50836