### PR TITLE
Add java as a dependency of linux analyze since it is required by ktlint

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -348,7 +348,7 @@ targets:
       shard: analyze
       dependencies: >-
         [
-          {"dependency": "ktlint", "version": "version_1_5_0"}
+          {"dependency": "ktlint", "version": "version_1_5_0"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -349,6 +349,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "ktlint", "version": "version_1_5_0"}
+          {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
         ["framework","hostonly","shard","linux"]


### PR DESCRIPTION
I did not find documentation for which java version was required but we use Java 21 for many tests and it passed locally for me with java 17 and 24 
https://github.com/pinterest/ktlint/releases  

https://github.com/flutter/flutter/pull/173869#issuecomment-3197941356 
A rerun fixed this issue which indicates some of our bots happen to have java and some do not. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
