### PR TITLE
Cleanup legacy `bringup: true` tasks, either removing or enabling

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -374,7 +374,6 @@ targets:
       task_name: analyzer_benchmark
 
   - name: Linux coverage
-    bringup: true # https://github.com/flutter/flutter/issues/164591
     presubmit: false
     recipe: flutter/coverage
     timeout: 90
@@ -1665,20 +1664,6 @@ targets:
 
   - name: Linux_android_emu_vulkan_stable android_engine_vulkan_tests
     recipe: flutter/flutter_drone
-    bringup: true
-    timeout: 60
-    properties:
-      shard: android_engine_vulkan_tests
-      tags: >
-         ["framework", "hostonly", "shard", "linux"]
-      dependencies: >-
-        [
-          {"dependency": "goldctl", "version": "git_revision:2387d6fff449587eecbb7e45b2692ca0710b63b9"}
-        ]
-
-  - name: Linux_mokey android_engine_vulkan_tests
-    recipe: flutter/flutter_drone
-    # TODO(matanlurey): https://github.com/flutter/flutter/issues/163025.
     bringup: true
     timeout: 60
     properties:
@@ -3718,17 +3703,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: dynamic_path_stroke_tessellation_perf_ios__timeline_summary
-
-  - name: Staging_build_linux analyze
-    presubmit: false
-    bringup: true
-    recipe: flutter/flutter_drone
-    timeout: 60
-    properties:
-      shard: analyze
-      ignore_flakiness: "true"
-      tags: >
-        ["framework","hostonly","shard","linux"]
 
   - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
     presubmit: false
@@ -7054,7 +7028,6 @@ targets:
     recipe: packaging/packaging
     timeout: 60
     scheduler: release
-    bringup: true
     enabled_branches:
       - beta
       - stable


### PR DESCRIPTION
Removed two builds we will never get green and are not prioritizing.

Enable the rest which are passing consistently in the background.