### PR TITLE
Move `Linux coverage` back to bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -375,6 +375,8 @@ targets:
       task_name: analyzer_benchmark
 
   - name: Linux coverage
+    # Because this only runs every 6 commits, it being flaky takes a long time to recover.
+    bringup: true 
     presubmit: false
     recipe: flutter/coverage
     timeout: 90


### PR DESCRIPTION
Because this only runs every 6 commits, it being flaky takes a long time to recover.

It's not a priority to keep green and un-flaky at the moment.