### PR TITLE
Fix `onSelect` called twice in `DropdownMenuFormField`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_form_field.dart
@@ -75,11 +75,6 @@ class DropdownMenuFormField<T> extends FormField<T> {
          autovalidateMode: autovalidateMode,
          builder: (FormFieldState<T> field) {
            final _DropdownMenuFormFieldState<T> state = field as _DropdownMenuFormFieldState<T>;
-           void onSelectedHandler(T? value) {
-             field.didChange(value);
-             onSelected?.call(value);
-           }
-
            return UnmanagedRestorationScope(
              bucket: field.bucket,
              child: DropdownMenu<T>(
@@ -103,7 +98,7 @@ class DropdownMenuFormField<T> extends FormField<T> {
                menuStyle: menuStyle,
                controller: controller,
                initialSelection: state.value,
-               onSelected: onSelectedHandler,
+               onSelected: field.didChange,
                focusNode: focusNode,
                requestFocusOnTap: requestFocusOnTap,
                expandedInsets: expandedInsets,

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -1176,4 +1176,52 @@ void main() {
 
     expect(formFieldState.currentState!.value, MenuItem.menuItem2);
   });
+
+  testWidgets('onSelect is called exactly once when a selection is made.', (
+    WidgetTester tester,
+  ) async {
+    int onSelectedCallCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            dropdownMenuEntries: menuEntries,
+            initialSelection: MenuItem.menuItem0,
+            onSelected: (MenuItem? value) {
+              onSelectedCallCount++;
+            },
+          ),
+        ),
+      ),
+    );
+    // Select a different item than the initial one.
+    await tester.tap(find.byType(DropdownMenu<MenuItem>));
+    await tester.pump();
+    await tester.tap(findMenuItem(MenuItem.menuItem2));
+    await tester.pump();
+
+    expect(onSelectedCallCount, 1);
+  });
+
+  testWidgets('onSelect is called exactly once when reseted', (WidgetTester tester) async {
+    int onSelectedCallCount = 0;
+    final GlobalKey<FormFieldState<MenuItem>> fieldKey = GlobalKey<FormFieldState<MenuItem>>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DropdownMenuFormField<MenuItem>(
+            key: fieldKey,
+            dropdownMenuEntries: menuEntries,
+            onSelected: (MenuItem? value) {
+              onSelectedCallCount++;
+            },
+          ),
+        ),
+      ),
+    );
+
+    fieldKey.currentState!.reset();
+    await tester.pump();
+    expect(onSelectedCallCount, 1);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/173977

Currently `onSelect` isn't called twice during reset, but I still added a test for it.
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
