### PR TITLE
Add `open_jdk` to `Linux analyze`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -348,7 +348,8 @@ targets:
       shard: analyze
       dependencies: >-
         [
-          {"dependency": "ktlint", "version": "version_1_5_0"}
+          {"dependency": "ktlint", "version": "version_1_5_0"},
+          {"dependency": "open_jdk", "version": "version:21"}
         ]
       tags: >
         ["framework","hostonly","shard","linux"]


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/173986.

This build _never_ declared (either directly or through `platform_properties`) that it required the Java JDK, and appears to have been "accidentally" getting it installed via a (now expired) cache of the Java JDK.