### PR TITLE
Fix the issue where SingleChildScrollView resets its scroll position after relayout.

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -806,10 +806,15 @@ class _TabBarScrollPosition extends ScrollPositionWithSingleContext {
     // guard because the super call below would start a ballistic scroll activity.
     if (!_viewportDimensionWasNonZero || _needsPixelsCorrection) {
       _needsPixelsCorrection = false;
-      correctPixels(
-        tabBar._initialScrollOffset(viewportDimension, minScrollExtent, maxScrollExtent),
+      final double newPixels = tabBar._initialScrollOffset(
+        viewportDimension,
+        minScrollExtent,
+        maxScrollExtent,
       );
-      result = false;
+      if (newPixels != (hasPixels ? pixels : null)) {
+        correctPixels(newPixels);
+        result = false;
+      }
     }
     return super.applyContentDimensions(minScrollExtent, maxScrollExtent) && result;
   }

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -493,6 +493,8 @@ class _RenderSingleChildViewport extends RenderBox
     return constraints.constrain(childSize);
   }
 
+  static const int _maxLayoutCycles = 10;
+
   @override
   void performLayout() {
     final BoxConstraints constraints = this.constraints;
@@ -502,8 +504,7 @@ class _RenderSingleChildViewport extends RenderBox
       child!.layout(_getInnerConstraints(constraints), parentUsesSize: true);
       size = constraints.constrain(child!.size);
     }
-
-    while (true) {
+    for (int i = 0; i < _maxLayoutCycles; i++) {
       final bool didAcceptViewportDimension = offset.applyViewportDimension(_viewportExtent);
       final bool didAcceptContentDimension = offset.applyContentDimensions(
         _minScrollExtent,

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -503,8 +503,16 @@ class _RenderSingleChildViewport extends RenderBox
       size = constraints.constrain(child!.size);
     }
 
-    offset.applyViewportDimension(_viewportExtent);
-    while (!offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent)) {}
+    while (true) {
+      final bool didAcceptViewportDimension = offset.applyViewportDimension(_viewportExtent);
+      final bool didAcceptContentDimension = offset.applyContentDimensions(
+        _minScrollExtent,
+        _maxScrollExtent,
+      );
+      if (didAcceptViewportDimension && didAcceptContentDimension) {
+        break;
+      }
+    }
   }
 
   Offset get _paintOffset => _paintOffsetForPosition(offset.pixels);

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -504,7 +504,6 @@ class _RenderSingleChildViewport extends RenderBox
     }
 
     offset.applyViewportDimension(_viewportExtent);
-    // offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent);
     while (!offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent)) {}
   }
 

--- a/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/single_child_scroll_view.dart
@@ -400,7 +400,7 @@ class _RenderSingleChildViewport extends RenderBox
   }
 
   void _hasScrolled() {
-    markNeedsPaint();
+    markNeedsLayout();
     markNeedsSemanticsUpdate();
   }
 
@@ -503,16 +503,9 @@ class _RenderSingleChildViewport extends RenderBox
       size = constraints.constrain(child!.size);
     }
 
-    if (offset.hasPixels) {
-      if (offset.pixels > _maxScrollExtent) {
-        offset.correctBy(_maxScrollExtent - offset.pixels);
-      } else if (offset.pixels < _minScrollExtent) {
-        offset.correctBy(_minScrollExtent - offset.pixels);
-      }
-    }
-
     offset.applyViewportDimension(_viewportExtent);
-    offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent);
+    // offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent);
+    while (!offset.applyContentDimensions(_minScrollExtent, _maxScrollExtent)) {}
   }
 
   Offset get _paintOffset => _paintOffsetForPosition(offset.pixels);

--- a/packages/flutter/test/widgets/clamp_overscrolls_test.dart
+++ b/packages/flutter/test/widgets/clamp_overscrolls_test.dart
@@ -103,7 +103,8 @@ void main() {
       await tester.pumpWidget(buildFrame(physics, scrollController: scrollController));
       final ScrollableState scrollable = tester.state(find.byType(Scrollable));
 
-      // The initialScrollOffset will be corrected during the first frame.
+      expect(scrollable.position.pixels, equals(initialOffset));
+      await tester.pump(const Duration(seconds: 1)); // Allow overscroll to settle
       expect(scrollable.position.pixels, equals(expectedOffset));
     }
 

--- a/packages/flutter/test/widgets/scroll_notification_test.dart
+++ b/packages/flutter/test/widgets/scroll_notification_test.dart
@@ -45,13 +45,14 @@ void main() {
     await gesture.up();
     await tester.pump(const Duration(seconds: 1));
 
-    expect(events.length, 5);
+    expect(events.length, 6);
     // user scroll do not trigger the ScrollMetricsNotification.
     expect(events[0] is ScrollStartNotification, true);
     expect(events[1] is UserScrollNotification, true);
     expect(events[2] is ScrollUpdateNotification, true);
-    expect(events[3] is ScrollEndNotification, true);
-    expect(events[4] is UserScrollNotification, true);
+    expect(events[3] is ScrollMetricsNotification, true);
+    expect(events[4] is ScrollEndNotification, true);
+    expect(events[5] is UserScrollNotification, true);
 
     events.clear();
     // Change the content dimensions again.
@@ -222,10 +223,12 @@ void main() {
     ScrollNotification? notification;
 
     void handleNotification(ScrollNotification value) {
-      if (value is ScrollStartNotification ||
-          value is ScrollUpdateNotification ||
-          value is ScrollEndNotification) {
-        notification = value;
+      switch (value) {
+        case ScrollStartNotification():
+        case ScrollUpdateNotification(dragDetails: DragUpdateDetails _):
+        case ScrollEndNotification():
+          notification = value;
+        default:
       }
     }
 

--- a/packages/flutter/test/widgets/scroll_notification_test.dart
+++ b/packages/flutter/test/widgets/scroll_notification_test.dart
@@ -46,7 +46,6 @@ void main() {
     await tester.pump(const Duration(seconds: 1));
 
     expect(events.length, 6);
-    // user scroll do not trigger the ScrollMetricsNotification.
     expect(events[0] is ScrollStartNotification, true);
     expect(events[1] is UserScrollNotification, true);
     expect(events[2] is ScrollUpdateNotification, true);

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1275,7 +1275,7 @@ void main() {
 
     // Make the outer constraints larger that the scrollable widget is no longer able to scroll.
     await tester.pumpWidget(build(300.0));
-    expect(controller.position.pixels, 0.0);
+    expect(controller.position.pixels, 100.0);
     expect(controller.position.maxScrollExtent, 0.0);
 
     // Hover over the scroll view and create a zero offset pointer scroll.

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -1126,8 +1126,6 @@ void main() {
     expect(tester.testTextInput.isVisible, isFalse);
   });
 
-  testWidgets('', (WidgetTester tester) async {});
-
   // Regression test for https://github.com/flutter/flutter/issues/173225
   testWidgets('ValueListenableBuilder rebuild does not interrupt ongoing scroll gesture', (
     WidgetTester tester,


### PR DESCRIPTION
Fixes: #145078
Fixes: #173225
Fixes: #149018

This PR adopts the scroll correction approach from `RenderViewport`, repeatedly calling `applyContentDimensions`. Additionally, it triggers a relayout on every scroll (as `RenderViewport` does) to update `_lastMetrics` in [scroll_position.dart](https://github.com/flutter/flutter/blob/da5c047a13d70a3797ca3edba3cc3220801fb84f/packages/flutter/lib/src/widgets/scroll_position.dart#L679).  
This PR also reverts several tests that were changed in #136239, because the code added in #136239 has now been replaced by this PR. Some tests modified by #136239 have been restored to their original state, but the new tests added by #136239 are still retained.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
