### PR TITLE
[Impeller] Make sure inline passes always do a clear action.

### DIFF
--- a/engine/src/flutter/impeller/entity/inline_pass_context.cc
+++ b/engine/src/flutter/impeller/entity/inline_pass_context.cc
@@ -108,7 +108,7 @@ const std::shared_ptr<RenderPass>& InlinePassContext::GetRenderPass() {
   bool is_msaa = color0.resolve_texture != nullptr;
 
   if (pass_count_ > 0) {
-    color0.load_action = LoadAction::kLoad;
+    color0.load_action = is_msaa ? LoadAction::kClear : LoadAction::kLoad;
   } else {
     color0.load_action = LoadAction::kClear;
   }

--- a/engine/src/flutter/impeller/entity/inline_pass_context.cc
+++ b/engine/src/flutter/impeller/entity/inline_pass_context.cc
@@ -108,10 +108,7 @@ const std::shared_ptr<RenderPass>& InlinePassContext::GetRenderPass() {
   bool is_msaa = color0.resolve_texture != nullptr;
 
   if (pass_count_ > 0) {
-    // When MSAA is being used, we end up overriding the entire backdrop by
-    // drawing the previous pass texture, and so we don't have to clear it and
-    // can use kDontCare.
-    color0.load_action = is_msaa ? LoadAction::kDontCare : LoadAction::kLoad;
+    color0.load_action = LoadAction::kLoad;
   } else {
     color0.load_action = LoadAction::kClear;
   }


### PR DESCRIPTION
The assumption they could avoid this is no longer valid.

issue: https://github.com/flutter/flutter/issues/171772

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
