### PR TITLE
See if java 21 presubmits will pass

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -16,7 +16,7 @@ platform_properties:
       # CIPD flutter/java/openjdk/$platform
       dependencies: >-
         [
-          {"dependency": "open_jdk", "version": "version:17"},
+          {"dependency": "open_jdk", "version": "version:21"},
           {"dependency": "gradle_cache", "version": "none"}
         ]
       device_type: none
@@ -27,7 +27,7 @@ platform_properties:
       # CIPD flutter/java/openjdk/$platform
       dependencies: >-
         [
-          {"dependency": "open_jdk", "version": "version:17"}
+          {"dependency": "open_jdk", "version": "version:21"}
         ]
       device_type: none
       os: Mac-14|Mac-15
@@ -40,7 +40,7 @@ platform_properties:
       # CIPD flutter/java/openjdk/$platform
       dependencies: >-
         [
-          {"dependency": "open_jdk", "version": "version:17"}
+          {"dependency": "open_jdk", "version": "version:21"}
         ]
       device_type: none
       os: Windows-10


### PR DESCRIPTION
We are seeing failures because java is not installed on builds where java should be installed. 
https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20Engine%20Drone/3520859/overview 

Thread on this topic. 
https://chat.google.com/room/AAAAm69vf-M/dDN5s5vjedA 

Hypothesis is that java is installed but some builds need java 21 instead of 17. 

Related to https://github.com/flutter/flutter/issues/173986

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
