### PR TITLE
Check that the windows architecture is 64-bit and not the process architecture

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -14,9 +14,11 @@ REM --------------------------------------------------------------------------
 SETLOCAL
 
 REM Ensure we are running on 64-bit windows (32-bit is not supported)
-IF "%PROCESSOR_ARCHITECTURE%"=="x86" IF "%PROCESSOR_ARCHITEW6432%"=="" (
-  ECHO Flutter requires 64-bit versions of Windows
-  EXIT 1
+IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
+  IF "%PROCESSOR_ARCHITEW6432%"=="" (
+    ECHO Flutter requires 64-bit versions of Windows
+    EXIT 1
+  )
 )
 
 SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -13,7 +13,10 @@ REM --------------------------------------------------------------------------
 
 SETLOCAL
 
-REM Ensure we are running on 64-bit windows (32-bit is not supported)
+REM Ensure we are running on 64-bit Windows (32-bit is not supported).
+REM If this is a 32-bit process emulated by WOW64,
+REM PROCESSOR_ARCHITECTURE is the process architecture and
+REM PROCESSOR_ARCHITEW6432 is the processor architecture.
 IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
   IF "%PROCESSOR_ARCHITEW6432%"=="" (
     ECHO Flutter requires 64-bit versions of Windows

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -13,8 +13,8 @@ REM --------------------------------------------------------------------------
 
 SETLOCAL
 
-REM Ensure we are runnng on 64-bit windows (32-bit is not supported)
-IF "%PROCESSOR_ARCHITECTURE%"=="x86" (
+REM Ensure we are running on 64-bit windows (32-bit is not supported)
+IF "%PROCESSOR_ARCHITECTURE%"=="x86" IF "%PROCESSOR_ARCHITEW6432%"=="" (
   ECHO Flutter requires 64-bit versions of Windows
   EXIT 1
 )


### PR DESCRIPTION
Changes the platform detection for Windows - so that it can be invoked from a 32-bit process when we are on a 64-bit system.
This is the case for example 'make' for windows which only comes with a 32-bit version.

_PROCESSOR_ARCHITEW6432_ is only set if the process architecture differs from the platform architecture.

See https://learn.microsoft.com/de-de/windows/win32/winprog64/wow64-implementation-details#environment-variables

Fixes https://github.com/flutter/flutter/issues/174017

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
