### PR TITLE
Read `bin/cache/flutter.version.json` instead of `version` for `flutter_gallery`

### DIFF
--- a/dev/integration_tests/flutter_gallery/android/app/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/app/build.gradle
@@ -21,8 +21,11 @@ if (flutterRoot == null) {
 }
 
 // The Gallery app's version is defined by the Flutter framework's version.
-def flutterVersion = file("$flutterRoot/version").text
+def flutterVersionFile = file("$flutterRoot/bin/cache/flutter.version.json")
+def flutterVersionJson = new groovy.json.JsonSlurper().parse(flutterVersionFile)
+def flutterVersion = flutterVersionJson.frameworkVersion
 def flutterVersionComponents = flutterVersion.split(/[^0-9]+/)
+
 // Let the integer version code of xx.yy.zz-pre.nnn be xxyyzznnn.
 int flutterVersionNumber = Math.min(flutterVersionComponents[0].toInteger(), 20) * 100000000
 flutterVersionNumber += Math.min(flutterVersionComponents[1].toInteger(), 99) * 1000000


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/171900.