### PR TITLE
NavigatorPopScope examples no longer use deprecated onPop.

### DIFF
--- a/examples/api/lib/widgets/navigator_pop_handler/navigator_pop_handler.0.dart
+++ b/examples/api/lib/widgets/navigator_pop_handler/navigator_pop_handler.0.dart
@@ -84,8 +84,8 @@ class _NestedNavigatorsPageState extends State<_NestedNavigatorsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return NavigatorPopHandler(
-      onPop: () {
+    return NavigatorPopHandler<void>(
+      onPopWithResult: (void result) {
         _nestedNavigatorKey.currentState!.maybePop();
       },
       child: Navigator(

--- a/examples/api/lib/widgets/navigator_pop_handler/navigator_pop_handler.1.dart
+++ b/examples/api/lib/widgets/navigator_pop_handler/navigator_pop_handler.1.dart
@@ -192,8 +192,8 @@ class _BottomNavTabState extends State<_BottomNavTab> {
 
   @override
   Widget build(BuildContext context) {
-    return NavigatorPopHandler(
-      onPop: () {
+    return NavigatorPopHandler<void>(
+      onPopWithResult: (void result) {
         _navigatorKey.currentState?.maybePop();
       },
       child: Navigator(


### PR DESCRIPTION
I just noticed that these example are using a deprecated member.