### PR TITLE
[web] Expose rasterizers in Renderer

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -36,7 +36,7 @@ enum CanvasKitVariant {
   experimentalWebParagraph,
 }
 
-class CanvasKitRenderer implements Renderer {
+class CanvasKitRenderer extends Renderer {
   static CanvasKitRenderer get instance => _instance;
   static late CanvasKitRenderer _instance;
 
@@ -54,8 +54,6 @@ class CanvasKitRenderer implements Renderer {
   DomElement? _sceneHost;
   DomElement? get sceneHost => _sceneHost;
 
-  Rasterizer _rasterizer = _createRasterizer();
-
   static Rasterizer _createRasterizer() {
     if (configuration.canvasKitForceMultiSurfaceRasterizer || isSafari || isFirefox) {
       return MultiSurfaceRasterizer();
@@ -63,31 +61,16 @@ class CanvasKitRenderer implements Renderer {
     return OffscreenCanvasRasterizer();
   }
 
-  /// Resets the [Rasterizer] to the default value. Used in tests.
+  @override
   void debugResetRasterizer() {
-    _rasterizer = _createRasterizer();
+    rasterizer = _createRasterizer();
   }
 
-  /// Override the rasterizer with the given [_rasterizer]. Used in tests.
-  void debugOverrideRasterizer(Rasterizer testRasterizer) {
-    _rasterizer = testRasterizer;
-  }
-
-  /// Returns the current [Rasterizer]. Used in tests.
-  Rasterizer debugGetRasterizer() {
-    return _rasterizer;
-  }
-
-  set resourceCacheMaxBytes(int bytes) => _rasterizer.setResourceCacheMaxBytes(bytes);
+  set resourceCacheMaxBytes(int bytes) => rasterizer.setResourceCacheMaxBytes(bytes);
 
   /// A surface used specifically for `Picture.toImage` when software rendering
   /// is supported.
   final Surface pictureToImageSurface = Surface();
-
-  // Listens for view creation events from the view manager.
-  StreamSubscription<int>? _onViewCreatedListener;
-  // Listens for view disposal events from the view manager.
-  StreamSubscription<int>? _onViewDisposedListener;
 
   @override
   Future<void> initialize() async {
@@ -101,18 +84,9 @@ class CanvasKitRenderer implements Renderer {
         canvasKit = await downloadCanvasKit();
         windowFlutterCanvasKit = canvasKit;
       }
-      // Views may have been registered before this renderer was initialized.
-      // Create rasterizers for them and then start listening for new view
-      // creation/disposal events.
-      final FlutterViewManager viewManager = EnginePlatformDispatcher.instance.viewManager;
-      if (_onViewCreatedListener == null) {
-        for (final EngineFlutterView view in viewManager.views) {
-          _onViewCreated(view.viewId);
-        }
-      }
-      _onViewCreatedListener ??= viewManager.onViewCreated.listen(_onViewCreated);
-      _onViewDisposedListener ??= viewManager.onViewDisposed.listen(_onViewDisposed);
+      rasterizer = _createRasterizer();
       _instance = this;
+      await super.initialize();
     }();
     return _initialized;
   }
@@ -459,10 +433,10 @@ class CanvasKitRenderer implements Renderer {
   @override
   Future<void> renderScene(ui.Scene scene, EngineFlutterView view) async {
     assert(
-      _rasterizers.containsKey(view.viewId),
+      rasterizers.containsKey(view.viewId),
       "Unable to render to a view which hasn't been registered",
     );
-    final ViewRasterizer rasterizer = _rasterizers[view.viewId]!;
+    final ViewRasterizer rasterizer = rasterizers[view.viewId]!;
     final RenderQueue renderQueue = rasterizer.queue;
     final FrameTimingRecorder? recorder = FrameTimingRecorder.frameTimingsEnabled
         ? FrameTimingRecorder()
@@ -518,45 +492,6 @@ class CanvasKitRenderer implements Renderer {
     recorder?.recordRasterFinish();
     recorder?.submitTimings();
   }
-
-  // Map from view id to the associated Rasterizer for that view.
-  final Map<int, ViewRasterizer> _rasterizers = <int, ViewRasterizer>{};
-
-  void _onViewCreated(int viewId) {
-    final EngineFlutterView view = EnginePlatformDispatcher.instance.viewManager[viewId]!;
-    _rasterizers[view.viewId] = _rasterizer.createViewRasterizer(view);
-  }
-
-  void _onViewDisposed(int viewId) {
-    // The view has already been disposed.
-    if (!_rasterizers.containsKey(viewId)) {
-      return;
-    }
-    final ViewRasterizer rasterizer = _rasterizers.remove(viewId)!;
-    rasterizer.dispose();
-  }
-
-  ViewRasterizer? debugGetRasterizerForView(EngineFlutterView view) {
-    return _rasterizers[view.viewId];
-  }
-
-  /// Disposes this renderer.
-  void dispose() {
-    _onViewCreatedListener?.cancel();
-    _onViewDisposedListener?.cancel();
-    for (final ViewRasterizer rasterizer in _rasterizers.values) {
-      rasterizer.dispose();
-    }
-    _rasterizers.clear();
-  }
-
-  @override
-  void debugClear() {
-    for (final ViewRasterizer rasterizer in _rasterizers.values) {
-      rasterizer.debugClear();
-    }
-  }
-
   @override
   void clearFragmentProgramCache() {
     _programs.clear();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -492,6 +492,7 @@ class CanvasKitRenderer extends Renderer {
     recorder?.recordRasterFinish();
     recorder?.submitTimings();
   }
+
   @override
   void clearFragmentProgramCache() {
     _programs.clear();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
@@ -7,6 +7,7 @@ import 'dart:js_interop';
 import 'dart:math' as math;
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/src/engine/skwasm/skwasm_impl.dart'
     if (dart.library.html) 'package:ui/src/engine/skwasm/skwasm_stub.dart';
@@ -22,6 +23,9 @@ Renderer get renderer => _renderer;
 /// primitives of the dart:ui library, as well as other backend-specific pieces
 /// of functionality needed by the rest of the generic web engine code.
 abstract class Renderer {
+  // Abstract generative constructor to allow extending this renderer.
+  Renderer();
+
   factory Renderer._internal() {
     if (FlutterConfiguration.flutterWebUseSkwasm) {
       return SkwasmRenderer();
@@ -38,7 +42,49 @@ abstract class Renderer {
   String get rendererTag;
   FlutterFontCollection get fontCollection;
 
-  FutureOr<void> initialize();
+  late Rasterizer rasterizer;
+
+  /// Resets the [Rasterizer] to the default value. Used in tests.
+  @visibleForTesting
+  void debugResetRasterizer();
+
+  /// Override the rasterizer with the given [_rasterizer]. Used in tests.
+  @visibleForTesting
+  void debugOverrideRasterizer(Rasterizer testRasterizer) {
+    rasterizer = testRasterizer;
+  }
+
+  // Listens for view creation events from the view manager.
+  late StreamSubscription<int> _onViewCreatedListener;
+  // Listens for view disposal events from the view manager.
+  late StreamSubscription<int> _onViewDisposedListener;
+
+  @mustCallSuper
+  FutureOr<void> initialize() {
+    // Views may have been registered before this renderer was initialized.
+    // Create rasterizers for them and then start listening for new view
+    // creation/disposal events.
+    final FlutterViewManager viewManager = EnginePlatformDispatcher.instance.viewManager;
+    for (final EngineFlutterView view in viewManager.views) {
+      _onViewCreated(view.viewId);
+    }
+    _onViewCreatedListener = viewManager.onViewCreated.listen(_onViewCreated);
+    _onViewDisposedListener = viewManager.onViewDisposed.listen(_onViewDisposed);
+  }
+
+  void _onViewCreated(int viewId) {
+    final EngineFlutterView view = EnginePlatformDispatcher.instance.viewManager[viewId]!;
+    rasterizers[view.viewId] = rasterizer.createViewRasterizer(view);
+  }
+
+  void _onViewDisposed(int viewId) {
+    // The view has already been disposed.
+    if (!rasterizers.containsKey(viewId)) {
+      return;
+    }
+    final ViewRasterizer rasterizer = rasterizers.remove(viewId)!;
+    rasterizer.dispose();
+  }
 
   ui.Paint createPaint();
 
@@ -226,10 +272,30 @@ abstract class Renderer {
 
   ui.ParagraphBuilder createParagraphBuilder(ui.ParagraphStyle style);
 
+  /// Map from view id to the associated [ViewRasterizer] for that view.
+  final Map<int, ViewRasterizer> rasterizers = <int, ViewRasterizer>{};
+
   Future<void> renderScene(ui.Scene scene, EngineFlutterView view);
 
   void dumpDebugInfo();
 
+  /// Disposes this renderer.
+  @mustCallSuper
+  void dispose() {
+    _onViewCreatedListener.cancel();
+    _onViewDisposedListener.cancel();
+    for (final ViewRasterizer rasterizer in rasterizers.values) {
+      rasterizer.dispose();
+    }
+    rasterizers.clear();
+    rasterizer.dispose();
+  }
+
   /// Clears the state of this renderer. Used in tests.
-  void debugClear();
+  @mustCallSuper
+  void debugClear() {
+    for (final ViewRasterizer rasterizer in rasterizers.values) {
+      rasterizer.debugClear();
+    }
+  }
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -14,7 +14,7 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-class SkwasmRenderer implements Renderer {
+class SkwasmRenderer extends Renderer {
   late SkwasmSurface surface;
   final Map<EngineFlutterView, EngineSceneView> _sceneViews =
       <EngineFlutterView, EngineSceneView>{};
@@ -324,6 +324,8 @@ class SkwasmRenderer implements Renderer {
   @override
   FutureOr<void> initialize() {
     surface = SkwasmSurface();
+    rasterizer = NoopRasterizer();
+    return super.initialize();
   }
 
   @override
@@ -564,10 +566,91 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  void debugClear() {
-    // TODO(harryterkelsen): See what needs to be cleaned up for tests and clear
-    // it here.
+  void debugResetRasterizer() {
+    rasterizer = NoopRasterizer();
   }
+}
+
+// A [Rasterizer] that does nothing. A placeholder that will be fleshed out
+// when Skwasm and CanvasKit renderers are unified. See: https://github.com/flutter/flutter/issues/172311
+class NoopRasterizer implements Rasterizer {
+  @override
+  ViewRasterizer createViewRasterizer(EngineFlutterView view) {
+    return NoopViewRasterizer();
+  }
+
+  @override
+  void dispose() {
+    // Do nothing
+  }
+
+  @override
+  void setResourceCacheMaxBytes(int bytes) {
+    // Do nothing
+  }
+}
+
+// A [ViewRasterizer] that does nothing. A placeholder that will be fleshed out
+// when Skwasm and CanvasKit renderers are unified. See: https://github.com/flutter/flutter/issues/172311
+class NoopViewRasterizer implements ViewRasterizer {
+  @override
+  BitmapSize currentFrameSize = BitmapSize.zero;
+
+  @override
+  CompositorContext get context => throw UnimplementedError();
+
+  @override
+  void debugClear() {
+    // Do nothing
+  }
+
+  @override
+  DisplayCanvasFactory<DisplayCanvas> get displayFactory => throw UnimplementedError();
+
+  @override
+  void dispose() {
+    // Do nothing
+  }
+
+  @override
+  Future<void> draw(LayerTree layerTree) {
+    throw UnimplementedError();
+  }
+
+  @override
+  DisplayCanvas getOverlay() {
+    throw UnimplementedError();
+  }
+
+  @override
+  void prepareToDraw() {}
+
+  @override
+  RenderQueue get queue => throw UnimplementedError();
+
+  @override
+  Future<void> rasterizeToCanvas(DisplayCanvas canvas, List<CkPicture> pictures) {
+    throw UnimplementedError();
+  }
+
+  @override
+  void releaseOverlay(DisplayCanvas overlay) {}
+
+  @override
+  void releaseOverlays() {}
+
+  @override
+  void removeOverlaysFromDom() {
+  }
+
+  @override
+  DomElement get sceneElement => throw UnimplementedError();
+
+  @override
+  EngineFlutterView get view => throw UnimplementedError();
+
+  @override
+  HtmlViewEmbedder get viewEmbedder => throw UnimplementedError();
 }
 
 class SkwasmPictureRenderer implements PictureRenderer {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -640,8 +640,7 @@ class NoopViewRasterizer implements ViewRasterizer {
   void releaseOverlays() {}
 
   @override
-  void removeOverlaysFromDom() {
-  }
+  void removeOverlaysFromDom() {}
 
   @override
   DomElement get sceneElement => throw UnimplementedError();

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -11,7 +11,7 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-class SkwasmRenderer implements Renderer {
+class SkwasmRenderer extends Renderer {
   bool get isMultiThreaded => false;
 
   @override
@@ -253,11 +253,6 @@ class SkwasmRenderer implements Renderer {
       throw UnimplementedError('Skwasm not implemented on this platform.');
 
   @override
-  FutureOr<void> initialize() {
-    throw UnimplementedError('Skwasm not implemented on this platform.');
-  }
-
-  @override
   Future<ui.Codec> instantiateImageCodec(
     Uint8List list, {
     int? targetWidth,
@@ -284,19 +279,12 @@ class SkwasmRenderer implements Renderer {
   String get rendererTag => throw UnimplementedError('Skwasm not implemented on this platform.');
 
   @override
-  void clearFragmentProgramCache() => _programs.clear();
-
-  static final Map<String, Future<ui.FragmentProgram>> _programs =
-      <String, Future<ui.FragmentProgram>>{};
+  void clearFragmentProgramCache() =>
+      throw UnimplementedError('Skwasm not implemented on this platform.');
 
   @override
   Future<ui.FragmentProgram> createFragmentProgram(String assetKey) {
-    if (_programs.containsKey(assetKey)) {
-      return _programs[assetKey]!;
-    }
-    return _programs[assetKey] = ui_web.assetManager.load(assetKey).then((ByteData data) {
-      return CkFragmentProgram.fromBytes(assetKey, data.buffer.asUint8List());
-    });
+    throw UnimplementedError('Skwasm not implemented on this platform.');
   }
 
   @override
@@ -333,7 +321,7 @@ class SkwasmRenderer implements Renderer {
   }
 
   @override
-  void debugClear() {
+  void debugResetRasterizer() {
     throw UnimplementedError('Skwasm not implemented on this platform.');
   }
 }

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/display_canvas_factory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/display_canvas_factory_test.dart
@@ -89,9 +89,8 @@ void testMain() {
 
       final EngineFlutterView implicitView = EnginePlatformDispatcher.instance.implicitView!;
 
-      final DisplayCanvasFactory<DisplayCanvas> originalFactory = CanvasKitRenderer.instance
-          .rasterizers[implicitView.viewId]!
-          .displayFactory;
+      final DisplayCanvasFactory<DisplayCanvas> originalFactory =
+          CanvasKitRenderer.instance.rasterizers[implicitView.viewId]!.displayFactory;
 
       // Cause the surface and its canvas to be attached to the page
       implicitView.dom.sceneHost.prepend(originalFactory.baseCanvas.hostElement);

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/display_canvas_factory_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/display_canvas_factory_test.dart
@@ -90,7 +90,7 @@ void testMain() {
       final EngineFlutterView implicitView = EnginePlatformDispatcher.instance.implicitView!;
 
       final DisplayCanvasFactory<DisplayCanvas> originalFactory = CanvasKitRenderer.instance
-          .debugGetRasterizerForView(implicitView)!
+          .rasterizers[implicitView.viewId]!
           .displayFactory;
 
       // Cause the surface and its canvas to be attached to the page

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -944,9 +944,8 @@ void testMain() {
       _expectSceneMatches(<_EmbeddedViewMarker>[_platformView, _platformView, _platformView]);
 
       expect(() {
-        final HtmlViewEmbedder embedder = (renderer as CanvasKitRenderer)
-            .rasterizers[implicitView.viewId]!
-            .viewEmbedder;
+        final HtmlViewEmbedder embedder =
+            (renderer as CanvasKitRenderer).rasterizers[implicitView.viewId]!.viewEmbedder;
         // The following line used to cause a "Concurrent modification during iteration"
         embedder.dispose();
       }, returnsNormally);
@@ -1121,7 +1120,8 @@ void testMain() {
       await renderScene(scene);
       _expectSceneMatches(<_EmbeddedViewMarker>[_overlay, _platformView, _platformView, _overlay]);
 
-      final Rendering rendering = CanvasKitRenderer.instance
+      final Rendering rendering = CanvasKitRenderer
+          .instance
           .rasterizers[implicitView.viewId]!
           .viewEmbedder
           .debugActiveRendering;
@@ -1357,7 +1357,8 @@ void testMain() {
       ]);
 
       // The second-to-last canvas should have all the extra pictures.
-      final Rendering rendering = CanvasKitRenderer.instance
+      final Rendering rendering = CanvasKitRenderer
+          .instance
           .rasterizers[implicitView.viewId]!
           .viewEmbedder
           .debugActiveRendering;
@@ -1418,7 +1419,8 @@ void testMain() {
       ]);
 
       // The last canvas should have all the pictures.
-      final Rendering secondRendering = CanvasKitRenderer.instance
+      final Rendering secondRendering = CanvasKitRenderer
+          .instance
           .rasterizers[implicitView.viewId]!
           .viewEmbedder
           .debugActiveRendering;

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -945,7 +945,7 @@ void testMain() {
 
       expect(() {
         final HtmlViewEmbedder embedder = (renderer as CanvasKitRenderer)
-            .debugGetRasterizerForView(implicitView)!
+            .rasterizers[implicitView.viewId]!
             .viewEmbedder;
         // The following line used to cause a "Concurrent modification during iteration"
         embedder.dispose();
@@ -1122,7 +1122,7 @@ void testMain() {
       _expectSceneMatches(<_EmbeddedViewMarker>[_overlay, _platformView, _platformView, _overlay]);
 
       final Rendering rendering = CanvasKitRenderer.instance
-          .debugGetRasterizerForView(implicitView)!
+          .rasterizers[implicitView.viewId]!
           .viewEmbedder
           .debugActiveRendering;
       final List<int> picturesPerCanvas = rendering.canvases
@@ -1358,7 +1358,7 @@ void testMain() {
 
       // The second-to-last canvas should have all the extra pictures.
       final Rendering rendering = CanvasKitRenderer.instance
-          .debugGetRasterizerForView(implicitView)!
+          .rasterizers[implicitView.viewId]!
           .viewEmbedder
           .debugActiveRendering;
       final List<int> numPicturesPerCanvas = rendering.canvases
@@ -1419,7 +1419,7 @@ void testMain() {
 
       // The last canvas should have all the pictures.
       final Rendering secondRendering = CanvasKitRenderer.instance
-          .debugGetRasterizerForView(implicitView)!
+          .rasterizers[implicitView.viewId]!
           .viewEmbedder
           .debugActiveRendering;
       final List<int> picturesPerCanvasInSecondRendering = secondRendering.canvases

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/multi_view_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/multi_view_test.dart
@@ -65,10 +65,10 @@ void testMain() {
         createDomElement('multi-view'),
       );
       EnginePlatformDispatcher.instance.viewManager.registerView(view);
-      expect(CanvasKitRenderer.instance.debugGetRasterizerForView(view), isNotNull);
+      expect(CanvasKitRenderer.instance.rasterizers[view.viewId], isNotNull);
 
       EnginePlatformDispatcher.instance.viewManager.disposeAndUnregisterView(view.viewId);
-      expect(CanvasKitRenderer.instance.debugGetRasterizerForView(view), isNull);
+      expect(CanvasKitRenderer.instance.rasterizers[view.viewId], isNull);
     });
 
     // Issue https://github.com/flutter/flutter/issues/142094
@@ -80,10 +80,10 @@ void testMain() {
         createDomElement('multi-view'),
       );
       EnginePlatformDispatcher.instance.viewManager.registerView(view);
-      expect(CanvasKitRenderer.instance.debugGetRasterizerForView(view), isNotNull);
+      expect(CanvasKitRenderer.instance.rasterizers[view.viewId], isNotNull);
 
       EnginePlatformDispatcher.instance.viewManager.disposeAndUnregisterView(view.viewId);
-      expect(CanvasKitRenderer.instance.debugGetRasterizerForView(view), isNull);
+      expect(CanvasKitRenderer.instance.rasterizers[view.viewId], isNull);
 
       expect(
         PlatformViewManager.instance.knowsViewType(

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/render_canvas_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/render_canvas_test.dart
@@ -74,7 +74,7 @@ void testMain() {
       await renderScene(scene);
 
       expect(
-        CanvasKitRenderer.instance.debugGetRasterizerForView(implicitView)!.currentFrameSize,
+        CanvasKitRenderer.instance.rasterizers[implicitView.viewId]!.currentFrameSize,
         const BitmapSize(200, 200),
       );
 

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/renderer_test.dart
@@ -186,9 +186,9 @@ void testMain() {
       'defaults to OffscreenCanvasRasterizer on Chrome and MultiSurfaceRasterizer on Firefox and Safari',
       () {
         if (isChromium) {
-          expect(CanvasKitRenderer.instance.debugGetRasterizer(), isA<OffscreenCanvasRasterizer>());
+          expect(CanvasKitRenderer.instance.rasterizer, isA<OffscreenCanvasRasterizer>());
         } else {
-          expect(CanvasKitRenderer.instance.debugGetRasterizer(), isA<MultiSurfaceRasterizer>());
+          expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
         }
       },
     );
@@ -199,7 +199,7 @@ void testMain() {
             as JsFlutterConfiguration?,
       );
       CanvasKitRenderer.instance.debugResetRasterizer();
-      expect(CanvasKitRenderer.instance.debugGetRasterizer(), isA<MultiSurfaceRasterizer>());
+      expect(CanvasKitRenderer.instance.rasterizer, isA<MultiSurfaceRasterizer>());
     });
   });
 }


### PR DESCRIPTION
This is a small tweak to the Renderer API that exposes a `Rasterizer` and a map of `View` to `ViewRasterizer` in the `Renderer`. The `Renderer` handles creating and disposing the `ViewRasterizer`s in response to `View`s being created and disposed.

This is a step towards https://github.com/flutter/flutter/issues/172311

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
