### PR TITLE
Add PredictiveBackGestureBuilder

### DIFF
--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -139,6 +139,7 @@ export 'src/material/paginated_data_table.dart';
 export 'src/material/popup_menu.dart';
 export 'src/material/popup_menu_theme.dart';
 export 'src/material/predictive_back_page_transitions_builder.dart';
+export 'src/material/predictive_back_transition.dart';
 export 'src/material/progress_indicator.dart';
 export 'src/material/progress_indicator_theme.dart';
 export 'src/material/radio.dart';

--- a/packages/flutter/lib/src/material/predictive_back_transition.dart
+++ b/packages/flutter/lib/src/material/predictive_back_transition.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -94,7 +96,7 @@ class PredictiveBackTransition extends StatelessWidget {
         ? renderObject.size.width
         : MediaQuery.widthOf(context);
 
-    final double maxShift = (width / _kDivisionFactor) - _kMargin;
+    final double maxShift = max(0, (width / _kDivisionFactor) - _kMargin);
 
     final SwipeEdge? swipeEdge = currentBackEvent?.swipeEdge;
 
@@ -112,7 +114,7 @@ class PredictiveBackTransition extends StatelessWidget {
     final double startTouchY = startBackEvent?.touchOffset?.dy ?? 0;
     final double currentTouchY = currentBackEvent?.touchOffset?.dy ?? 0;
 
-    final double yShiftMax = (height / _kDivisionFactor) - _kMargin;
+    final double yShiftMax = max(0, (height / _kDivisionFactor) - _kMargin);
 
     // Apply the decelerated gesture progress to the Y-shift so the preview is
     // more apparent at the start (matches Android docs recommendation).

--- a/packages/flutter/lib/src/material/predictive_back_transition.dart
+++ b/packages/flutter/lib/src/material/predictive_back_transition.dart
@@ -89,8 +89,8 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
       useInterpolation ? kCurve.transform(progress.value) : progress.value;
 
   double _calcXShift(BuildContext context) {
-    final RenderBox? renderObject = context.findRenderObject() as RenderBox?;
-    final double width = renderObject?.size.width ?? MediaQuery.widthOf(context);
+    final RenderObject? renderObject = context.findRenderObject();
+    final double width = renderObject is RenderBox ? renderObject.size.width : MediaQuery.widthOf(context);
 
     final double maxShift = (width / _kDivisionFactor) - _kMargin;
 

--- a/packages/flutter/lib/src/material/predictive_back_transition.dart
+++ b/packages/flutter/lib/src/material/predictive_back_transition.dart
@@ -126,7 +126,7 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
 
   double _calcScale() => 1 - (1 - _kMinScale) * _gestureProgress;
 
-  Matrix4 _createTransformMatrix(BuildContext context, double animationValue) {
+  Matrix4 _createTransformMatrix(BuildContext context) {
     final double scale = _calcScale();
     final double xShift = useXShift ? _calcXShift(context) : 0;
     final double yShift = useYShift ? _calcYShift(context) : 0;
@@ -141,7 +141,7 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
     return MatrixTransition(
       animation: progress,
       alignment: alignment ?? Alignment.center,
-      onTransform: (double animationValue) => _createTransformMatrix(context, animationValue),
+      onTransform: (_) => _createTransformMatrix(context),
       child: child,
     );
   }

--- a/packages/flutter/lib/src/material/predictive_back_transition.dart
+++ b/packages/flutter/lib/src/material/predictive_back_transition.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// A widget that applies Android-style predictive-back transform to `child`.
+class PredictiveBackSharedElementTransition extends StatelessWidget {
+  /// Creates a predictive back shared element transition.
+  ///
+  /// The [progress] animation drives the transform (scale + translation).
+  /// Use [startBackEvent] and [currentBackEvent] to compute Y-shift from the
+  /// user's touch movement and the [SwipeEdge] from [currentBackEvent] to
+  /// determine the X direction. Defaults: [useXShift]=true, [useYShift]=true,
+  /// [useInterpolation]=true. If [alignment] is omitted, the transform uses
+  /// `Alignment.center`.
+  const PredictiveBackSharedElementTransition({
+    super.key,
+    required this.progress,
+    required this.startBackEvent,
+    required this.currentBackEvent,
+    this.alignment,
+    this.useXShift = true,
+    this.useYShift = true,
+    this.useInterpolation = true,
+    required this.child,
+  });
+
+  /// Animation that drives the transform applied to [child].
+  ///
+  /// The animation's current `value` (typically in the range `0.0`..`1.0`)
+  /// is used to compute scale and shifts. When [useInterpolation] is `true`
+  /// the implementation applies the Android back-gesture curve to the raw
+  /// `value` before computing the transform.
+  final Animation<double> progress;
+
+  /// The initial back gesture event when the gesture began.
+  ///
+  /// Used as a reference point for computing the Y-axis shift based on how far
+  /// the touch point has moved since the gesture started. May be `null` if
+  /// such data is not available.
+  final PredictiveBackEvent? startBackEvent;
+
+  /// The most recent back gesture event.
+  ///
+  /// Provides the current touch offset and swipe edge (left/right) which are
+  /// used to compute direction and magnitude of X/Y shifts. May be `null`.
+  final PredictiveBackEvent? currentBackEvent;
+
+  /// If non-null, the alignment for the transform applied to [child].
+  ///
+  /// Defaults to `Alignment.center` when omitted.
+  final Alignment? alignment;
+
+  /// Whether to apply horizontal (X) shifting to the [child].
+  ///
+  /// When `true` the widget computes a small horizontal translation in the
+  /// direction of the back gesture to match Android's predictive back motion.
+  final bool useXShift;
+
+  /// Whether to apply vertical (Y) shifting to the [child].
+  ///
+  /// When `true` the widget computes a small vertical translation based on the
+  /// difference between [currentBackEvent] and [startBackEvent].
+  final bool useYShift;
+
+  /// Whether to apply the Android back-gesture interpolator to [progress].
+  ///
+  /// When `true` the gesture progress is transformed with [kCurve] to better
+  /// match the decelerated feel of the native Android motion.
+  final bool useInterpolation;
+
+  /// The widget below this widget in the tree to which the transform is applied.
+  final Widget child;
+
+  // Constants as per the motion specs
+  // https://developer.android.com/design/ui/mobile/guides/patterns/predictive-back#motion-specs
+  static const double _kMinScale = 0.90;
+  static const double _kDivisionFactor = 20.0;
+  static const double _kMargin = 8.0;
+
+  /// Curve used to interpolate the raw gesture progress to match Android's
+  /// back-gesture deceleration/interpolation.
+  ///
+  /// This curve is applied when [useInterpolation] is `true` so the visual
+  /// motion more closely follows the native Android behaviour.
+  //  https://cs.android.com/android/platform/superproject/+/android-16.0.0_r2:frameworks/base/core/java/android/view/animation/BackGestureInterpolator.java
+  static const Curve kCurve = Cubic(0.1, 0.1, 0.0, 1.0);
+
+  double get _gestureProgress =>
+      useInterpolation ? kCurve.transform(progress.value) : progress.value;
+
+  double _calcXShift(BuildContext context) {
+    final RenderBox? renderObject = context.findRenderObject() as RenderBox?;
+    final double width = renderObject?.size.width ?? MediaQuery.widthOf(context);
+
+    final double maxShift = (width / _kDivisionFactor) - _kMargin;
+
+    final SwipeEdge? swipeEdge = currentBackEvent?.swipeEdge;
+
+    final double direction = (swipeEdge == SwipeEdge.right) ? -1.0 : 1.0;
+
+    return direction * maxShift * _gestureProgress;
+  }
+
+  double _calcYShift(BuildContext context) {
+    final RenderBox? renderObject = context.findRenderObject() as RenderBox?;
+    final double height = renderObject?.size.height ?? MediaQuery.heightOf(context);
+
+    final double startTouchY = startBackEvent?.touchOffset?.dy ?? 0;
+    final double currentTouchY = currentBackEvent?.touchOffset?.dy ?? 0;
+
+    final double yShiftMax = (height / _kDivisionFactor) - _kMargin;
+
+    // Apply the decelerated gesture progress to the Y-shift so the preview is
+    // more apparent at the start (matches Android docs recommendation).
+    final double progressAdjustedYShiftMax = yShiftMax * _gestureProgress;
+
+    final double rawYShift = currentTouchY - startTouchY;
+    final double easedYShift =
+        // This curve was eyeballed on a Pixel 9 running Android 16.
+        Curves.easeOut.transform(clampDouble(rawYShift.abs() / height, 0.0, 1.0)) *
+        rawYShift.sign *
+        progressAdjustedYShiftMax;
+
+    return clampDouble(easedYShift, -progressAdjustedYShiftMax, progressAdjustedYShiftMax);
+  }
+
+  double _calcScale() => 1 - (1 - _kMinScale) * _gestureProgress;
+
+  Matrix4 _createTransformMatrix(BuildContext context, double animationValue) {
+    final double scale = _calcScale();
+    final double xShift = useXShift ? _calcXShift(context) : 0;
+    final double yShift = useYShift ? _calcYShift(context) : 0;
+
+    return Matrix4.identity()
+      ..scale(scale, scale, 1.0)
+      ..translate(xShift, yShift);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MatrixTransition(
+      animation: progress,
+      alignment: alignment ?? Alignment.center,
+      onTransform: (double animationValue) => _createTransformMatrix(context, animationValue),
+      child: child,
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/predictive_back_transition.dart
+++ b/packages/flutter/lib/src/material/predictive_back_transition.dart
@@ -102,8 +102,8 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
   }
 
   double _calcYShift(BuildContext context) {
-    final RenderBox? renderObject = context.findRenderObject() as RenderBox?;
-    final double height = renderObject?.size.height ?? MediaQuery.heightOf(context);
+    final RenderObject? renderObject = context.findRenderObject();
+    final double height = renderObject is RenderBox ? renderObject.size.height : MediaQuery.heightOf(context);
 
     final double startTouchY = startBackEvent?.touchOffset?.dy ?? 0;
     final double currentTouchY = currentBackEvent?.touchOffset?.dy ?? 0;

--- a/packages/flutter/lib/src/material/predictive_back_transition.dart
+++ b/packages/flutter/lib/src/material/predictive_back_transition.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 /// A widget that applies Android-style predictive-back transform to `child`.
-class PredictiveBackSharedElementTransition extends StatelessWidget {
+class PredictiveBackTransition extends StatelessWidget {
   /// Creates a predictive back shared element transition.
   ///
   /// The [progress] animation drives the transform (scale + translation).
@@ -12,7 +12,7 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
   /// determine the X direction. Defaults: [useXShift]=true, [useYShift]=true,
   /// [useInterpolation]=true. If [alignment] is omitted, the transform uses
   /// `Alignment.center`.
-  const PredictiveBackSharedElementTransition({
+  const PredictiveBackTransition({
     super.key,
     required this.progress,
     required this.startBackEvent,
@@ -90,7 +90,9 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
 
   double _calcXShift(BuildContext context) {
     final RenderObject? renderObject = context.findRenderObject();
-    final double width = renderObject is RenderBox ? renderObject.size.width : MediaQuery.widthOf(context);
+    final double width = renderObject is RenderBox
+        ? renderObject.size.width
+        : MediaQuery.widthOf(context);
 
     final double maxShift = (width / _kDivisionFactor) - _kMargin;
 
@@ -103,7 +105,9 @@ class PredictiveBackSharedElementTransition extends StatelessWidget {
 
   double _calcYShift(BuildContext context) {
     final RenderObject? renderObject = context.findRenderObject();
-    final double height = renderObject is RenderBox ? renderObject.size.height : MediaQuery.heightOf(context);
+    final double height = renderObject is RenderBox
+        ? renderObject.size.height
+        : MediaQuery.heightOf(context);
 
     final double startTouchY = startBackEvent?.touchOffset?.dy ?? 0;
     final double currentTouchY = currentBackEvent?.touchOffset?.dy ?? 0;

--- a/packages/flutter/lib/src/widgets/predictive_back_builder.dart
+++ b/packages/flutter/lib/src/widgets/predictive_back_builder.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/services.dart';
+
+import 'binding.dart';
+import 'framework.dart';
+import 'routes.dart';
+
+/// Phases of a predictive-back gesture.
+///
+/// These phases describe the lifecycle of the platform back gesture as it
+/// relates to widgets that want to respond visually.
+enum PredictiveBackPhase {
+  /// No back gesture is in progress.
+  idle,
+
+  /// The back gesture has started
+  start,
+
+  /// The gesture is ongoing and progress updates are being delivered.
+  update,
+
+  /// The gesture was completed and should be committed (e.g. pop).
+  commit,
+
+  /// The gesture was cancelled and should be reverted visually.
+  cancel,
+}
+
+/// A widget that listens to the platform's predictive-back gesture and rebuilds
+/// using a provided transition builder.
+///
+/// `PredictiveBackGestureBuilder` is a thin helper that registers for predictive
+/// back events via the framework binding (it implements
+/// [WidgetsBindingObserver]) and calls `transitionBuilder` with the current
+/// gesture phase and event data so the subtree can render gesture-driven
+/// UI (for example, a preview/transform of the page's content).
+///
+/// The widget does not itself implement a visual transition — that work is
+/// performed by the `transitionBuilder` callback which receives the current
+/// `PredictiveBackPhase`, the initial `startBackEvent` and the most recent
+/// `currentBackEvent`, as well as the `child` to embed.
+class PredictiveBackGestureBuilder extends StatefulWidget {
+  /// Creates a predictive-back gesture builder.
+  ///
+  /// Parameters:
+  ///  * [route] — the [ModalRoute] associated with this builder.
+  ///  * [transitionBuilder] — builder function that renders the UI for each
+  ///    phase and receives `startBackEvent` and [currentBackEvent].
+  ///  * [child] — the subtree to be passed to [transitionBuilder].
+  ///  * [updateRouteUserGestureProgress] — when `true`, forwards gesture
+  ///    progress updates to [route].
+  const PredictiveBackGestureBuilder({
+    super.key,
+    required this.route,
+    required this.transitionBuilder,
+    required this.child,
+    this.updateRouteUserGestureProgress = false,
+  });
+
+  /// The `ModalRoute` that this builder is associated with.
+  ///
+  /// If [updateRouteUserGestureProgress] is `true`, gesture progress/cancel/commit
+  /// calls will be forwarded to this route.
+  final ModalRoute<Object?> route;
+
+  /// Builder called when the gesture phase or events change.
+  ///
+  /// Parameters passed to the builder:
+  ///  * [context] — the build context.
+  ///  * [phase]  — the current [PredictiveBackPhase] to indicate idle/start/update/commit/cancel.
+  ///  * [startBackEvent] — the [PredictiveBackEvent] when the gesture started (may be null in idle and cancel phases).
+  ///  * [currentBackEvent] — the most recent [PredictiveBackEvent] (may be null in idle and cancel phases).
+  ///  * [child] — the `child` widget passed to this widget.
+  final Widget Function(
+    BuildContext context,
+    PredictiveBackPhase phase,
+    PredictiveBackEvent? startBackEvent,
+    PredictiveBackEvent? currentBackEvent,
+    Widget child,
+  )
+  transitionBuilder;
+
+  /// The subtree that will be provided to [transitionBuilder].
+  final Widget child;
+
+  /// When true, forwards gesture progress updates to [route].
+  final bool updateRouteUserGestureProgress;
+
+  @override
+  State<PredictiveBackGestureBuilder> createState() => _PredictiveBackGestureBuilderState();
+}
+
+class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuilder>
+    with WidgetsBindingObserver {
+  PredictiveBackPhase get phase => _phase;
+  PredictiveBackPhase _phase = PredictiveBackPhase.idle;
+  set phase(PredictiveBackPhase phase) {
+    if (_phase != phase && mounted) {
+      setState(() => _phase = phase);
+    }
+  }
+
+  PredictiveBackEvent? get startBackEvent => _startBackEvent;
+  PredictiveBackEvent? _startBackEvent;
+  set startBackEvent(PredictiveBackEvent? startBackEvent) {
+    if (_startBackEvent != startBackEvent && mounted) {
+      setState(() => _startBackEvent = startBackEvent);
+    }
+  }
+
+  PredictiveBackEvent? get currentBackEvent => _currentBackEvent;
+  PredictiveBackEvent? _currentBackEvent;
+  set currentBackEvent(PredictiveBackEvent? currentBackEvent) {
+    if (_currentBackEvent != currentBackEvent && mounted) {
+      setState(() => _currentBackEvent = currentBackEvent);
+    }
+  }
+
+  // Begin WidgetsBindingObserver.
+
+  @override
+  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
+    if (backEvent.isButtonEvent) {
+      return false;
+    }
+
+    if (widget.updateRouteUserGestureProgress) {
+      widget.route.handleStartBackGesture(progress: 1 - backEvent.progress);
+    }
+
+    phase = PredictiveBackPhase.start;
+    startBackEvent = currentBackEvent = backEvent;
+
+    return true;
+  }
+
+  @override
+  void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
+    if (widget.updateRouteUserGestureProgress) {
+      widget.route.handleUpdateBackGestureProgress(progress: 1 - backEvent.progress);
+    }
+
+    phase = PredictiveBackPhase.update;
+    currentBackEvent = backEvent;
+  }
+
+  @override
+  void handleCancelBackGesture() {
+    if (widget.updateRouteUserGestureProgress) {
+      widget.route.handleCancelBackGesture();
+    }
+    phase = PredictiveBackPhase.cancel;
+    startBackEvent = currentBackEvent = null;
+  }
+
+  @override
+  void handleCommitBackGesture() {
+    if (widget.updateRouteUserGestureProgress) {
+      widget.route.handleCommitBackGesture();
+    }
+    phase = PredictiveBackPhase.commit;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final PredictiveBackPhase effectivePhase = widget.route.popGestureInProgress
+        ? phase
+        : PredictiveBackPhase.idle;
+
+    return widget.transitionBuilder(
+      context,
+      effectivePhase,
+      startBackEvent,
+      currentBackEvent,
+      widget.child,
+    );
+  }
+}

--- a/packages/flutter/lib/src/widgets/predictive_back_builder.dart
+++ b/packages/flutter/lib/src/widgets/predictive_back_builder.dart
@@ -54,6 +54,7 @@ class PredictiveBackGestureBuilder extends StatefulWidget {
     required this.transitionBuilder,
     required this.child,
     this.updateRouteUserGestureProgress = false,
+    this.behavior = PredictiveBackObserverBehavior.updateOnly,
   });
 
   /// The `ModalRoute` that this builder is associated with.
@@ -84,6 +85,12 @@ class PredictiveBackGestureBuilder extends StatefulWidget {
 
   /// When true, forwards gesture progress updates to [route].
   final bool updateRouteUserGestureProgress;
+
+  /// Defines the behavior for handling back gesture updates.
+  /// [PredictiveBackObserverBehavior.updateOnly] - the observer only receives updates, controlling nothing.
+  /// [PredictiveBackObserverBehavior.takeControl] - the observer receives updates andё controls navigation.
+  /// [PredictiveBackObserverBehavior.updateIfControlled] - the observer receives updates if there is already an observer that controls navigation.
+  final PredictiveBackObserverBehavior behavior;
 
   @override
   State<PredictiveBackGestureBuilder> createState() => _PredictiveBackGestureBuilderState();
@@ -118,19 +125,19 @@ class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuil
   // Begin WidgetsBindingObserver.
 
   @override
-  bool handleStartBackGesture(PredictiveBackEvent backEvent) {
+  PredictiveBackObserverBehavior? handleStartBackGesture(PredictiveBackEvent backEvent) {
     if (backEvent.isButtonEvent) {
-      return false;
-    }
-
-    if (widget.updateRouteUserGestureProgress) {
-      widget.route.handleStartBackGesture(progress: 1 - backEvent.progress);
+      return null;
     }
 
     phase = PredictiveBackPhase.start;
     startBackEvent = currentBackEvent = backEvent;
 
-    return true;
+    if (widget.updateRouteUserGestureProgress) {
+      widget.route.handleStartBackGesture(progress: 1 - backEvent.progress);
+    }
+
+    return widget.behavior;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/predictive_back_builder.dart
+++ b/packages/flutter/lib/src/widgets/predictive_back_builder.dart
@@ -4,6 +4,8 @@ import 'binding.dart';
 import 'framework.dart';
 import 'routes.dart';
 
+export 'package:flutter/services.dart' show PredictiveBackEvent;
+
 /// Phases of a predictive-back gesture.
 ///
 /// These phases describe the lifecycle of the platform back gesture as it
@@ -50,7 +52,7 @@ class PredictiveBackGestureBuilder extends StatefulWidget {
   ///    progress updates to [route].
   const PredictiveBackGestureBuilder({
     super.key,
-    required this.route,
+    this.route,
     required this.transitionBuilder,
     required this.child,
     this.updateRouteUserGestureProgress = false,
@@ -61,7 +63,7 @@ class PredictiveBackGestureBuilder extends StatefulWidget {
   ///
   /// If [updateRouteUserGestureProgress] is `true`, gesture progress/cancel/commit
   /// calls will be forwarded to this route.
-  final ModalRoute<Object?> route;
+  final ModalRoute<Object?>? route;
 
   /// Builder called when the gesture phase or events change.
   ///
@@ -98,6 +100,15 @@ class PredictiveBackGestureBuilder extends StatefulWidget {
 
 class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuilder>
     with WidgetsBindingObserver {
+  late ModalRoute<dynamic>? route;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    route = widget.route ?? ModalRoute.of(context);
+  }
+
   PredictiveBackPhase get phase => _phase;
   PredictiveBackPhase _phase = PredictiveBackPhase.idle;
   set phase(PredictiveBackPhase phase) {
@@ -134,7 +145,7 @@ class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuil
     startBackEvent = currentBackEvent = backEvent;
 
     if (widget.updateRouteUserGestureProgress) {
-      widget.route.handleStartBackGesture(progress: 1 - backEvent.progress);
+      route?.handleStartBackGesture(progress: 1 - backEvent.progress);
     }
 
     return widget.behavior;
@@ -143,7 +154,7 @@ class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuil
   @override
   void handleUpdateBackGestureProgress(PredictiveBackEvent backEvent) {
     if (widget.updateRouteUserGestureProgress) {
-      widget.route.handleUpdateBackGestureProgress(progress: 1 - backEvent.progress);
+      route?.handleUpdateBackGestureProgress(progress: 1 - backEvent.progress);
     }
 
     phase = PredictiveBackPhase.update;
@@ -153,7 +164,7 @@ class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuil
   @override
   void handleCancelBackGesture() {
     if (widget.updateRouteUserGestureProgress) {
-      widget.route.handleCancelBackGesture();
+      route?.handleCancelBackGesture();
     }
     phase = PredictiveBackPhase.cancel;
     startBackEvent = currentBackEvent = null;
@@ -162,7 +173,7 @@ class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuil
   @override
   void handleCommitBackGesture() {
     if (widget.updateRouteUserGestureProgress) {
-      widget.route.handleCommitBackGesture();
+      route?.handleCommitBackGesture();
     }
     phase = PredictiveBackPhase.commit;
   }
@@ -181,7 +192,7 @@ class _PredictiveBackGestureBuilderState extends State<PredictiveBackGestureBuil
 
   @override
   Widget build(BuildContext context) {
-    final PredictiveBackPhase effectivePhase = widget.route.popGestureInProgress
+    final PredictiveBackPhase effectivePhase = route?.popGestureInProgress ?? true
         ? phase
         : PredictiveBackPhase.idle;
 

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -104,6 +104,7 @@ export 'src/widgets/platform_menu_bar.dart';
 export 'src/widgets/platform_selectable_region_context_menu.dart';
 export 'src/widgets/platform_view.dart';
 export 'src/widgets/pop_scope.dart';
+export 'src/widgets/predictive_back_builder.dart';
 export 'src/widgets/preferred_size.dart';
 export 'src/widgets/primary_scroll_controller.dart';
 export 'src/widgets/radio_group.dart';


### PR DESCRIPTION
This PR introduces a public PredictiveBackGestureBuilder, providing developers with a simple way to implement predictive back animations for custom transitions.

The Material animation variant has been extracted into a separate widget.

Usage:
PredictiveBackPageTransitionsBuilder: https://github.com/flutter/flutter/pull/174337
Dialogs / BottomSheets: \<soon\>

**Critical Issue:**
During the implementation of PredictiveBackPageTransitionsBuilder, it was discovered that the current approach using multiple _predictiveBackObservers in WidgetsBindingObserver only works if we use the same types of transitions and do not consider dialogs or bottom sheets.

If the top page doesn't have an observer, but the one below it does, the back gesture stops working because the default handler is disabled.
I don't have any ideas on how to solve this yet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

