### PR TITLE
Remove `embedded_android_views` (on-device) tests, same as emulator test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2731,15 +2731,6 @@ targets:
         ["devicelab", "android", "linux", "pixel", "7pro"]
       task_name: drive_perf_debug_warning
 
-  - name: Linux_pixel_7pro embedded_android_views_integration_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "android", "linux", "pixel", "7pro"]
-      task_name: embedded_android_views_integration_test
-
   - name: Linux_android_emu external_textures_integration_test
     recipe: devicelab/devicelab_drone
     bringup: true
@@ -2977,17 +2968,6 @@ targets:
       - dev/**
       - DEPS
       - engine/**
-
-  # linux mokey test
-  - name: Linux_mokey hybrid_android_views_integration_test
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/148085
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "android", "linux", "mokey"]
-      task_name: hybrid_android_views_integration_test
 
   # linux mokey benchmark
   - name: Linux_mokey image_list_jit_reported_duration

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2969,6 +2969,17 @@ targets:
       - DEPS
       - engine/**
 
+  # linux mokey test
+  - name: Linux_mokey hybrid_android_views_integration_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true # https://github.com/flutter/flutter/issues/148085
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "mokey"]
+      task_name: hybrid_android_views_integration_test
+
   # linux mokey benchmark
   - name: Linux_mokey image_list_jit_reported_duration
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
These tests are identical to the `Linux_android_emu` test that runs on presubmit:

https://github.com/flutter/flutter/blob/9583f282a50f88a269f5716f1ecfe42f6b6387a3/.ci.yaml#L408-L416

These tests do not report benchmarks or any other statistics that would benefit from a real (on-device) test.