### PR TITLE
Add `open_jdk` to `Linux linux_android_emulator.debug_x64`

### DIFF
--- a/engine/src/flutter/ci/builders/linux_android_emulator.json
+++ b/engine/src/flutter/ci/builders/linux_android_emulator.json
@@ -23,6 +23,10 @@
                 {
                     "dependency": "goldctl",
                     "version": "git_revision:720a542f6fe4f92922c3b8f0fdcc4d2ac6bb83cd"
+                },
+                {
+                    "dependency": "open_jdk",
+                    "version": "version:21"
                 }
             ],
             "name": "ci/android_emulator_debug_x64",


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/173986.

This build _never_ declared (either directly or through `platform_properties`) that it required the Java JDK, and appears to have been "accidentally" getting it installed via a (now expired) cache of the Java JDK.

I'll file a separate issue of "should platform properties be inherited by engine v2 sub-builds".

/cc @jason-simmons @gaaclarke for FYI.