### PR TITLE
Update team-text-input issue triage query

### DIFF
--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -291,7 +291,7 @@ PRs are reviewed weekly across the framework, packages, and engine repositories:
 
 - [P0 list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22a%3A+text+input%22%2Cteam-text-input%2Cfyi-text-input+sort%3Aupdated-asc+label%3AP0+)
 - [PR list](https://github.com/flutter/flutter/pulls?q=is%3Aopen+is%3Apr+sort%3Acreated-desc+draft%3Afalse+label%3A%22a%3A+text+input%22%2Cteam-text-input%2Cfyi-text-input+)
-- [Incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aopen+is%3Aissue+label%3A%22a%3A+text+input%22%2Cteam-text-input%2Cfyi-text-input+no%3Aassignee+-label%3A%22triaged-design%22+-label%3A%22triaged-framework%22+-label%3A%22triaged-linux%22+-label%3A%22triaged-macos%22+-label%3A%22triaged-windows%22+-label%3A%22triaged-android%22+-label%3A%22triaged-ios%22+-label%3A%22triaged-web%22+-label%3A%22triaged-ecosystem%22+-label%3A%22triaged-engine%22+-label%3A%22triaged-tool%22+-label%3A%22triaged-text-input%22+-project%3Aflutter%2F111+)
+- [Incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22a%3A%20text%20input%22%2Cteam-text-input%2Cfyi-text-input%20no%3Aassignee%20-label%3A%22triaged-accessibility%22%20-label%3A%22triaged-android%22%20-label%3A%22triaged-design%22%20-label%3A%22triaged-ecosystem%22%20-label%3A%22triaged-engine%22%20-label%3A%22triaged-framework%22%20-label%3A%22triaged-ios%22%20-label%3A%22triaged-linux%22%20-label%3A%22triaged-macos%22%20-label%3A%22triaged-text-input%22%20-label%3A%22triaged-tool%22%20-label%3A%22triaged-web%22%20-label%3A%22triaged-windows%22%20-project%3Aflutter%2F111)
 
 ### Flutter Tool team (`team-tool`)
 

--- a/docs/triage/README.md
+++ b/docs/triage/README.md
@@ -291,7 +291,7 @@ PRs are reviewed weekly across the framework, packages, and engine repositories:
 
 - [P0 list](https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22a%3A+text+input%22%2Cteam-text-input%2Cfyi-text-input+sort%3Aupdated-asc+label%3AP0+)
 - [PR list](https://github.com/flutter/flutter/pulls?q=is%3Aopen+is%3Apr+sort%3Acreated-desc+draft%3Afalse+label%3A%22a%3A+text+input%22%2Cteam-text-input%2Cfyi-text-input+)
-- [Incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22a%3A%20text%20input%22%2Cteam-text-input%2Cfyi-text-input%20no%3Aassignee%20-label%3A%22triaged-accessibility%22%20-label%3A%22triaged-android%22%20-label%3A%22triaged-design%22%20-label%3A%22triaged-ecosystem%22%20-label%3A%22triaged-engine%22%20-label%3A%22triaged-framework%22%20-label%3A%22triaged-ios%22%20-label%3A%22triaged-linux%22%20-label%3A%22triaged-macos%22%20-label%3A%22triaged-text-input%22%20-label%3A%22triaged-tool%22%20-label%3A%22triaged-web%22%20-label%3A%22triaged-windows%22%20-project%3Aflutter%2F111)
+- [Incoming issue list](https://github.com/flutter/flutter/issues?q=is%3Aopen%20is%3Aissue%20label%3A%22a%3A%20text%20input%22%2Cteam-text-input%2Cfyi-text-input%20no%3Aassignee%20-label%3A%22triaged-accessibility%22%2C%22triaged-android%22%2C%22triaged-codelabs%22%2C%22triaged-design%22%2C%22triaged-ecosystem%22%2C%22triaged-engine%22%2C%22triaged-framework%22%2C%22triaged-games%22%2C%22triaged-infra%22%2C%22triaged-ios%22%2C%22triaged-linux%22%2C%22triaged-macos%22%2C%22triaged-news%22%2C%22triaged-text-input%22%2C%22triaged-tool%22%2C%22triaged-web%22%2C%22triaged-windows%22%20-project%3Aflutter%2F111)
 
 ### Flutter Tool team (`team-tool`)
 


### PR DESCRIPTION
This updates the text input team's issue triage query to exclude issues that have the following labels:

1. `triaged-accessibility`
2. `triaged-codelabs`
3. `triaged-games`
4. `triaged-infra`
5. `triaged-news`
   
### Background
In last week's triage, we discussed removing the [`a: text input` label](https://github.com/flutter/flutter/issues?q=state%3Aopen%20label%3A%22a%3A%20text%20input%22) from our issue triage query as this bubbled up issues that did not need triaging.

It turns out that this query _should_ exclude triaged issues, since it excludes issues with labels like `triaged-windows`. However, the query was missing a few triage teams. Adding these triage team exclusions allow us to see _all_ untriaged text input issues, regardless of which triage team they are assigned to. I think this balances noise with our ability to see all text input issues.

Let me know if you have any feedback on this approach!



