### PR TITLE
Revert "[ios][tools]do not log "bonjour not found" at all (unless verbose)"

### DIFF
--- a/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_backend_test.dart
@@ -390,135 +390,64 @@ void main() {
       );
     });
 
+    test('Missing NSBonjourServices key in Info.plist should not fail Xcode compilation', () {
+      final Directory buildDir = fileSystem.directory('/path/to/builds')
+        ..createSync(recursive: true);
+      final File infoPlist = buildDir.childFile('Info.plist')..createSync();
+      final context = TestContext(
+        <String>['test_vm_service_bonjour_service'],
+        <String, String>{
+          'CONFIGURATION': 'Debug',
+          'BUILT_PRODUCTS_DIR': buildDir.path,
+          'INFOPLIST_PATH': 'Info.plist',
+        },
+        commands: <FakeCommand>[
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-extract',
+              'NSBonjourServices',
+              'xml1',
+              '-o',
+              '-',
+              infoPlist.path,
+            ],
+            exitCode: 1,
+            stderr: 'No value at that key path or invalid key path: NSBonjourServices',
+          ),
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-insert',
+              'NSBonjourServices',
+              '-json',
+              '["_dartVmService._tcp"]',
+              infoPlist.path,
+            ],
+          ),
+          FakeCommand(
+            command: <String>[
+              'plutil',
+              '-extract',
+              'NSLocalNetworkUsageDescription',
+              'xml1',
+              '-o',
+              '-',
+              infoPlist.path,
+            ],
+          ),
+        ],
+        fileSystem: fileSystem,
+      )..run();
+      expect(context.stderr, isNot(contains('error: ')));
+    });
+
     test(
-      'Missing NSBonjourServices key in Info.plist should not fail Xcode compilation, and no plutil error in stdout without verbose mode',
+      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation',
       () {
         final Directory buildDir = fileSystem.directory('/path/to/builds')
           ..createSync(recursive: true);
         final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-        const plutilErrorMessage =
-            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
-
-        final context = TestContext(
-          <String>['test_vm_service_bonjour_service'],
-          <String, String>{
-            'CONFIGURATION': 'Debug',
-            'BUILT_PRODUCTS_DIR': buildDir.path,
-            'INFOPLIST_PATH': 'Info.plist',
-          },
-          commands: <FakeCommand>[
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSBonjourServices',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-              exitCode: 1,
-              stderr: plutilErrorMessage,
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-insert',
-                'NSBonjourServices',
-                '-json',
-                '["_dartVmService._tcp"]',
-                infoPlist.path,
-              ],
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSLocalNetworkUsageDescription',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-            ),
-          ],
-          fileSystem: fileSystem,
-        )..run();
-        expect(context.stderr, isNot(startsWith('error: ')));
-        expect(context.stderr, isNot(contains(plutilErrorMessage)));
-        expect(context.stdout, isNot(contains(plutilErrorMessage)));
-      },
-    );
-
-    test(
-      'Missing NSBonjourServices key in Info.plist should not fail Xcode compilation, and has plutil error in stdout under verbose mode',
-      () {
-        final Directory buildDir = fileSystem.directory('/path/to/builds')
-          ..createSync(recursive: true);
-        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-        const plutilErrorMessage =
-            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
-
-        final context = TestContext(
-          <String>['test_vm_service_bonjour_service'],
-          <String, String>{
-            'CONFIGURATION': 'Debug',
-            'BUILT_PRODUCTS_DIR': buildDir.path,
-            'INFOPLIST_PATH': 'Info.plist',
-            'VERBOSE_SCRIPT_LOGGING': 'YES',
-          },
-          commands: <FakeCommand>[
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSBonjourServices',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-              exitCode: 1,
-              stderr: plutilErrorMessage,
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-insert',
-                'NSBonjourServices',
-                '-json',
-                '["_dartVmService._tcp"]',
-                infoPlist.path,
-              ],
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSLocalNetworkUsageDescription',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-            ),
-          ],
-          fileSystem: fileSystem,
-        )..run();
-        expect(context.stderr, isNot(startsWith('error: ')));
-        expect(context.stderr, isNot(contains(plutilErrorMessage)));
-        expect(context.stdout, contains(plutilErrorMessage));
-      },
-    );
-
-    test(
-      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation, and no plutil error in stdout without verbose mode',
-      () {
-        final Directory buildDir = fileSystem.directory('/path/to/builds')
-          ..createSync(recursive: true);
-        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-        const plutilErrorMessage =
-            'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
         final context = TestContext(
           <String>['test_vm_service_bonjour_service'],
           <String, String>{
@@ -559,7 +488,8 @@ void main() {
                 infoPlist.path,
               ],
               exitCode: 1,
-              stderr: plutilErrorMessage,
+              stderr:
+                  'No value at that key path or invalid key path: NSLocalNetworkUsageDescription',
             ),
             FakeCommand(
               command: <String>[
@@ -574,79 +504,7 @@ void main() {
           ],
           fileSystem: fileSystem,
         )..run();
-        expect(context.stderr, isNot(startsWith('error: ')));
-        expect(context.stderr, isNot(contains(plutilErrorMessage)));
-        expect(context.stdout, isNot(contains(plutilErrorMessage)));
-      },
-    );
-
-    test(
-      'Missing NSLocalNetworkUsageDescription in Info.plist should not fail Xcode compilation, and has plutil error in stdout under verbose mode',
-      () {
-        final Directory buildDir = fileSystem.directory('/path/to/builds')
-          ..createSync(recursive: true);
-        final File infoPlist = buildDir.childFile('Info.plist')..createSync();
-        const plutilErrorMessage =
-            'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
-        final context = TestContext(
-          <String>['test_vm_service_bonjour_service'],
-          <String, String>{
-            'CONFIGURATION': 'Debug',
-            'BUILT_PRODUCTS_DIR': buildDir.path,
-            'INFOPLIST_PATH': 'Info.plist',
-            'VERBOSE_SCRIPT_LOGGING': 'YES',
-          },
-          commands: <FakeCommand>[
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSBonjourServices',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-insert',
-                'NSBonjourServices.0',
-                '-string',
-                '_dartVmService._tcp',
-                infoPlist.path,
-              ],
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-extract',
-                'NSLocalNetworkUsageDescription',
-                'xml1',
-                '-o',
-                '-',
-                infoPlist.path,
-              ],
-              exitCode: 1,
-              stderr: plutilErrorMessage,
-            ),
-            FakeCommand(
-              command: <String>[
-                'plutil',
-                '-insert',
-                'NSLocalNetworkUsageDescription',
-                '-string',
-                'Allow Flutter tools on your computer to connect and debug your application. This prompt will not appear on release builds.',
-                infoPlist.path,
-              ],
-            ),
-          ],
-          fileSystem: fileSystem,
-        )..run();
-        expect(context.stderr, isNot(startsWith('error: ')));
-        expect(context.stderr, isNot(contains(plutilErrorMessage)));
-        expect(context.stdout, contains(plutilErrorMessage));
+        expect(context.stderr, isNot(contains('error: ')));
       },
     );
   });

--- a/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
+++ b/packages/flutter_tools/test/integration.shard/xcode_backend_test.dart
@@ -132,7 +132,7 @@ void main() {
     });
 
     for (final buildConfiguration in <String>['Debug', 'Profile']) {
-      test('add keys in $buildConfiguration without verbose mode', () async {
+      test('add keys in $buildConfiguration', () async {
         infoPlist.writeAsStringSync(emptyPlist);
 
         final ProcessResult result = await Process.run(
@@ -151,43 +151,14 @@ void main() {
         expect(actualInfoPlist, contains('NSLocalNetworkUsageDescription'));
 
         expect(result.stderr, isNot(startsWith('error:')));
-        const plutilErrorMessage =
-            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
-        expect(result.stderr, isNot(contains(plutilErrorMessage)));
-        expect(result.stdout, isNot(contains(plutilErrorMessage)));
-        expect(result, const ProcessResultMatcher());
-      });
-
-      test('add keys in $buildConfiguration under verbose mode', () async {
-        infoPlist.writeAsStringSync(emptyPlist);
-
-        final ProcessResult result = await Process.run(
-          xcodeBackendPath,
-          <String>['test_vm_service_bonjour_service'],
-          environment: <String, String>{
-            'CONFIGURATION': buildConfiguration,
-            'BUILT_PRODUCTS_DIR': buildDirectory.path,
-            'INFOPLIST_PATH': 'Info.plist',
-            'VERBOSE_SCRIPT_LOGGING': 'YES',
-          },
-        );
-
-        final String actualInfoPlist = infoPlist.readAsStringSync();
-        expect(actualInfoPlist, contains('NSBonjourServices'));
-        expect(actualInfoPlist, contains('dartVmService'));
-        expect(actualInfoPlist, contains('NSLocalNetworkUsageDescription'));
-
-        expect(result.stderr, isNot(startsWith('error:')));
-        const plutilErrorMessage =
-            'Could not extract value, error: No value at that key path or invalid key path: NSBonjourServices';
-        expect(result.stderr, isNot(contains(plutilErrorMessage)));
-        expect(result.stdout, contains(plutilErrorMessage));
         expect(result, const ProcessResultMatcher());
       });
     }
 
-    test('adds to existing Bonjour services, does not override network usage description', () async {
-      infoPlist.writeAsStringSync('''
+    test(
+      'adds to existing Bonjour services, does not override network usage description',
+      () async {
+        infoPlist.writeAsStringSync('''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -201,17 +172,17 @@ void main() {
 </dict>
 </plist>''');
 
-      final ProcessResult result = await Process.run(
-        xcodeBackendPath,
-        <String>['test_vm_service_bonjour_service'],
-        environment: <String, String>{
-          'CONFIGURATION': 'Debug',
-          'BUILT_PRODUCTS_DIR': buildDirectory.path,
-          'INFOPLIST_PATH': 'Info.plist',
-        },
-      );
+        final ProcessResult result = await Process.run(
+          xcodeBackendPath,
+          <String>['test_vm_service_bonjour_service'],
+          environment: <String, String>{
+            'CONFIGURATION': 'Debug',
+            'BUILT_PRODUCTS_DIR': buildDirectory.path,
+            'INFOPLIST_PATH': 'Info.plist',
+          },
+        );
 
-      expect(infoPlist.readAsStringSync(), '''
+        expect(infoPlist.readAsStringSync(), '''
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -227,13 +198,10 @@ void main() {
 </plist>
 ''');
 
-      const plutilErrorMessage =
-          'Could not extract value, error: No value at that key path or invalid key path: NSLocalNetworkUsageDescription';
-      expect(result.stderr, isNot(startsWith('error:')));
-      expect(result.stderr, isNot(contains(plutilErrorMessage)));
-      expect(result.stdout, isNot(contains(plutilErrorMessage)));
-      expect(result, const ProcessResultMatcher());
-    });
+        expect(result.stderr, isNot(startsWith('error:')));
+        expect(result, const ProcessResultMatcher());
+      },
+    );
 
     test('does not add bonjour settings when port publication is disabled', () async {
       infoPlist.writeAsStringSync('''


### PR DESCRIPTION
Reverts flutter/flutter#173569

Sorry I have to revert this one as it didn't work. 

# Why didn't work

From the comment, it looks like `echoError` is only used for verbose mode, and `streamOutput` is used for non-verbose mode (I am still looking into how this is setup)

https://github.com/flutter/flutter/blob/e4f27cd09734db6c6ed94e104ab5333c48dfc544/packages/flutter_tools/bin/xcode_backend.dart#L151

# How to fix

## Possible Fix 1

I tested this works, by changing this line: 

https://github.com/flutter/flutter/blob/master/packages/flutter_tools/bin/xcode_backend.dart#L159

into this: 

```
if (!verbose && exitCode == 0 && !skipErrorLog)
```

## Possible fix 2: 

Surprisingly this also works: 
```
if (!verbose && exitCode == 0) {
  streamOutput(errorOutput.string().replaceAll('error', '');
}
```

Although we made sure `errorOutput` doesn't start with `error:`, there's an `error:` in the middle of the string. 

Possibly because of this code in `mac.dart`: 
https://github.com/flutter/flutter/blob/e4f27cd09734db6c6ed94e104ab5333c48dfc544/packages/flutter_tools/lib/src/ios/mac.dart#L431-L433

# Why we missed it? 

I tested my initial code code and assumed updated code would work, because I incorrectly thought `echoError` was the one triggered the output in non-verbose mode. I should have verified it.  
