### PR TITLE
[ Widget Preview ] Add support for DevTools configuration

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -136,6 +136,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     }
     addPubOptions();
     addMachineOutputFlag(verboseHelp: verbose);
+    addDevToolsOptions(verboseHelp: verbose);
     argParser
       ..addFlag(
         kWebServer,
@@ -450,6 +451,8 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
         ),
         webEnableExposeUrl: false,
         webRunHeadless: boolArg(kHeadless),
+        enableDevTools: boolArg(FlutterCommand.kEnableDevTools),
+        devToolsServerAddress: devToolsServerAddress,
       );
       final String target = bundle.defaultMainPath;
       final FlutterDevice flutterDevice = await FlutterDevice.create(

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -914,6 +914,9 @@ class ResidentWebRunner extends ResidentRunner {
 
 Uri _httpUriFromWebsocketUri(Uri websocketUri) {
   const wsPath = '/ws';
-  final String path = websocketUri.path;
-  return websocketUri.replace(scheme: 'http', path: path.substring(0, path.length - wsPath.length));
+  String path = websocketUri.path;
+  if (path.endsWith(wsPath)) {
+    path = path.substring(0, path.length - wsPath.length);
+  }
+  return websocketUri.replace(scheme: 'http', path: path);
 }

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -769,7 +769,6 @@ class ResidentWebRunner extends ResidentRunner {
       }
       _wipConnection = await chromeTab.connect();
     }
-    Uri? websocketUri;
     if (supportsServiceProtocol) {
       assert(connectDebug != null);
       unawaited(
@@ -837,7 +836,7 @@ class ResidentWebRunner extends ResidentRunner {
             vmService: _vmService.service,
           );
 
-          websocketUri = Uri.parse(_connectionResult!.debugConnection!.uri);
+          final Uri websocketUri = Uri.parse(_connectionResult!.debugConnection!.uri);
           device!.vmService = _vmService;
 
           // Run main immediately if the app is not started paused or if there
@@ -855,14 +854,15 @@ class ResidentWebRunner extends ResidentRunner {
             });
           }
 
-          if (websocketUri != null) {
-            if (debuggingOptions.vmserviceOutFile != null) {
-              _fileSystem.file(debuggingOptions.vmserviceOutFile)
-                ..createSync(recursive: true)
-                ..writeAsStringSync(websocketUri.toString());
-            }
-            _logger.printStatus('Debug service listening on $websocketUri');
+          if (debuggingOptions.vmserviceOutFile != null) {
+            _fileSystem.file(debuggingOptions.vmserviceOutFile)
+              ..createSync(recursive: true)
+              ..writeAsStringSync(websocketUri.toString());
           }
+          // TODO(bkonyi): consider removing this log message and using only the standard VM
+          // service message instead.
+          _logger.printStatus('Debug service listening on $websocketUri');
+          printDebuggerList();
           connectionInfoCompleter?.complete(DebugConnectionInfo(wsUri: websocketUri));
         }),
       );

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -652,6 +652,7 @@ name: my_app
         'Launching lib/main.dart on FakeDevice in debug mode...\n'
         'Waiting for connection from debug service on FakeDevice...\n'
         'Debug service listening on ws://127.0.0.1/abcd/\n'
+        'A Dart VM Service on FakeDevice is available at: http://127.0.0.1/abcd/\n'
         '\n'
         'first\n'
         '\n'

--- a/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
+++ b/packages/flutter_tools/test/integration.shard/widget_preview_test.dart
@@ -60,6 +60,7 @@ void main() {
     process = null;
     await dtdLauncher?.dispose();
     await devtoolsLauncher?.close();
+    devtoolsLauncher = null;
     dtdLauncher = null;
     tryToDelete(tempDir);
   });


### PR DESCRIPTION
Adds support for the `--devtools-server-address=<uri>` and `--devtools` options.

Also fixes an issue where the VM service + DevTools connection information was not printed to STDOUT for web devices.

Fixes https://github.com/flutter/flutter/issues/173617