### PR TITLE
[a11y] remove the deprecated `focusable` flag in Focus widget. 

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_scope.dart
+++ b/packages/flutter/lib/src/widgets/focus_scope.dart
@@ -723,7 +723,6 @@ class _FocusState extends State<Focus> {
         onFocus: defaultTargetPlatform != TargetPlatform.iOS && _couldRequestFocus
             ? focusNode.requestFocus
             : null,
-        focusable: _couldRequestFocus,
         focused: _couldRequestFocus ? _hadPrimaryFocus : null,
         child: widget.child,
       );

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3803,7 +3803,7 @@ void main() {
     await tester.pumpWidget(buildDropdownMenu(requestFocusOnTap: true));
 
     expect(
-      tester.getSemantics(find.byType(TextField)),
+      tester.getSemantics(find.text('Test')),
       matchesSemantics(
         hasFocusAction: true,
         hasTapAction: true,
@@ -3819,7 +3819,7 @@ void main() {
     await tester.pumpWidget(buildDropdownMenu(requestFocusOnTap: false));
 
     expect(
-      tester.getSemantics(find.byType(TextField)),
+      tester.getSemantics(find.text('Test')),
       matchesSemantics(
         hasFocusAction: true,
         isTextField: true,

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -4410,27 +4410,21 @@ void main() {
                             ),
                             TestSemantics(
                               id: 6,
-                              rect: const Rect.fromLTRB(0.0, 0.0, 120.0, 64.0),
+                              rect: const Rect.fromLTRB(0.0, 0.0, 120.0, 48.0),
+                              flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                               children: <TestSemantics>[
                                 TestSemantics(
                                   id: 7,
+                                  label: 'Item 0',
                                   rect: const Rect.fromLTRB(0.0, 0.0, 120.0, 48.0),
-                                  flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                                  children: <TestSemantics>[
-                                    TestSemantics(
-                                      id: 8,
-                                      label: 'Item 0',
-                                      rect: const Rect.fromLTRB(0.0, 0.0, 120.0, 48.0),
-                                      flags: <SemanticsFlag>[
-                                        SemanticsFlag.hasEnabledState,
-                                        SemanticsFlag.isEnabled,
-                                        SemanticsFlag.isFocusable,
-                                      ],
-                                      actions: <SemanticsAction>[
-                                        SemanticsAction.tap,
-                                        SemanticsAction.focus,
-                                      ],
-                                    ),
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.hasEnabledState,
+                                    SemanticsFlag.isEnabled,
+                                    SemanticsFlag.isFocusable,
+                                  ],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
                                   ],
                                 ),
                               ],

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1350,9 +1350,7 @@ void main() {
       invoked = 0;
     });
 
-    testWidgets('Shortcuts does not insert a semantics node when includeSemantics is false', (
-      WidgetTester tester,
-    ) async {
+    testWidgets('Shortcuts does not insert a semantics', (WidgetTester tester) async {
       final SemanticsTester semanticsTester = SemanticsTester(tester);
       addTearDown(semanticsTester.dispose);
 
@@ -1363,11 +1361,7 @@ void main() {
 
       expect(
         semanticsTester,
-        hasSemantics(
-          TestSemantics.root(children: <TestSemantics>[TestSemantics(id: 1)]),
-          ignoreRect: true,
-          ignoreTransform: true,
-        ),
+        hasSemantics(TestSemantics.root(), ignoreRect: true, ignoreTransform: true),
       );
 
       await tester.pumpWidget(


### PR DESCRIPTION
This is a follow-up to https://github.com/flutter/flutter/pull/170935.


Noticed when in some cases Semantics(focusable: false, focused: false) becomes Semantics(focused: null). Although they are the same in flag values. However, the first one is annotated in the semantics tree, while the second one is not. This difference can sometimes cause the tree structure to change. 


<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
