### PR TITLE
[ Tool ] Throw `ToolExit` when asset entries use absolute paths

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1015,18 +1015,11 @@ class ManifestAssetBundle implements AssetBundle {
     required List<AssetTransformerEntry> transformers,
   }) {
     final String directoryPath;
-    try {
-      directoryPath = _fileSystem.path.join(
-        assetBase,
-        assetUri.toFilePath(windows: _platform.isWindows),
-      );
-    } on UnsupportedError catch (e) {
-      throwToolExit(
-        'Unable to search for asset files in directory path "${assetUri.path}". '
-        'Please ensure that this entry in pubspec.yaml is a valid file path.\n'
-        'Error details:\n$e',
-      );
-    }
+    ensureAssetPathIsValid(assetsBaseDir: assetBase, assetUri: assetUri);
+    directoryPath = _fileSystem.path.join(
+      assetBase,
+      assetUri.toFilePath(windows: _platform.isWindows),
+    );
 
     if (!_fileSystem.directory(directoryPath).existsSync()) {
       _logger.printError('Error: unable to find directory entry in pubspec.yaml: $directoryPath');
@@ -1182,6 +1175,27 @@ class ManifestAssetBundle implements AssetBundle {
     throwToolExit(errorMessage.toString());
   }
 
+  void ensureAssetPathIsValid({required String assetsBaseDir, required Uri assetUri}) {
+    if (!assetUri.isScheme('file') && assetUri.scheme.isNotEmpty) {
+      throwToolExit(
+        'Asset path "$assetUri" has scheme "${assetUri.scheme}" and is not a valid file or '
+        'directory path. Please update this entry in the pubspec.yaml to point to a valid file '
+        'path.',
+      );
+    }
+    if (Uri.directory(
+          assetsBaseDir,
+          windows: _platform.isWindows,
+        ).resolveUri(assetUri).toFilePath(windows: _platform.isWindows) ==
+        assetUri.toFilePath(windows: _platform.isWindows)) {
+      throwToolExit(
+        '"${assetUri.toFilePath(windows: _platform.isWindows)}" is not a valid asset path. '
+        'Asset paths must be relative to the location of pubspec.yaml. Please update this entry '
+        'in the pubspec.yaml to use a relative path.',
+      );
+    }
+  }
+
   _Asset _resolveAsset(
     PackageConfig packageConfig,
     String assetsBaseDir,
@@ -1193,9 +1207,11 @@ class ManifestAssetBundle implements AssetBundle {
     required Set<String> flavors,
     required List<AssetTransformerEntry> transformers,
   }) {
-    final String assetPath = _fileSystem.path.fromUri(assetUri);
+    ensureAssetPathIsValid(assetsBaseDir: assetsBaseDir, assetUri: assetUri);
     if (assetUri.pathSegments.first == 'packages' &&
-        !_fileSystem.isFileSync(_fileSystem.path.join(assetsBaseDir, assetPath))) {
+        !_fileSystem.isFileSync(
+          _fileSystem.path.join(assetsBaseDir, _fileSystem.path.fromUri(assetUri)),
+        )) {
       // The asset is referenced in the pubspec.yaml as
       // 'packages/PACKAGE_NAME/PATH/TO/ASSET .
       final _Asset? packageAsset = _resolvePackageAsset(

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1015,7 +1015,7 @@ class ManifestAssetBundle implements AssetBundle {
     required List<AssetTransformerEntry> transformers,
   }) {
     final String directoryPath;
-    ensureAssetPathIsValid(assetsBaseDir: assetBase, assetUri: assetUri);
+    _ensureAssetPathIsValid(assetsBaseDir: assetBase, assetUri: assetUri);
     directoryPath = _fileSystem.path.join(
       assetBase,
       assetUri.toFilePath(windows: _platform.isWindows),
@@ -1175,7 +1175,7 @@ class ManifestAssetBundle implements AssetBundle {
     throwToolExit(errorMessage.toString());
   }
 
-  void ensureAssetPathIsValid({required String assetsBaseDir, required Uri assetUri}) {
+  void _ensureAssetPathIsValid({required String assetsBaseDir, required Uri assetUri}) {
     if (!assetUri.isScheme('file') && assetUri.scheme.isNotEmpty) {
       throwToolExit(
         'Asset path "$assetUri" has scheme "${assetUri.scheme}" and is not a valid file or '
@@ -1207,7 +1207,7 @@ class ManifestAssetBundle implements AssetBundle {
     required Set<String> flavors,
     required List<AssetTransformerEntry> transformers,
   }) {
-    ensureAssetPathIsValid(assetsBaseDir: assetsBaseDir, assetUri: assetUri);
+    _ensureAssetPathIsValid(assetsBaseDir: assetsBaseDir, assetUri: assetUri);
     if (assetUri.pathSegments.first == 'packages' &&
         !_fileSystem.isFileSync(
           _fileSystem.path.join(assetsBaseDir, _fileSystem.path.fromUri(assetUri)),

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -416,7 +416,7 @@ class FlutterManifest {
         continue;
       }
       try {
-        results.add(Uri(pathSegments: item.split('/')));
+        results.add(Uri.parse(item));
       } on FormatException {
         _logger.printError('$singularName manifest contains invalid uri: $item.');
       }
@@ -822,7 +822,7 @@ class AssetsEntry {
   static (AssetsEntry? assetsEntry, String? error) parseFromYamlSafe(Object? yaml) {
     (Uri?, String?) tryParseUri(String uri) {
       try {
-        return (Uri(pathSegments: uri.split('/')), null);
+        return (Uri.parse(uri), null);
       } on FormatException {
         return (null, 'Asset manifest contains invalid uri: $uri.');
       }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -477,97 +477,84 @@ flutter:
   });
 
   group('AssetBundle.build', () {
-    testWithoutContext(
-      'throws ToolExit when directory entry contains invalid characters (Windows only)',
-      () async {
-        final fileSystem = MemoryFileSystem(style: FileSystemStyle.windows);
-        final logger = BufferLogger.test();
-        final platform = FakePlatform(operatingSystem: 'windows');
-        final String flutterRoot = Cache.defaultFlutterRoot(
-          platform: platform,
-          fileSystem: fileSystem,
-          userMessages: UserMessages(),
-        );
+    testWithoutContext('throws ToolExit when directory entry has an invalid scheme', () async {
+      final fileSystem = MemoryFileSystem(style: FileSystemStyle.windows);
+      final logger = BufferLogger.test();
+      final platform = FakePlatform(operatingSystem: 'windows');
+      final String flutterRoot = Cache.defaultFlutterRoot(
+        platform: platform,
+        fileSystem: fileSystem,
+        userMessages: UserMessages(),
+      );
 
-        writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_app');
-        fileSystem.file('pubspec.yaml')
-          ..createSync()
-          ..writeAsStringSync(r'''
+      writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_app');
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync(r'''
 name: my_app
 flutter:
   assets:
     - https://mywebsite.com/images/
 ''');
-        final bundle = ManifestAssetBundle(
-          logger: logger,
-          fileSystem: fileSystem,
-          platform: platform,
-          flutterRoot: flutterRoot,
-        );
+      final bundle = ManifestAssetBundle(
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+        flutterRoot: flutterRoot,
+      );
 
-        expect(
-          () => bundle.build(
-            packageConfigPath: '.dart_tool/package_config.json',
-            flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          ),
-          throwsToolExit(
-            message:
-                'Unable to search for asset files in directory path "https%3A//mywebsite.com/images/". '
-                'Please ensure that this entry in pubspec.yaml is a valid file path.\n'
-                'Error details:\n'
-                'Unsupported operation: Illegal character in path: https:',
-          ),
-        );
-      },
-    );
+      expect(
+        () => bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        ),
+        throwsToolExit(
+          message:
+              'Asset path "https://mywebsite.com/images/" has scheme "https" and is not a valid '
+              'file or directory path. Please update this entry in the pubspec.yaml to point to a '
+              'valid file path.',
+        ),
+      );
+    });
 
-    testWithoutContext(
-      'throws ToolExit when file entry contains invalid characters (Windows only)',
-      () async {
-        final FileSystem fileSystem = MemoryFileSystem(
-          style: FileSystemStyle.windows,
-          opHandle: (String context, FileSystemOp operation) {
-            if (operation == FileSystemOp.exists && context == r'C:\http:\\website.com') {
-              throw const FileSystemException(
-                r"FileSystemException: Exists failed, path = 'C:\http:\\website.com' "
-                '(OS Error: The filename, directory name, or volume label syntax is '
-                'incorrect., errno = 123)',
-              );
-            }
-          },
-        );
-        final logger = BufferLogger.test();
-        final platform = FakePlatform(operatingSystem: 'windows');
-        final String flutterRoot = Cache.defaultFlutterRoot(
-          platform: platform,
-          fileSystem: fileSystem,
-          userMessages: UserMessages(),
-        );
-        writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_app');
-        fileSystem.file('pubspec.yaml')
-          ..createSync()
-          ..writeAsStringSync(r'''
+    testWithoutContext('throws ToolExit when file entry has an invalid scheme', () async {
+      final FileSystem fileSystem = MemoryFileSystem(style: FileSystemStyle.windows);
+      final logger = BufferLogger.test();
+      final platform = FakePlatform(operatingSystem: 'windows');
+      final String flutterRoot = Cache.defaultFlutterRoot(
+        platform: platform,
+        fileSystem: fileSystem,
+        userMessages: UserMessages(),
+      );
+      writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_app');
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync(r'''
 name: example
 flutter:
   assets:
     - http://website.com/hi.png
 ''');
-        final bundle = ManifestAssetBundle(
-          logger: logger,
-          fileSystem: fileSystem,
-          platform: platform,
-          flutterRoot: flutterRoot,
-        );
+      final bundle = ManifestAssetBundle(
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+        flutterRoot: flutterRoot,
+      );
 
-        expect(
-          () => bundle.build(
-            packageConfigPath: '.dart_tool/package_config.json',
-            flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
-          ),
-          throwsToolExit(message: 'Unable to check the existence of asset file '),
-        );
-      },
-    );
+      expect(
+        () => bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        ),
+        throwsToolExit(
+          message:
+              'Asset path "http://website.com/hi.png" has scheme "http" and is not a valid '
+              'file or directory path. Please update this entry in the pubspec.yaml to point to a '
+              'valid file path.',
+        ),
+      );
+    });
 
     testWithoutContext(
       "AssetBundleEntry::content::isModified is true when an asset's transformers change in between builds",
@@ -1354,4 +1341,105 @@ flutter:
       Platform: () => FakePlatform(),
     },
   );
+
+  group('reports error for absolute paths', () {
+    Future<void> testCase({
+      required String pubspecContents,
+      required Uri assetPath,
+      required FileSystem fileSystem,
+      required Platform platform,
+    }) async {
+      final logger = BufferLogger.test();
+      expect(pubspecContents, contains(assetPath.toString()));
+      final String flutterRoot = Cache.defaultFlutterRoot(
+        platform: platform,
+        fileSystem: fileSystem,
+        userMessages: UserMessages(),
+      );
+      writePackageConfigFiles(directory: fileSystem.currentDirectory, mainLibName: 'my_app');
+      fileSystem.file('pubspec.yaml')
+        ..createSync()
+        ..writeAsStringSync(pubspecContents);
+
+      final bundle = ManifestAssetBundle(
+        logger: logger,
+        fileSystem: fileSystem,
+        platform: platform,
+        flutterRoot: flutterRoot,
+      );
+      expect(
+        () => bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        ),
+        throwsToolExit(
+          message:
+              'is not a valid asset path. Asset paths must be relative to the location of '
+              'pubspec.yaml. Please update this entry in the pubspec.yaml to use a relative path.',
+        ),
+      );
+    }
+
+    for (final platform in <FakePlatform>[
+      FakePlatform(),
+      FakePlatform(operatingSystem: 'windows'),
+    ]) {
+      group('on ${platform.isWindows ? 'Windows' : 'POSIX'} for', () {
+        final FileSystem fileSystem = MemoryFileSystem(
+          style: platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+        );
+        fileSystem.currentDirectory = fileSystem.systemTempDirectory;
+        final assetPath = Uri.file(
+          platform.isWindows ? r'c:\asset\path.json' : '/asset/path.json',
+          windows: platform.isWindows,
+        );
+        testWithoutContext('standard assets', () async {
+          await testCase(
+            pubspecContents:
+                '''
+name: my_app
+flutter:
+  assets:
+    - $assetPath
+''',
+            assetPath: assetPath,
+            fileSystem: fileSystem,
+            platform: platform,
+          );
+        });
+
+        testWithoutContext('font assets', () async {
+          await testCase(
+            pubspecContents:
+                '''
+name: my_app
+flutter:
+  fonts:
+    - family: Foo
+      fonts:
+        - asset: $assetPath
+''',
+            assetPath: assetPath,
+            fileSystem: fileSystem,
+            platform: platform,
+          );
+        });
+
+        testWithoutContext('shader assets', () async {
+          await testCase(
+            pubspecContents:
+                '''
+name: my_app
+flutter:
+  shaders:
+    - $assetPath
+''',
+            assetPath: assetPath,
+            fileSystem: fileSystem,
+            platform: platform,
+          );
+        });
+      });
+    }
+  });
 }

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -98,7 +98,7 @@ flutter:
 
       expect(assets, <AssetsEntry>[
         AssetsEntry(uri: Uri.parse('lib/gallery/abc#xyz')),
-        AssetsEntry(uri: Uri.parse('lib/gallery/abc?Fxyz')),
+        AssetsEntry(uri: Uri.parse('lib/gallery/abc?xyz')),
         AssetsEntry(uri: Uri.parse('lib/gallery/aaa%20bbb')),
       ]);
     });

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_assets_test.dart
@@ -97,8 +97,8 @@ flutter:
       final List<AssetsEntry> assets = flutterManifest.assets;
 
       expect(assets, <AssetsEntry>[
-        AssetsEntry(uri: Uri.parse('lib/gallery/abc%23xyz')),
-        AssetsEntry(uri: Uri.parse('lib/gallery/abc%3Fxyz')),
+        AssetsEntry(uri: Uri.parse('lib/gallery/abc#xyz')),
+        AssetsEntry(uri: Uri.parse('lib/gallery/abc?Fxyz')),
         AssetsEntry(uri: Uri.parse('lib/gallery/aaa%20bbb')),
       ]);
     });


### PR DESCRIPTION
Our documentation states that "the value of an asset is a relative path from the pubspec.yaml file", but this was never actually verified by the tool. On systems with POSIX semantics, this would simply result in invalid asset paths being built, but on Windows this could cause an exception to be thrown as the built URI would not be a valid `file://` URI.

This change adds checks to ensure that asset paths are relative and that they are valid file paths.

Fixes https://github.com/flutter/flutter/issues/173405