### PR TITLE
Refactor: Migrate page transition builder class to widgets

### DIFF
--- a/examples/api/lib/widgets/page_transitions_builder/page_transitions_builder.0.dart
+++ b/examples/api/lib/widgets/page_transitions_builder/page_transitions_builder.0.dart
@@ -1,0 +1,129 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Flutter code sample for custom [PageTransitionsBuilder].
+
+void main() => runApp(const PageTransitionsBuilderExampleApp());
+
+class PageTransitionsBuilderExampleApp extends StatelessWidget {
+  const PageTransitionsBuilderExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Custom Page Transitions',
+      theme: ThemeData(
+        pageTransitionsTheme: const PageTransitionsTheme(
+          builders: <TargetPlatform, PageTransitionsBuilder>{
+            TargetPlatform.android: SlideRightPageTransitionsBuilder(),
+            TargetPlatform.iOS: SlideRightPageTransitionsBuilder(),
+          },
+        ),
+      ),
+      home: const HomePage(),
+    );
+  }
+}
+
+class SlideRightPageTransitionsBuilder extends PageTransitionsBuilder {
+  const SlideRightPageTransitionsBuilder();
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    const Offset begin = Offset(1.0, 0.0);
+    const Offset end = Offset.zero;
+    final Animatable<Offset> tween = Tween<Offset>(
+      begin: begin,
+      end: end,
+    ).chain(CurveTween(curve: Curves.ease));
+
+    return SlideTransition(
+      position: animation.drive(tween),
+      child: FadeTransition(opacity: animation, child: child),
+    );
+  }
+}
+
+class CustomPageRoute<T> extends PageRoute<T> {
+  CustomPageRoute({
+    required this.builder,
+    this.transitionsBuilder = const SlideRightPageTransitionsBuilder(),
+    super.settings,
+  });
+
+  final WidgetBuilder builder;
+  final PageTransitionsBuilder transitionsBuilder;
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return builder(context);
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return transitionsBuilder.buildTransitions(this, context, animation, secondaryAnimation, child);
+  }
+}
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Custom Page Transitions')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.of(
+              context,
+            ).push(CustomPageRoute<void>(builder: (BuildContext context) => const SecondPage()));
+          },
+          child: const Text('Navigate with Custom Transition'),
+        ),
+      ),
+    );
+  }
+}
+
+class SecondPage extends StatelessWidget {
+  const SecondPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Second Page')),
+      body: const Center(child: Text('This page appeared with a custom transition!')),
+    );
+  }
+}

--- a/examples/api/test/widgets/page_transitions_builder/page_transitions_builder.0_test.dart
+++ b/examples/api/test/widgets/page_transitions_builder/page_transitions_builder.0_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/page_transitions_builder/page_transitions_builder.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Custom page transition example', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.PageTransitionsBuilderExampleApp());
+
+    // Find the initial page
+    expect(find.text('Custom Page Transitions'), findsOneWidget);
+    expect(find.text('Navigate with Custom Transition'), findsOneWidget);
+
+    // Tap the button to navigate
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+
+    // Verify we're on the second page
+    expect(find.text('Second Page'), findsOneWidget);
+    expect(find.text('This page appeared with a custom transition!'), findsOneWidget);
+
+    // Go back
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    // Verify we're back on the first page
+    expect(find.text('Custom Page Transitions'), findsOneWidget);
+    expect(find.text('Navigate with Custom Transition'), findsOneWidget);
+  });
+
+  testWidgets('SlideRightPageTransitionsBuilder creates slide and fade transitions', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const example.PageTransitionsBuilderExampleApp());
+
+    // Navigate to second page
+    await tester.tap(find.byType(ElevatedButton));
+
+    // Pump one frame to start the animation
+    await tester.pump();
+
+    // The transition should be in progress
+    await tester.pump(const Duration(milliseconds: 150));
+
+    // The second page should be visible but still animating
+    expect(find.text('Second Page'), findsOneWidget);
+
+    // Complete the animation
+    await tester.pumpAndSettle();
+
+    // The second page should be fully visible
+    expect(find.text('This page appeared with a custom transition!'), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -596,61 +596,6 @@ class _FadeForwardsPageTransition extends StatelessWidget {
   }
 }
 
-/// Used by [PageTransitionsTheme] to define a [MaterialPageRoute] page
-/// transition animation.
-///
-/// Apps can configure the map of builders for [ThemeData.pageTransitionsTheme]
-/// to customize the default [MaterialPageRoute] page transition animation
-/// for different platforms.
-///
-/// See also:
-///
-///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android O.
-///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android P.
-///  * [ZoomPageTransitionsBuilder], which defines the default page transition
-///    that's similar to the one provided in Android Q.
-///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
-///    transition that matches native iOS page transitions.
-///  * [FadeForwardsPageTransitionsBuilder], which defines a page transition
-///    that's similar to the one provided by Android U.
-abstract class PageTransitionsBuilder {
-  /// Abstract const constructor. This constructor enables subclasses to provide
-  /// const constructors so that they can be used in const expressions.
-  const PageTransitionsBuilder();
-
-  /// Provides a secondary transition to the previous route.
-  ///
-  /// {@macro flutter.widgets.delegatedTransition}
-  DelegatedTransitionBuilder? get delegatedTransition => null;
-
-  /// {@macro flutter.widgets.TransitionRoute.transitionDuration}
-  ///
-  /// Defaults to 300 milliseconds.
-  Duration get transitionDuration => const Duration(milliseconds: 300);
-
-  /// {@macro flutter.widgets.TransitionRoute.reverseTransitionDuration}
-  ///
-  /// Defaults to 300 milliseconds.
-  Duration get reverseTransitionDuration => transitionDuration;
-
-  /// Wraps the child with one or more transition widgets which define how [route]
-  /// arrives on and leaves the screen.
-  ///
-  /// The [MaterialPageRoute.buildTransitions] method looks up the
-  /// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`
-  /// and delegates to this method with a [PageTransitionsBuilder] based
-  /// on the theme's [ThemeData.platform].
-  Widget buildTransitions<T>(
-    PageRoute<T> route,
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  );
-}
-
 /// Used by [PageTransitionsTheme] to define a vertically fading
 /// [MaterialPageRoute] page transition animation that looks like
 /// the default page transition used on Android O.

--- a/packages/flutter/lib/src/widgets/page_transitions_builder.dart
+++ b/packages/flutter/lib/src/widgets/page_transitions_builder.dart
@@ -1,0 +1,88 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// @docImport 'package:flutter/material.dart';
+library;
+
+import 'basic.dart';
+import 'framework.dart';
+import 'pages.dart';
+import 'transitions.dart';
+
+/// Defines a page transition animation for a [PageRoute].
+///
+/// PageTransitionsBuilder can be used directly with widget layer primitives
+/// in any design system. Custom [PageRoute] subclasses can accept a
+/// PageTransitionsBuilder and delegate to its [buildTransitions] method when
+/// overriding [ModalRoute.buildTransitions]. This enables reusable transition
+/// animations that work with [Navigator] and other navigation primitives.
+///
+/// ## Example usage
+///
+/// {@tool dartpad}
+/// This example shows how to create a custom [PageTransitionsBuilder] that
+/// slides the new page in from the right while fading it in, and how to use
+/// it with a custom [PageRoute].
+///
+/// ** See code in examples/api/lib/widgets/page_transitions_builder/page_transitions_builder.0.dart **
+/// {@end-tool}
+///
+/// As an example of usage, in the Material library this class is used by
+/// [PageTransitionsTheme] to define a [MaterialPageRoute] page transition
+/// animation. Apps can configure the map of builders for
+/// [ThemeData.pageTransitionsTheme] to customize the default
+/// [MaterialPageRoute] page transition animation for different platforms.
+///
+/// See also:
+///
+///  * [PageTransitionsTheme], which uses this class to configure page transitions.
+///  * [MaterialPageRoute], which uses this class to build its transition.
+///  * [FadeUpwardsPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android O.
+///  * [OpenUpwardsPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android P.
+///  * [ZoomPageTransitionsBuilder], which defines the default page transition
+///    that's similar to the one provided in Android Q.
+///  * [CupertinoPageTransitionsBuilder], which defines a horizontal page
+///    transition that matches native iOS page transitions.
+///  * [FadeForwardsPageTransitionsBuilder], which defines a page transition
+///    that's similar to the one provided by Android U.
+abstract class PageTransitionsBuilder {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const PageTransitionsBuilder();
+
+  /// Provides a secondary transition to the previous route.
+  ///
+  /// {@macro flutter.widgets.delegatedTransition}
+  DelegatedTransitionBuilder? get delegatedTransition => null;
+
+  /// {@macro flutter.widgets.TransitionRoute.transitionDuration}
+  ///
+  /// Defaults to 300 milliseconds.
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+
+  /// {@macro flutter.widgets.TransitionRoute.reverseTransitionDuration}
+  ///
+  /// Defaults to 300 milliseconds.
+  Duration get reverseTransitionDuration => transitionDuration;
+
+  /// Wraps the child with one or more transition widgets which define how [route]
+  /// arrives on and leaves the screen.
+  ///
+  /// Subclasses override this method to create a transition animation.
+  ///
+  /// The [MaterialPageRoute.buildTransitions] method is an example of a method
+  /// that uses this to build a transition. It looks up the current
+  /// [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`
+  /// and delegates to this method with a [PageTransitionsBuilder] based
+  /// on the theme's [ThemeData.platform].
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  );
+}

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -93,6 +93,7 @@ export 'src/widgets/overflow_bar.dart';
 export 'src/widgets/overlay.dart';
 export 'src/widgets/overscroll_indicator.dart';
 export 'src/widgets/page_storage.dart';
+export 'src/widgets/page_transitions_builder.dart';
 export 'src/widgets/page_view.dart';
 export 'src/widgets/pages.dart';
 export 'src/widgets/performance_overlay.dart';

--- a/packages/flutter/test/widgets/page_transitions_builder_test.dart
+++ b/packages/flutter/test/widgets/page_transitions_builder_test.dart
@@ -1,0 +1,246 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('PageTransitionsBuilder buildTransitions method is called correctly', (
+    WidgetTester tester,
+  ) async {
+    bool buildTransitionsCalled = false;
+    PageRoute<dynamic>? capturedRoute;
+    BuildContext? capturedContext;
+    Animation<double>? capturedAnimation;
+    Animation<double>? capturedSecondaryAnimation;
+    Widget? capturedChild;
+
+    final _TestPageTransitionsBuilder builderWithCapture = _TestPageTransitionsBuilder(
+      onBuildTransitions:
+          <T>(
+            PageRoute<T> route,
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+            Widget child,
+          ) {
+            buildTransitionsCalled = true;
+            capturedRoute = route;
+            capturedContext = context;
+            capturedAnimation = animation;
+            capturedSecondaryAnimation = secondaryAnimation;
+            capturedChild = child;
+
+            return SlideTransition(
+              position: Tween<Offset>(
+                begin: const Offset(1.0, 0.0),
+                end: Offset.zero,
+              ).animate(animation),
+              child: child,
+            );
+          },
+    );
+
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => Material(
+        child: TextButton(
+          child: const Text('push'),
+          onPressed: () {
+            Navigator.of(context).pushNamed('/test');
+          },
+        ),
+      ),
+      '/test': (BuildContext context) => const Material(child: Text('test page')),
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          pageTransitionsTheme: PageTransitionsTheme(
+            builders: <TargetPlatform, PageTransitionsBuilder>{
+              TargetPlatform.android: builderWithCapture,
+            },
+          ),
+        ),
+        routes: routes,
+      ),
+    );
+
+    // Trigger navigation
+    await tester.tap(find.text('push'));
+    await tester.pump();
+
+    // Verify buildTransitions was called with correct parameters
+    expect(buildTransitionsCalled, isTrue);
+    expect(capturedRoute, isNotNull);
+    expect(capturedContext, isNotNull);
+    expect(capturedAnimation, isNotNull);
+    expect(capturedSecondaryAnimation, isNotNull);
+    expect(capturedChild, isNotNull);
+    expect(capturedRoute!.settings.name, '/');
+  });
+
+  testWidgets('PageTransitionsBuilder works with custom Navigator and PageRoute', (
+    WidgetTester tester,
+  ) async {
+    final _TestPageTransitionsBuilder customTransitionsBuilder = _TestPageTransitionsBuilder(
+      onBuildTransitions:
+          <T>(
+            PageRoute<T> route,
+            BuildContext context,
+            Animation<double> animation,
+            Animation<double> secondaryAnimation,
+            Widget child,
+          ) {
+            return FadeTransition(
+              opacity: animation,
+              child: ScaleTransition(
+                scale: animation.drive(
+                  Tween<double>(begin: 0.5, end: 1.0).chain(CurveTween(curve: Curves.easeInOut)),
+                ),
+                child: child,
+              ),
+            );
+          },
+    );
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Navigator(
+          onGenerateRoute: (RouteSettings settings) {
+            return _CustomPageRoute<void>(
+              settings: settings,
+              transitionsBuilder: customTransitionsBuilder,
+              builder: (BuildContext context) {
+                if (settings.name == '/') {
+                  return Center(
+                    child: GestureDetector(
+                      onTap: () {
+                        Navigator.of(context).pushNamed('/second');
+                      },
+                      child: Container(
+                        width: 200,
+                        height: 50,
+                        color: const Color(0xFF2196F3),
+                        child: const Center(
+                          child: Text('Navigate', style: TextStyle(color: Color(0xFFFFFFFF))),
+                        ),
+                      ),
+                    ),
+                  );
+                }
+                return const ColoredBox(
+                  color: Color(0xFF4CAF50),
+                  child: Center(
+                    child: Text(
+                      'Second Page',
+                      style: TextStyle(color: Color(0xFFFFFFFF), fontSize: 24),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('Navigate'), findsOneWidget);
+    expect(find.text('Second Page'), findsNothing);
+
+    await tester.tap(find.text('Navigate'));
+    await tester.pump();
+
+    expect(find.text('Navigate'), findsOneWidget);
+    expect(find.text('Second Page'), findsOneWidget);
+
+    await tester.pump(const Duration(milliseconds: 50));
+
+    final FadeTransition fadeTransition = tester.widget<FadeTransition>(
+      find.byType(FadeTransition).first,
+    );
+    expect(fadeTransition.opacity.value, greaterThan(0.0));
+    expect(fadeTransition.opacity.value, lessThanOrEqualTo(1.0));
+
+    final ScaleTransition scaleTransition = tester.widget<ScaleTransition>(
+      find.byType(ScaleTransition).first,
+    );
+    expect(scaleTransition.scale.value, greaterThanOrEqualTo(0.5));
+    expect(scaleTransition.scale.value, lessThanOrEqualTo(1.0));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Navigate'), findsNothing);
+    expect(find.text('Second Page'), findsOneWidget);
+  });
+}
+
+class _CustomPageRoute<T> extends PageRoute<T> {
+  _CustomPageRoute({required this.builder, required this.transitionsBuilder, super.settings});
+
+  final WidgetBuilder builder;
+  final PageTransitionsBuilder transitionsBuilder;
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 300);
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  Color? get barrierColor => null;
+
+  @override
+  String? get barrierLabel => null;
+
+  @override
+  Widget buildPage(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+  ) {
+    return builder(context);
+  }
+
+  @override
+  Widget buildTransitions(
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return transitionsBuilder.buildTransitions<T>(
+      this,
+      context,
+      animation,
+      secondaryAnimation,
+      child,
+    );
+  }
+}
+
+class _TestPageTransitionsBuilder extends PageTransitionsBuilder {
+  const _TestPageTransitionsBuilder({required this.onBuildTransitions});
+
+  final Widget Function<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  )
+  onBuildTransitions;
+
+  @override
+  Widget buildTransitions<T>(
+    PageRoute<T> route,
+    BuildContext context,
+    Animation<double> animation,
+    Animation<double> secondaryAnimation,
+    Widget child,
+  ) {
+    return onBuildTransitions(route, context, animation, secondaryAnimation, child);
+  }
+}


### PR DESCRIPTION
Changes
* Move PageTransitionsBuilder from `material/page_transitions_theme.dart` to `widget/page_transitions_builder.dart`

part of: #172929

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.