### PR TITLE
[ Tool ] Cleanup widget preview and frontend server shutdown

### DIFF
--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -28,6 +28,9 @@ typedef ShutdownHook = FutureOr<void> Function();
 abstract class ShutdownHooks {
   factory ShutdownHooks() = _DefaultShutdownHooks;
 
+  /// Indicates whether the shutdown hooks have been run.
+  bool get isShuttingDown;
+
   /// Registers a [ShutdownHook] to be executed before the VM exits.
   void addShutdownHook(ShutdownHook shutdownHook);
 
@@ -53,6 +56,10 @@ class _DefaultShutdownHooks implements ShutdownHooks {
   @override
   final registeredHooks = <ShutdownHook>[];
 
+  @override
+  bool get isShuttingDown => _isShuttingDown;
+  var _isShuttingDown = false;
+
   var _shutdownHooksRunning = false;
 
   @override
@@ -63,6 +70,10 @@ class _DefaultShutdownHooks implements ShutdownHooks {
 
   @override
   Future<void> runShutdownHooks(Logger logger) async {
+    if (_isShuttingDown) {
+      return;
+    }
+    _isShuttingDown = true;
     logger.printTrace(
       'Running ${registeredHooks.length} shutdown hook${registeredHooks.length == 1 ? '' : 's'}',
     );

--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -254,8 +254,6 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     // Start the timer tracking how long it takes to launch the preview environment.
     previewAnalytics.initializeLaunchStopwatch();
 
-    registerShutdownHooks();
-
     final String? customPreviewScaffoldOutput = stringArg(kWidgetPreviewScaffoldOutputDir);
     final Directory widgetPreviewScaffold = customPreviewScaffoldOutput != null
         ? fs.directory(customPreviewScaffoldOutput)
@@ -332,6 +330,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
       throwToolExit('Failed to launch the widget previewer.', exitCode: result);
     }
 
+    await _previewDetector.dispose();
     return FlutterCommandResult.success();
   }
 
@@ -344,12 +343,6 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   void onHotRestartRequest() {
     logger.printStatus('Triggering restart based on request from preview environment.');
     _widgetPreviewApp?.restart(fullRestart: true);
-  }
-
-  void registerShutdownHooks() {
-    shutdownHooks.addShutdownHook(() async {
-      await _previewDetector.dispose();
-    });
   }
 
   /// Configures the Dart Tooling Daemon connection.

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -16,6 +16,7 @@ import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/logger.dart';
 import 'base/platform.dart';
+import 'base/process.dart';
 import 'build_info.dart';
 import 'convert.dart';
 
@@ -505,6 +506,7 @@ abstract class ResidentCompiler {
     required Artifacts artifacts,
     required Platform platform,
     required FileSystem fileSystem,
+    required ShutdownHooks shutdownHooks,
     bool testCompilation,
     bool trackWidgetCreation,
     String packagesPath,
@@ -625,6 +627,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     required this.artifacts,
     required Platform platform,
     required FileSystem fileSystem,
+    required ShutdownHooks shutdownHooks,
     this.testCompilation = false,
     this.trackWidgetCreation = true,
     this.packagesPath,
@@ -642,6 +645,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     @visibleForTesting StdoutHandler? stdoutHandler,
   }) : _logger = logger,
        _processManager = processManager,
+       _shutdownHooks = shutdownHooks,
        _stdoutHandler = stdoutHandler ?? StdoutHandler(logger: logger, fileSystem: fileSystem),
        _platform = platform,
        dartDefines = dartDefines ?? const <String>[],
@@ -654,6 +658,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
   final ProcessManager _processManager;
   final Artifacts artifacts;
   final Platform _platform;
+  final ShutdownHooks _shutdownHooks;
 
   final bool testCompilation;
   final BuildMode buildMode;
@@ -906,7 +911,9 @@ class DefaultResidentCompiler implements ResidentCompiler {
 
     unawaited(
       _server?.exitCode.then((int code) {
-        if (code != 0) {
+        // The frontend server exits with a 253 error code when we shutdown due to a signal.
+        // Don't treat this as an error if we're in the middle of the shutdown sequence.
+        if (code != 0 && !_shutdownHooks.isShuttingDown) {
           throwToolExit('The Dart compiler exited unexpectedly.');
         }
       }),

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -72,6 +72,7 @@ class FlutterDevice {
              logger: globals.logger,
              platform: globals.platform,
              fileSystem: globals.fs,
+             shutdownHooks: globals.shutdownHooks,
            );
 
   /// Create a [FlutterDevice] with optional code generation enabled.
@@ -152,6 +153,7 @@ class FlutterDevice {
         logger: globals.logger,
         fileSystem: globals.fs,
         platform: platform,
+        shutdownHooks: globals.shutdownHooks,
       );
     } else {
       List<String> extraFrontEndOptions = buildInfo.extraFrontEndOptions;
@@ -187,6 +189,7 @@ class FlutterDevice {
         logger: globals.logger,
         platform: platform,
         fileSystem: globals.fs,
+        shutdownHooks: globals.shutdownHooks,
       );
     }
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -105,6 +105,7 @@ interface class FlutterTestRunner {
             artifacts: globals.artifacts!,
             processManager: globals.processManager,
             config: globals.config,
+            shutdownHooks: globals.shutdownHooks,
           ).initialize(
             projectDirectory: flutterProject!.directory,
             testOutputDir: tempBuildDir,
@@ -572,6 +573,7 @@ class SpawnPlugin extends PlatformPlugin {
       fileSystem: globals.fs,
       fileSystemRoots: debuggingOptions.buildInfo.fileSystemRoots,
       fileSystemScheme: debuggingOptions.buildInfo.fileSystemScheme,
+      shutdownHooks: globals.shutdownHooks,
     );
 
     await residentCompiler.recompile(

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -195,6 +195,7 @@ class TestCompiler {
       fileSystem: globals.fs,
       fileSystemRoots: buildInfo.fileSystemRoots,
       fileSystemScheme: buildInfo.fileSystemScheme,
+      shutdownHooks: globals.shutdownHooks,
     );
     return residentCompiler;
   }

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -32,18 +32,21 @@ class WebTestCompiler {
     required Platform platform,
     required ProcessManager processManager,
     required Config config,
+    required ShutdownHooks shutdownHooks,
   }) : _logger = logger,
        _fileSystem = fileSystem,
        _artifacts = artifacts,
        _platform = platform,
        _processManager = processManager,
-       _config = config;
+       _config = config,
+       _shutdownHooks = shutdownHooks;
 
   final Logger _logger;
   final FileSystem _fileSystem;
   final Artifacts _artifacts;
   final Platform _platform;
   final ProcessManager _processManager;
+  final ShutdownHooks _shutdownHooks;
   final Config _config;
 
   Future<File> _generateTestEntrypoint({
@@ -160,6 +163,7 @@ class WebTestCompiler {
       logger: _logger,
       platform: _platform,
       fileSystem: _fileSystem,
+      shutdownHooks: _shutdownHooks,
     );
 
     final CompilerOutput? output = await residentCompiler.recompile(

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -39,6 +39,8 @@ class PreviewDetector {
   StreamSubscription<WatchEvent>? _fileWatcher;
   final _mutex = PreviewDetectorMutex();
 
+  var _disposed = false;
+
   @visibleForTesting
   PreviewDependencyGraph get dependencyGraph => _dependencyGraph;
   final PreviewDependencyGraph _dependencyGraph = PreviewDependencyGraph();
@@ -67,6 +69,10 @@ class PreviewDetector {
   }
 
   Future<void> dispose() async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     // Guard disposal behind a mutex to make sure the analyzer has finished
     // processing the latest file updates to avoid throwing an exception.
     await _mutex.runGuarded(() async {

--- a/packages/flutter_tools/test/general.shard/base/signals_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/signals_test.dart
@@ -7,13 +7,12 @@ import 'dart:io' as io;
 
 import 'package:flutter_tools/src/base/exit.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/signals.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 
 void main() {
   group('Signals', () {
@@ -197,7 +196,7 @@ void main() {
 
       fakeSignal.controller.add(fakeSignal);
       await completer.future;
-      expect(shutdownHooks.ranShutdownHooks, isTrue);
+      expect(shutdownHooks.isShuttingDown, isTrue);
     });
 
     testUsingContext('ShutdownHooks run before exiting', () async {
@@ -217,7 +216,7 @@ void main() {
 
       fakeSignal.controller.add(fakeSignal);
       await completer.future;
-      expect(shutdownHooks.ranShutdownHooks, isTrue);
+      expect(shutdownHooks.isShuttingDown, isTrue);
     });
   });
 }
@@ -227,13 +226,4 @@ class FakeProcessSignal extends Fake implements io.ProcessSignal {
 
   @override
   Stream<io.ProcessSignal> watch() => controller.stream;
-}
-
-class FakeShutdownHooks extends Fake implements ShutdownHooks {
-  var ranShutdownHooks = false;
-
-  @override
-  Future<void> runShutdownHooks(Logger logger) async {
-    ranShutdownHooks = true;
-  }
 }

--- a/packages/flutter_tools/test/general.shard/compile_expression_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_expression_test.dart
@@ -41,6 +41,7 @@ void main() {
       logger: testLogger,
       platform: FakePlatform(),
       fileSystem: fileSystem,
+      shutdownHooks: FakeShutdownHooks(),
     );
 
     stdErrStreamController = StreamController<String>();

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -64,6 +64,7 @@ void main() {
       platform: FakePlatform(),
       fileSystem: MemoryFileSystem.test(),
       stdoutHandler: generatorStdoutHandler,
+      shutdownHooks: FakeShutdownHooks(),
     );
     generatorWithScheme = DefaultResidentCompiler(
       'sdkroot',
@@ -76,6 +77,7 @@ void main() {
       fileSystemScheme: 'scheme',
       fileSystem: MemoryFileSystem.test(),
       stdoutHandler: generatorWithSchemeStdoutHandler,
+      shutdownHooks: FakeShutdownHooks(),
     );
     generatorWithPlatformDillAndLibrariesSpec = DefaultResidentCompiler(
       'sdkroot',
@@ -88,6 +90,7 @@ void main() {
       stdoutHandler: generatorStdoutHandler,
       platformDill: '/foo/platform.dill',
       librariesSpec: '/bar/libraries.json',
+      shutdownHooks: FakeShutdownHooks(),
     );
   });
 

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -591,6 +591,7 @@ void main() {
       platform: FakePlatform(),
       fileSystem: fileSystem,
       stdoutHandler: generatorStdoutHandler,
+      shutdownHooks: FakeShutdownHooks(),
     );
 
     fileSystem.file('lib/foo.txt.dill').createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -1197,7 +1196,7 @@ void main() {
           deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
         });
 
-        final shutDownHooks = FakeShutDownHooks();
+        final shutDownHooks = FakeShutdownHooks();
 
         final LaunchResult launchResult = await device.startApp(
           iosApp,
@@ -1208,7 +1207,7 @@ void main() {
         );
 
         expect(launchResult.started, true);
-        expect(shutDownHooks.hooks.length, 1);
+        expect(shutDownHooks.registeredHooks.length, 1);
         expect(fakeAnalytics.sentEvents, [
           Event.appleUsageEvent(
             workflow: 'ios-physical-deployment',
@@ -1686,14 +1685,6 @@ class FakeXcodeDebug extends Fake implements XcodeDebug {
 }
 
 class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {}
-
-class FakeShutDownHooks extends Fake implements ShutdownHooks {
-  var hooks = <ShutdownHook>[];
-  @override
-  void addShutdownHook(ShutdownHook shutdownHook) {
-    hooks.add(shutdownHook);
-  }
-}
 
 class FakeXcode extends Fake implements Xcode {
   FakeXcode({this.currentVersion});

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -1908,11 +1908,6 @@ class FakeXcodeProjectInterpreter extends Fake implements XcodeProjectInterprete
 
 class FakeXcodeDebug extends Fake implements XcodeDebug {}
 
-class FakeShutdownHooks extends Fake implements ShutdownHooks {
-  @override
-  void addShutdownHook(ShutdownHook shutdownHook) {}
-}
-
 class FakeIOSCoreDeviceControl extends Fake implements IOSCoreDeviceControl {
   var devices = <FakeIOSCoreDevice>[];
 

--- a/packages/flutter_tools/test/general.shard/test/web_test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/web_test_compiler_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/web/compile.dart';
 import 'package:test/expect.dart';
 
 import '../../src/context.dart';
+import '../../src/fakes.dart';
 
 void main() {
   testUsingContext('web test compiler issues valid compile command', () async {
@@ -74,6 +75,7 @@ void main() {
       artifacts: Artifacts.test(),
       processManager: processManager,
       config: config,
+      shutdownHooks: FakeShutdownHooks(),
     );
 
     const buildInfo = BuildInfo(
@@ -143,6 +145,7 @@ void main() {
       artifacts: Artifacts.test(),
       processManager: processManager,
       config: config,
+      shutdownHooks: FakeShutdownHooks(),
     );
 
     const buildInfo = BuildInfo(

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/time.dart';
 import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/cache.dart';
@@ -78,6 +79,26 @@ class FakeProcess implements Process {
   @override
   bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
     return true;
+  }
+}
+
+/// A [ShutdownHooks] implementation that does not actually execute any hooks.
+class FakeShutdownHooks extends Fake implements ShutdownHooks {
+  @override
+  bool get isShuttingDown => _isShuttingDown;
+  var _isShuttingDown = false;
+
+  @override
+  final registeredHooks = <ShutdownHook>[];
+
+  @override
+  void addShutdownHook(ShutdownHook shutdownHook) {
+    registeredHooks.add(shutdownHook);
+  }
+
+  @override
+  Future<void> runShutdownHooks(Logger logger) async {
+    _isShuttingDown = true;
   }
 }
 


### PR DESCRIPTION
Prevents the frontend server from throwing ToolExit with the "The Dart compiler exited unexpectedly." on shutdown via a signal.