### PR TITLE
Migrate to use `WidgetStateProperty`

### DIFF
--- a/packages/flutter/test/material/navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/navigation_bar_theme_test.dart
@@ -112,7 +112,7 @@ void main() {
                 elevation: elevation,
                 indicatorColor: indicatorColor,
                 indicatorShape: indicatorShape,
-                iconTheme: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                iconTheme: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                   if (states.contains(MaterialState.selected)) {
                     return const IconThemeData(
                       size: selectedIconSize,
@@ -126,7 +126,7 @@ void main() {
                     opacity: unselectedIconOpacity,
                   );
                 }),
-                labelTextStyle: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                labelTextStyle: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                   if (states.contains(MaterialState.selected)) {
                     return const TextStyle(fontSize: selectedLabelFontSize);
                   }
@@ -248,7 +248,7 @@ void main() {
       const Color hoverColor = Color(0xff0000ff);
       const Color focusColor = Color(0xff00ffff);
       const Color pressedColor = Color(0xffff00ff);
-      final MaterialStateProperty<Color?> overlayColor = MaterialStateProperty.resolveWith<Color>((
+      final WidgetStateProperty<Color?> overlayColor = WidgetStateProperty.resolveWith<Color>((
         Set<MaterialState> states,
       ) {
         if (states.contains(MaterialState.hovered)) {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -425,7 +425,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: OutlinedButton(
           style: ButtonStyle(
-            overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
+            overlayColor: WidgetStateProperty.resolveWith<Color?>(getOverlayColor),
           ),
           onPressed: () {},
           child: const Text('button'),
@@ -458,7 +458,7 @@ void main() {
         theme: theme,
         home: OutlinedButton(
           style: ButtonStyle(
-            overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
+            overlayColor: WidgetStateProperty.resolveWith<Color?>(getOverlayColor),
           ),
           focusNode: focusNode,
           onPressed: () {},
@@ -504,7 +504,7 @@ void main() {
         home: OutlinedButton(
           autofocus: true,
           style: ButtonStyle(
-            overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
+            overlayColor: WidgetStateProperty.resolveWith<Color?>(getOverlayColor),
           ),
           focusNode: focusNode,
           onPressed: () {},
@@ -609,7 +609,7 @@ void main() {
               child: OutlinedButtonTheme(
                 data: OutlinedButtonThemeData(
                   style: ButtonStyle(
-                    foregroundColor: MaterialStateProperty.resolveWith<Color>(getTextColor),
+                    foregroundColor: WidgetStateProperty.resolveWith<Color>(getTextColor),
                   ),
                 ),
                 child: Builder(
@@ -685,7 +685,7 @@ void main() {
           body: Center(
             child: OutlinedButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color>(getTextColor),
+                foregroundColor: WidgetStateProperty.resolveWith<Color>(getTextColor),
               ),
               onPressed: () {},
               focusNode: focusNode,
@@ -753,7 +753,7 @@ void main() {
           body: Center(
             child: OutlinedButton.icon(
               key: buttonKey,
-              style: ButtonStyle(iconColor: MaterialStateProperty.resolveWith<Color>(getIconColor)),
+              style: ButtonStyle(iconColor: WidgetStateProperty.resolveWith<Color>(getIconColor)),
               icon: const Icon(Icons.add),
               label: const Text('OutlinedButton'),
               onPressed: () {},
@@ -820,7 +820,7 @@ void main() {
           body: Center(
             child: OutlinedButton(
               style: ButtonStyle(
-                side: MaterialStateProperty.resolveWith<BorderSide>(getBorderSide),
+                side: WidgetStateProperty.resolveWith<BorderSide>(getBorderSide),
                 // Test assumes a rounded rect for the shape
                 shape: ButtonStyleButton.allOrNull(
                   const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
@@ -1137,9 +1137,7 @@ void main() {
                     backgroundColor: fillColor,
                     minimumSize: const Size(64, 36),
                   ).copyWith(
-                    side: MaterialStateProperty.resolveWith<BorderSide>((
-                      Set<MaterialState> states,
-                    ) {
+                    side: WidgetStateProperty.resolveWith<BorderSide>((Set<MaterialState> states) {
                       if (states.contains(MaterialState.disabled)) {
                         return disabledBorderSide;
                       }

--- a/packages/flutter/test/material/outlined_button_theme_test.dart
+++ b/packages/flutter/test/material/outlined_button_theme_test.dart
@@ -198,11 +198,11 @@ void main() {
       expect(material.shadowColor, shadowColor);
       expect(material.elevation, elevation);
       expect(
-        MaterialStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, enabled),
+        WidgetStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, enabled),
         enabledMouseCursor,
       );
       expect(
-        MaterialStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, disabled),
+        WidgetStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, disabled),
         disabledMouseCursor,
       );
       expect(inkWell.overlayColor!.resolve(hovered), foregroundColor.withOpacity(0.08));

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -1423,7 +1423,7 @@ void main() {
   });
 
   testWidgets('PaginatedDataTable custom heading row color', (WidgetTester tester) async {
-    const MaterialStateProperty<Color> headingRowColor = MaterialStatePropertyAll<Color>(
+    const WidgetStateProperty<Color> headingRowColor = MaterialStatePropertyAll<Color>(
       Color(0xffFF0000),
     );
 

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3783,7 +3783,7 @@ void main() {
     WidgetTester tester,
   ) async {
     final Key popupMenuButtonKey = UniqueKey();
-    final MaterialStateProperty<TextStyle?> labelTextStyle = MaterialStateProperty.resolveWith((
+    final WidgetStateProperty<TextStyle?> labelTextStyle = WidgetStateProperty.resolveWith((
       Set<MaterialState> states,
     ) {
       if (states.contains(MaterialState.selected)) {

--- a/packages/flutter/test/material/popup_menu_theme_test.dart
+++ b/packages/flutter/test/material/popup_menu_theme_test.dart
@@ -13,7 +13,7 @@ PopupMenuThemeData _popupMenuThemeM2() {
     shape: const BeveledRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12))),
     elevation: 12.0,
     textStyle: const TextStyle(color: Color(0xffffffff), textBaseline: TextBaseline.alphabetic),
-    mouseCursor: MaterialStateProperty.resolveWith<MouseCursor?>((Set<MaterialState> states) {
+    mouseCursor: WidgetStateProperty.resolveWith<MouseCursor?>((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
         return SystemMouseCursors.contextMenu;
       }
@@ -30,13 +30,13 @@ PopupMenuThemeData _popupMenuThemeM3() {
     elevation: 12.0,
     shadowColor: const Color(0xff00ff00),
     surfaceTintColor: const Color(0xff00ff00),
-    labelTextStyle: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+    labelTextStyle: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
         return const TextStyle(color: Color(0xfff99ff0), fontSize: 12.0);
       }
       return const TextStyle(color: Color(0xfff12099), fontSize: 17.0);
     }),
-    mouseCursor: MaterialStateProperty.resolveWith<MouseCursor?>((Set<MaterialState> states) {
+    mouseCursor: WidgetStateProperty.resolveWith<MouseCursor?>((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
         return SystemMouseCursors.contextMenu;
       }
@@ -95,7 +95,7 @@ void main() {
       shadowColor: const Color(0xfffffff2),
       surfaceTintColor: const Color(0xfffffff3),
       textStyle: const TextStyle(color: Color(0xfffffff4)),
-      labelTextStyle: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      labelTextStyle: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
         if (states.contains(MaterialState.disabled)) {
           return const TextStyle(color: Color(0xfffffff5), fontSize: 12.0);
         }
@@ -403,13 +403,13 @@ void main() {
                   return <PopupMenuEntry<void>>[
                     PopupMenuItem<void>(
                       key: popupItemKey,
-                      labelTextStyle: MaterialStateProperty.all<TextStyle>(textStyle),
+                      labelTextStyle: WidgetStateProperty.all<TextStyle>(textStyle),
                       mouseCursor: cursor,
                       child: const Text('Example'),
                     ),
                     CheckedPopupMenuItem<void>(
                       checked: true,
-                      labelTextStyle: MaterialStateProperty.all<TextStyle>(textStyle),
+                      labelTextStyle: WidgetStateProperty.all<TextStyle>(textStyle),
                       child: const Text('Checked item'),
                     ),
                   ];
@@ -704,7 +704,7 @@ void main() {
                     return <PopupMenuEntry<void>>[
                       PopupMenuItem<void>(
                         key: popupItemKey,
-                        labelTextStyle: MaterialStateProperty.all<TextStyle>(textStyle),
+                        labelTextStyle: WidgetStateProperty.all<TextStyle>(textStyle),
                         mouseCursor: cursor,
                         child: const Text('Example'),
                       ),

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -711,7 +711,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           radioTheme: RadioThemeData(
-            fillColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+            fillColor: WidgetStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
               return states.contains(MaterialState.selected) ? fillColor : null;
             }),
           ),
@@ -903,7 +903,7 @@ void main() {
       return inactiveEnabledFillColor;
     }
 
-    final MaterialStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     Widget buildApp({required bool enabled}) {
@@ -989,7 +989,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     Widget buildApp() {
@@ -1136,7 +1136,7 @@ void main() {
             groupValue: true,
             onChanged: (_) {},
             fillColor: const MaterialStatePropertyAll<Color>(fillColor),
-            overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
+            overlayColor: useOverlay ? WidgetStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
           ),
         ),
@@ -1430,9 +1430,7 @@ void main() {
                 groupValue: true,
                 onChanged: (_) {},
                 fillColor: const MaterialStatePropertyAll<Color>(fillColor),
-                overlayColor: useOverlay
-                    ? MaterialStateProperty.resolveWith(getOverlayColor)
-                    : null,
+                overlayColor: useOverlay ? WidgetStateProperty.resolveWith(getOverlayColor) : null,
                 hoverColor: hoverColor,
               ),
             ),
@@ -2158,7 +2156,7 @@ void main() {
       return inactiveEnabledBackgroundColor;
     }
 
-    final MaterialStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
       getBackgroundColor,
     );
 
@@ -2245,7 +2243,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
       getBackgroundColor,
     );
 
@@ -2296,7 +2294,7 @@ void main() {
   });
 
   testWidgets('radioInnerRadius is passed to the Radio', (WidgetTester tester) async {
-    final WidgetStateProperty<double?> innerRadius = MaterialStateProperty.all(6);
+    final WidgetStateProperty<double?> innerRadius = WidgetStateProperty.all(6);
     await tester.pumpWidget(
       MaterialApp(
         home: Material(

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/src/gestures/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -1153,7 +1154,7 @@ void main() {
       return inactiveEnabledFillColor;
     }
 
-    final MaterialStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     const Key radioKey = Key('radio');
@@ -1270,7 +1271,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     const Key radioKey = Key('radio');
@@ -1362,7 +1363,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     const Key radioKey = Key('radio');
@@ -1484,7 +1485,7 @@ void main() {
             groupValue: true,
             onChanged: (_) {},
             fillColor: const MaterialStatePropertyAll<Color>(fillColor),
-            overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
+            overlayColor: useOverlay ? WidgetStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
             focusColor: focusColor,
             splashRadius: splashRadius,
@@ -2167,7 +2168,7 @@ void main() {
       return inactiveEnabledBackgroundColor;
     }
 
-    final MaterialStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
       getBackgroundColor,
     );
 
@@ -2281,7 +2282,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
       getBackgroundColor,
     );
 

--- a/packages/flutter/test/material/radio_theme_test.dart
+++ b/packages/flutter/test/material/radio_theme_test.dart
@@ -434,7 +434,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           radioTheme: RadioThemeData(
-            fillColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            fillColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return themeSelectedFillColor;
               }
@@ -497,7 +497,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           radioTheme: RadioThemeData(
-            overlayColor: MaterialStateProperty.resolveWith(getOverlayColor),
+            overlayColor: WidgetStateProperty.resolveWith(getOverlayColor),
             splashRadius: splashRadius,
           ),
         ),

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -2416,7 +2416,7 @@ void main() {
                   child: MouseRegion(
                     cursor: SystemMouseCursors.forbidden,
                     child: RangeSlider(
-                      mouseCursor: MaterialStateProperty.resolveWith<MouseCursor?>((
+                      mouseCursor: WidgetStateProperty.resolveWith<MouseCursor?>((
                         Set<MaterialState> states,
                       ) {
                         if (states.contains(MaterialState.disabled)) {
@@ -2774,7 +2774,7 @@ void main() {
                   child: RangeSlider(
                     values: values,
                     max: 100.0,
-                    overlayColor: MaterialStateProperty.resolveWith<Color?>((
+                    overlayColor: WidgetStateProperty.resolveWith<Color?>((
                       Set<MaterialState> states,
                     ) {
                       if (states.contains(MaterialState.hovered)) {

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -884,7 +884,7 @@ void main() {
         MaterialApp(
           theme: ThemeData(
             useMaterial3: false,
-            scrollbarTheme: ScrollbarThemeData(thumbVisibility: MaterialStateProperty.all(true)),
+            scrollbarTheme: ScrollbarThemeData(thumbVisibility: WidgetStateProperty.all(true)),
           ),
           home: const SingleChildScrollView(child: SizedBox(width: 4000.0, height: 4000.0)),
         ),
@@ -933,8 +933,8 @@ void main() {
           theme: ThemeData(
             useMaterial3: false,
             scrollbarTheme: ScrollbarThemeData(
-              thumbVisibility: MaterialStateProperty.all(true),
-              trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              thumbVisibility: WidgetStateProperty.all(true),
+              trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return true;
                 }
@@ -1013,13 +1013,11 @@ void main() {
           theme: ThemeData(
             useMaterial3: false,
             scrollbarTheme: ScrollbarThemeData(
-              thumbVisibility: MaterialStateProperty.resolveWith(
-                (Set<MaterialState> states) => true,
-              ),
-              trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              thumbVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) => true),
+              trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 return states.contains(MaterialState.hovered);
               }),
-              thickness: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              thickness: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return 40.0;
                 }
@@ -1087,8 +1085,8 @@ void main() {
           theme: ThemeData(
             useMaterial3: false,
             scrollbarTheme: ScrollbarThemeData(
-              thumbVisibility: MaterialStateProperty.all(true),
-              trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              thumbVisibility: WidgetStateProperty.all(true),
+              trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return true;
                 }
@@ -1155,8 +1153,8 @@ void main() {
           theme: ThemeData(
             useMaterial3: false,
             scrollbarTheme: ScrollbarThemeData(
-              thumbVisibility: MaterialStateProperty.all(true),
-              trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              thumbVisibility: WidgetStateProperty.all(true),
+              trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return true;
                 }

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -38,7 +38,7 @@ void main() {
           theme: ThemeData(
             useMaterial3: false,
             scrollbarTheme: ScrollbarThemeData(
-              trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return true;
                 }
@@ -236,7 +236,7 @@ void main() {
           behavior: const NoScrollbarBehavior(),
           child: ScrollbarTheme(
             data: _scrollbarTheme().copyWith(
-              thumbColor: MaterialStateProperty.all(const Color(0xFF000000)),
+              thumbColor: WidgetStateProperty.all(const Color(0xFF000000)),
             ),
             child: Scrollbar(
               thumbVisibility: true,
@@ -387,7 +387,7 @@ void main() {
           theme: ThemeData(
             colorScheme: const ColorScheme.light(),
             scrollbarTheme: ScrollbarThemeData(
-              trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return true;
                 }
@@ -492,7 +492,7 @@ void main() {
         final ScrollController scrollController = ScrollController();
         final ThemeData theme = appTheme.copyWith(
           scrollbarTheme: ScrollbarThemeData(
-            trackVisibility: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackVisibility: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.hovered)) {
                 return true;
               }
@@ -679,7 +679,7 @@ void main() {
         MaterialApp(
           theme: ThemeData(useMaterial3: false).copyWith(
             scrollbarTheme: _scrollbarTheme(
-              trackVisibility: MaterialStateProperty.resolveWith(getTrackVisibility),
+              trackVisibility: WidgetStateProperty.resolveWith(getTrackVisibility),
             ),
           ),
           home: ScrollConfiguration(
@@ -730,12 +730,12 @@ void main() {
   testWidgets('ScrollbarTheme implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     ScrollbarThemeData(
-      thickness: MaterialStateProperty.resolveWith(_getThickness),
-      thumbVisibility: MaterialStateProperty.resolveWith(_getThumbVisibility),
+      thickness: WidgetStateProperty.resolveWith(_getThickness),
+      thumbVisibility: WidgetStateProperty.resolveWith(_getThumbVisibility),
       radius: const Radius.circular(3.0),
-      thumbColor: MaterialStateProperty.resolveWith(_getThumbColor),
-      trackColor: MaterialStateProperty.resolveWith(_getTrackColor),
-      trackBorderColor: MaterialStateProperty.resolveWith(_getTrackBorderColor),
+      thumbColor: WidgetStateProperty.resolveWith(_getThumbColor),
+      trackColor: WidgetStateProperty.resolveWith(_getTrackColor),
+      trackBorderColor: WidgetStateProperty.resolveWith(_getTrackBorderColor),
       crossAxisMargin: 3.0,
       mainAxisMargin: 6.0,
       minThumbLength: 120.0,
@@ -774,22 +774,22 @@ class NoScrollbarBehavior extends ScrollBehavior {
 }
 
 ScrollbarThemeData _scrollbarTheme({
-  MaterialStateProperty<double?>? thickness,
-  MaterialStateProperty<bool?>? trackVisibility,
-  MaterialStateProperty<bool?>? thumbVisibility,
+  WidgetStateProperty<double?>? thickness,
+  WidgetStateProperty<bool?>? trackVisibility,
+  WidgetStateProperty<bool?>? thumbVisibility,
   Radius radius = const Radius.circular(6.0),
-  MaterialStateProperty<Color?>? thumbColor,
-  MaterialStateProperty<Color?>? trackColor,
-  MaterialStateProperty<Color?>? trackBorderColor,
+  WidgetStateProperty<Color?>? thumbColor,
+  WidgetStateProperty<Color?>? trackColor,
+  WidgetStateProperty<Color?>? trackBorderColor,
   double crossAxisMargin = 5.0,
   double mainAxisMargin = 10.0,
   double minThumbLength = 50.0,
 }) {
   return ScrollbarThemeData(
-    thickness: thickness ?? MaterialStateProperty.resolveWith(_getThickness),
+    thickness: thickness ?? WidgetStateProperty.resolveWith(_getThickness),
     trackVisibility:
         trackVisibility ??
-        MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.hovered)) {
             return true;
           }
@@ -797,9 +797,9 @@ ScrollbarThemeData _scrollbarTheme({
         }),
     thumbVisibility: thumbVisibility,
     radius: radius,
-    thumbColor: thumbColor ?? MaterialStateProperty.resolveWith(_getThumbColor),
-    trackColor: trackColor ?? MaterialStateProperty.resolveWith(_getTrackColor),
-    trackBorderColor: trackBorderColor ?? MaterialStateProperty.resolveWith(_getTrackBorderColor),
+    thumbColor: thumbColor ?? WidgetStateProperty.resolveWith(_getThumbColor),
+    trackColor: trackColor ?? WidgetStateProperty.resolveWith(_getTrackColor),
+    trackBorderColor: trackBorderColor ?? WidgetStateProperty.resolveWith(_getTrackBorderColor),
     crossAxisMargin: crossAxisMargin,
     mainAxisMargin: mainAxisMargin,
     minThumbLength: minThumbLength,

--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -384,7 +384,7 @@ void main() {
       MaterialApp(
         home: Center(
           child: Material(
-            child: SearchBar(elevation: MaterialStateProperty.resolveWith<double>(getElevation)),
+            child: SearchBar(elevation: WidgetStateProperty.resolveWith<double>(getElevation)),
           ),
         ),
       ),
@@ -424,7 +424,7 @@ void main() {
       MaterialApp(
         home: Center(
           child: Material(
-            child: SearchBar(backgroundColor: MaterialStateProperty.resolveWith<Color>(_getColor)),
+            child: SearchBar(backgroundColor: WidgetStateProperty.resolveWith<Color>(_getColor)),
           ),
         ),
       ),
@@ -464,7 +464,7 @@ void main() {
       MaterialApp(
         home: Center(
           child: Material(
-            child: SearchBar(shadowColor: MaterialStateProperty.resolveWith<Color>(_getColor)),
+            child: SearchBar(shadowColor: WidgetStateProperty.resolveWith<Color>(_getColor)),
           ),
         ),
       ),
@@ -504,7 +504,7 @@ void main() {
       MaterialApp(
         home: Center(
           child: Material(
-            child: SearchBar(surfaceTintColor: MaterialStateProperty.resolveWith<Color>(_getColor)),
+            child: SearchBar(surfaceTintColor: WidgetStateProperty.resolveWith<Color>(_getColor)),
           ),
         ),
       ),
@@ -549,7 +549,7 @@ void main() {
           child: Material(
             child: SearchBar(
               focusNode: focusNode,
-              overlayColor: MaterialStateProperty.resolveWith<Color>(_getColor),
+              overlayColor: WidgetStateProperty.resolveWith<Color>(_getColor),
             ),
           ),
         ),
@@ -638,8 +638,8 @@ void main() {
         home: Center(
           child: Material(
             child: SearchBar(
-              side: MaterialStateProperty.resolveWith<BorderSide>(getSide),
-              shape: MaterialStateProperty.resolveWith<OutlinedBorder>(getShape),
+              side: WidgetStateProperty.resolveWith<BorderSide>(getSide),
+              shape: WidgetStateProperty.resolveWith<OutlinedBorder>(getShape),
             ),
           ),
         ),
@@ -708,7 +708,7 @@ void main() {
           child: Material(
             child: SearchBar(
               hintText: 'hint text',
-              hintStyle: MaterialStateProperty.resolveWith<TextStyle?>(_getTextStyle),
+              hintStyle: WidgetStateProperty.resolveWith<TextStyle?>(_getTextStyle),
             ),
           ),
         ),
@@ -747,7 +747,7 @@ void main() {
           child: Material(
             child: SearchBar(
               controller: controller,
-              textStyle: MaterialStateProperty.resolveWith<TextStyle?>(_getTextStyle),
+              textStyle: WidgetStateProperty.resolveWith<TextStyle?>(_getTextStyle),
             ),
           ),
         ),
@@ -1007,7 +1007,7 @@ void main() {
           child: Material(
             child: SearchBar(
               hintText: 'hint text',
-              hintStyle: MaterialStateProperty.resolveWith<TextStyle?>(_getTextStyle),
+              hintStyle: WidgetStateProperty.resolveWith<TextStyle?>(_getTextStyle),
               textStyle: const MaterialStatePropertyAll<TextStyle>(TextStyle(color: Colors.pink)),
             ),
           ),

--- a/packages/flutter/test/material/search_bar_theme_test.dart
+++ b/packages/flutter/test/material/search_bar_theme_test.dart
@@ -123,32 +123,30 @@ void main() {
     const TextStyle textStyleValue = TextStyle(color: Color(0xff000005), fontSize: 20.0);
     const TextStyle hintStyleValue = TextStyle(color: Color(0xff000006), fontSize: 18.0);
 
-    const MaterialStateProperty<double?> elevation = MaterialStatePropertyAll<double>(
-      elevationValue,
-    );
-    const MaterialStateProperty<Color?> backgroundColor = MaterialStatePropertyAll<Color>(
+    const WidgetStateProperty<double?> elevation = MaterialStatePropertyAll<double>(elevationValue);
+    const WidgetStateProperty<Color?> backgroundColor = MaterialStatePropertyAll<Color>(
       backgroundColorValue,
     );
-    const MaterialStateProperty<Color?> shadowColor = MaterialStatePropertyAll<Color>(
+    const WidgetStateProperty<Color?> shadowColor = MaterialStatePropertyAll<Color>(
       shadowColorValue,
     );
-    const MaterialStateProperty<Color?> surfaceTintColor = MaterialStatePropertyAll<Color>(
+    const WidgetStateProperty<Color?> surfaceTintColor = MaterialStatePropertyAll<Color>(
       surfaceTintColorValue,
     );
-    const MaterialStateProperty<Color?> overlayColor = MaterialStatePropertyAll<Color>(
+    const WidgetStateProperty<Color?> overlayColor = MaterialStatePropertyAll<Color>(
       overlayColorValue,
     );
-    const MaterialStateProperty<BorderSide?> side = MaterialStatePropertyAll<BorderSide>(sideValue);
-    const MaterialStateProperty<OutlinedBorder?> shape = MaterialStatePropertyAll<OutlinedBorder>(
+    const WidgetStateProperty<BorderSide?> side = MaterialStatePropertyAll<BorderSide>(sideValue);
+    const WidgetStateProperty<OutlinedBorder?> shape = MaterialStatePropertyAll<OutlinedBorder>(
       shapeValue,
     );
-    const MaterialStateProperty<EdgeInsetsGeometry?> padding = MaterialStatePropertyAll<EdgeInsets>(
+    const WidgetStateProperty<EdgeInsetsGeometry?> padding = MaterialStatePropertyAll<EdgeInsets>(
       paddingValue,
     );
-    const MaterialStateProperty<TextStyle?> textStyle = MaterialStatePropertyAll<TextStyle>(
+    const WidgetStateProperty<TextStyle?> textStyle = MaterialStatePropertyAll<TextStyle>(
       textStyleValue,
     );
-    const MaterialStateProperty<TextStyle?> hintStyle = MaterialStatePropertyAll<TextStyle>(
+    const WidgetStateProperty<TextStyle?> hintStyle = MaterialStatePropertyAll<TextStyle>(
       hintStyleValue,
     );
     const BoxConstraints constraints = BoxConstraints(

--- a/packages/flutter/test/material/segmented_button_theme_test.dart
+++ b/packages/flutter/test/material/segmented_button_theme_test.dart
@@ -122,7 +122,7 @@ void main() {
     final ThemeData theme = ThemeData(
       segmentedButtonTheme: SegmentedButtonThemeData(
         style: ButtonStyle(
-          backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          backgroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
             if (states.contains(MaterialState.disabled)) {
               return Colors.blue;
             }
@@ -131,7 +131,7 @@ void main() {
             }
             return null;
           }),
-          foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          foregroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
             if (states.contains(MaterialState.disabled)) {
               return Colors.yellow;
             }
@@ -213,7 +213,7 @@ void main() {
   testWidgets('SegmentedButtonTheme overrides ThemeData and defaults', (WidgetTester tester) async {
     final SegmentedButtonThemeData global = SegmentedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        backgroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.blue;
           }
@@ -222,7 +222,7 @@ void main() {
           }
           return null;
         }),
-        foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        foregroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.yellow;
           }
@@ -237,7 +237,7 @@ void main() {
     );
     final SegmentedButtonThemeData segmentedTheme = SegmentedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        backgroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.lightBlue;
           }
@@ -246,7 +246,7 @@ void main() {
           }
           return null;
         }),
-        foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        foregroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.lime;
           }
@@ -348,7 +348,7 @@ void main() {
   ) async {
     final SegmentedButtonThemeData global = SegmentedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        backgroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.blue;
           }
@@ -357,7 +357,7 @@ void main() {
           }
           return null;
         }),
-        foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        foregroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.yellow;
           }
@@ -372,7 +372,7 @@ void main() {
     );
     final SegmentedButtonThemeData segmentedTheme = SegmentedButtonThemeData(
       style: ButtonStyle(
-        backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        backgroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.lightBlue;
           }
@@ -381,7 +381,7 @@ void main() {
           }
           return null;
         }),
-        foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        foregroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.disabled)) {
             return Colors.lime;
           }
@@ -411,7 +411,7 @@ void main() {
                 selected: const <int>{2},
                 onSelectionChanged: (Set<int> selected) {},
                 style: ButtonStyle(
-                  backgroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                  backgroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                     if (states.contains(MaterialState.disabled)) {
                       return Colors.black12;
                     }
@@ -420,7 +420,7 @@ void main() {
                     }
                     return null;
                   }),
-                  foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                  foregroundColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
                     if (states.contains(MaterialState.disabled)) {
                       return Colors.amberAccent;
                     }

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -1264,7 +1264,7 @@ void main() {
               builder: (BuildContext context, StateSetter setState) {
                 return Stepper(
                   type: StepperType.horizontal,
-                  connectorColor: MaterialStateProperty.resolveWith<Color>(
+                  connectorColor: WidgetStateProperty.resolveWith<Color>(
                     (Set<MaterialState> states) =>
                         states.contains(MaterialState.selected) ? selectedColor : disabledColor,
                   ),

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -512,7 +512,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           switchTheme: SwitchThemeData(
-            thumbColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+            thumbColor: WidgetStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
               return states.contains(MaterialState.selected) ? thumbColor : null;
             }),
           ),
@@ -748,7 +748,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile({required bool enabled, required bool selected}) {
       return MaterialApp(
@@ -843,7 +843,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile({required bool enabled, required bool selected}) {
       return MaterialApp(
@@ -921,7 +921,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile() {
       return MaterialApp(
@@ -988,7 +988,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile() {
       return MaterialApp(
@@ -1052,7 +1052,7 @@ void main() {
       return inactiveEnabledTrackColor;
     }
 
-    final MaterialStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitchListTile({required bool enabled, required bool selected}) {
       return wrap(
@@ -1110,7 +1110,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitchListTile() {
       return wrap(
@@ -1141,8 +1141,8 @@ void main() {
     const Icon activeIcon = Icon(Icons.check);
     const Icon inactiveIcon = Icon(Icons.close);
 
-    MaterialStateProperty<Icon?> thumbIcon(Icon? activeIcon, Icon? inactiveIcon) {
-      return MaterialStateProperty.resolveWith<Icon?>((Set<MaterialState> states) {
+    WidgetStateProperty<Icon?> thumbIcon(Icon? activeIcon, Icon? inactiveIcon) {
+      return WidgetStateProperty.resolveWith<Icon?>((Set<MaterialState> states) {
         if (states.contains(MaterialState.selected)) {
           return activeIcon;
         }
@@ -1612,13 +1612,13 @@ void main() {
             body: SwitchListTile(
               value: active,
               onChanged: (_) {},
-              thumbColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+              thumbColor: WidgetStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                 if (states.contains(MaterialState.selected)) {
                   return activeThumbColor;
                 }
                 return inactiveThumbColor;
               }),
-              overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
+              overlayColor: useOverlay ? WidgetStateProperty.resolveWith(getOverlayColor) : null,
               hoverColor: hoverColor,
             ),
           ),
@@ -1717,7 +1717,7 @@ void main() {
       return inactiveEnabledTrackOutlineColor;
     }
 
-    final MaterialStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
       getOutlineColor,
     );
 
@@ -1787,7 +1787,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> outlineColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> outlineColor = MaterialStateColor.resolveWith(
       getTrackOutlineColor,
     );
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -17,6 +17,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -2272,7 +2273,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return MaterialApp(
@@ -2387,7 +2388,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Theme(
@@ -2493,7 +2494,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch() {
       return MaterialApp(
@@ -2575,7 +2576,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch() {
       return MaterialApp(
@@ -2657,7 +2658,7 @@ void main() {
       return inactiveEnabledTrackColor;
     }
 
-    final MaterialStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return MaterialApp(
@@ -2744,7 +2745,7 @@ void main() {
       return inactiveEnabledTrackColor;
     }
 
-    final MaterialStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Theme(
@@ -2830,7 +2831,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch() {
       return MaterialApp(
@@ -2902,7 +2903,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final MaterialStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch() {
       return Theme(
@@ -2968,7 +2969,7 @@ void main() {
       return Colors.black;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
@@ -3025,7 +3026,7 @@ void main() {
       return Colors.black;
     }
 
-    final MaterialStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
@@ -3107,13 +3108,13 @@ void main() {
             autofocus: focused,
             value: active,
             onChanged: (_) {},
-            thumbColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+            thumbColor: WidgetStateProperty.resolveWith<Color>((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return activeThumbColor;
               }
               return inactiveThumbColor;
             }),
-            overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
+            overlayColor: useOverlay ? WidgetStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
             focusColor: focusColor,
             splashRadius: splashRadius,
@@ -3652,7 +3653,7 @@ void main() {
         return inactiveEnabledTrackOutlineColor;
       }
 
-      final MaterialStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
+      final WidgetStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
         getTrackOutlineColor,
       );
 
@@ -3733,7 +3734,7 @@ void main() {
         return Colors.transparent;
       }
 
-      final MaterialStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
+      final WidgetStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
         getTrackOutlineColor,
       );
 
@@ -3804,7 +3805,7 @@ void main() {
         return inactiveEnabledTrackOutlineWidth;
       }
 
-      final MaterialStateProperty<double> trackOutlineWidth = MaterialStateProperty.resolveWith(
+      final WidgetStateProperty<double> trackOutlineWidth = WidgetStateProperty.resolveWith(
         getTrackOutlineWidth,
       );
 
@@ -3884,7 +3885,7 @@ void main() {
         return 8.0;
       }
 
-      final MaterialStateProperty<double> trackOutlineWidth = MaterialStateProperty.resolveWith(
+      final WidgetStateProperty<double> trackOutlineWidth = WidgetStateProperty.resolveWith(
         getTrackOutlineWidth,
       );
 
@@ -3939,8 +3940,8 @@ void main() {
         brightness: Brightness.light,
       );
 
-      MaterialStateProperty<Icon?> thumbIcon(Icon? activeIcon, Icon? inactiveIcon) {
-        return MaterialStateProperty.resolveWith<Icon?>((Set<MaterialState> states) {
+      WidgetStateProperty<Icon?> thumbIcon(Icon? activeIcon, Icon? inactiveIcon) {
+        return WidgetStateProperty.resolveWith<Icon?>((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return activeIcon;
           }

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -110,25 +110,25 @@ void main() {
     final ThemeData themeData = ThemeData(
       useMaterial3: false,
       switchTheme: SwitchThemeData(
-        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedThumbColor;
           }
           return defaultThumbColor;
         }),
-        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedTrackColor;
           }
           return defaultTrackColor;
         }),
-        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedTrackOutlineColor;
           }
           return defaultTrackOutlineColor;
         }),
-        trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineWidth: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedTrackOutlineWidth;
           }
@@ -136,7 +136,7 @@ void main() {
         }),
         mouseCursor: const MaterialStatePropertyAll<MouseCursor>(mouseCursor),
         materialTapTargetSize: materialTapTargetSize,
-        overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        overlayColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.focused)) {
             return focusOverlayColor;
           }
@@ -146,7 +146,7 @@ void main() {
           return null;
         }),
         splashRadius: splashRadius,
-        thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbIcon: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return icon1;
           }
@@ -238,25 +238,25 @@ void main() {
 
     final ThemeData themeData = ThemeData(
       switchTheme: SwitchThemeData(
-        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedThumbColor;
           }
           return defaultThumbColor;
         }),
-        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedTrackColor;
           }
           return defaultTrackColor;
         }),
-        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedTrackOutlineColor;
           }
           return defaultTrackOutlineColor;
         }),
-        trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineWidth: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return selectedTrackOutlineWidth;
           }
@@ -264,7 +264,7 @@ void main() {
         }),
         mouseCursor: const MaterialStatePropertyAll<MouseCursor>(mouseCursor),
         materialTapTargetSize: materialTapTargetSize,
-        overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        overlayColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.focused)) {
             return focusOverlayColor;
           }
@@ -274,7 +274,7 @@ void main() {
           return null;
         }),
         splashRadius: splashRadius,
-        thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbIcon: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return icon1;
           }
@@ -377,25 +377,25 @@ void main() {
     final ThemeData themeData = ThemeData(
       useMaterial3: false,
       switchTheme: SwitchThemeData(
-        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedThumbColor;
           }
           return themeDefaultThumbColor;
         }),
-        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedTrackColor;
           }
           return themeDefaultTrackColor;
         }),
-        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedOutlineColor;
           }
           return themeDefaultOutlineColor;
         }),
-        trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineWidth: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedOutlineWidth;
           }
@@ -403,7 +403,7 @@ void main() {
         }),
         mouseCursor: const MaterialStatePropertyAll<MouseCursor>(themeMouseCursor),
         materialTapTargetSize: themeMaterialTapTargetSize,
-        overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        overlayColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.focused)) {
             return themeFocusOverlayColor;
           }
@@ -413,7 +413,7 @@ void main() {
           return null;
         }),
         splashRadius: themeSplashRadius,
-        thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbIcon: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return null;
           }
@@ -430,25 +430,25 @@ void main() {
             value: selected,
             onChanged: (bool value) {},
             autofocus: autofocus,
-            thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedThumbColor;
               }
               return defaultThumbColor;
             }),
-            trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedTrackColor;
               }
               return defaultTrackColor;
             }),
-            trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackOutlineColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedOutlineColor;
               }
               return defaultOutlineColor;
             }),
-            trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackOutlineWidth: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedOutlineWidth;
               }
@@ -459,7 +459,7 @@ void main() {
             focusColor: focusColor,
             hoverColor: hoverColor,
             splashRadius: splashRadius,
-            thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            thumbIcon: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return const Icon(Icons.add);
               }
@@ -551,25 +551,25 @@ void main() {
 
     final ThemeData themeData = ThemeData(
       switchTheme: SwitchThemeData(
-        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedThumbColor;
           }
           return themeDefaultThumbColor;
         }),
-        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedTrackColor;
           }
           return themeDefaultTrackColor;
         }),
-        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedOutlineColor;
           }
           return themeDefaultOutlineColor;
         }),
-        trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackOutlineWidth: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedOutlineWidth;
           }
@@ -577,7 +577,7 @@ void main() {
         }),
         mouseCursor: const MaterialStatePropertyAll<MouseCursor>(themeMouseCursor),
         materialTapTargetSize: themeMaterialTapTargetSize,
-        overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        overlayColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.focused)) {
             return themeFocusOverlayColor;
           }
@@ -587,7 +587,7 @@ void main() {
           return null;
         }),
         splashRadius: themeSplashRadius,
-        thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbIcon: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return null;
           }
@@ -604,25 +604,25 @@ void main() {
             value: selected,
             onChanged: (bool value) {},
             autofocus: autofocus,
-            thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedThumbColor;
               }
               return defaultThumbColor;
             }),
-            trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedTrackColor;
               }
               return defaultTrackColor;
             }),
-            trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackOutlineColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedOutlineColor;
               }
               return defaultOutlineColor;
             }),
-            trackOutlineWidth: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            trackOutlineWidth: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedOutlineWidth;
               }
@@ -633,7 +633,7 @@ void main() {
             focusColor: focusColor,
             hoverColor: hoverColor,
             splashRadius: splashRadius,
-            thumbIcon: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+            thumbIcon: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return const Icon(Icons.add);
               }
@@ -703,13 +703,13 @@ void main() {
     final ThemeData themeData = ThemeData(
       useMaterial3: false,
       switchTheme: SwitchThemeData(
-        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedThumbColor;
           }
           return themeDefaultThumbColor;
         }),
-        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedTrackColor;
           }
@@ -781,13 +781,13 @@ void main() {
 
     final ThemeData themeData = ThemeData(
       switchTheme: SwitchThemeData(
-        thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        thumbColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedThumbColor;
           }
           return themeDefaultThumbColor;
         }),
-        trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+        trackColor: WidgetStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
             return themeSelectedTrackColor;
           }
@@ -856,7 +856,7 @@ void main() {
     final ThemeData themeData = ThemeData(
       useMaterial3: false,
       switchTheme: SwitchThemeData(
-        overlayColor: MaterialStateProperty.resolveWith(getOverlayColor),
+        overlayColor: WidgetStateProperty.resolveWith(getOverlayColor),
         splashRadius: splashRadius,
       ),
     );
@@ -914,7 +914,7 @@ void main() {
     const double splashRadius = 24.0;
     final ThemeData themeData = ThemeData(
       switchTheme: SwitchThemeData(
-        overlayColor: MaterialStateProperty.resolveWith(getOverlayColor),
+        overlayColor: WidgetStateProperty.resolveWith(getOverlayColor),
         splashRadius: splashRadius,
       ),
     );

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -4753,7 +4753,7 @@ void main() {
             length: 1,
             child: TabBar(
               tabs: const <Tab>[Tab(text: 'A')],
-              overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+              overlayColor: WidgetStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                 if (states.contains(MaterialState.hovered)) {
                   return const Color(0xff00ff00);
                 }
@@ -4793,7 +4793,7 @@ void main() {
               length: 1,
               child: TabBar(
                 tabs: const <Tab>[Tab(text: 'A')],
-                overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+                overlayColor: WidgetStateProperty.resolveWith<Color>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.hovered)) {
                     return const Color(0xff00ff00);
                   }
@@ -6272,7 +6272,7 @@ void main() {
 
   testWidgets('TabBar InkWell splashFactory and overlayColor', (WidgetTester tester) async {
     const InteractiveInkFeatureFactory splashFactory = NoSplash.splashFactory;
-    final MaterialStateProperty<Color?> overlayColor = MaterialStateProperty.resolveWith<Color?>(
+    final WidgetStateProperty<Color?> overlayColor = WidgetStateProperty.resolveWith<Color?>(
       (Set<MaterialState> states) => Colors.transparent,
     );
 
@@ -6328,7 +6328,7 @@ void main() {
         child: DefaultTabController(
           length: 1,
           child: TabBar(
-            overlayColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+            overlayColor: WidgetStateProperty.resolveWith<Color>((Set<MaterialState> states) {
               if (states.contains(MaterialState.hovered)) {
                 return hoverColor;
               }

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -398,7 +399,7 @@ void main() {
               child: TextButtonTheme(
                 data: TextButtonThemeData(
                   style: ButtonStyle(
-                    foregroundColor: MaterialStateProperty.resolveWith<Color>(getTextColor),
+                    foregroundColor: WidgetStateProperty.resolveWith<Color>(getTextColor),
                   ),
                 ),
                 child: Builder(
@@ -537,7 +538,7 @@ void main() {
           body: Center(
             child: TextButton(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color>(getTextColor),
+                foregroundColor: WidgetStateProperty.resolveWith<Color>(getTextColor),
               ),
               onPressed: () {},
               focusNode: focusNode,
@@ -605,8 +606,8 @@ void main() {
           body: Center(
             child: TextButton.icon(
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color>(getTextColor),
-                iconColor: MaterialStateProperty.resolveWith<Color>(getTextColor),
+                foregroundColor: WidgetStateProperty.resolveWith<Color>(getTextColor),
+                iconColor: WidgetStateProperty.resolveWith<Color>(getTextColor),
               ),
               key: buttonKey,
               icon: const Icon(Icons.add),
@@ -674,7 +675,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: TextButton(
           style: ButtonStyle(
-            overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
+            overlayColor: WidgetStateProperty.resolveWith<Color?>(getOverlayColor),
           ),
           child: Container(),
           onPressed: () {
@@ -708,7 +709,7 @@ void main() {
         textDirection: TextDirection.ltr,
         child: TextButton(
           style: ButtonStyle(
-            overlayColor: MaterialStateProperty.resolveWith<Color?>(getOverlayColor),
+            overlayColor: WidgetStateProperty.resolveWith<Color?>(getOverlayColor),
           ),
           focusNode: focusNode,
           onPressed: () {},

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -204,11 +204,11 @@ void main() {
       expect(material.shadowColor, shadowColor);
       expect(material.elevation, elevation);
       expect(
-        MaterialStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, enabled),
+        WidgetStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, enabled),
         enabledMouseCursor,
       );
       expect(
-        MaterialStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, disabled),
+        WidgetStateProperty.resolveAs<MouseCursor?>(inkWell.mouseCursor, disabled),
         disabledMouseCursor,
       );
       expect(inkWell.overlayColor!.resolve(hovered), foregroundColor.withOpacity(0.08));


### PR DESCRIPTION
Follow up of https://github.com/flutter/flutter/pull/174268

Final PR to migrate the usages of `MaterialStateProperty` to `WidgetStateProperty`

I'll work on the other elements of `packages/flutter/lib/src/material/material_state.dart` into other PRs

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
