### PR TITLE
Load fonts in the order addFont is called

### DIFF
--- a/packages/flutter/lib/src/services/font_loader.dart
+++ b/packages/flutter/lib/src/services/font_loader.dart
@@ -31,6 +31,8 @@ class FontLoader {
   ///
   /// The [bytes] argument specifies the actual font asset bytes. Currently,
   /// only OpenType (OTF) and TrueType (TTF) fonts are supported.
+  ///
+  /// [load] will load fonts in the order this is called.
   void addFont(Future<ByteData> bytes) {
     if (_loaded) {
       throw StateError('FontLoader is already loaded');
@@ -59,10 +61,9 @@ class FontLoader {
     }
     _loaded = true;
 
-    final Iterable<Future<void>> loadFutures = _fontFutures.map(
-      (Future<Uint8List> f) => f.then<void>((Uint8List list) => loadFont(list, family)),
-    );
-    await Future.wait(loadFutures.toList());
+    for (final Future<Uint8List> fontFuture in _fontFutures) {
+      await loadFont(await fontFuture, family);
+    }
   }
 
   /// Hook called to load a font asset into the engine.

--- a/packages/flutter/lib/src/services/font_loader.dart
+++ b/packages/flutter/lib/src/services/font_loader.dart
@@ -32,7 +32,7 @@ class FontLoader {
   /// The [bytes] argument specifies the actual font asset bytes. Currently,
   /// only OpenType (OTF) and TrueType (TTF) fonts are supported.
   ///
-  /// [load] will load fonts in the order this is called.
+  /// The [load] method will load fonts in the order this is called.
   void addFont(Future<ByteData> bytes) {
     if (_loaded) {
       throw StateError('FontLoader is already loaded');


### PR DESCRIPTION
Before this change, `load` loads fonts in a non-deterministic order. After this change, it loads the fonts sequentially.

See cl/797583429 for the full context. We found that the order of how fonts load for a specific font family actually affects runtime behavior, and the current non-deterministic order of loading fonts leads to flakiness.

Consider the following:

- foo.ttf has glyphs 'A' and 'B'
- foo-italic.ttf only has glyph 'B'

If `addFont(foo-italic.ttf)` is called before `addFont(foo.ttf)`, the font loader will load `foo-italic.ttf` first and use that as the base font. When looking for the 'A' glyph, it may will look for the glyph only in `foo-italic.ttf`, which doesn't have it, and will show an incorrect empty placeholder glyph.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

