### PR TITLE
[VPAT][A11y] NavigationRail correct traversal order

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -524,28 +524,31 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
       mainGroup = SingleChildScrollView(child: mainGroup);
     }
 
-    return _ExtendedNavigationRailAnimation(
-      animation: _extendedAnimation,
-      child: Semantics(
-        explicitChildNodes: true,
-        child: Material(
-          elevation: elevation,
-          color: backgroundColor,
-          child: SafeArea(
-            right: isRTLDirection,
-            left: !isRTLDirection,
-            child: Column(
-              children: <Widget>[
-                _verticalSpacer,
-                if (widget.leadingAtTop && widget.leading != null) ...<Widget>[
-                  widget.leading!,
+    return Semantics(
+      container: true,
+      child: _ExtendedNavigationRailAnimation(
+        animation: _extendedAnimation,
+        child: Semantics(
+          explicitChildNodes: true,
+          child: Material(
+            elevation: elevation,
+            color: backgroundColor,
+            child: SafeArea(
+              right: isRTLDirection,
+              left: !isRTLDirection,
+              child: Column(
+                children: <Widget>[
                   _verticalSpacer,
+                  if (widget.leadingAtTop && widget.leading != null) ...<Widget>[
+                    widget.leading!,
+                    _verticalSpacer,
+                  ],
+                  Flexible(
+                    child: Align(alignment: Alignment(0, groupAlignment), child: mainGroup),
+                  ),
+                  if (widget.trailingAtBottom && widget.trailing != null) widget.trailing!,
                 ],
-                Flexible(
-                  child: Align(alignment: Alignment(0, groupAlignment), child: mainGroup),
-                ),
-                if (widget.trailingAtBottom && widget.trailing != null) widget.trailing!,
-              ],
+              ),
             ),
           ),
         ),

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -6201,7 +6201,7 @@ TestSemantics _expectedSemantics({bool scrollable = false}) {
               TestSemantics(
                 flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                 children: <TestSemantics>[
-                  ...destinations,
+                  TestSemantics(children: destinations),
                   TestSemantics(label: 'body', textDirection: TextDirection.ltr),
                 ],
               ),


### PR DESCRIPTION
Fix [[VPAT] [A11y] Navigation Rail has unexpected semantics traversal order](https://github.com/flutter/flutter/issues/172992)
Fix b/428718875
Fix b/429353997