### PR TITLE
[CP] Blocks exynos9820 chip from vulkan

### DIFF
--- a/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.cc
+++ b/engine/src/flutter/shell/platform/android/android_context_dynamic_impeller.cc
@@ -17,21 +17,25 @@ namespace {
 
 static const constexpr char* kAndroidHuawei = "android-huawei";
 
-/// These are SoCs that crash when using AHB imports.
-static constexpr const char* kBLC[] = {
-    // Most Exynos Series SoC
+static constexpr const char* kBadSocs[] = {
+    // Most Exynos Series SoC. These are SoCs that crash when using AHB imports.
     "exynos7870",  //
     "exynos7880",  //
     "exynos7872",  //
     "exynos7884",  //
     "exynos7885",  //
+    "exynos7904",  //
+    // Mongoose line.
     "exynos8890",  //
     "exynos8895",  //
-    "exynos7904",  //
     "exynos9609",  //
     "exynos9610",  //
     "exynos9611",  //
-    "exynos9810"   //
+    "exynos9810",  //
+    // `exynos9820` and `exynos9825` have graphical errors:
+    // https://github.com/flutter/flutter/issues/171992.
+    "exynos9820",  //
+    "exynos9825"   //
 };
 
 static bool IsDeviceEmulator(std::string_view product_model) {
@@ -41,7 +45,7 @@ static bool IsDeviceEmulator(std::string_view product_model) {
 static bool IsKnownBadSOC(std::string_view hardware) {
   // TODO(jonahwilliams): if the list gets too long (> 16), convert
   // to a hash map first.
-  for (const auto& board : kBLC) {
+  for (const auto& board : kBadSocs) {
     if (strcmp(board, hardware.data()) == 0) {
       return true;
     }
@@ -83,7 +87,8 @@ GetActualRenderingAPIForImpeller(
 
   __system_property_get("ro.product.board", product_model);
   if (IsKnownBadSOC(product_model)) {
-    // Avoid using Vulkan on known bad SoCs.
+    FML_LOG(INFO)
+        << "Known bad Vulkan driver encountered, falling back to OpenGLES.";
     return nullptr;
   }
 


### PR DESCRIPTION
(cherry picked from commit 4abea340e19db0c8cf2df804104335a503e37ec0)


Fixes of #171992 for the stable branch.
Cherry-pick of [https://github.com/flutter/flutter/pull/173807](https://github.com/flutter/flutter/pull/173807) onto stable.


**Impacted Users**
Developers and end-users of Flutter applications running on Samsung Galaxy S10 or Note 10 series devices equipped with Exynos 9820/9825 SoCs.

**Impact Description**
Due to malfunctioning Vulkan drivers on these SoCs, platform views that rely on `SurfaceView` fail to render correctly. The original PR addresses this by blocklisting the affected SoCs, forcing them to use Impeller with OpenGL ES instead of Vulkan.

**Workaround**
Aside from setting `io.flutter.embedding.android.ImpellerBackend` (which is not available in production) or disabling Impeller entirely, there is no practical workaround for this issue on affected devices.

**Risk**
The risk of this cherry-pick is low. The original PR only adds specific SoCs to the blocklist and renames a static variable, which does not affect other devices regardless of whether they use this mechanism.

**Test Coverage**
Due to the nature of the issue and the fix, validation can only be performed through manual testing on the affected devices. As the reporter of the original issue, I have verified the fix on the Galaxy S10 5G(SM-G977N, Exynos 9820), confirming that the change resolves the rendering problem.

**Validation Steps**

1. Create a test Flutter app that uses a platform view with `SurfaceView` (e.g., [https://github.com/bc-lee/test-flutter-android-texture](https://github.com/bc-lee/test-flutter-android-texture) or [https://github.com/gaaclarke/surface_platformview](https://github.com/gaaclarke/surface_platformview)).
2. Run the app on the targeted devices.
3. Verify that the application renders correctly without graphical issues.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
