### PR TITLE
Revert "Update the AccessibilityPlugin::Announce method to account fo…

### DIFF
--- a/dev/integration_tests/new_gallery/lib/pages/backdrop.dart
+++ b/dev/integration_tests/new_gallery/lib/pages/backdrop.dart
@@ -264,8 +264,7 @@ class _SettingsIcon extends AnimatedWidget {
             child: InkWell(
               onTap: () {
                 toggleSettings();
-                SemanticsService.sendAnnouncement(
-                  View.of(context),
+                SemanticsService.announce(
                   _settingsSemanticLabel(isSettingsOpenNotifier.value, context),
                   GalleryOptions.of(context).resolvedTextDirection()!,
                 );

--- a/engine/src/flutter/shell/platform/windows/accessibility_plugin.cc
+++ b/engine/src/flutter/shell/platform/windows/accessibility_plugin.cc
@@ -20,7 +20,6 @@ static constexpr char kAccessibilityChannelName[] = "flutter/accessibility";
 static constexpr char kTypeKey[] = "type";
 static constexpr char kDataKey[] = "data";
 static constexpr char kMessageKey[] = "message";
-static constexpr char kViewIdKey[] = "viewId";
 static constexpr char kAnnounceValue[] = "announce";
 
 // Handles messages like:
@@ -62,20 +61,7 @@ void HandleMessage(AccessibilityPlugin* plugin, const EncodableValue& message) {
       return;
     }
 
-    const auto& view_itr = data->find(EncodableValue{kViewIdKey});
-    if (view_itr == data->end()) {
-      FML_LOG(ERROR) << "Announce message 'viewId' property is missing.";
-      return;
-    }
-
-    const auto* view_id_val = std::get_if<FlutterViewId>(&view_itr->second);
-    if (!view_id_val) {
-      FML_LOG(ERROR)
-          << "Announce message 'viewId' property must be a FlutterViewId.";
-      return;
-    }
-
-    plugin->Announce(*view_id_val, *message);
+    plugin->Announce(*message);
   } else {
     FML_LOG(WARNING) << "Accessibility message type '" << *type
                      << "' is not supported.";
@@ -103,13 +89,14 @@ void AccessibilityPlugin::SetUp(BinaryMessenger* binary_messenger,
       });
 }
 
-void AccessibilityPlugin::Announce(const FlutterViewId view_id,
-                                   const std::string_view message) {
+void AccessibilityPlugin::Announce(const std::string_view message) {
   if (!engine_->semantics_enabled()) {
     return;
   }
 
-  auto view = engine_->view(view_id);
+  // TODO(loicsharma): Remove implicit view assumption.
+  // https://github.com/flutter/flutter/issues/142845
+  auto view = engine_->view(kImplicitViewId);
   if (!view) {
     return;
   }

--- a/engine/src/flutter/shell/platform/windows/accessibility_plugin.h
+++ b/engine/src/flutter/shell/platform/windows/accessibility_plugin.h
@@ -12,7 +12,6 @@
 
 namespace flutter {
 
-using FlutterViewId = int64_t;
 class FlutterWindowsEngine;
 
 // Handles messages on the flutter/accessibility channel.
@@ -28,8 +27,7 @@ class AccessibilityPlugin {
                     AccessibilityPlugin* plugin);
 
   // Announce a message through the assistive technology.
-  virtual void Announce(const FlutterViewId view_id,
-                        const std::string_view message);
+  virtual void Announce(const std::string_view message);
 
  private:
   // The engine that owns this plugin.

--- a/engine/src/flutter/shell/platform/windows/fixtures/main.dart
+++ b/engine/src/flutter/shell/platform/windows/fixtures/main.dart
@@ -60,9 +60,9 @@ Future<void> sendAccessibilityAnnouncement() async {
 
   // Standard message codec magic number identifiers.
   // See: https://github.com/flutter/flutter/blob/ee94fe262b63b0761e8e1f889ae52322fef068d2/packages/flutter/lib/src/services/message_codecs.dart#L262
-  const int valueMap = 13, valueString = 7, valueInt64 = 4;
+  const int valueMap = 13, valueString = 7;
 
-  // Corresponds to: {"type": "announce", "data": {"viewId": 0, "message": "hello"}}
+  // Corresponds to: {"type": "announce", "data": {"message": "hello"}}
   // See: https://github.com/flutter/flutter/blob/b781da9b5822de1461a769c3b245075359f5464d/packages/flutter/lib/src/semantics/semantics_event.dart#L86
   final Uint8List data = Uint8List.fromList([
     // Map with 2 entries
@@ -73,12 +73,8 @@ Future<void> sendAccessibilityAnnouncement() async {
     valueString, 'announce'.length, ...'announce'.codeUnits,
     // Map key: "data"
     valueString, 'data'.length, ...'data'.codeUnits,
-    // Map value: map with 2 entries
-    valueMap, 2,
-    // Map key: "viewId"
-    valueString, 'viewId'.length, ...'viewId'.codeUnits,
-    // Map value: 0
-    valueInt64, 0, 0, 0, 0, 0, 0, 0, 0,
+    // Map value: map with 1 entry
+    valueMap, 1,
     // Map key: "message"
     valueString, 'message'.length, ...'message'.codeUnits,
     // Map value: "hello"

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -236,8 +236,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
       _announcedInitialDate = true;
       final bool isToday = widget.calendarDelegate.isSameDay(widget.currentDate, _selectedDate);
       final String semanticLabelSuffix = isToday ? ', ${_localizations.currentDateLabel}' : '';
-      SemanticsService.sendAnnouncement(
-        View.of(context),
+      SemanticsService.announce(
         '${_localizations.formatFullDate(_selectedDate!)}$semanticLabelSuffix',
         _textDirection,
       );
@@ -266,7 +265,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
           DatePickerMode.day => widget.calendarDelegate.formatMonthYear(selected, _localizations),
           DatePickerMode.year => widget.calendarDelegate.formatYear(selected.year, _localizations),
         };
-        SemanticsService.sendAnnouncement(View.of(context), message, _textDirection);
+        SemanticsService.announce(message, _textDirection);
       }
     });
   }
@@ -316,8 +315,7 @@ class _CalendarDatePickerState extends State<CalendarDatePicker> {
         case TargetPlatform.windows:
           final bool isToday = widget.calendarDelegate.isSameDay(widget.currentDate, _selectedDate);
           final String semanticLabelSuffix = isToday ? ', ${_localizations.currentDateLabel}' : '';
-          SemanticsService.sendAnnouncement(
-            View.of(context),
+          SemanticsService.announce(
             '${_localizations.selectedDateLabel} ${widget.calendarDelegate.formatFullDate(_selectedDate!, _localizations)}$semanticLabelSuffix',
             _textDirection,
           );
@@ -667,8 +665,7 @@ class _MonthPickerState extends State<_MonthPicker> {
           // the same day of the month.
           _focusedDay = _focusableDayForMonth(_currentMonth, _focusedDay!.day);
         }
-        SemanticsService.sendAnnouncement(
-          View.of(context),
+        SemanticsService.announce(
           widget.calendarDelegate.formatMonthYear(_currentMonth, _localizations),
           _textDirection,
         );

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -538,12 +538,12 @@ class _ExpansionTileState extends State<ExpansionTile> {
       // semantic announcements on iOS. https://github.com/flutter/flutter/issues/122101.
       _timer?.cancel();
       _timer = Timer(const Duration(seconds: 1), () {
-        SemanticsService.sendAnnouncement(View.of(context), stateHint, textDirection);
+        SemanticsService.announce(stateHint, textDirection);
         _timer?.cancel();
         _timer = null;
       });
     } else {
-      SemanticsService.sendAnnouncement(View.of(context), stateHint, textDirection);
+      SemanticsService.announce(stateHint, textDirection);
     }
     widget.onExpansionChanged?.call(_tileController.isExpanded);
   }

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -93,17 +93,12 @@ abstract class SemanticsEvent {
 /// [1]: https://developer.android.com/reference/android/view/View#announceForAccessibility(java.lang.CharSequence)
 ///
 class AnnounceSemanticsEvent extends SemanticsEvent {
-  /// Constructs an event that triggers an announcement by the platform
-  /// for the provided view.
+  /// Constructs an event that triggers an announcement by the platform.
   const AnnounceSemanticsEvent(
     this.message,
-    this.textDirection,
-    this.viewId, {
+    this.textDirection, {
     this.assertiveness = Assertiveness.polite,
   }) : super('announce');
-
-  /// The view that this announcement is on.
-  final int viewId;
 
   /// The message to announce.
   final String message;
@@ -122,7 +117,6 @@ class AnnounceSemanticsEvent extends SemanticsEvent {
   @override
   Map<String, dynamic> getDataMap() {
     return <String, dynamic>{
-      'viewId': viewId,
       'message': message,
       'textDirection': textDirection.index,
       if (assertiveness != Assertiveness.polite) 'assertiveness': assertiveness.index,

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -5,7 +5,7 @@
 /// @docImport 'package:flutter/widgets.dart';
 library;
 
-import 'dart:ui' show FlutterView, PlatformDispatcher, TextDirection;
+import 'dart:ui' show TextDirection;
 
 import 'package:flutter/services.dart' show SystemChannels;
 
@@ -23,9 +23,6 @@ export 'dart:ui' show TextDirection;
 abstract final class SemanticsService {
   /// Sends a semantic announcement.
   ///
-  /// This method is deprecated. Prefer using [sendAnnouncement] instead.
-  ///
-  /// {@template flutter.semantics.service.announce}
   /// This should be used for announcement that are not seamlessly announced by
   /// the system as a result of a UI state change.
   ///
@@ -46,48 +43,15 @@ abstract final class SemanticsService {
   /// trigger announcements.
   ///
   /// [1]: https://developer.android.com/reference/android/view/View#announceForAccessibility(java.lang.CharSequence)
-  /// {@endtemplate}
   ///
-  @Deprecated(
-    'Use sendAnnouncement instead. '
-    'This API is incompatible with multiple windows. '
-    'This feature was deprecated after v3.35.0-0.1.pre.',
-  )
   static Future<void> announce(
     String message,
     TextDirection textDirection, {
     Assertiveness assertiveness = Assertiveness.polite,
   }) async {
-    final FlutterView? view = PlatformDispatcher.instance.implicitView;
-    assert(
-      view != null,
-      'SemanticsService.announce is incompatible with multiple windows. '
-      'Use SemanticsService.sendAnnouncement instead.',
-    );
     final AnnounceSemanticsEvent event = AnnounceSemanticsEvent(
       message,
       textDirection,
-      view!.viewId,
-      assertiveness: assertiveness,
-    );
-    await SystemChannels.accessibility.send(event.toMap());
-  }
-
-  /// Sends a semantic announcement for a particular view.
-  ///
-  /// One can use [View.of] to get the current [FlutterView].
-  ///
-  /// {@macro flutter.semantics.service.announce}
-  static Future<void> sendAnnouncement(
-    FlutterView view,
-    String message,
-    TextDirection textDirection, {
-    Assertiveness assertiveness = Assertiveness.polite,
-  }) async {
-    final AnnounceSemanticsEvent event = AnnounceSemanticsEvent(
-      message,
-      textDirection,
-      view.viewId,
       assertiveness: assertiveness,
     );
     await SystemChannels.accessibility.send(event.toMap());

--- a/packages/flutter/lib/src/widgets/form.dart
+++ b/packages/flutter/lib/src/widgets/form.dart
@@ -7,7 +7,6 @@
 library;
 
 import 'dart:async';
-import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -23,7 +22,6 @@ import 'pop_scope.dart';
 import 'restoration.dart';
 import 'restoration_properties.dart';
 import 'routes.dart';
-import 'view.dart';
 import 'will_pop_scope.dart';
 
 // Duration for delay before announcement in IOS so that the announcement won't be interrupted.
@@ -273,10 +271,10 @@ class FormState extends State<Form> {
   Widget build(BuildContext context) {
     switch (widget.autovalidateMode) {
       case AutovalidateMode.always:
-        _validate(View.of(context));
+        _validate();
       case AutovalidateMode.onUserInteraction:
         if (_hasInteractedByUser) {
-          _validate(View.of(context));
+          _validate();
         }
       case AutovalidateMode.onUnfocus:
       case AutovalidateMode.disabled:
@@ -337,7 +335,7 @@ class FormState extends State<Form> {
   bool validate() {
     _hasInteractedByUser = true;
     _forceRebuild();
-    return _validate(View.of(context));
+    return _validate();
   }
 
   /// Validates every [FormField] that is a descendant of this [Form], and
@@ -354,11 +352,11 @@ class FormState extends State<Form> {
     final Set<FormFieldState<Object?>> invalidFields = <FormFieldState<Object?>>{};
     _hasInteractedByUser = true;
     _forceRebuild();
-    _validate(View.of(context), invalidFields);
+    _validate(invalidFields);
     return invalidFields;
   }
 
-  bool _validate(FlutterView view, [Set<FormFieldState<Object?>>? invalidFields]) {
+  bool _validate([Set<FormFieldState<Object?>>? invalidFields]) {
     bool hasError = false;
     String errorMessage = '';
     final bool validateOnFocusChange = widget.autovalidateMode == AutovalidateMode.onUnfocus;
@@ -385,8 +383,7 @@ class FormState extends State<Form> {
         unawaited(
           Future<void>(() async {
             await Future<void>.delayed(_kIOSAnnouncementDelayDuration);
-            SemanticsService.sendAnnouncement(
-              view,
+            SemanticsService.announce(
               errorMessage,
               directionality,
               assertiveness: Assertiveness.assertive,
@@ -394,8 +391,7 @@ class FormState extends State<Form> {
           }),
         );
       } else {
-        SemanticsService.sendAnnouncement(
-          view,
+        SemanticsService.announce(
           errorMessage,
           directionality,
           assertiveness: Assertiveness.assertive,

--- a/packages/flutter/test/semantics/semantics_service_test.dart
+++ b/packages/flutter/test/semantics/semantics_service_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Semantic announcement', (WidgetTester tester) async {
+  test('Semantic announcement', () async {
     final List<Map<dynamic, dynamic>> log = <Map<dynamic, dynamic>>[];
 
     Future<dynamic> handleMessage(dynamic mockMessage) async {
@@ -20,9 +20,8 @@ void main() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, handleMessage);
 
-    await SemanticsService.sendAnnouncement(tester.view, 'announcement 1', TextDirection.ltr);
-    await SemanticsService.sendAnnouncement(
-      tester.view,
+    await SemanticsService.announce('announcement 1', TextDirection.ltr);
+    await SemanticsService.announce(
       'announcement 2',
       TextDirection.rtl,
       assertiveness: Assertiveness.assertive,
@@ -32,16 +31,11 @@ void main() {
       equals(<Map<String, dynamic>>[
         <String, dynamic>{
           'type': 'announce',
-          'data': <String, dynamic>{
-            'viewId': tester.view.viewId,
-            'message': 'announcement 1',
-            'textDirection': 1,
-          },
+          'data': <String, dynamic>{'message': 'announcement 1', 'textDirection': 1},
         },
         <String, dynamic>{
           'type': 'announce',
           'data': <String, dynamic>{
-            'viewId': tester.view.viewId,
             'message': 'announcement 2',
             'textDirection': 0,
             'assertiveness': 1,

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -701,14 +701,13 @@ void main() {
         isFalse,
       );
 
-      await SemanticsService.sendAnnouncement(tester.view, 'announcement 1', TextDirection.ltr);
-      await SemanticsService.sendAnnouncement(
-        tester.view,
+      await SemanticsService.announce('announcement 1', TextDirection.ltr);
+      await SemanticsService.announce(
         'announcement 2',
         TextDirection.rtl,
         assertiveness: Assertiveness.assertive,
       );
-      await SemanticsService.sendAnnouncement(tester.view, 'announcement 3', TextDirection.rtl);
+      await SemanticsService.announce('announcement 3', TextDirection.rtl);
 
       final List<CapturedAccessibilityAnnouncement> list = tester.takeAnnouncements();
       expect(list, hasLength(3));
@@ -730,7 +729,7 @@ void main() {
       expect(emptyList, <CapturedAccessibilityAnnouncement>[]);
     });
 
-    testWidgets('New test API is not breaking existing tests', (WidgetTester tester) async {
+    test('New test API is not breaking existing tests', () async {
       final List<Map<dynamic, dynamic>> log = <Map<dynamic, dynamic>>[];
 
       Future<dynamic> handleMessage(dynamic mockMessage) async {
@@ -741,8 +740,7 @@ void main() {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, handleMessage);
 
-      await SemanticsService.sendAnnouncement(
-        tester.view,
+      await SemanticsService.announce(
         'announcement 1',
         TextDirection.rtl,
         assertiveness: Assertiveness.assertive,
@@ -753,7 +751,6 @@ void main() {
           <String, dynamic>{
             'type': 'announce',
             'data': <String, dynamic>{
-              'viewId': 0,
               'message': 'announcement 1',
               'textDirection': 0,
               'assertiveness': 1,


### PR DESCRIPTION
…r the view (#172669)"

This reverts commit e131243b0043f4f9944632acc734ea171c6b4105.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

pr causes internal breakage

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
