### PR TITLE
[ Widget Preview ] Don't crash when directory watcher restarts on Windows

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -223,6 +223,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   );
 
   late final _previewDetector = PreviewDetector(
+    platform: platform,
     previewAnalytics: previewAnalytics,
     projectRoot: rootProject.directory,
     logger: logger,

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -14,21 +14,31 @@ import 'package:watcher/watcher.dart';
 
 import '../base/file_system.dart';
 import '../base/logger.dart';
+import '../base/platform.dart';
 import '../base/utils.dart';
 import 'analytics.dart';
 import 'dependency_graph.dart';
 import 'utils.dart';
 
+typedef WatcherBuilder = Watcher Function(String path);
+
+Watcher _defaultWatcherBuilder(String path) {
+  return Watcher(path);
+}
+
 class PreviewDetector {
   PreviewDetector({
+    required this.platform,
     required this.previewAnalytics,
     required this.projectRoot,
     required this.fs,
     required this.logger,
     required this.onChangeDetected,
     required this.onPubspecChangeDetected,
+    @visibleForTesting this.watcherBuilder = _defaultWatcherBuilder,
   });
 
+  final Platform platform;
   final WidgetPreviewAnalytics previewAnalytics;
   final Directory projectRoot;
   final FileSystem fs;
@@ -36,6 +46,12 @@ class PreviewDetector {
   final void Function(PreviewDependencyGraph) onChangeDetected;
   final void Function(String path) onPubspecChangeDetected;
 
+  @visibleForTesting
+  static const kDirectoryWatcherClosedUnexpectedlyPrefix = 'Directory watcher closed unexpectedly';
+  @visibleForTesting
+  static const kWindowsFileWatcherRestartedMessage =
+      'WindowsDirectoryWatcher has closed and been restarted.';
+  final WatcherBuilder watcherBuilder;
   StreamSubscription<WatchEvent>? _fileWatcher;
   final _mutex = PreviewDetectorMutex();
 
@@ -57,8 +73,22 @@ class PreviewDetector {
     // Determine which files have transitive dependencies with compile time errors.
     _propagateErrors();
 
-    final watcher = Watcher(projectRoot.path);
-    _fileWatcher = watcher.events.listen(_onFileSystemEvent);
+    final Watcher watcher = watcherBuilder(projectRoot.path);
+    _fileWatcher = watcher.events.listen(
+      _onFileSystemEvent,
+      onError: (Object e, StackTrace st) {
+        if (platform.isWindows &&
+            e is FileSystemException &&
+            e.message.startsWith(kDirectoryWatcherClosedUnexpectedlyPrefix)) {
+          // The Windows directory watcher sometimes decides to shutdown on its own. It's
+          // automatically restarted by package:watcher, but we need to handle this exception.
+          // See https://github.com/dart-lang/tools/issues/1713 for details.
+          logger.printTrace(kWindowsFileWatcherRestartedMessage);
+          return;
+        }
+        Error.throwWithStackTrace(e, st);
+      },
+    );
 
     // Wait for file watcher to finish initializing, otherwise we might miss changes and cause
     // tests to flake.

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -45,13 +45,13 @@ class PreviewDetector {
   final Logger logger;
   final void Function(PreviewDependencyGraph) onChangeDetected;
   final void Function(String path) onPubspecChangeDetected;
+  final WatcherBuilder watcherBuilder;
 
   @visibleForTesting
   static const kDirectoryWatcherClosedUnexpectedlyPrefix = 'Directory watcher closed unexpectedly';
   @visibleForTesting
   static const kWindowsFileWatcherRestartedMessage =
       'WindowsDirectoryWatcher has closed and been restarted.';
-  final WatcherBuilder watcherBuilder;
   StreamSubscription<WatchEvent>? _fileWatcher;
   final _mutex = PreviewDetectorMutex();
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -171,6 +171,7 @@ void main() {
         ..childFile('lib/src/transitive_error.dart').writeAsStringSync(kTransitiveErrorLibrary);
       project = FlutterProject.fromDirectoryTest(projectDir);
       previewDetector = PreviewDetector(
+        platform: FakePlatform(),
         previewAnalytics: WidgetPreviewAnalytics(
           analytics: getInitializedFakeAnalyticsInstance(
             // We don't care about anything written to the file system by analytics, so we're safe

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -50,6 +50,7 @@ PreviewDetector createTestPreviewDetector() {
   }
   _projectRoot = _fs.systemTempDirectory.createTempSync('root');
   return PreviewDetector(
+    platform: FakePlatform(),
     previewAnalytics: WidgetPreviewAnalytics(
       analytics: getInitializedFakeAnalyticsInstance(
         fakeFlutterVersion: FakeFlutterVersion(),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/173895

This is a top-10 crasher for `3.35.{0,1}`.