### PR TITLE
[CP-stable][ Widget Preview ] Report an error if a web device is unavailable (#174036)

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:args/args.dart';
+import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:process/process.dart';
@@ -26,6 +27,7 @@ import '../project.dart';
 import '../resident_runner.dart';
 import '../runner/flutter_command.dart';
 import '../runner/flutter_command_runner.dart';
+import '../web/web_device.dart';
 import '../widget_preview/analytics.dart';
 import '../widget_preview/dependency_graph.dart';
 import '../widget_preview/dtd_services.dart';
@@ -160,6 +162,10 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
 
   /// Environment variable used to pass the DTD URI to the widget preview scaffold.
   static const kWidgetPreviewDtdUriEnvVar = 'WIDGET_PREVIEW_DTD_URI';
+
+  @visibleForTesting
+  static const kBrowserNotFoundErrorMessage =
+      'Failed to locate browser. Make sure you are using an up-to-date Chrome or Edge.';
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{
@@ -302,12 +308,14 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
       await _previewPubspecBuilder.populatePreviewPubspec(rootProject: rootProject);
     }
 
+    shutdownHooks.addShutdownHook(() async {
+      await _widgetPreviewApp?.exitApp();
+      await _previewDetector.dispose();
+    });
+
     final PreviewDependencyGraph graph = await _previewDetector.initialize();
     _previewCodeGenerator.populatePreviewsInGeneratedPreviewScaffold(graph);
 
-    shutdownHooks.addShutdownHook(() async {
-      await _widgetPreviewApp?.exitApp();
-    });
     await configureDtd();
     final int result = await runPreviewEnvironment(
       widgetPreviewScaffoldProject: rootProject.widgetPreviewScaffoldProject,
@@ -316,7 +324,6 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
       throwToolExit('Failed to launch the widget previewer.', exitCode: result);
     }
 
-    await _previewDetector.dispose();
     return FlutterCommandResult.success();
   }
 
@@ -368,11 +375,25 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
           deviceConnectionInterface: DeviceConnectionInterface.attached,
         ),
       );
-      assert(devices.length == 1);
-      final Device device = devices.first;
+      if (devices.isEmpty) {
+        throwToolExit(kBrowserNotFoundErrorMessage);
+      }
+      final Device device;
+      if (devices.length > 1) {
+        // Prefer Google Chrome as the target browser.
+        device =
+            devices.firstWhereOrNull((device) => device is GoogleChromeDevice) ?? devices.first;
+
+        logger.printTrace(
+          'Detected ${devices.length} web devices (${devices.map((e) => e.displayName).join(', ')}). '
+          'Defaulting to ${device.displayName}.',
+        );
+      } else {
+        device = devices.single;
+      }
 
       // WARNING: this log message is used by test/integration.shard/widget_preview_test.dart
-      logger.printStatus('Launching the Widget Preview Scaffold...');
+      logger.printStatus('Launching the Widget Preview Scaffold on ${device.displayName}...');
 
       final debuggingOptions = DebuggingOptions.enabled(
         BuildInfo(

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -183,9 +183,10 @@ class GoogleChromeDevice extends ChromiumDevice {
   final ProcessManager _processManager;
 
   static const kChromeDeviceId = 'chrome';
+  static const kChromeDeviceName = 'Chrome';
 
   @override
-  String get name => 'Chrome';
+  String get name => kChromeDeviceName;
 
   @override
   late final Future<String> sdkNameAndVersion = _computeSdkNameAndVersion();
@@ -239,9 +240,10 @@ class MicrosoftEdgeDevice extends ChromiumDevice {
   static const _kFirstChromiumEdgeMajorVersion = 79;
 
   static const kEdgeDeviceId = 'edge';
+  static const kEdgeDeviceName = 'Edge';
 
   @override
-  String get name => 'Edge';
+  String get name => kEdgeDeviceName;
 
   Future<bool> _meetsVersionConstraint() async {
     final String rawVersion = (await sdkNameAndVersion).replaceFirst('Microsoft Edge ', '');
@@ -286,7 +288,7 @@ class WebDevices extends PollingDeviceDiscovery {
     required FeatureFlags featureFlags,
   }) : _featureFlags = featureFlags,
        _webServerDevice = WebServerDevice(logger: logger),
-       super('Chrome') {
+       super(GoogleChromeDevice.kChromeDeviceName) {
     final operatingSystemUtils = OperatingSystemUtils(
       fileSystem: fileSystem,
       platform: platform,

--- a/packages/flutter_tools/lib/src/widget_preview/analytics.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/analytics.dart
@@ -58,7 +58,7 @@ class WidgetPreviewAnalytics {
   ///
   /// This should be invoked when a file system event is detected in the preview detector.
   void startPreviewReloadStopwatch() {
-    assert(!_launchTimer.isRunning);
+    assert(!_reloadTimer.isRunning);
     _reloadTimer.start();
   }
 

--- a/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_detector.dart
@@ -70,6 +70,7 @@ class PreviewDetector {
     // processing the latest file updates to avoid throwing an exception.
     await _mutex.runGuarded(() async {
       await _fileWatcher?.cancel();
+      _fileWatcher = null;
       await collection.dispose();
     });
   }

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/web/web_device.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/dtd_services.dart';
 import 'package:flutter_tools/src/widget_preview/preview_code_generator.dart';
@@ -29,7 +30,6 @@ import 'package:unified_analytics/unified_analytics.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/fake_devices.dart';
 import '../../../src/fakes.dart';
 import '../../../src/test_flutter_command_runner.dart';
 import '../utils/project_testing_utils.dart';
@@ -48,10 +48,44 @@ class FakeWidgetPreviewScaffoldDtdServices extends Fake implements WidgetPreview
   Future<void> launchAndConnect() async {}
 }
 
+class FakeGoogleChromeDevice extends Fake implements GoogleChromeDevice {
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+
+  @override
+  PlatformType? get platformType => PlatformType.web;
+
+  @override
+  String get displayName => GoogleChromeDevice.kChromeDeviceName;
+}
+
+class FakeMicrosoftEdgeDevice extends Fake implements MicrosoftEdgeDevice {
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+
+  @override
+  PlatformType? get platformType => PlatformType.web;
+
+  @override
+  String get displayName => MicrosoftEdgeDevice.kEdgeDeviceName;
+}
+
+class FakeCustomBrowserDevice extends Fake implements ChromiumDevice {
+  @override
+  Future<TargetPlatform> get targetPlatform async => TargetPlatform.web_javascript;
+
+  @override
+  PlatformType? get platformType => PlatformType.web;
+
+  @override
+  String get displayName => 'Dartium';
+}
+
 void main() {
   late Directory originalCwd;
   late Directory tempDir;
   late LoggingProcessManager loggingProcessManager;
+  late ShutdownHooks shutdownHooks;
   late FakeStdio mockStdio;
   late Logger logger;
   // We perform this initialization just so we can build the generated file path for test
@@ -61,11 +95,15 @@ void main() {
   late Platform platform;
   late FakeDeviceManager fakeDeviceManager;
   late FakeAnalytics fakeAnalytics;
+  late FakeGoogleChromeDevice fakeGoogleChromeDevice;
+  late FakeMicrosoftEdgeDevice fakeMicrosoftEdgeDevice;
+  late FakeCustomBrowserDevice fakeCustomBrowserDevice;
 
   setUp(() async {
     originalCwd = globals.fs.currentDirectory;
     await ensureFlutterToolsSnapshot();
     loggingProcessManager = LoggingProcessManager();
+    shutdownHooks = ShutdownHooks();
     logger = BufferLogger.test();
     fs = LocalFileSystem.test(signals: Signals.test());
     botDetector = const FakeBotDetector(false);
@@ -73,13 +111,15 @@ void main() {
     mockStdio = FakeStdio();
     platform = FakePlatform.fromPlatform(const LocalPlatform());
 
+    fakeGoogleChromeDevice = FakeGoogleChromeDevice();
+    fakeMicrosoftEdgeDevice = FakeMicrosoftEdgeDevice();
+    fakeCustomBrowserDevice = FakeCustomBrowserDevice();
+
     // Create a fake device manager which only contains a single Chrome device.
-    const kChromeDeviceId = 'chrome-id';
-    final fakeChromeDevice = FakeDevice('chrome', kChromeDeviceId)
-      ..targetPlatform = Future<TargetPlatform>.value(TargetPlatform.web_javascript);
     fakeDeviceManager = FakeDeviceManager()
-      ..addAttachedDevice(fakeChromeDevice)
-      ..specifiedDeviceId = kChromeDeviceId;
+      ..addAttachedDevice(fakeGoogleChromeDevice)
+      ..addAttachedDevice(fakeMicrosoftEdgeDevice)
+      ..addAttachedDevice(fakeCustomBrowserDevice);
 
     fakeAnalytics = getInitializedFakeAnalyticsInstance(
       fs: MemoryFileSystem.test(),
@@ -93,9 +133,10 @@ void main() {
     Cache.flutterRoot = fs.path.absolute('..', '..');
   });
 
-  tearDown(() {
+  tearDown(() async {
+    await shutdownHooks.runShutdownHooks(logger);
     tryToDelete(tempDir);
-    fs.dispose();
+    await fs.dispose();
     globals.fs.currentDirectory = originalCwd;
   });
 
@@ -116,7 +157,7 @@ void main() {
         projectFactory: FlutterProjectFactory(logger: logger, fileSystem: fs),
         cache: Cache.test(processManager: loggingProcessManager, platform: platform),
         platform: platform,
-        shutdownHooks: ShutdownHooks(),
+        shutdownHooks: shutdownHooks,
         os: OperatingSystemUtils(
           fileSystem: fs,
           processManager: loggingProcessManager,
@@ -142,6 +183,14 @@ void main() {
 
   void expectNoPreviewLaunchTimingEvents() => expectNPreviewLaunchTimingEvents(0);
   void expectSinglePreviewLaunchTimingEvent() => expectNPreviewLaunchTimingEvents(1);
+
+  void expectDeviceSelected(Device device) {
+    final bufferLogger = logger as BufferLogger;
+    expect(
+      bufferLogger.statusText,
+      contains('Launching the Widget Preview Scaffold on ${device.displayName}...'),
+    );
+  }
 
   Future<void> startWidgetPreview({
     required Directory? rootProject,
@@ -419,6 +468,84 @@ List<_i1.WidgetPreview> previews() => [
       overrides: <Type, Generator>{
         Analytics: () => fakeAnalytics,
         DeviceManager: () => fakeDeviceManager,
+        ProcessManager: () => loggingProcessManager,
+        Pub: () => Pub.test(
+          fileSystem: fs,
+          logger: logger,
+          processManager: loggingProcessManager,
+          botDetector: botDetector,
+          platform: platform,
+          stdio: mockStdio,
+        ),
+      },
+    );
+
+    testUsingContext(
+      'start exits if no web target is available.',
+      () async {
+        // Regression test for https://github.com/flutter/flutter/issues/173960.
+        final Directory rootProject = await createRootProject();
+        await expectToolExitLater(
+          startWidgetPreview(rootProject: rootProject),
+          contains(WidgetPreviewStartCommand.kBrowserNotFoundErrorMessage),
+        );
+      },
+      overrides: <Type, Generator>{
+        Analytics: () => fakeAnalytics,
+        DeviceManager: () => fakeDeviceManager..attachedDevices.clear(),
+        FileSystem: () => fs,
+        ProcessManager: () => loggingProcessManager,
+        Pub: () => Pub.test(
+          fileSystem: fs,
+          logger: logger,
+          processManager: loggingProcessManager,
+          botDetector: botDetector,
+          platform: platform,
+          stdio: mockStdio,
+        ),
+      },
+    );
+
+    testUsingContext(
+      'always starts with Chrome when available.',
+      () async {
+        final Directory rootProject = await createRootProject();
+        await startWidgetPreview(rootProject: rootProject);
+        expectDeviceSelected(fakeGoogleChromeDevice);
+      },
+      overrides: <Type, Generator>{
+        Analytics: () => fakeAnalytics,
+        DeviceManager: () => fakeDeviceManager
+          ..attachedDevices.clear()
+          ..addAttachedDevice(fakeMicrosoftEdgeDevice)
+          // Register the Chrome device second to ensure we're not just grabbing the first device.
+          ..addAttachedDevice(fakeGoogleChromeDevice),
+        FileSystem: () => fs,
+        ProcessManager: () => loggingProcessManager,
+        Pub: () => Pub.test(
+          fileSystem: fs,
+          logger: logger,
+          processManager: loggingProcessManager,
+          botDetector: botDetector,
+          platform: platform,
+          stdio: mockStdio,
+        ),
+      },
+    );
+
+    testUsingContext(
+      'starts with Edge if Chrome is not available.',
+      () async {
+        final Directory rootProject = await createRootProject();
+        await startWidgetPreview(rootProject: rootProject);
+        expectDeviceSelected(fakeMicrosoftEdgeDevice);
+      },
+      overrides: <Type, Generator>{
+        Analytics: () => fakeAnalytics,
+        DeviceManager: () => fakeDeviceManager
+          ..attachedDevices.clear()
+          ..addAttachedDevice(fakeMicrosoftEdgeDevice),
+        FileSystem: () => fs,
         ProcessManager: () => loggingProcessManager,
         Pub: () => Pub.test(
           fileSystem: fs,

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -20,16 +20,15 @@ import '../src/context.dart';
 import 'test_data/basic_project.dart';
 import 'test_utils.dart';
 
-const firstLaunchMessagesWeb = <String>[
+final launchingOnDeviceRegExp = RegExp(r'Launching the Widget Preview Scaffold on [a-zA-Z]+...');
+
+final firstLaunchMessagesWeb = <Pattern>[
   'Creating widget preview scaffolding at:',
-  'Launching the Widget Preview Scaffold...',
+  launchingOnDeviceRegExp,
   'Done loading previews.',
 ];
 
-const subsequentLaunchMessagesWeb = <String>[
-  'Launching the Widget Preview Scaffold...',
-  'Done loading previews.',
-];
+final subsequentLaunchMessagesWeb = <Pattern>[launchingOnDeviceRegExp, 'Done loading previews.'];
 
 void main() {
   late Directory tempDir;
@@ -53,7 +52,7 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  Future<void> runWidgetPreview({required List<String> expectedMessages, Uri? dtdUri}) async {
+  Future<void> runWidgetPreview({required List<Pattern> expectedMessages, Uri? dtdUri}) async {
     expect(expectedMessages, isNotEmpty);
     var i = 0;
     process = await processManager.start(<String>[


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/173960

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

Starting the widget previewer fails if Chrome or Edge is not installed.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

The Flutter tool crashes with a `StateError` if `flutter widget-preview start` is run on a host with no Chrome or Edge installed without providing any meaningful error message.

### Workaround:
Is there a workaround for this issue?

Installing Chrome or Edge, but it's not clear that this needs to be done based on the failure mode.

### Risk:
What is the risk level of this cherry-pick?

  - [X] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [X] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Run `flutter widget-preview start` on a device without Chrome or Edge and verify that there's an error message telling users to install Chrome or Edge.

