### PR TITLE
Bump Dart to 3.10

### DIFF
--- a/dev/a11y_assessments/pubspec.yaml
+++ b/dev/a11y_assessments/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project
 version: 5.0.0+5
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_automated_tests
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: complex_layout
 description: A benchmark of a relatively complex layout.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/imitation_game_flutter/pubspec.yaml
+++ b/dev/benchmarks/imitation_game_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/macrobenchmarks/pubspec.yaml
+++ b/dev/benchmarks/macrobenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: macrobenchmarks
 description: Performance benchmarks using flutter drive.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: microbenchmarks
 description: Small benchmarks for very specific parts of the Flutter framework.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/multiple_flutters/module/pubspec.yaml
+++ b/dev/benchmarks/multiple_flutters/module/pubspec.yaml
@@ -4,7 +4,7 @@ description: A module that is embedded in the multiple_flutters benchmark test.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
+++ b/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/platform_views_layout/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout
 description: A benchmark for platform views.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout_hybrid_composition
 description: A benchmark for platform views, using hybrid composition on android.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/benchmarks/test_apps/stocks/pubspec.yaml
+++ b/dev/benchmarks/test_apps/stocks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stocks
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/bots/pubspec.yaml
+++ b/dev/bots/pubspec.yaml
@@ -2,7 +2,7 @@ name: tests_on_bots
 description: Scripts which run on bots.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/customer_testing/pubspec.yaml
+++ b/dev/customer_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: customer_testing
 description: Tool to run the tests listed in the flutter/tests repository.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/docs/platform_integration/pubspec.yaml
+++ b/dev/docs/platform_integration/pubspec.yaml
@@ -1,4 +1,4 @@
 name: platform_integration
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/dev/docs/renderers/pubspec.yaml
+++ b/dev/docs/renderers/pubspec.yaml
@@ -1,4 +1,4 @@
 name: renderers
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/dev/forbidden_from_release_tests/pubspec.yaml
+++ b/dev/forbidden_from_release_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: forbidden_from_release_tests
 publish_to: 'none'
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/android_engine_test/pubspec.yaml
+++ b/dev/integration_tests/android_engine_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: android_engine_test
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/android_semantics_testing/pubspec.yaml
+++ b/dev/integration_tests/android_semantics_testing/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_semantics_testing
 description: Integration testing library for Android semantics
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/android_verified_input/pubspec.yaml
+++ b/dev/integration_tests/android_verified_input/pubspec.yaml
@@ -3,7 +3,7 @@ description: "An integration test for verified MotionEvents."
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/dev/integration_tests/android_views/pubspec.yaml
+++ b/dev/integration_tests/android_views/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 description: An integration test for embedded platform views
 version: 1.0.0+1
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/channels/pubspec.yaml
+++ b/dev/integration_tests/channels/pubspec.yaml
@@ -2,7 +2,7 @@ name: channels
 description: Integration test for platform channels.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/deferred_components_test/pubspec.yaml
+++ b/dev/integration_tests/deferred_components_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration test application for basic deferred components function
 publish_to: 'none'
 version: 1.0.0+1
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/display_cutout_rotation/pubspec.yaml
+++ b/dev/integration_tests/display_cutout_rotation/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/external_textures/pubspec.yaml
+++ b/dev/integration_tests/external_textures/pubspec.yaml
@@ -2,7 +2,7 @@ name: external_textures
 description: A test of Flutter integrating external textures.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/flavors/pubspec.yaml
+++ b/dev/integration_tests/flavors/pubspec.yaml
@@ -2,7 +2,7 @@ name: flavors
 description: Integration test for build flavors.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/flutter_gallery/pubspec.yaml
+++ b/dev/integration_tests/flutter_gallery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gallery
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/hook_user_defines/pubspec.yaml
+++ b/dev/integration_tests/hook_user_defines/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.0.1
 # resolution: workspace
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 hooks:
   user_defines:

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new flutter module project.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -13,7 +13,7 @@ name: ios_app_with_extensions
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
+++ b/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
@@ -3,7 +3,7 @@ name: ios_platform_view_tests
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/keyboard_hot_restart/pubspec.yaml
+++ b/dev/integration_tests/keyboard_hot_restart/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/link_hook/pubspec.yaml
+++ b/dev/integration_tests/link_hook/pubspec.yaml
@@ -3,7 +3,7 @@ description: 'A new Dart FFI package project.'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/new_gallery/pubspec.yaml
+++ b/dev/integration_tests/new_gallery/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/flutter/dev/integration_tests/new_gallery
 version: 2.10.2+021002 # See README.md for details on versioning.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 resolution: workspace
 
 

--- a/dev/integration_tests/platform_interaction/pubspec.yaml
+++ b/dev/integration_tests/platform_interaction/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_interaction
 description: Integration test for platform interactions.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/release_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/release_smoke_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: release_smoke_test
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/spell_check/pubspec.yaml
+++ b/dev/integration_tests/spell_check/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: integration_ui
 description: Flutter non-plugin UI integration tests.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/web/pubspec.yaml
+++ b/dev/integration_tests/web/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_integration
 description: Integration test for web compilation.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/web_compile_tests/pubspec.yaml
+++ b/dev/integration_tests/web_compile_tests/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_compile_tests
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/web_e2e_tests/pubspec.yaml
+++ b/dev/integration_tests/web_e2e_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_e2e_tests
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/wide_gamut_test/pubspec.yaml
+++ b/dev/integration_tests/wide_gamut_test/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/integration_tests/widget_preview_scaffold/pubspec.yaml
+++ b/dev/integration_tests/widget_preview_scaffold/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   flutter:

--- a/dev/integration_tests/windowing_test/pubspec.yaml
+++ b/dev/integration_tests/windowing_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: windowing_test
 description: Flutter windowing integration tests.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   flutter:

--- a/dev/integration_tests/windows_startup_test/pubspec.yaml
+++ b/dev/integration_tests/windows_startup_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: windows_startup_test
 description: Integration test for Windows app's startup.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: manual_tests
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/missing_dependency_tests/pubspec.yaml
+++ b/dev/missing_dependency_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: missing_dependency_tests
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   flutter:

--- a/dev/packages_autoroller/pubspec.yaml
+++ b/dev/packages_autoroller/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter Automated Release Tool
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/snippets/pubspec.yaml
+++ b/dev/snippets/pubspec.yaml
@@ -2,7 +2,7 @@ name: snippets
 description: A package for parsing and manipulating code samples in Flutter repo dartdoc comments.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/tools/android_driver_extensions/pubspec.yaml
+++ b/dev/tools/android_driver_extensions/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_driver_extensions
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/tools/gen_defaults/pubspec.yaml
+++ b/dev/tools/gen_defaults/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command line script to generate Material component defaults from 
 version: 1.0.0
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/tools/gen_keycodes/pubspec.yaml
+++ b/dev/tools/gen_keycodes/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_keycodes
 description: Generates keycode source files from various resources.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -2,7 +2,7 @@ name: dev_tools
 description: Various repository development tools for flutter.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/dev/tracing_tests/pubspec.yaml
+++ b/dev/tracing_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracing_tests
 description: Various tests for tracing in flutter/flutter
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/engine/src/flutter/ci/pubspec.yaml
+++ b/engine/src/flutter/ci/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/flutter_frontend_server/pubspec.yaml
+++ b/engine/src/flutter/flutter_frontend_server/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/impeller/tessellator/dart/pubspec.yaml
+++ b/engine/src/flutter/impeller/tessellator/dart/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/lib/gpu/pubspec.yaml
+++ b/engine/src/flutter/lib/gpu/pubspec.yaml
@@ -8,7 +8,7 @@ homepage: https://flutter.dev
 repository: https://github.com/flutter/engine/tree/main/lib/gpu
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/engine/src/flutter/lib/snapshot/pubspec.yaml
+++ b/engine/src/flutter/lib/snapshot/pubspec.yaml
@@ -6,4 +6,4 @@
 name: _snapshot_but_this_package_name_is_not_used
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/lib/web_ui/pubspec.yaml
+++ b/engine/src/flutter/lib/web_ui/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 # Keep the SDK version range in sync with pubspecs under web_sdk
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   meta: ^1.14.0

--- a/engine/src/flutter/pubspec.yaml
+++ b/engine/src/flutter/pubspec.yaml
@@ -76,7 +76,7 @@ name: _engine_workspace
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # Declare all packages that are part of the workspace.
 workspace:

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/fuchsia/pubspec.yaml
@@ -3,4 +3,4 @@
 # found in the LICENSE file.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon/pubspec.yaml
@@ -5,7 +5,7 @@
 name: zircon
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 
 # Uncomment block for local testing

--- a/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart-pkg/zircon_ffi/pubspec.yaml
@@ -1,7 +1,7 @@
 name: zircon_ffi
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   ffi: ^1.0.0

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/embedder/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/embedder/pubspec.yaml
@@ -6,5 +6,5 @@
 # template in BUILD.gn.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/vmservice/pubspec.yaml
@@ -3,5 +3,5 @@
 # found in the LICENSE file.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/kernel/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/kernel/pubspec.yaml
@@ -3,4 +3,4 @@
 # found in the LICENSE file.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/child-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: child_view2
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/embedder/parent-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: parent-view2
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/mouse-input/mouse-input-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: mouse-input-view
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/text-input/text-input-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: text-input-view
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/embedding-flutter-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: embedding-flutter-view
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/integration/touch-input/touch-input-view/pubspec.yaml
@@ -5,4 +5,4 @@
 name: touch-input-view
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: profiler_symbols
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 version: 0
 description: Extracts a minimal symbols table for the Dart VM profiler
 author: Dart Team <misc@dartlang.org>

--- a/engine/src/flutter/shell/vmservice/pubspec.yaml
+++ b/engine/src/flutter/shell/vmservice/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/sky/packages/sky_engine/pubspec.yaml
+++ b/engine/src/flutter/sky/packages/sky_engine/pubspec.yaml
@@ -1,3 +1,3 @@
 name: sky_engine
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0

--- a/engine/src/flutter/testing/benchmark/pubspec.yaml
+++ b/engine/src/flutter/testing/benchmark/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/testing/dart/pubspec.yaml
+++ b/engine/src/flutter/testing/dart/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/testing/ios_scenario_app/pubspec.yaml
+++ b/engine/src/flutter/testing/ios_scenario_app/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/testing/skia_gold_client/pubspec.yaml
+++ b/engine/src/flutter/testing/skia_gold_client/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/testing/smoke_test_failure/pubspec.yaml
+++ b/engine/src/flutter/testing/smoke_test_failure/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/testing/symbols/pubspec.yaml
+++ b/engine/src/flutter/testing/symbols/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/third_party/web_locale_keymap/pubspec.yaml
+++ b/engine/src/flutter/third_party/web_locale_keymap/pubspec.yaml
@@ -3,7 +3,7 @@ name: web_locale_keymap
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dev_dependencies:
   test: ^1.21.7

--- a/engine/src/flutter/third_party/web_test_fonts/pubspec.yaml
+++ b/engine/src/flutter/third_party/web_test_fonts/pubspec.yaml
@@ -3,7 +3,7 @@ name: web_test_fonts
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dev_dependencies:
   args: any

--- a/engine/src/flutter/tools/android_lint/pubspec.yaml
+++ b/engine/src/flutter/tools/android_lint/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/api_check/pubspec.yaml
+++ b/engine/src/flutter/tools/api_check/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/build_bucket_golden_scraper/pubspec.yaml
+++ b/engine/src/flutter/tools/build_bucket_golden_scraper/pubspec.yaml
@@ -6,7 +6,7 @@ name: build_bucket_golden_scraper
 publish_to: none
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/clang_tidy/pubspec.yaml
+++ b/engine/src/flutter/tools/clang_tidy/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/clangd_check/pubspec.yaml
+++ b/engine/src/flutter/tools/clangd_check/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/compare_goldens/pubspec.yaml
+++ b/engine/src/flutter/tools/compare_goldens/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/const_finder/pubspec.yaml
+++ b/engine/src/flutter/tools/const_finder/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/engine_tool/pubspec.yaml
+++ b/engine/src/flutter/tools/engine_tool/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/gen_web_locale_keymap/pubspec.yaml
+++ b/engine/src/flutter/tools/gen_web_locale_keymap/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/githooks/pubspec.yaml
+++ b/engine/src/flutter/tools/githooks/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/golden_tests_harvester/pubspec.yaml
+++ b/engine/src/flutter/tools/golden_tests_harvester/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/header_guard_check/pubspec.yaml
+++ b/engine/src/flutter/tools/header_guard_check/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/mcp/pubspec.yaml
+++ b/engine/src/flutter/tools/mcp/pubspec.yaml
@@ -1,7 +1,7 @@
 name: engine_mcp
 publish_to: none
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 resolution: workspace
 dependencies:
   async: any

--- a/engine/src/flutter/tools/path_ops/dart/pubspec.yaml
+++ b/engine/src/flutter/tools/path_ops/dart/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/pkg/engine_build_configs/pubspec.yaml
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/pkg/engine_repo_tools/pubspec.yaml
+++ b/engine/src/flutter/tools/pkg/engine_repo_tools/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/pkg/git_repo_tools/pubspec.yaml
+++ b/engine/src/flutter/tools/pkg/git_repo_tools/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/tools/pkg/process_fakes/pubspec.yaml
+++ b/engine/src/flutter/tools/pkg/process_fakes/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 
 # Required for workspace support.
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # This package is managed as part of the engine workspace.
 resolution: workspace

--- a/engine/src/flutter/web_sdk/pubspec.yaml
+++ b/engine/src/flutter/web_sdk/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_sdk_tests
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   args: any # see dependency_overrides

--- a/engine/src/flutter/web_sdk/web_engine_tester/pubspec.yaml
+++ b/engine/src/flutter/web_sdk/web_engine_tester/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_engine_tester
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   stream_channel: 2.1.4

--- a/engine/src/flutter/web_sdk/web_test_utils/pubspec.yaml
+++ b/engine/src/flutter/web_sdk/web_test_utils/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_test_utils
 
 # Keep the SDK version range in sync with lib/web_ui/pubspec.yaml
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   image: 4.5.3

--- a/examples/api/pubspec.yaml
+++ b/examples/api/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 resolution: workspace
 
 

--- a/examples/flutter_view/pubspec.yaml
+++ b/examples/flutter_view/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_view
 description: A new flutter project.
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hello_world
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/image_list/pubspec.yaml
+++ b/examples/image_list/pubspec.yaml
@@ -4,7 +4,7 @@ description: Simple Flutter project used for benchmarking image loading over net
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_examples_layers
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/multiple_windows/pubspec.yaml
+++ b/examples/multiple_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: multiple_windows
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 dependencies:
   flutter:

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/platform_channel_swift/pubspec.yaml
+++ b/examples/platform_channel_swift/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel_swift
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/platform_view/pubspec.yaml
+++ b/examples/platform_view/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_view
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/splash/pubspec.yaml
+++ b/examples/splash/pubspec.yaml
@@ -1,7 +1,7 @@
 name: splash
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/examples/texture/pubspec.yaml
+++ b/examples/texture/pubspec.yaml
@@ -1,7 +1,7 @@
 name: texture
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: A framework for writing Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter/test_private/pubspec.yaml
+++ b/packages/flutter/test_private/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_test_private
 description: Tests private interfaces of the flutter
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter/test_private/test/pubspec.yaml
+++ b/packages/flutter/test_private/test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animated_icons_private_test
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration and performance test API for Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter_goldens/pubspec.yaml
+++ b/packages/flutter_goldens/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_goldens
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter_localizations/pubspec.yaml
+++ b/packages/flutter_localizations/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_localizations
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_test
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/flutter_test/test/test_config/project_root/pubspec.yaml
+++ b/packages/flutter_test/test/test_config/project_root/pubspec.yaml
@@ -4,6 +4,6 @@
 name: dummy
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 # PUBSPEC CHECKSUM: 1

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -98,7 +98,7 @@ description: 'Project for testing user-defines.'
 version: 0.0.1
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 hooks:
   user_defines:

--- a/packages/flutter_web_plugins/pubspec.yaml
+++ b/packages/flutter_web_plugins/pubspec.yaml
@@ -3,7 +3,7 @@ description: Library to register Flutter Web plugins
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/fuchsia_remote_debug_protocol/pubspec.yaml
+++ b/packages/fuchsia_remote_debug_protocol/pubspec.yaml
@@ -4,7 +4,7 @@ description: Provides an API to test/debug Flutter applications on remote Fuchsi
 homepage: https://flutter.dev
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the integration_test plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 resolution: workspace
 
 

--- a/packages/integration_test/integration_test_macos/pubspec.yaml
+++ b/packages/integration_test/integration_test_macos/pubspec.yaml
@@ -10,7 +10,7 @@ flutter:
         pluginClass: IntegrationTestPlugin
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Runs tests that use the flutter_test API as integration tests.
 publish_to: none
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 resolution: workspace
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: _flutter_packages
 
 environment:
-  sdk: ^3.9.0-0
+  sdk: ^3.10.0-0
 
 workspace:
   - dev/a11y_assessments


### PR DESCRIPTION
This version of Dart supports dot shorthands.

Follow-up to: https://github.com/flutter/flutter/issues/180607

See also:

 * https://flutter.dev/go/flutter-style-updates
 * https://github.com/flutter/flutter/pull/181934