### PR TITLE
Add unit tests for BaseFlutterTaskHelper and FlutterTaskHelper

### DIFF
--- a/packages/flutter_tools/gradle/bin/main/AppLinkSettings.kt
+++ b/packages/flutter_tools/gradle/bin/main/AppLinkSettings.kt
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+/*
+ * See https://developer.android.com/training/app-links/ for more information about app link.
+ */
+data class AppLinkSettings(
+    val applicationId: String?
+) {
+    var deeplinkingFlagEnabled = false
+    val deeplinks = mutableSetOf<Deeplink>()
+
+    // An example json:
+    // {
+    //   applicationId: "com.example.app",
+    //   deeplinks: [
+    //     {"scheme":"http", "host":"example.com", "path":".*"},
+    //     {"scheme":"https","host":"example.com","path":".*"}
+    //   ]
+    // }
+    fun toJson(): JsonObject =
+        buildJsonObject {
+            put("applicationId", applicationId)
+            put("deeplinkingFlagEnabled", deeplinkingFlagEnabled)
+            putJsonArray("deeplinks") {
+                for (deeplink: Deeplink in deeplinks) {
+                    add(deeplink.toJson())
+                }
+            }
+        }
+}

--- a/packages/flutter_tools/gradle/bin/main/BaseApplicationNameHandler.kt
+++ b/packages/flutter_tools/gradle/bin/main/BaseApplicationNameHandler.kt
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Project
+
+// TODO(gmackall): maybe migrate this to a package-level function when FGP conversion is done.
+object BaseApplicationNameHandler {
+    internal const val DEFAULT_BASE_APPLICATION_NAME: String = "android.app.Application"
+
+    internal const val GRADLE_BASE_APPLICATION_NAME_PROPERTY: String = "base-application-name"
+
+    @JvmStatic fun setBaseName(project: Project) {
+        // Only set the base application name for apps, skip otherwise (LibraryExtension, DynamicFeatureExtension).
+        val androidComponentsExtension: ApplicationExtension =
+            project.extensions.findByType(ApplicationExtension::class.java) ?: return
+
+        // Setting to android.app.Application is the same as omitting the attribute.
+        var baseApplicationName: String = DEFAULT_BASE_APPLICATION_NAME
+
+        // Respect this property if it set by the Flutter tool.
+        if (project.hasProperty(GRADLE_BASE_APPLICATION_NAME_PROPERTY)) {
+            baseApplicationName = project.property(GRADLE_BASE_APPLICATION_NAME_PROPERTY).toString()
+        }
+
+        androidComponentsExtension.defaultConfig.manifestPlaceholders["applicationName"] =
+            baseApplicationName
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/Deeplink.kt
+++ b/packages/flutter_tools/gradle/bin/main/Deeplink.kt
@@ -1,0 +1,42 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+// TODO(gmackall): Identify which of these can be val instead of var.
+class Deeplink(
+    private var scheme: String?,
+    private var host: String?,
+    var path: String?,
+    private var intentFilterCheck: IntentFilterCheck
+) {
+    // TODO(gmackall): This behavior was kept identical to the original Groovy behavior as part of
+    // the Groovy->Kotlin conversion, but should be changed once the conversion is complete.
+    override fun equals(other: Any?): Boolean {
+        if (other == null) {
+            throw NullPointerException()
+        }
+        if (other.javaClass != javaClass) {
+            return false
+        }
+        val otherAsDeeplink = other as Deeplink
+        return scheme == otherAsDeeplink.scheme &&
+            host == otherAsDeeplink.host &&
+            path == otherAsDeeplink.path
+    }
+
+    override fun hashCode(): Int = scheme.hashCode() + host.hashCode() + path.hashCode()
+
+    fun toJson(): JsonObject =
+        buildJsonObject {
+            put("scheme", scheme)
+            put("host", host)
+            put("path", path)
+            put("intentFilterCheck", intentFilterCheck.toJson())
+        }
+}

--- a/packages/flutter_tools/gradle/bin/main/DependencyVersionChecker.kt
+++ b/packages/flutter_tools/gradle/bin/main/DependencyVersionChecker.kt
@@ -1,0 +1,450 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import androidx.annotation.VisibleForTesting
+import com.android.build.api.AndroidPluginVersion
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.kotlin.dsl.extra
+import org.jetbrains.kotlin.gradle.plugin.KotlinAndroidPluginWrapper
+
+object DependencyVersionChecker {
+    // Logging constants.
+    @VisibleForTesting internal const val GRADLE_NAME: String = "Gradle"
+
+    @VisibleForTesting internal const val JAVA_NAME: String = "Java"
+
+    @VisibleForTesting internal const val AGP_NAME: String = "Android Gradle Plugin"
+
+    @VisibleForTesting internal const val KGP_NAME: String = "Kotlin"
+
+    @VisibleForTesting internal const val MIN_SDK_NAME: String = "minimum Android SDK"
+
+    // String constant that defines the name of the Gradle extra property that we set when
+    // detecting that the project is using versions outside of Flutter's support range.
+    // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-project/index.html#-2107180640%2FProperties%2F-1867656071.
+    @VisibleForTesting internal const val OUT_OF_SUPPORT_RANGE_PROPERTY = "usesUnsupportedDependencyVersions"
+
+    // The task prefix for assemble builds.
+    @VisibleForTesting
+    internal const val ASSEMBLE_PREFIX = "assemble"
+
+    // The task postfix to use when checking the minimum SDK version for each flavor.
+    internal const val MIN_SDK_CHECK_TASK_POSTFIX = "MinSdkCheck"
+
+    // The following messages represent best effort guesses at where a Flutter developer should
+    // look to upgrade a dependency that is below the corresponding threshold. Developers can
+    // change some of these locations, so they are not guaranteed to be accurate.
+    @VisibleForTesting internal fun getPotentialGradleFix(projectDirectory: String): String =
+        "Your project's gradle version is typically " +
+            "defined in the gradle wrapper file. By default, this can be found at " +
+            "$projectDirectory/gradle/wrapper/gradle-wrapper.properties. \n" +
+            "For more information, see https://docs.gradle.org/current/userguide/gradle_wrapper.html.\n"
+
+    // The potential java fix does not make use of the project directory,
+    // so it left as a constant.
+    @VisibleForTesting internal const val POTENTIAL_JAVA_FIX: String =
+        "The Java version used by Flutter can be " +
+            "set with `flutter config --jdk-dir=<path>`. \nFor more information about how Flutter " +
+            "chooses which version of Java to use, see the --jdk-dir section of the " +
+            "output of `flutter config -h`.\n"
+
+    @VisibleForTesting internal fun getPotentialAGPFix(projectDirectory: String): String =
+        "Your project's AGP version is typically " +
+            "defined in the plugins block of the `settings.gradle` file " +
+            "($projectDirectory/settings.gradle), by a plugin with the id of " +
+            "com.android.application. \nIf you don't see a plugins block, your project " +
+            "was likely created with an older template version. In this case it is most " +
+            "likely defined in the top-level build.gradle file " +
+            "($projectDirectory/build.gradle) by the following line in the dependencies" +
+            " block of the buildscript: \"classpath 'com.android.tools.build:gradle:<version>'\".\n"
+
+    @VisibleForTesting internal fun getPotentialKGPFix(projectDirectory: String): String =
+        "Your project's KGP version is typically " +
+            "defined in the plugins block of the `settings.gradle` file " +
+            "($projectDirectory/settings.gradle), by a plugin with the id of " +
+            "org.jetbrains.kotlin.android. \nIf you don't see a plugins block, your project " +
+            "was likely created with an older template version, in which case it is most " +
+            "likely defined in the top-level build.gradle file " +
+            "($projectDirectory/build.gradle) by the ext.kotlin_version property.\n"
+
+    @VisibleForTesting internal fun getPotentialSDKFix(projectDirectory: String): String =
+        "Your project's minimum Android SDK version is typically " +
+            "defined in the android block of the app-level `build.gradle(.kts)` file " +
+            "($projectDirectory/app/build.gradle(.kts))."
+
+    // The following versions define our support policy for Gradle, Java, AGP, and KGP.
+    // Before updating any "error" version, ensure that you have updated the corresponding
+    // "warn" version for a full release to provide advanced warning. See
+    // flutter.dev/go/android-dependency-versions for more.
+    @VisibleForTesting internal val warnGradleVersion: Version = Version(7, 4, 2)
+
+    @VisibleForTesting internal val errorGradleVersion: Version = Version(7, 0, 2)
+
+    @VisibleForTesting internal val warnJavaVersion: JavaVersion = JavaVersion.VERSION_11
+
+    @VisibleForTesting internal val errorJavaVersion: JavaVersion = JavaVersion.VERSION_1_1
+
+    @VisibleForTesting internal val warnAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 3, 0)
+
+    @VisibleForTesting internal val errorAGPVersion: AndroidPluginVersion = AndroidPluginVersion(7, 0, 0)
+
+    @VisibleForTesting internal val warnKGPVersion: Version = Version(1, 8, 10)
+
+    @VisibleForTesting internal val errorKGPVersion: Version = Version(1, 7, 0)
+
+    // If this value is changed, then make sure to change the documentation on https://docs.flutter.dev/reference/supported-platforms
+    @VisibleForTesting
+    internal val warnMinSdkVersion: Int = 21
+
+    @VisibleForTesting
+    internal val errorMinSdkVersion: Int = 1
+
+    /**
+     * Checks if the project's Android build time dependencies are each within the respective
+     * version range that we support. When we can't find a version for a given dependency
+     * we treat it as within the range for the purpose of this check.
+     */
+    @JvmStatic fun checkDependencyVersions(project: Project) {
+        project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false)
+
+        checkGradleVersion(getGradleVersion(project), project)
+        checkJavaVersion(getJavaVersion(), project)
+
+        configureMinSdkCheck(project)
+
+        val agpVersion: AndroidPluginVersion? = getAGPVersion(project)
+        if (agpVersion != null) {
+            checkAGPVersion(agpVersion, project)
+        } else {
+            project.logger.error(
+                "Warning: unable to detect project AGP version. Skipping " +
+                    "version checking. \nThis may be because you have applied AGP after the Flutter Gradle Plugin."
+            )
+        }
+
+        val kgpVersion: Version? = getKGPVersion(project)
+        if (kgpVersion != null) {
+            checkKGPVersion(kgpVersion, project)
+        }
+        // KGP is not required, so don't log any warning if we can't find the version.
+    }
+
+    private fun configureMinSdkCheck(project: Project) {
+        val androidComponents =
+            project.extensions.findByType(AndroidComponentsExtension::class.java)
+
+        androidComponents?.onVariants(
+            androidComponents.selector().all()
+        ) {
+            val taskName = generateMinSdkCheckTaskName(it)
+            val minSdkCheckTask =
+                project.tasks.register(taskName) {
+                    doLast {
+                        val minSdkVersion = getMinSdkVersion(project, it)
+                        try {
+                            checkMinSdkVersion(minSdkVersion, project.rootDir.path, project.logger)
+                        } catch (e: DependencyValidationException) {
+                            project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
+                            throw e
+                        }
+                    }
+                }
+
+            project.afterEvaluate {
+                // Make assemble task depend on minSdkCheckTask for this variant.
+                project.tasks
+                    .named(generateAssembleTaskName(it))
+                    .configure {
+                        dependsOn(minSdkCheckTask)
+                    }
+            }
+        }
+    }
+
+    private fun generateAssembleTaskName(it: Variant) = "$ASSEMBLE_PREFIX${FlutterPluginUtils.capitalize(it.name)}"
+
+    private fun generateMinSdkCheckTaskName(it: Variant) = "${FlutterPluginUtils.capitalize(it.name)}$MIN_SDK_CHECK_TASK_POSTFIX"
+
+    private fun getMinSdkVersion(
+        project: Project,
+        it: Variant
+    ): MinSdkVersion {
+        val agpVersion: AndroidPluginVersion? = getAGPVersion(project)
+        return if (agpVersion != null && agpVersion.major >= 8 && agpVersion.minor >= 1) {
+            MinSdkVersion(it.name, it.minSdk.apiLevel)
+        } else {
+            MinSdkVersion(it.name, it.minSdkVersion.apiLevel)
+        }
+    }
+
+    // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.invocation/-gradle/index.html#-837060600%2FFunctions%2F-1793262594
+    @VisibleForTesting internal fun getGradleVersion(project: Project): Version {
+        val untrimmedGradleVersion: String = project.gradle.gradleVersion
+        // Trim to handle candidate gradle versions (example 7.6-rc-4). This means we treat all
+        // candidate versions of gradle as the same as their base version
+        // (i.e., "7.6"="7.6-rc-4").
+        return Version.fromString(untrimmedGradleVersion.substringBefore('-'))
+    }
+
+    // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api/-java-version/index.html#-1790786897%2FFunctions%2F-1793262594
+    @VisibleForTesting internal fun getJavaVersion(): JavaVersion = JavaVersion.current()
+
+    @VisibleForTesting internal fun getAGPVersion(project: Project): AndroidPluginVersion? {
+        val androidPluginVersion: AndroidPluginVersion? =
+            project.extensions
+                .findByType(
+                    AndroidComponentsExtension::class.java
+                )?.pluginVersion
+        return androidPluginVersion
+    }
+
+    // TODO(gmackall): AGP has a getKotlinAndroidPluginVersion(), and KGP has a
+    //                 getKotlinPluginVersion(). Consider replacing this implementation with one of
+    //                 those.
+    @VisibleForTesting internal fun getKGPVersion(project: Project): Version? {
+        val kotlinVersionProperty = "kotlin_version"
+        val firstKotlinVersionFieldName = "pluginVersion"
+        val secondKotlinVersionFieldName = "kotlinPluginVersion"
+        // This property corresponds to application of the Kotlin Gradle plugin in the
+        // top-level build.gradle file.
+        if (project.hasProperty(kotlinVersionProperty)) {
+            return Version.fromString(project.properties[kotlinVersionProperty] as String)
+        }
+        val kotlinPlugin =
+            project.plugins
+                .findPlugin(KotlinAndroidPluginWrapper::class.java)
+        val versionField =
+            kotlinPlugin?.javaClass?.kotlin?.members?.first {
+                it.name == firstKotlinVersionFieldName || it.name == secondKotlinVersionFieldName
+            }
+        val versionString = versionField?.call(kotlinPlugin)
+        return if (versionString == null) {
+            null
+        } else {
+            Version.fromString(versionString as String)
+        }
+    }
+
+    @VisibleForTesting internal fun getErrorMessage(
+        dependencyName: String,
+        versionString: String,
+        errorVersion: String,
+        potentialFix: String
+    ): String =
+        "Error: Your project's $dependencyName version ($versionString) is lower " +
+            "than Flutter's minimum supported version of $errorVersion. Please upgrade " +
+            "your $dependencyName version. \nAlternatively, use the flag " +
+            "\"--android-skip-build-dependency-validation\" to bypass this check.\n\n" +
+            "Potential fix: $potentialFix"
+
+    @VisibleForTesting internal fun getWarnMessage(
+        dependencyName: String,
+        versionString: String,
+        warnVersion: String,
+        potentialFix: String
+    ): String =
+        "Warning: Flutter support for your project's $dependencyName version " +
+            "($versionString) will soon be dropped. Please upgrade your $dependencyName " +
+            "version to a version of at least $warnVersion soon." +
+            "\nAlternatively, use the flag \"--android-skip-build-dependency-validation\"" +
+            " to bypass this check.\n\nPotential fix: $potentialFix"
+
+    @VisibleForTesting
+    internal fun getFlavorSpecificMessage(
+        flavorName: String?,
+        dependencyName: String
+    ): String = dependencyName + (if (flavorName != null) " (flavor='$flavorName')" else "")
+
+    @VisibleForTesting internal fun checkGradleVersion(
+        version: Version,
+        project: Project
+    ) {
+        if (version < errorGradleVersion) {
+            val errorMessage: String =
+                getErrorMessage(
+                    GRADLE_NAME,
+                    version.toString(),
+                    errorGradleVersion.toString(),
+                    getPotentialGradleFix(project.rootDir.path)
+                )
+            project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
+            throw DependencyValidationException(errorMessage)
+        } else if (version < warnGradleVersion) {
+            val warnMessage: String =
+                getWarnMessage(
+                    GRADLE_NAME,
+                    version.toString(),
+                    warnGradleVersion.toString(),
+                    getPotentialGradleFix(project.rootDir.path)
+                )
+            project.logger.error(warnMessage)
+        }
+    }
+
+    @VisibleForTesting internal fun checkJavaVersion(
+        version: JavaVersion,
+        project: Project
+    ) {
+        if (version < errorJavaVersion) {
+            val errorMessage: String =
+                getErrorMessage(
+                    JAVA_NAME,
+                    version.toString(),
+                    errorJavaVersion.toString(),
+                    POTENTIAL_JAVA_FIX
+                )
+            project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
+            throw DependencyValidationException(errorMessage)
+        } else if (version < warnJavaVersion) {
+            val warnMessage: String =
+                getWarnMessage(
+                    JAVA_NAME,
+                    version.toString(),
+                    warnJavaVersion.toString(),
+                    POTENTIAL_JAVA_FIX
+                )
+            project.logger.error(warnMessage)
+        }
+    }
+
+    @VisibleForTesting internal fun checkAGPVersion(
+        androidPluginVersion: AndroidPluginVersion,
+        project: Project
+    ) {
+        if (androidPluginVersion < errorAGPVersion) {
+            val errorMessage: String =
+                getErrorMessage(
+                    AGP_NAME,
+                    androidPluginVersion.toString(),
+                    errorAGPVersion.toString(),
+                    getPotentialAGPFix(project.rootDir.path)
+                )
+            project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
+            throw DependencyValidationException(errorMessage)
+        } else if (androidPluginVersion < warnAGPVersion) {
+            val warnMessage: String =
+                getWarnMessage(
+                    AGP_NAME,
+                    androidPluginVersion.toString(),
+                    warnAGPVersion.toString(),
+                    getPotentialAGPFix(project.rootDir.path)
+                )
+            project.logger.error(warnMessage)
+        }
+    }
+
+    @VisibleForTesting internal fun checkKGPVersion(
+        version: Version,
+        project: Project
+    ) {
+        if (version < errorKGPVersion) {
+            val errorMessage: String =
+                getErrorMessage(
+                    KGP_NAME,
+                    version.toString(),
+                    errorKGPVersion.toString(),
+                    getPotentialKGPFix(project.rootDir.path)
+                )
+            project.extra.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true)
+            throw DependencyValidationException(errorMessage)
+        } else if (version < warnKGPVersion) {
+            val warnMessage: String =
+                getWarnMessage(
+                    KGP_NAME,
+                    version.toString(),
+                    warnKGPVersion.toString(),
+                    getPotentialKGPFix(project.rootDir.path)
+                )
+            project.logger.error(warnMessage)
+        }
+    }
+
+    @VisibleForTesting internal fun checkMinSdkVersion(
+        minSdkVersion: MinSdkVersion,
+        projectDirectory: String,
+        logger: Logger
+    ) {
+        // For Android SDK, only the major version is relevant, no need to do a full version check.
+        if (minSdkVersion.version < errorMinSdkVersion) {
+            val errorMessage: String =
+                getErrorMessage(
+                    getFlavorSpecificMessage(minSdkVersion.flavor, MIN_SDK_NAME),
+                    minSdkVersion.version.toString(),
+                    errorMinSdkVersion.toString(),
+                    getPotentialSDKFix(projectDirectory)
+                )
+            throw DependencyValidationException(errorMessage)
+        } else if (minSdkVersion.version < warnMinSdkVersion) {
+            val warnMessage: String =
+                getWarnMessage(
+                    getFlavorSpecificMessage(minSdkVersion.flavor, MIN_SDK_NAME),
+                    minSdkVersion.version.toString(),
+                    warnMinSdkVersion.toString(),
+                    getPotentialSDKFix(projectDirectory)
+                )
+            logger.error(warnMessage)
+        }
+    }
+}
+
+// Helper class to parse the versions that are provided as plain strings (Gradle, Kotlin) and
+// perform easy comparisons. All versions will have a major, minor, and patch value. These values
+// default to 0 when they are not provided or are otherwise unparseable.
+// For example the version strings "8.2", "8.2.2hfd", and "8.2.0" would parse to the same version.
+internal class Version(
+    val major: Int,
+    val minor: Int,
+    val patch: Int
+) : Comparable<Version> {
+    companion object {
+        fun fromString(version: String): Version {
+            val asList: List<String> = version.split(".")
+            val convertedToNumbers: List<Int> = asList.map { it.toIntOrNull() ?: 0 }
+            return Version(
+                major = convertedToNumbers.getOrElse(0) { 0 },
+                minor = convertedToNumbers.getOrElse(1) { 0 },
+                patch = convertedToNumbers.getOrElse(2) { 0 }
+            )
+        }
+    }
+
+    override fun compareTo(other: Version): Int {
+        if (major != other.major) {
+            return major - other.major
+        }
+        if (minor != other.minor) {
+            return minor - other.minor
+        }
+        if (patch != other.patch) {
+            return patch - other.patch
+        }
+        return 0
+    }
+
+    override fun toString(): String = "$major.$minor.$patch"
+}
+
+// Custom error for when the dependency_version_checker.kts script finds a dependency out of
+// the defined support range.
+@VisibleForTesting internal class DependencyValidationException(
+    message: String? = null,
+    cause: Throwable? = null
+) : Exception(message, cause)
+
+/**
+ * Represents the minimum Android SDK version for a specific product flavor.
+ *
+ * @param flavor The product flavor name, or null for the default configuration.
+ * @param version The minimum Android SDK version (API level).
+ */
+@VisibleForTesting internal class MinSdkVersion(
+    val flavor: String,
+    val version: Int
+)

--- a/packages/flutter_tools/gradle/bin/main/FlutterAppPluginLoaderPlugin.kt
+++ b/packages/flutter_tools/gradle/bin/main/FlutterAppPluginLoaderPlugin.kt
@@ -1,0 +1,67 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import java.io.File
+import java.nio.file.Paths
+import java.util.Properties
+
+private const val FLUTTER_SDK_PATH = "flutterSdkPath"
+
+// Integration tests that cover this class include
+// - packages/flutter_tools/test/integration.shard/android_gradle_daemon_cache_test.dart
+// - packages/flutter_tools/test/integration.shard/android_plugin_compilesdkversion_mismatch_test.dart
+// And can be run by following the README in  packages/flutter_tools/.
+
+/**
+ * This plugin applies the native plugin loader plugin (../scripts/native_plugin_loader.gradle.kts)
+ * and then configures the main project to `include` each of the loaded flutter plugins.
+ */
+@Suppress("unused") // This class is used by packages/flutter_tools/gradle/build.gradle.kts.
+class FlutterAppPluginLoaderPlugin : Plugin<Settings> {
+    override fun apply(settings: Settings) {
+        val flutterProjectRoot: File = settings.settingsDir.parentFile
+
+        if (!settings.extraProperties.has(FLUTTER_SDK_PATH)) {
+            val properties = Properties()
+            val localPropertiesFile = File(settings.rootProject.projectDir, "local.properties")
+            localPropertiesFile.inputStream().use { properties.load(it) }
+            settings.extraProperties.set(FLUTTER_SDK_PATH, properties.getProperty("flutter.sdk"))
+            assert(
+                settings.extraProperties.get(FLUTTER_SDK_PATH) != null
+            ) { "flutter.sdk not set in local.properties" }
+        }
+
+        settings.apply {
+            from(
+                Paths.get(
+                    settings.extraProperties.get(FLUTTER_SDK_PATH) as String,
+                    "packages",
+                    "flutter_tools",
+                    "gradle",
+                    "src",
+                    "main",
+                    "scripts",
+                    "native_plugin_loader.gradle.kts"
+                )
+            )
+        }
+
+        NativePluginLoaderReflectionBridge
+            .getPlugins(settings.extraProperties, flutterProjectRoot)
+            .forEach { androidPlugin ->
+                val pluginDirectory = File(androidPlugin["path"] as String, "android")
+                check(
+                    pluginDirectory.exists()
+                ) { "Plugin directory does not exist: ${pluginDirectory.absolutePath}" }
+                val pluginName = androidPlugin["name"] as String
+                settings.include(":$pluginName")
+                settings.project(":$pluginName").projectDir = pluginDirectory
+            }
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/FlutterExtension.kt
+++ b/packages/flutter_tools/gradle/bin/main/FlutterExtension.kt
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import org.gradle.api.GradleException
+
+/**
+ * For apps only. Provides the flutter extension used in the app-level Gradle
+ * build file (app/build.gradle or app/build.gradle.kts).
+ *
+ * The versions specified here should match the values in
+ * packages/flutter_tools/lib/src/android/gradle_utils.dart, so when bumping,
+ * make sure to update the versions specified there.
+ *
+ * Learn more about extensions in Gradle:
+ *  * https://docs.gradle.org/8.0.2/userguide/custom_plugins.html#sec:getting_input_from_the_build
+ */
+@Suppress("unused") // The values in this class are used in Flutter developers app-level build.gradle file.
+open class FlutterExtension {
+    /** Sets the compileSdkVersion used by default in Flutter app projects. */
+    val compileSdkVersion: Int = 35
+
+    /** Sets the minSdkVersion used by default in Flutter app projects. */
+    val minSdkVersion: Int = 21
+
+    /**
+     * Sets the targetSdkVersion used by default in Flutter app projects.
+     * targetSdkVersion should always be the latest available stable version.
+     *
+     * See https://developer.android.com/guide/topics/manifest/uses-sdk-element.
+     */
+    val targetSdkVersion: Int = 35
+
+    /**
+     * Sets the ndkVersion used by default in Flutter app projects.
+     * Chosen as default version of the AGP version below as found in
+     * https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp.
+     */
+    val ndkVersion: String = "26.3.11579264"
+
+    /**
+     * Specifies the relative directory to the Flutter project directory.
+     * In an app project, this is ../.. since the app's Gradle build file is under android/app.
+     */
+    var source: String? = "../.."
+
+    /** Allows to override the target file. Otherwise, the target is lib/main.dart. */
+    var target: String? = null
+
+    /** The versionCode that was read from app's local.properties. */
+    var flutterVersionCode: String? = null
+
+    /** The versionName that was read from app's local.properties. */
+    var flutterVersionName: String? = null
+
+    /** Returns flutterVersionCode as an integer with error handling. */
+    fun getVersionCode(): Int {
+        val versionCode =
+            flutterVersionCode
+                ?: throw GradleException("flutterVersionCode must not be null.")
+
+        return versionCode.toIntOrNull()
+            ?: throw GradleException("flutterVersionCode must be an integer.")
+    }
+
+    /** Returns flutterVersionName with error handling. */
+    fun getVersionName(): String =
+        flutterVersionName
+            ?: throw GradleException("flutterVersionName must not be null.")
+
+    // The default getter name that Kotlin creates conflicts with the above methods.
+    @get:JvmName("getVersionCodeProperty")
+    val versionCode: Int
+        get() = getVersionCode()
+
+    // The default getter name that Kotlin creates conflicts with the above methods.
+    @get:JvmName("getVersionNameProperty")
+    val versionName: String
+        get() = getVersionName()
+}

--- a/packages/flutter_tools/gradle/bin/main/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/bin/main/FlutterPlugin.kt
@@ -1,0 +1,774 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.gradle.AbstractAppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.tasks.PackageAndroidArtifact
+import com.android.build.gradle.tasks.ProcessAndroidResources
+import com.flutter.gradle.FlutterPluginUtils.readPropertiesIfExist
+import com.flutter.gradle.plugins.PluginHandler
+import com.flutter.gradle.tasks.FlutterTask
+import org.gradle.api.GradleException
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.file.Directory
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.process.ExecOperations
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Paths
+import java.util.Properties
+
+class FlutterPlugin : Plugin<Project> {
+    private var project: Project? = null
+    private var flutterRoot: File? = null
+    private var flutterExecutable: File? = null
+    private var localEngine: String? = null
+    private var localEngineHost: String? = null
+    private var localEngineSrcPath: String? = null
+    private var localProperties: Properties? = null
+    private var engineVersion: String? = null
+    private var engineRealm: String? = null
+    private var pluginHandler: PluginHandler? = null
+
+    override fun apply(project: Project) {
+        this.project = project
+
+        val rootProject = project.rootProject
+        if (FlutterPluginUtils.isFlutterAppProject(project)) {
+            addTaskForLockfileGeneration(rootProject)
+        }
+
+        val flutterRootSystemVal: String? = System.getenv("FLUTTER_ROOT")
+        val flutterRootPath: String =
+            resolveFlutterSdkProperty(flutterRootSystemVal)
+                ?: throw GradleException(
+                    "Flutter SDK not found. Define location with flutter.sdk in the " +
+                        "local.properties file or with a FLUTTER_ROOT environment variable."
+                )
+
+        flutterRoot = project.file(flutterRootPath)
+        if (!flutterRoot!!.isDirectory) {
+            throw GradleException("flutter.sdk must point to the Flutter SDK directory")
+        }
+
+        engineVersion =
+            if (FlutterPluginUtils.shouldProjectUseLocalEngine(project)) {
+                "+" // Match any version since there's only one.
+            } else {
+                val engineStampPath =
+                    Paths.get(flutterRoot!!.absolutePath, "bin", "cache", "engine.stamp")
+                val engineStampContent = engineStampPath.toFile().readText().trim()
+                "1.0.0-$engineStampContent"
+            }
+
+        engineRealm =
+            Paths
+                .get(flutterRoot!!.absolutePath, "bin", "cache", "engine.realm")
+                .toFile()
+                .readText()
+                .trim()
+        if (engineRealm!!.isNotEmpty()) {
+            engineRealm += "/"
+        }
+
+        // Configure the Maven repository.
+        val hostedRepository: String =
+            System.getenv(FlutterPluginConstants.FLUTTER_STORAGE_BASE_URL)
+                ?: FlutterPluginConstants.DEFAULT_MAVEN_HOST
+        val repository: String? =
+            if (FlutterPluginUtils.shouldProjectUseLocalEngine(project)) {
+                project.property(PROP_LOCAL_ENGINE_REPO) as String?
+            } else {
+                "$hostedRepository/${engineRealm}download.flutter.io"
+            }
+        rootProject.allprojects {
+            repositories.maven {
+                url = uri(repository!!)
+            }
+        }
+
+        project.apply {
+            from(
+                Paths.get(
+                    flutterRoot!!.absolutePath,
+                    "packages",
+                    "flutter_tools",
+                    "gradle",
+                    "src",
+                    "main",
+                    "scripts",
+                    "native_plugin_loader.gradle.kts"
+                )
+            )
+        }
+
+        val flutterExtension: FlutterExtension =
+            project.extensions.create("flutter", FlutterExtension::class.java)
+
+        // TODO(gmackall): is this actually a different properties file than the previous one?
+        val rootProjectLocalProperties = Properties()
+        val rootProjectLocalPropertiesFile = rootProject.file("local.properties")
+        if (rootProjectLocalPropertiesFile.exists()) {
+            rootProjectLocalPropertiesFile.reader(StandardCharsets.UTF_8).use { reader ->
+                rootProjectLocalProperties.load(reader)
+            }
+        }
+        flutterExtension.flutterVersionCode =
+            rootProjectLocalProperties.getProperty("flutter.versionCode", "1")
+        flutterExtension.flutterVersionName =
+            rootProjectLocalProperties.getProperty("flutter.versionName", "1.0")
+
+        this.addFlutterTasks(project)
+        FlutterPluginUtils.forceNdkDownload(project, flutterRootPath)
+
+        // By default, assembling APKs generates fat APKs if multiple platforms are passed.
+        // Configuring split per ABI allows to generate separate APKs for each abi.
+        // This is a noop when building a bundle.
+        if (FlutterPluginUtils.shouldProjectSplitPerAbi(project)) {
+            FlutterPluginUtils.getAndroidExtension(project).splits.abi {
+                isEnable = true
+                reset()
+                isUniversalApk = false
+            }
+        }
+        val propDeferredComponentNames = "deferred-component-names"
+        val deferredComponentNamesValue: String? =
+            project.findProperty(propDeferredComponentNames) as? String
+        if (deferredComponentNamesValue != null) {
+            val componentNames: Set<String> =
+                deferredComponentNamesValue
+                    .split(',')
+                    .map { ":$it" }
+                    .toSet()
+            // TODO(gmackall): Unify the types we use for the android extension. This is yet
+            //   another type we need unfortunately.
+            val androidExtensionAsApplicationExtension =
+                project.extensions.getByType(ApplicationExtension::class.java)
+            // TODO(gmackall): Should we clear here? I think this is equivalent to what we used to
+            //    do, but unsure. Can't use a closure.
+            androidExtensionAsApplicationExtension.dynamicFeatures.clear()
+            androidExtensionAsApplicationExtension.dynamicFeatures.addAll(componentNames)
+        }
+
+        FlutterPluginUtils.getTargetPlatforms(project).forEach { targetArch ->
+            val abiValue: String? = FlutterPluginConstants.PLATFORM_ARCH_MAP[targetArch]
+            val androidExtension: BaseExtension = FlutterPluginUtils.getAndroidExtension(project)
+            androidExtension.splits.abi.include(abiValue!!)
+        }
+
+        val flutterExecutableName = getExecutableNameForPlatform("flutter")
+        flutterExecutable =
+            Paths.get(flutterRoot!!.absolutePath, "bin", flutterExecutableName).toFile()
+
+        // Validate that the provided Gradle, Java, AGP, and KGP versions are all within our
+        // supported range.
+        val shouldSkipDependencyChecks: Boolean =
+            project.hasProperty("skipDependencyChecks") &&
+                (
+                    project.properties["skipDependencyChecks"] as? Boolean
+                        ?: false
+                )
+        if (!shouldSkipDependencyChecks) {
+            try {
+                DependencyVersionChecker.checkDependencyVersions(project)
+            } catch (e: Exception) {
+                if (!project.hasProperty("usesUnsupportedDependencyVersions") ||
+                    !(project.properties["usesUnsupportedDependencyVersions"] as Boolean)
+                ) {
+                    // Possible bug in dependency checking code - warn and do not block build.
+                    project.logger.error(
+                        "Warning: Flutter was unable to detect project Gradle, Java, " +
+                            "AGP, and KGP versions. Skipping dependency version checking. Error was: " +
+                            e
+                    )
+                } else {
+                    // If usesUnsupportedDependencyVersions is set, the exception was thrown by us
+                    // in the dependency version checker plugin so re-throw it here.
+                    throw e
+                }
+            }
+        }
+
+        BaseApplicationNameHandler.setBaseName(project)
+        val flutterProguardRules: String =
+            Paths
+                .get(
+                    flutterRoot!!.absolutePath,
+                    "packages",
+                    "flutter_tools",
+                    "gradle",
+                    "flutter_proguard_rules.pro"
+                ).toString()
+        // TODO(gmackall): reconsider getting the android extension every time
+        FlutterPluginUtils.getAndroidExtension(project).buildTypes {
+            // Add profile build type.
+            create("profile") {
+                initWith(getByName("debug"))
+                // TODO(gmackall): do we need to clear?
+                this.matchingFallbacks.clear()
+                this.matchingFallbacks.addAll(listOf("debug", "release"))
+            }
+
+            // TODO(garyq): Shrinking is only false for multi apk split aot builds, where shrinking is not allowed yet.
+            // This limitation has been removed experimentally in gradle plugin version 4.2, so we can remove
+            // this check when we upgrade to 4.2+ gradle. Currently, deferred components apps may see
+            // increased app size due to this.
+            if (FlutterPluginUtils.shouldShrinkResources(project)) {
+                getByName("release") {
+                    isMinifyEnabled = true
+                    // Enables resource shrinking, which is performed by the Android Gradle plugin.
+                    // The resource shrinker can't be used for libraries.
+                    isShrinkResources = FlutterPluginUtils.isBuiltAsApp(project)
+                    // Fallback to `android/app/proguard-rules.pro`.
+                    // This way, custom Proguard rules can be configured as needed.
+                    proguardFiles(
+                        FlutterPluginUtils
+                            .getAndroidExtension(project)
+                            .getDefaultProguardFile("proguard-android-optimize.txt"),
+                        flutterProguardRules,
+                        "proguard-rules.pro"
+                    )
+                }
+            }
+        }
+
+        if (FlutterPluginUtils.shouldProjectUseLocalEngine(project)) {
+            // This is required to pass the local engine to flutter build aot.
+            val engineOutPath: String = project.properties["local-engine-out"] as String
+            val engineOut: File = project.file(engineOutPath)
+            if (!engineOut.isDirectory) {
+                throw GradleException("local-engine-out must point to a local engine build")
+            }
+            localEngine = engineOut.name
+            localEngineSrcPath = engineOut.parentFile.parent
+
+            val engineHostOutPath: String = project.properties["local-engine-host-out"] as String
+            val engineHostOut: File = project.file(engineHostOutPath)
+            if (!engineHostOut.isDirectory) {
+                throw GradleException("local-engine-host-out must point to a local engine host build")
+            }
+            localEngineHost = engineHostOut.name
+        }
+        FlutterPluginUtils.getAndroidExtension(project).buildTypes.all {
+            addFlutterDependencies(this)
+        }
+    }
+
+    private fun addFlutterDependencies(buildType: com.android.builder.model.BuildType) {
+        FlutterPluginUtils.addFlutterDependencies(
+            project!!,
+            buildType,
+            getPluginHandler(project!!),
+            engineVersion!!
+        )
+    }
+
+    private fun getExecutableNameForPlatform(baseExecutableName: String): String =
+        if (OperatingSystem.current().isWindows) "$baseExecutableName.bat" else baseExecutableName
+
+    private fun resolveFlutterSdkProperty(defaultValue: String?): String? {
+        val propertyName = "flutter.sdk"
+        if (localProperties == null) {
+            localProperties =
+                readPropertiesIfExist(File(project!!.projectDir.parentFile, "local.properties"))
+        }
+        return project?.findProperty(propertyName) as? String ?: localProperties!!.getProperty(
+            propertyName,
+            defaultValue
+        )
+    }
+
+    private fun addTaskForLockfileGeneration(rootProject: Project) {
+        rootProject.tasks.register("generateLockfiles") {
+            doLast {
+                rootProject.subprojects.forEach { subproject ->
+                    val gradlew: String =
+                        getExecutableNameForPlatform("${rootProject.projectDir}/gradlew")
+                    val execOps = rootProject.serviceOf<ExecOperations>()
+                    execOps.exec {
+                        workingDir(rootProject.projectDir)
+                        executable(gradlew)
+                        args(":${subproject.name}:dependencies", "--write-locks")
+                    }
+                }
+            }
+        }
+    }
+
+    private fun addFlutterTasks(projectToAddTasksTo: Project) {
+        if (projectToAddTasksTo.state.failure != null) {
+            return
+        }
+
+        FlutterPluginUtils.addTaskForJavaVersion(projectToAddTasksTo)
+        if (FlutterPluginUtils.isFlutterAppProject(projectToAddTasksTo)) {
+            FlutterPluginUtils.addTaskForPrintBuildVariants(projectToAddTasksTo)
+            FlutterPluginUtils.addTasksForOutputsAppLinkSettings(projectToAddTasksTo)
+        }
+
+        val targetPlatforms: List<String> =
+            FlutterPluginUtils.getTargetPlatforms(projectToAddTasksTo)
+
+        val flutterPlugin = this
+
+        if (FlutterPluginUtils.isFlutterAppProject(projectToAddTasksTo)) {
+            // TODO(gmackall): I think this can be BaseExtension, with findByType.
+            val android: AbstractAppExtension =
+                projectToAddTasksTo.extensions.findByName("android") as AbstractAppExtension
+            android.applicationVariants.configureEach {
+                val variant = this
+                val assembleTask = variant.assembleProvider.get()
+                if (!FlutterPluginUtils.shouldConfigureFlutterTask(
+                        projectToAddTasksTo,
+                        assembleTask
+                    )
+                ) {
+                    return@configureEach
+                }
+                val copyFlutterAssetsTask: Task =
+                    addFlutterDeps(variant, flutterPlugin, targetPlatforms)
+
+                // TODO(gmackall): Migrate to AGPs variant api.
+                //    https://github.com/flutter/flutter/issues/166550
+                @Suppress("DEPRECATION")
+                val variantOutput: com.android.build.gradle.api.BaseVariantOutput = variant.outputs.first()
+                val processResources: ProcessAndroidResources =
+                    try {
+                        variantOutput.processResourcesProvider.get()
+                    } catch (e: UnknownTaskException) {
+                        // TODO(gmackall): Migrate to AGPs variant api.
+                        //    https://github.com/flutter/flutter/issues/166550
+                        @Suppress("DEPRECATION")
+                        variantOutput.processResources
+                    }
+                processResources.dependsOn(copyFlutterAssetsTask)
+
+                // Copy the output APKs into a known location, so `flutter run` or `flutter build apk`
+                // can discover them. By default, this is `<app-dir>/build/app/outputs/flutter-apk/<filename>.apk`.
+                //
+                // The filename consists of `app<-abi>?<-flavor-name>?-<build-mode>.apk`.
+                // Where:
+                //   * `abi` can be `armeabi-v7a|arm64-v8a|x86|x86_64` only if the flag `split-per-abi` is set.
+                //   * `flavor-name` is the flavor used to build the app in lower case if the assemble task is called.
+                //   * `build-mode` can be `release|debug|profile`.
+                variant.outputs.forEach { output ->
+                    assembleTask.doLast {
+                        // TODO(gmackall): Migrate to AGPs variant api.
+                        //    https://github.com/flutter/flutter/issues/166550
+                        @Suppress("DEPRECATION")
+                        output as com.android.build.gradle.api.ApkVariantOutput
+                        val packageApplicationProvider: PackageAndroidArtifact =
+                            variant.packageApplicationProvider.get()
+                        val outputDirectory: Directory =
+                            packageApplicationProvider.outputDirectory.get()
+                        val outputDirectoryStr: String = outputDirectory.toString()
+                        var filename = "app"
+
+                        // TODO(gmackall): Migrate to AGPs variant api.
+                        //    https://github.com/flutter/flutter/issues/166550
+                        @Suppress("DEPRECATION")
+                        val abi = output.getFilter(com.android.build.VariantOutput.FilterType.ABI)
+                        if (abi != null && abi.isNotEmpty()) {
+                            filename += "-$abi"
+                        }
+                        if (variant.flavorName != null && variant.flavorName.isNotEmpty()) {
+                            filename += "-${FlutterPluginUtils.lowercase(variant.flavorName)}"
+                        }
+                        filename += "-${FlutterPluginUtils.buildModeFor(variant.buildType)}"
+                        projectToAddTasksTo.copy {
+                            from(File("$outputDirectoryStr/${output.outputFileName}"))
+                            into(
+                                File(
+                                    "${
+                                        projectToAddTasksTo.layout.buildDirectory.dir("outputs/flutter-apk")
+                                            .get()
+                                    }"
+                                )
+                            )
+                            rename { "$filename.apk" }
+                        }
+                    }
+                }
+            }
+            // Copy the native assets created by build.dart and placed here by flutter assemble.
+            // This path is not flavor specific and must only be added once.
+            // If support for flavors is added to native assets, then they must only be added
+            // once per flavor; see https://github.com/dart-lang/native/issues/1359.
+            val nativeAssetsDir =
+                "${projectToAddTasksTo.layout.buildDirectory.get()}/../native_assets/android/jniLibs/lib/"
+            android.sourceSets
+                .getByName("main")
+                .jniLibs
+                .srcDir(nativeAssetsDir)
+            getPluginHandler(projectToAddTasksTo).configurePlugins(engineVersion!!)
+            FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(
+                projectToAddTasksTo,
+                getPluginHandler(projectToAddTasksTo).getPluginList()
+            )
+            return
+        }
+        // Flutter host module project (Add-to-app).
+        val hostAppProjectName: String? =
+            if (projectToAddTasksTo.rootProject.hasProperty("flutter.hostAppProjectName")) {
+                projectToAddTasksTo.rootProject.property(
+                    "flutter.hostAppProjectName"
+                ) as? String
+            } else {
+                "app"
+            }
+        val appProject: Project? =
+            projectToAddTasksTo.rootProject.findProject(":$hostAppProjectName")
+        check(appProject != null) {
+            "Project :$hostAppProjectName doesn't exist. To customize the host app project name, set `flutter.hostAppProjectName=<project-name>` in gradle.properties."
+        }
+        // Wait for the host app project configuration.
+        appProject.afterEvaluate {
+            val androidLibraryExtension =
+                projectToAddTasksTo.extensions.findByType(LibraryExtension::class.java)
+            check(androidLibraryExtension != null)
+            androidLibraryExtension.libraryVariants.all libraryVariantAll@{
+                val libraryVariant = this
+                var copyFlutterAssetsTask: Task? = null
+                val androidAppExtension =
+                    appProject.extensions.findByName("android") as? AbstractAppExtension
+                check(androidAppExtension != null)
+                androidAppExtension.applicationVariants.all applicationVariantAll@{
+                    val appProjectVariant = this
+                    val appAssembleTask: Task = appProjectVariant.assembleProvider.get()
+                    if (!FlutterPluginUtils.shouldConfigureFlutterTask(project, appAssembleTask)) {
+                        return@applicationVariantAll
+                    }
+
+                    // Find a compatible application variant in the host app.
+                    //
+                    // For example, consider a host app that defines the following variants:
+                    // | ----------------- | ----------------------------- |
+                    // |   Build Variant   |   Flutter Equivalent Variant  |
+                    // | ----------------- | ----------------------------- |
+                    // |   freeRelease     |   release                     |
+                    // |   freeDebug       |   debug                       |
+                    // |   freeDevelop     |   debug                       |
+                    // |   profile         |   profile                     |
+                    // | ----------------- | ----------------------------- |
+                    //
+                    // This mapping is based on the following rules:
+                    // 1. If the host app build variant name is `profile` then the equivalent
+                    //    Flutter variant is `profile`.
+                    // 2. If the host app build variant is debuggable
+                    //    (e.g. `buildType.debuggable = true`), then the equivalent Flutter
+                    //    variant is `debug`.
+                    // 3. Otherwise, the equivalent Flutter variant is `release`.
+                    val variantBuildMode: String =
+                        FlutterPluginUtils.buildModeFor(libraryVariant.buildType)
+                    if (FlutterPluginUtils.buildModeFor(appProjectVariant.buildType) != variantBuildMode) {
+                        return@applicationVariantAll
+                    }
+                    copyFlutterAssetsTask = copyFlutterAssetsTask ?: addFlutterDeps(
+                        libraryVariant,
+                        flutterPlugin,
+                        targetPlatforms
+                    )
+                    // TODO(gmackall): Migrate to AGPs variant api.
+                    //    https://github.com/flutter/flutter/issues/166550
+                    val mergeAssets =
+                        projectToAddTasksTo
+                            .tasks
+                            .findByPath(":$hostAppProjectName:merge${FlutterPluginUtils.capitalize(appProjectVariant.name)}Assets")
+                    check(mergeAssets != null)
+                    mergeAssets.dependsOn(copyFlutterAssetsTask)
+                }
+            }
+        }
+        getPluginHandler(projectToAddTasksTo).configurePlugins(engineVersion!!)
+        FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(
+            projectToAddTasksTo,
+            getPluginHandler(projectToAddTasksTo).getPluginList()
+        )
+    }
+
+    private fun getPluginHandler(project: Project): PluginHandler {
+        if (this.pluginHandler == null) {
+            this.pluginHandler = PluginHandler(project)
+        }
+        return this.pluginHandler!!
+    }
+
+    companion object {
+        const val PROP_LOCAL_ENGINE_REPO: String = "local-engine-repo"
+
+        /**
+         * The name prefix for flutter builds. This is used to identify gradle tasks
+         * where we expect the flutter tool to provide any error output, and skip the
+         * standard Gradle error output in the FlutterEventLogger. If you change this,
+         * be sure to change any instances of this string in symbols in the code below
+         * to match.
+         */
+        private const val FLUTTER_BUILD_PREFIX: String = "flutterBuild"
+
+        /**
+         * Finds a task by name, returning null if the task does not exist.
+         */
+        private fun findTaskOrNull(
+            project: Project,
+            taskName: String
+        ): Task? =
+            try {
+                project.tasks.named(taskName).get()
+            } catch (ignored: UnknownTaskException) {
+                null
+            }
+
+        // TODO(gmackall): Migrate to AGPs variant api.
+        //    https://github.com/flutter/flutter/issues/166550
+        private fun addFlutterDeps(
+            @Suppress("DEPRECATION") variant: com.android.build.gradle.api.BaseVariant,
+            flutterPlugin: FlutterPlugin,
+            targetPlatforms: List<String>
+        ): Task {
+            // Shorthand
+            val project: Project = flutterPlugin.project!!
+
+            val fileSystemRootsValue: Array<String>? =
+                project
+                    .findProperty("filesystem-roots")
+                    ?.toString()
+                    ?.split("\\|")
+                    ?.toTypedArray()
+            val fileSystemSchemeValue: String? =
+                project.findProperty("filesystem-scheme")?.toString()
+            val trackWidgetCreationValue: Boolean =
+                project.findProperty("track-widget-creation")?.toString()?.toBoolean() ?: true
+            val frontendServerStarterPathValue: String? =
+                project.findProperty("frontend-server-starter-path")?.toString()
+            val extraFrontEndOptionsValue: String? =
+                project.findProperty("extra-front-end-options")?.toString()
+            val extraGenSnapshotOptionsValue: String? =
+                project.findProperty("extra-gen-snapshot-options")?.toString()
+            val splitDebugInfoValue: String? = project.findProperty("split-debug-info")?.toString()
+            val dartObfuscationValue: Boolean =
+                project.findProperty("dart-obfuscation")?.toString()?.toBoolean() ?: false
+            val treeShakeIconsOptionsValue: Boolean =
+                project.findProperty("tree-shake-icons")?.toString()?.toBoolean() ?: false
+            val dartDefinesValue: String? = project.findProperty("dart-defines")?.toString()
+            val performanceMeasurementFileValue: String? =
+                project.findProperty("performance-measurement-file")?.toString()
+            val codeSizeDirectoryValue: String? =
+                project.findProperty("code-size-directory")?.toString()
+            val deferredComponentsValue: Boolean =
+                project.findProperty("deferred-components")?.toString()?.toBoolean() ?: false
+            val validateDeferredComponentsValue: Boolean =
+                project.findProperty("validate-deferred-components")?.toString()?.toBoolean() ?: true
+
+            if (FlutterPluginUtils.shouldProjectSplitPerAbi(project)) {
+                variant.outputs.forEach { output ->
+                    // need to force this as the API does not return the right thing for our use.
+                    // TODO(gmackall): Migrate to AGPs variant api.
+                    //    https://github.com/flutter/flutter/issues/166550
+                    @Suppress("DEPRECATION")
+                    output as com.android.build.gradle.api.ApkVariantOutput
+                    // TODO(gmackall): Migrate to AGPs variant api.
+                    //    https://github.com/flutter/flutter/issues/166550
+                    @Suppress("DEPRECATION")
+                    val filterIdentifier: String =
+                        output.getFilter(com.android.build.VariantOutput.FilterType.ABI)
+                    val abiVersionCode: Int? = FlutterPluginConstants.ABI_VERSION[filterIdentifier]
+                    if (abiVersionCode != null) {
+                        output.versionCodeOverride
+                    }
+                }
+            }
+
+            // Build an AAR when this property is defined.
+            val isBuildingAar: Boolean = project.hasProperty("is-plugin")
+            // In add to app scenarios, a Gradle project contains a `:flutter` and `:app` project.
+            // `:flutter` is used as a subproject when these tasks exists and the build isn't building an AAR.
+            // TODO(gmackall): I think this is just always null? Which is great news! Consider removing.
+            val packageAssets: Task? =
+                findTaskOrNull(
+                    project,
+                    "package${FlutterPluginUtils.capitalize(variant.name)}Assets"
+                )
+            val cleanPackageAssets: Task? =
+                findTaskOrNull(
+                    project,
+                    "cleanPackage${FlutterPluginUtils.capitalize(variant.name)}Assets"
+                )
+
+            val isUsedAsSubproject: Boolean =
+                packageAssets != null && cleanPackageAssets != null && !isBuildingAar
+
+            val variantBuildMode: String = FlutterPluginUtils.buildModeFor(variant.buildType)
+            val flavorValue: String = variant.flavorName
+            val taskName: String =
+                FlutterPluginUtils.toCamelCase(
+                    listOf(
+                        "compile",
+                        FLUTTER_BUILD_PREFIX,
+                        variant.name
+                    )
+                )
+            // The task provider below will shadow a lot of the variable names, so provide this reference
+            // to access them within that scope.
+
+            // Be careful when configuring task below, Groovy has bizarre
+            // scoping rules: writing `verbose isVerbose()` means calling
+            // `isVerbose` on the task itself - which would return `verbose`
+            // original value. You either need to hoist the value
+            // into a separate variable `verbose verboseValue` or prefix with
+            // `this` (`verbose this.isVerbose()`).
+            val compileTaskProvider: TaskProvider<FlutterTask> =
+                project.tasks.register(taskName, FlutterTask::class.java) {
+                    flutterRoot = flutterPlugin.flutterRoot
+                    flutterExecutable = flutterPlugin.flutterExecutable
+                    buildMode = variantBuildMode
+                    minSdkVersion = variant.mergedFlavor.minSdkVersion!!.apiLevel
+                    localEngine = flutterPlugin.localEngine
+                    localEngineHost = flutterPlugin.localEngineHost
+                    localEngineSrcPath = flutterPlugin.localEngineSrcPath
+                    targetPath = FlutterPluginUtils.getFlutterTarget(project)
+                    verbose = FlutterPluginUtils.isProjectVerbose(project)
+                    fastStart = FlutterPluginUtils.isProjectFastStart(project)
+                    fileSystemRoots = fileSystemRootsValue
+                    fileSystemScheme = fileSystemSchemeValue
+                    trackWidgetCreation = trackWidgetCreationValue
+                    targetPlatformValues = targetPlatforms
+                    sourceDir = FlutterPluginUtils.getFlutterSourceDirectory(project)
+                    intermediateDir =
+                        project.file(
+                            project.layout.buildDirectory.dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/${variant.name}/")
+                        )
+                    frontendServerStarterPath = frontendServerStarterPathValue
+                    extraFrontEndOptions = extraFrontEndOptionsValue
+                    extraGenSnapshotOptions = extraGenSnapshotOptionsValue
+                    splitDebugInfo = splitDebugInfoValue
+                    treeShakeIcons = treeShakeIconsOptionsValue
+                    dartObfuscation = dartObfuscationValue
+                    dartDefines = dartDefinesValue
+                    performanceMeasurementFile = performanceMeasurementFileValue
+                    codeSizeDirectory = codeSizeDirectoryValue
+                    deferredComponents = deferredComponentsValue
+                    validateDeferredComponents = validateDeferredComponentsValue
+                    flavor = flavorValue
+                }
+            val compileTask: FlutterTask = compileTaskProvider.get()
+            val libJar: File =
+                project.file(
+                    project.layout.buildDirectory.dir("${FlutterPluginConstants.INTERMEDIATES_DIR}/flutter/${variant.name}/libs.jar")
+                )
+            val packJniLibsTaskProvider: TaskProvider<Jar> =
+                project.tasks.register(
+                    "packJniLibs${FLUTTER_BUILD_PREFIX}${FlutterPluginUtils.capitalize(variant.name)}",
+                    Jar::class.java
+                ) {
+                    destinationDirectory.set(libJar.parentFile)
+                    archiveFileName.set(libJar.name)
+                    dependsOn(compileTask)
+                    targetPlatforms.forEach { targetPlatform ->
+                        val abi: String? = FlutterPluginConstants.PLATFORM_ARCH_MAP[targetPlatform]
+                        from("${compileTask.intermediateDir}/$abi") {
+                            include("*.so")
+                            // Move `app.so` to `lib/<abi>/libapp.so`
+                            rename { filename: String -> "lib/$abi/lib$filename" }
+                        }
+                        // Copy the native assets created by build.dart and placed in build/native_assets by flutter assemble.
+                        // The `$project.layout.buildDirectory` is '.android/Flutter/build/' instead of 'build/'.
+                        val buildDir =
+                            "${FlutterPluginUtils.getFlutterSourceDirectory(project)}/build"
+                        val nativeAssetsDir =
+                            "$buildDir/native_assets/android/jniLibs/lib"
+                        from("$nativeAssetsDir/$abi") {
+                            include("*.so")
+                            rename { filename: String -> "lib/$abi/$filename" }
+                        }
+                    }
+                }
+            val packJniLibsTask: Task = packJniLibsTaskProvider.get()
+            FlutterPluginUtils.addApiDependencies(
+                project,
+                variant.name,
+                project.files({
+                    packJniLibsTask
+                })
+            )
+            val copyFlutterAssetsTaskProvider: TaskProvider<Copy> =
+                project.tasks.register(
+                    "copyFlutterAssets${FlutterPluginUtils.capitalize(variant.name)}",
+                    Copy::class.java
+                ) {
+                    dependsOn(compileTask)
+                    with(compileTask.assets)
+                    // TODO(gmackall): Replace with filePermissions.user.read/write = true once
+                    //   minimum supported Gradle version is 8.3.
+                    @Suppress("DEPRECATION")
+                    fileMode = 420 // corresponds to unix 0644 in base 8
+                    if (isUsedAsSubproject) {
+                        // TODO(gmackall): above is always false, can delete
+                        dependsOn(packageAssets)
+                        dependsOn(cleanPackageAssets)
+                        into(packageAssets!!.outputs)
+                    }
+                    val mergeAssets =
+                        try {
+                            variant.mergeAssetsProvider.get()
+                        } catch (e: IllegalStateException) {
+                            // TODO(gmackall): Migrate to AGPs variant api.
+                            //    https://github.com/flutter/flutter/issues/166550
+                            @Suppress("DEPRECATION")
+                            variant.mergeAssets
+                        }
+                    dependsOn(mergeAssets)
+                    dependsOn("clean${FlutterPluginUtils.capitalize(mergeAssets.name)}")
+                    mergeAssets.mustRunAfter("clean${FlutterPluginUtils.capitalize(mergeAssets.name)}")
+                    into(mergeAssets.outputDir)
+                }
+            val copyFlutterAssetsTask: Task = copyFlutterAssetsTaskProvider.get()
+            if (!isUsedAsSubproject) {
+                // TODO(gmackall): Migrate to AGPs variant api.
+                //    https://github.com/flutter/flutter/issues/166550
+                @Suppress("DEPRECATION")
+                val variantOutput: com.android.build.gradle.api.BaseVariantOutput = variant.outputs.first()
+                val processResources =
+                    try {
+                        variantOutput.processResourcesProvider.get()
+                    } catch (e: IllegalStateException) {
+                        // TODO(gmackall): Migrate to AGPs variant api.
+                        //    https://github.com/flutter/flutter/issues/166550
+                        @Suppress("DEPRECATION")
+                        variantOutput.processResources
+                    }
+                processResources.dependsOn(copyFlutterAssetsTask)
+            }
+            // The following tasks use the output of copyFlutterAssetsTask,
+            // so it's necessary to declare it as an dependency since Gradle 8.
+            // See https://docs.gradle.org/8.1/userguide/validation_problems.html#implicit_dependency.
+            val tasksToCheck =
+                listOf(
+                    "compress${FlutterPluginUtils.capitalize(variant.name)}Assets",
+                    "bundle${FlutterPluginUtils.capitalize(variant.name)}Aar",
+                    "bundle${FlutterPluginUtils.capitalize(variant.name)}LocalLintAar"
+                )
+            tasksToCheck.forEach { taskTocheck ->
+                try {
+                    project.tasks.named(taskTocheck).configure {
+                        dependsOn(copyFlutterAssetsTask)
+                    }
+                } catch (ignored: UnknownTaskException) {
+                    // ignored
+                }
+            }
+            return copyFlutterAssetsTask
+        }
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/FlutterPluginConstants.kt
+++ b/packages/flutter_tools/gradle/bin/main/FlutterPluginConstants.kt
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+// TODO(gmackall): this should be collapsed back into the core FlutterPlugin once the Groovy to
+//                 kotlin conversion is complete.
+object FlutterPluginConstants {
+    /** The platforms that can be passed to the `--Ptarget-platform` flag. */
+    private const val PLATFORM_ARM32 = "android-arm"
+    private const val PLATFORM_ARM64 = "android-arm64"
+    private const val PLATFORM_X86 = "android-x86"
+    private const val PLATFORM_X86_64 = "android-x64"
+
+    /** The ABI architectures supported by Flutter. */
+    private const val ARCH_ARM32 = "armeabi-v7a"
+    private const val ARCH_ARM64 = "arm64-v8a"
+    private const val ARCH_X86 = "x86"
+    private const val ARCH_X86_64 = "x86_64"
+
+    const val INTERMEDIATES_DIR = "intermediates"
+    const val FLUTTER_STORAGE_BASE_URL = "FLUTTER_STORAGE_BASE_URL"
+    const val DEFAULT_MAVEN_HOST = "https://storage.googleapis.com"
+
+    /** Maps platforms to ABI architectures. */
+    @JvmStatic val PLATFORM_ARCH_MAP =
+        mapOf(
+            PLATFORM_ARM32 to ARCH_ARM32,
+            PLATFORM_ARM64 to ARCH_ARM64,
+            PLATFORM_X86 to ARCH_X86,
+            PLATFORM_X86_64 to ARCH_X86_64
+        )
+
+    /**
+     * The version code that gives each ABI a value.
+     * For each APK variant, use the following versions to override the version of the Universal APK.
+     * Otherwise, the Play Store will complain that the APK variants have the same version.
+     */
+    @JvmStatic val ABI_VERSION =
+        mapOf(
+            ARCH_ARM32 to 1,
+            ARCH_ARM64 to 2,
+            ARCH_X86 to 3,
+            ARCH_X86_64 to 4
+        )
+
+    /** When split is enabled, multiple APKs are generated per each ABI. */
+    @JvmStatic val DEFAULT_PLATFORMS =
+        listOf(
+            PLATFORM_ARM32,
+            PLATFORM_ARM64,
+            PLATFORM_X86_64
+        )
+}

--- a/packages/flutter_tools/gradle/bin/main/FlutterPluginUtils.kt
+++ b/packages/flutter_tools/gradle/bin/main/FlutterPluginUtils.kt
@@ -1,0 +1,967 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.gradle.AbstractAppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.tasks.ProcessAndroidResources
+import com.android.builder.model.BuildType
+import com.flutter.gradle.plugins.PluginHandler
+import groovy.lang.Closure
+import groovy.util.Node
+import org.gradle.api.GradleException
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.logging.Logger
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.Properties
+
+/**
+ * A collection of static utility functions used by the Flutter Gradle Plugin.
+ */
+object FlutterPluginUtils {
+    private const val MANIFEST_NAME_KEY = "android:name"
+    private const val MANIFEST_VALUE_KEY = "android:value"
+    private const val MANIFEST_VALUE_TRUE = "true"
+
+    // Gradle properties. These must correspond to the values used in
+    // flutter/packages/flutter_tools/lib/src/android/gradle.dart, and therefore it is not
+    // recommended to use these const values in tests.
+    internal const val PROP_SHOULD_SHRINK_RESOURCES = "shrink"
+    internal const val PROP_SPLIT_PER_ABI = "split-per-abi"
+    internal const val PROP_LOCAL_ENGINE_REPO = "local-engine-repo"
+    internal const val PROP_IS_VERBOSE = "verbose"
+    internal const val PROP_IS_FAST_START = "fast-start"
+    internal const val PROP_TARGET = "target"
+    internal const val PROP_LOCAL_ENGINE_BUILD_MODE = "local-engine-build-mode"
+    internal const val PROP_TARGET_PLATFORM = "target-platform"
+
+    // ----------------- Methods for string manipulation and comparison. -----------------
+
+    @JvmStatic
+    fun toCamelCase(parts: List<String>): String {
+        if (parts.isEmpty()) {
+            return ""
+        }
+        return parts[0] +
+            parts.drop(1).joinToString("") { capitalize(it) }
+    }
+
+    // Kotlin's capitalize function is deprecated, but the suggested replacement uses syntax that
+    // our minimum version doesn't support yet. Centralize the use to one place, so that when our
+    // minimum version does support the replacement we can replace by changing a single line.
+    @JvmStatic
+    @Suppress("DEPRECATION")
+    internal fun capitalize(string: String): String = string.capitalize()
+
+    // Kotlin's toLowerCase function is deprecated, but the suggested replacement is not supported
+    // by the minimum version of Kotlin that we support. Centralize the use to one place, so that
+    // when our minimum version does support the replacement we can replace by changing a single
+    // line.
+    @Suppress("DEPRECATION")
+    internal fun lowercase(string: String): String = string.toLowerCase()
+
+    // compareTo implementation of version strings in the format of ints and periods
+    // Will not crash on RC candidate strings but considers all RC candidates the same version.
+    // Returns -1 if firstString < secondString, 0 if firstString == secondString, 1 if firstString > secondString
+    @JvmStatic
+    @JvmName("compareVersionStrings")
+    internal fun compareVersionStrings(
+        firstString: String,
+        secondString: String
+    ): Int {
+        val firstVersion = firstString.split(".")
+        val secondVersion = secondString.split(".")
+
+        val commonIndices = minOf(firstVersion.size, secondVersion.size)
+
+        for (i in 0 until commonIndices) {
+            var firstAtIndex = firstVersion[i]
+            var secondAtIndex = secondVersion[i]
+            var firstInt = 0
+            var secondInt = 0
+
+            // Strip any chars after "-". For example "8.6-rc-2"
+            firstAtIndex = firstAtIndex.substringBefore("-")
+            try {
+                firstInt = firstAtIndex.toInt()
+            } catch (nfe: NumberFormatException) {
+                println(nfe)
+            }
+
+            secondAtIndex = secondAtIndex.substringBefore("-")
+            try {
+                secondInt = secondAtIndex.toInt()
+            } catch (nfe: NumberFormatException) {
+                println(nfe)
+            }
+
+            val comparisonResult = firstInt.compareTo(secondInt)
+            if (comparisonResult != 0) {
+                return comparisonResult
+            }
+        }
+
+        // If we got this far then all the common indices are identical, so whichever version is longer must be more recent
+        return firstVersion.size.compareTo(secondVersion.size)
+    }
+
+    @JvmStatic
+    @JvmName("formatPlatformString")
+    fun formatPlatformString(platform: String): String = FlutterPluginConstants.PLATFORM_ARCH_MAP[platform]!!.replace("-", "_")
+
+    @JvmStatic
+    @JvmName("readPropertiesIfExist")
+    internal fun readPropertiesIfExist(propertiesFile: File): Properties {
+        val result = Properties()
+        if (propertiesFile.exists()) {
+            propertiesFile
+                .reader(StandardCharsets.UTF_8)
+                .use { reader ->
+                    // Use Kotlin's reader with UTF-8 and 'use' for auto-closing
+                    result.load(reader)
+                }
+        }
+        return result
+    }
+
+    // ----------------- Methods that interact primarily with the Gradle project. -----------------
+
+    @JvmStatic
+    @JvmName("shouldShrinkResources")
+    fun shouldShrinkResources(project: Project): Boolean {
+        if (project.hasProperty(PROP_SHOULD_SHRINK_RESOURCES)) {
+            val propertyValue = project.property(PROP_SHOULD_SHRINK_RESOURCES)
+            return propertyValue.toString().toBoolean()
+        }
+        return true
+    }
+
+    // TODO(54566): Can remove this function and its call sites once resolved.
+
+    /**
+     * Returns the Gradle settings script for the build. When both Groovy and
+     * Kotlin variants exist, then Groovy (settings.gradle) is preferred over
+     * Kotlin (settings.gradle.kts). This is the same behavior as Gradle 8.5.
+     */
+    @JvmStatic
+    @JvmName("getSettingsGradleFileFromProjectDir")
+    internal fun getSettingsGradleFileFromProjectDir(
+        projectDirectory: File,
+        logger: Logger
+    ): File {
+        val settingsGradle = File(projectDirectory.parentFile, "settings.gradle")
+        val settingsGradleKts = File(projectDirectory.parentFile, "settings.gradle.kts")
+        if (settingsGradle.exists() && settingsGradleKts.exists()) {
+            logger.error(
+                """
+                Both settings.gradle and settings.gradle.kts exist, so
+                settings.gradle.kts is ignored. This is likely a mistake.
+                """.trimIndent()
+            )
+        }
+
+        return if (settingsGradle.exists()) settingsGradle else settingsGradleKts
+    }
+
+    /**
+     * Returns the Gradle build script for the build. When both Groovy and
+     * Kotlin variants exist, then Groovy (build.gradle) is preferred over
+     * Kotlin (build.gradle.kts). This is the same behavior as Gradle 8.5.
+     */
+    @JvmStatic
+    @JvmName("getBuildGradleFileFromProjectDir")
+    internal fun getBuildGradleFileFromProjectDir(
+        projectDirectory: File,
+        logger: Logger
+    ): File {
+        val buildGradle = File(File(projectDirectory.parentFile, "app"), "build.gradle")
+        val buildGradleKts = File(File(projectDirectory.parentFile, "app"), "build.gradle.kts")
+        if (buildGradle.exists() && buildGradleKts.exists()) {
+            logger.error(
+                """
+                Both build.gradle and build.gradle.kts exist, so
+                build.gradle.kts is ignored. This is likely a mistake.
+                """.trimIndent()
+            )
+        }
+
+        return if (buildGradle.exists()) buildGradle else buildGradleKts
+    }
+
+    @JvmStatic
+    @JvmName("shouldProjectSplitPerAbi")
+    internal fun shouldProjectSplitPerAbi(project: Project): Boolean =
+        project
+            .findProperty(
+                PROP_SPLIT_PER_ABI
+            )?.toString()
+            ?.toBoolean() ?: false
+
+    @JvmStatic
+    @JvmName("shouldProjectUseLocalEngine")
+    internal fun shouldProjectUseLocalEngine(project: Project): Boolean = project.hasProperty(PROP_LOCAL_ENGINE_REPO)
+
+    @JvmStatic
+    @JvmName("isProjectVerbose")
+    internal fun isProjectVerbose(project: Project): Boolean = project.findProperty(PROP_IS_VERBOSE)?.toString()?.toBoolean() ?: false
+
+    /** Whether to build the debug app in "fast-start" mode. */
+    @JvmStatic
+    @JvmName("isProjectFastStart")
+    internal fun isProjectFastStart(project: Project): Boolean =
+        project
+            .findProperty(
+                PROP_IS_FAST_START
+            )?.toString()
+            ?.toBoolean() ?: false
+
+    /**
+     * TODO: Remove this AGP hack. https://github.com/flutter/flutter/issues/109560
+     *
+     * In AGP 4.0, the Android linter task depends on the JAR tasks that generate `libapp.so`.
+     * When building APKs, this causes an issue where building release requires the debug JAR,
+     * but Gradle won't build debug.
+     *
+     * To workaround this issue, only configure the JAR task that is required given the task
+     * from the command line.
+     *
+     * The AGP team said that this issue is fixed in Gradle 7.0, which isn't released at the
+     * time of adding this code. Once released, this can be removed. However, after updating to
+     * AGP/Gradle 7.2.0/7.5, removing this hack still causes build failures. Further
+     * investigation necessary to remove this.
+     *
+     * Tested cases:
+     * * `./gradlew assembleRelease`
+     * * `./gradlew app:assembleRelease.`
+     * * `./gradlew assemble{flavorName}Release`
+     * * `./gradlew app:assemble{flavorName}Release`
+     * * `./gradlew assemble.`
+     * * `./gradlew app:assemble.`
+     * * `./gradlew bundle.`
+     * * `./gradlew bundleRelease.`
+     * * `./gradlew app:bundleRelease.`
+     *
+     * Related issues:
+     * https://issuetracker.google.com/issues/158060799
+     * https://issuetracker.google.com/issues/158753935
+     */
+    @JvmStatic
+    @JvmName("shouldConfigureFlutterTask")
+    internal fun shouldConfigureFlutterTask(
+        project: Project,
+        assembleTask: Task
+    ): Boolean {
+        val cliTasksNames = project.gradle.startParameter.taskNames
+        if (cliTasksNames.size != 1 || !cliTasksNames.first().contains("assemble")) {
+            return true
+        }
+        val taskName = cliTasksNames.first().split(":").last()
+        if (taskName == "assemble") {
+            return true
+        }
+        if (taskName == assembleTask.name) {
+            return true
+        }
+        if (taskName.endsWith("Release") && assembleTask.name.endsWith("Release")) {
+            return true
+        }
+        if (taskName.endsWith("Debug") && assembleTask.name.endsWith("Debug")) {
+            return true
+        }
+        if (taskName.endsWith("Profile") && assembleTask.name.endsWith("Profile")) {
+            return true
+        }
+        return false
+    }
+
+    private fun getFlutterExtensionOrNull(project: Project): FlutterExtension? = project.extensions.findByType(FlutterExtension::class.java)
+
+    /**
+     * Gets the directory that contains the Flutter source code.
+     * This is the directory containing the `android/` directory.
+     */
+    @JvmStatic
+    @JvmName("getFlutterSourceDirectory")
+    internal fun getFlutterSourceDirectory(project: Project): File {
+        val flutterExtension = getFlutterExtensionOrNull(project)
+        // TODO(gmackall): clean up this NPE that is still around from the Groovy conversion.
+        if (flutterExtension!!.source == null) {
+            throw GradleException("Flutter source directory not set.")
+        }
+        return project.file(flutterExtension.source!!)
+    }
+
+    /**
+     * Gets the target file. This is typically `lib/main.dart`.
+     *
+     * Returns
+     *  1. the value of the `target` property, if it exists
+     *  2. the target value set in the FlutterExtension, if it exists
+     *  3. `lib/main.dart` otherwise
+     */
+    @JvmStatic
+    @JvmName("getFlutterTarget")
+    internal fun getFlutterTarget(project: Project): String {
+        if (project.hasProperty(PROP_TARGET)) {
+            return project.property(PROP_TARGET).toString()
+        }
+        val target: String = getFlutterExtensionOrNull(project)!!.target ?: "lib/main.dart"
+        return target
+    }
+
+    @JvmStatic
+    @JvmName("isBuiltAsApp")
+    internal fun isBuiltAsApp(project: Project): Boolean {
+        // Projects are built as applications when the they use the `com.android.application`
+        // plugin.
+        return project.plugins.hasPlugin("com.android.application")
+    }
+
+    // Optional parameters don't work when Groovy makes calls into Kotlin, so provide an additional
+    // signature for the 3 argument version.
+    @JvmStatic
+    @JvmName("addApiDependencies")
+    internal fun addApiDependencies(
+        project: Project,
+        variantName: String,
+        dependency: Any
+    ) {
+        addApiDependencies(project, variantName, dependency, null)
+    }
+
+    @JvmStatic
+    @JvmName("addApiDependencies")
+    internal fun addApiDependencies(
+        project: Project,
+        variantName: String,
+        dependency: Any,
+        config: Closure<Any>?
+    ) {
+        var configuration: String
+        try {
+            project.configurations.named("api")
+            configuration = "${variantName}Api"
+        } catch (ignored: UnknownTaskException) {
+            // TODO(gmackall): The docs say the above should actually be an UnknownDomainObjectException.
+            configuration = "${variantName}Compile"
+        }
+
+        if (config == null) {
+            project.dependencies.add(
+                configuration,
+                dependency
+            )
+        } else {
+            project.dependencies.add(configuration, dependency, config)
+        }
+    }
+
+    /**
+     * Returns a Flutter build mode suitable for the specified Android buildType.
+     *
+     * @return "debug", "profile", or "release" (fall-back).
+     */
+    @JvmStatic
+    @JvmName("buildModeFor")
+    internal fun buildModeFor(buildType: BuildType): String {
+        if (buildType.name == "profile") {
+            return "profile"
+        } else if (buildType.isDebuggable) {
+            return "debug"
+        }
+        return "release"
+    }
+
+    /**
+     * Returns true if the build mode is supported by the current call to Gradle.
+     * This only relevant when using a local engine. Because the engine
+     * is built for a specific mode, the call to Gradle must match that mode.
+     */
+    @JvmStatic
+    @JvmName("supportsBuildMode")
+    internal fun supportsBuildMode(
+        project: Project,
+        flutterBuildMode: String
+    ): Boolean {
+        if (!shouldProjectUseLocalEngine(project)) {
+            return true
+        }
+        check(project.hasProperty(PROP_LOCAL_ENGINE_BUILD_MODE)) { "Project must have property '$PROP_LOCAL_ENGINE_BUILD_MODE'" }
+        // Don't configure dependencies for a build mode that the local engine
+        // doesn't support.
+        return project.property(PROP_LOCAL_ENGINE_BUILD_MODE) == flutterBuildMode
+    }
+
+    internal fun getAndroidExtension(project: Project): BaseExtension {
+        // Common supertype of the android extension types.
+        // But maybe this should be https://developer.android.com/reference/tools/gradle-api/8.7/com/android/build/api/dsl/TestedExtension.
+        return project.extensions.findByType(BaseExtension::class.java)!!
+    }
+
+    // TODO: Use find by type and AbstractAppExtension instead. Or delete in favor of getAndroidExtension.
+    //       see https://github.com/flutter/flutter/issues/165882
+    private fun getAndroidAppExtensionOrNull(project: Project): AbstractAppExtension? =
+        project.extensions.findByName("android") as? AbstractAppExtension
+
+    /**
+     * Expected format of getAndroidExtension(project).compileSdkVersion is a string of the form
+     * `android-` followed by either the numeric version, e.g. `android-35`, or a preview version,
+     * e.g. `android-UpsideDownCake`.
+     */
+    @JvmStatic
+    @JvmName("getCompileSdkFromProject")
+    internal fun getCompileSdkFromProject(project: Project): String = getAndroidExtension(project).compileSdkVersion!!.substring(8)
+
+    /**
+     * Returns:
+     *  The default platforms if the `target-platform` property is not set.
+     *  The requested platforms after verifying they are supported by the Flutter plugin, otherwise.
+     * Throws a GradleException if any of the requested platforms are not supported.
+     */
+    @JvmStatic
+    @JvmName("getTargetPlatforms")
+    internal fun getTargetPlatforms(project: Project): List<String> {
+        if (!project.hasProperty(PROP_TARGET_PLATFORM)) {
+            return FlutterPluginConstants.DEFAULT_PLATFORMS
+        }
+        val platformsString = project.property(PROP_TARGET_PLATFORM) as String
+        return platformsString.split(",").map { platform ->
+            if (!FlutterPluginConstants.PLATFORM_ARCH_MAP.containsKey(platform)) {
+                throw GradleException("Invalid platform: $platform")
+            }
+            platform
+        }
+    }
+
+    private fun logPluginCompileSdkWarnings(
+        maxPluginCompileSdkVersion: Int,
+        projectCompileSdkVersion: Int,
+        logger: Logger,
+        pluginsWithHigherSdkVersion: List<PluginVersionPair>,
+        projectDirectory: File
+    ) {
+        logger.error(
+            "Your project is configured to compile against Android SDK $projectCompileSdkVersion, but the following plugin(s) require to be compiled against a higher Android SDK version:"
+        )
+        for (pluginToCompileSdkVersion in pluginsWithHigherSdkVersion) {
+            logger.error(
+                "- ${pluginToCompileSdkVersion.name} compiles against Android SDK ${pluginToCompileSdkVersion.version}"
+            )
+        }
+        val buildGradleFile =
+            getBuildGradleFileFromProjectDir(
+                projectDirectory,
+                logger
+            )
+        logger.error(
+            """
+            Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
+            Add the following to ${buildGradleFile.path}:
+
+                android {
+                    compileSdk = $maxPluginCompileSdkVersion
+                    ...
+                }
+            """.trimIndent()
+        )
+    }
+
+    private fun logPluginNdkWarnings(
+        maxPluginNdkVersion: String,
+        projectNdkVersion: String,
+        logger: Logger,
+        pluginsWithDifferentNdkVersion: List<PluginVersionPair>,
+        projectDirectory: File
+    ) {
+        logger.error(
+            "Your project is configured with Android NDK $projectNdkVersion, but the following plugin(s) depend on a different Android NDK version:"
+        )
+        for (pluginToNdkVersion in pluginsWithDifferentNdkVersion) {
+            logger.error("- ${pluginToNdkVersion.name} requires Android NDK ${pluginToNdkVersion.version}")
+        }
+        val buildGradleFile =
+            getBuildGradleFileFromProjectDir(
+                projectDirectory,
+                logger
+            )
+        logger.error(
+            """
+            Fix this issue by using the highest Android NDK version (they are backward compatible).
+            Add the following to ${buildGradleFile.path}:
+
+                android {
+                    ndkVersion = "$maxPluginNdkVersion"
+                    ...
+                }
+            """.trimIndent()
+        )
+    }
+
+    /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
+    @JvmStatic
+    @JvmName("detectLowCompileSdkVersionOrNdkVersion")
+    internal fun detectLowCompileSdkVersionOrNdkVersion(
+        project: Project,
+        pluginList: List<Map<String?, Any?>>
+    ) {
+        project.afterEvaluate {
+            // getCompileSdkFromProject returns a string if the project uses a preview compileSdkVersion
+            // so default to Int.MAX_VALUE in that case.
+            val projectCompileSdkVersion: Int =
+                getCompileSdkFromProject(project).toIntOrNull() ?: Int.MAX_VALUE
+
+            var maxPluginCompileSdkVersion = projectCompileSdkVersion
+            // TODO(gmackall): This should be updated to reflect newer templates.
+            // The default for AGP 4.1.0 used in old templates.
+            val ndkVersionIfUnspecified = "21.1.6352462"
+
+            // TODO(gmackall): We can remove this elvis when our minimum AGP is >= 8.2.
+            //  This value (ndkVersion) is nullable on AGP versions below that.
+            //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
+            @Suppress("USELESS_ELVIS")
+            val projectNdkVersion: String =
+                getAndroidExtension(project).ndkVersion ?: ndkVersionIfUnspecified
+            var maxPluginNdkVersion = projectNdkVersion
+            var numProcessedPlugins = pluginList.size
+            val pluginsWithHigherSdkVersion = mutableListOf<PluginVersionPair>()
+            val pluginsWithDifferentNdkVersion = mutableListOf<PluginVersionPair>()
+            pluginList.forEach { pluginObject ->
+                val pluginName: String =
+                    requireNotNull(
+                        pluginObject["name"] as? String
+                    ) { "Missing valid \"name\" property for plugin object: $pluginObject" }
+                val pluginProject: Project =
+                    project.rootProject.findProject(":$pluginName") ?: return@forEach
+                pluginProject.afterEvaluate {
+                    val pluginCompileSdkVersion: Int =
+                        getCompileSdkFromProject(pluginProject).toIntOrNull() ?: Int.MAX_VALUE
+                    maxPluginCompileSdkVersion =
+                        maxOf(maxPluginCompileSdkVersion, pluginCompileSdkVersion)
+                    if (pluginCompileSdkVersion > projectCompileSdkVersion) {
+                        pluginsWithHigherSdkVersion.add(
+                            PluginVersionPair(
+                                pluginName,
+                                pluginCompileSdkVersion.toString()
+                            )
+                        )
+                    }
+
+                    // TODO(gmackall): We can remove this elvis when our minimum AGP is >= 8.2.
+                    //  This value (ndkVersion) is nullable on AGP versions below that.
+                    //  See https://developer.android.com/reference/tools/gradle-api/8.1/com/android/build/api/dsl/CommonExtension#ndkVersion().
+                    @Suppress("USELESS_ELVIS")
+                    val pluginNdkVersion: String =
+                        getAndroidExtension(pluginProject).ndkVersion ?: ndkVersionIfUnspecified
+                    maxPluginNdkVersion =
+                        VersionUtils.mostRecentSemanticVersion(
+                            pluginNdkVersion,
+                            maxPluginNdkVersion
+                        )
+                    if (pluginNdkVersion != projectNdkVersion) {
+                        pluginsWithDifferentNdkVersion.add(
+                            PluginVersionPair(
+                                pluginName,
+                                pluginNdkVersion
+                            )
+                        )
+                    }
+
+                    numProcessedPlugins--
+                    if (numProcessedPlugins == 0) {
+                        if (maxPluginCompileSdkVersion > projectCompileSdkVersion) {
+                            logPluginCompileSdkWarnings(
+                                maxPluginCompileSdkVersion = maxPluginCompileSdkVersion,
+                                projectCompileSdkVersion = projectCompileSdkVersion,
+                                logger = project.logger,
+                                pluginsWithHigherSdkVersion = pluginsWithHigherSdkVersion,
+                                projectDirectory = project.projectDir
+                            )
+                        }
+                        if (maxPluginNdkVersion != projectNdkVersion) {
+                            logPluginNdkWarnings(
+                                maxPluginNdkVersion = maxPluginNdkVersion,
+                                projectNdkVersion = projectNdkVersion,
+                                logger = project.logger,
+                                pluginsWithDifferentNdkVersion = pluginsWithDifferentNdkVersion,
+                                projectDirectory = project.projectDir
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Forces the project to download the NDK by configuring properties that makes AGP think the
+     * project actually requires the NDK.
+     */
+    @JvmStatic
+    @JvmName("forceNdkDownload")
+    internal fun forceNdkDownload(
+        gradleProject: Project,
+        flutterSdkRootPath: String
+    ) {
+        // If the project is already configuring a native build, we don't need to do anything.
+        val gradleProjectAndroidExtension = getAndroidExtension(gradleProject)
+        val forcingNotRequired: Boolean =
+            gradleProjectAndroidExtension.externalNativeBuild.cmake.path != null
+        if (forcingNotRequired) {
+            return
+        }
+
+        // Otherwise, point to an empty CMakeLists.txt, and ignore associated warnings.
+        gradleProjectAndroidExtension.externalNativeBuild.cmake.path(
+            "$flutterSdkRootPath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt"
+        )
+
+        // AGP defaults to outputting build artifacts in `android/app/.cxx`. This directory is a
+        // build artifact, so we move it from that directory to within Flutter's build directory
+        // to avoid polluting source directories with build artifacts.
+        //
+        // AGP explicitely recommends not setting the buildStagingDirectory to be within a build
+        // directory in
+        // https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/Cmake#buildStagingDirectory(kotlin.Any),
+        // but as we are not actually building anything (and are instead only tricking AGP into
+        // downloading the NDK), it is acceptable for the buildStagingDirectory to be removed
+        // and rebuilt when running clean builds.
+        gradleProjectAndroidExtension.externalNativeBuild.cmake.buildStagingDirectory(
+            gradleProject.layout.buildDirectory
+                .dir("../.cxx")
+                .get()
+                .asFile.path
+        )
+
+        // CMake will print warnings when you try to build an empty project.
+        // These arguments silence the warnings - our project is intentionally
+        // empty.
+        gradleProjectAndroidExtension.defaultConfig.externalNativeBuild.cmake
+            .arguments("-Wno-dev", "--no-warn-unused-cli")
+    }
+
+    @JvmStatic
+    @JvmName("isFlutterAppProject")
+    internal fun isFlutterAppProject(project: Project): Boolean = project.extensions.findByType(AbstractAppExtension::class.java) != null
+
+    /**
+     * Ensures that the dependencies required by the Flutter project are available.
+     * This includes:
+     *    1. The embedding
+     *    2. libflutter.so
+     *
+     * Should only be called on the main gradle [Project] for this application
+     * of the [FlutterPlugin].
+     */
+    @JvmStatic
+    @JvmName("addFlutterDependencies")
+    internal fun addFlutterDependencies(
+        project: Project,
+        buildType: BuildType,
+        pluginHandler: PluginHandler,
+        engineVersion: String
+    ) {
+        val flutterBuildMode: String = buildModeFor(buildType)
+        if (!supportsBuildMode(project, flutterBuildMode)) {
+            project.logger.quiet(
+                "Project does not support Flutter build mode: $flutterBuildMode, " +
+                    "skipping adding flutter dependencies"
+            )
+            return
+        }
+        // The embedding is set as an API dependency in a Flutter plugin.
+        // Therefore, don't make the app project depend on the embedding if there are Flutter
+        // plugin dependencies. In release mode, dev dependencies are stripped, so we do not
+        // consider those in the check.
+        // This prevents duplicated classes when using custom build types. That is, a custom build
+        // type like profile is used, and the plugin and app projects have API dependencies on the
+        // embedding.
+        val pluginsThatIncludeFlutterEmbeddingAsTransitiveDependency: List<Map<String?, Any?>> =
+            if (flutterBuildMode == "release") {
+                pluginHandler.getPluginListWithoutDevDependencies()
+            } else {
+                pluginHandler.getPluginList()
+            }
+
+        if (!isFlutterAppProject(project) || pluginsThatIncludeFlutterEmbeddingAsTransitiveDependency.isEmpty()) {
+            addApiDependencies(
+                project,
+                buildType.name,
+                "io.flutter:flutter_embedding_$flutterBuildMode:$engineVersion"
+            )
+        }
+        val platforms: List<String> = getTargetPlatforms(project)
+        platforms.forEach { platform ->
+            val arch: String = formatPlatformString(platform)
+            // Add the `libflutter.so` dependency.
+            addApiDependencies(
+                project,
+                buildType.name,
+                "io.flutter:${arch}_$flutterBuildMode:$engineVersion"
+            )
+        }
+    }
+
+    // ------------------ Task adders (a subset of the above category)
+
+    // Add a task that can be called on flutter projects that prints the Java version used in Gradle.
+    //
+    // Format of the output of this task can be used in debugging what version of Java Gradle is using.
+    // Not recommended for use in time sensitive commands like `flutter run` or `flutter build` as
+    // Gradle is slower than we want. Particularly in light of https://github.com/flutter/flutter/issues/119196.
+    @JvmStatic
+    @JvmName("addTaskForJavaVersion")
+    internal fun addTaskForJavaVersion(project: Project) {
+        project.tasks.register("javaVersion") {
+            description = "Print the current java version used by gradle. see: " +
+                "https://docs.gradle.org/current/javadoc/org/gradle/api/JavaVersion.html"
+            doLast {
+                println(JavaVersion.current())
+            }
+        }
+    }
+
+    // Add a task that can be called on Flutter projects that prints the available build variants
+    // in Gradle.
+    //
+    // This task prints variants in this format:
+    //
+    // BuildVariant: debug
+    // BuildVariant: release
+    // BuildVariant: profile
+    //
+    // Format of the output of this task is used by `AndroidProject.getBuildVariants`.
+    @JvmStatic
+    @JvmName("addTaskForPrintBuildVariants")
+    internal fun addTaskForPrintBuildVariants(project: Project) {
+        // Groovy was dynamically getting a different subtype here than our Kotlin getAndroidExtension method.
+        // TODO(gmackall): We should take another pass at the different types we are using in our conversion of
+        //                 the groovy `flutter.android` lines.
+        val androidExtension = project.extensions.getByType(AbstractAppExtension::class.java)
+        project.tasks.register("printBuildVariants") {
+            description = "Prints out all build variants for this Android project"
+            doLast {
+                androidExtension.applicationVariants.forEach { variant ->
+                    println("BuildVariant: ${variant.name}")
+                }
+            }
+        }
+    }
+
+    // TODO(gmackall): Migrate to AGPs variant api.
+    //    https://github.com/flutter/flutter/issues/166550
+    @Suppress("DEPRECATION")
+    private fun findProcessResources(baseVariantOutput: com.android.build.gradle.api.BaseVariantOutput): ProcessAndroidResources =
+        baseVariantOutput.processResourcesProvider?.get() ?: baseVariantOutput.processResources
+
+    /**
+     * Adds required tasks for the AppLinkSettings feature.
+     *
+     * Should only be called if the build target is an app, as opposed to an aar/module.
+     *
+     * Add a task that can be called on Flutter projects that outputs app link related project
+     * settings into a json file.
+     * See https://developer.android.com/training/app-links/ for more information about app link.
+     * The json will be saved in path stored in outputPath parameter.
+     *
+     * An example json:
+     *  {
+     *      applicationId: "com.example.app",
+     *          deeplinks: [
+     *              {"scheme":"http", "host":"example.com", "path":".*"},
+     *              {"scheme":"https","host":"example.com","path":".*"}
+     *          ]
+     *  }
+     * The output file is parsed and used by devtool.
+     */
+    @JvmStatic
+    @JvmName("addTasksForOutputsAppLinkSettings")
+    internal fun addTasksForOutputsAppLinkSettings(project: Project) {
+        // Integration test for AppLinkSettings task defined in
+        // flutter/flutter/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
+        val android = getAndroidAppExtensionOrNull(project)
+        if (android == null) {
+            project.logger.info("addTasksForOutputsAppLinkSettings called on project without android extension.")
+            return
+        }
+        android.applicationVariants.configureEach {
+            val variant = this
+            project.tasks.register("output${capitalize(variant.name)}AppLinkSettings") {
+                val task: Task = this
+                task.description =
+                    "stores app links settings for the given build variant of this Android project into a json file."
+                variant.outputs.configureEach {
+                    // TODO(gmackall): Migrate to AGPs variant api.
+                    //    https://github.com/flutter/flutter/issues/166550
+                    @Suppress("DEPRECATION")
+                    val baseVariantOutput: com.android.build.gradle.api.BaseVariantOutput = this
+                    // Deeplinks are defined in AndroidManifest.xml and is only available after
+                    // processResourcesProvider.
+                    dependsOn(findProcessResources(baseVariantOutput))
+                }
+                doLast {
+                    // We are configuring the same object before a doLast and in a doLast.
+                    // without a clear reason why. That is not good.
+                    variant.outputs.configureEach {
+                        val appLinkSettings = createAppLinkSettings(variant, this)
+                        File(project.property("outputPath").toString()).writeText(
+                            appLinkSettings.toJson().toString()
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Extracts app deeplink information from the Android manifest file of a variant then returns
+     * an AppLinkSettings object.
+     *
+     * @param BaseVariantOutput The output of a specific build variant (e.g., debug, release).
+     * @param variant The application variant being processed.
+     */
+    @Suppress("KDocUnresolvedReference")
+    private fun createAppLinkSettings(
+        // TODO(gmackall): Migrate to AGPs variant api.
+        //    https://github.com/flutter/flutter/issues/166550
+        @Suppress("DEPRECATION") variant: com.android.build.gradle.api.ApplicationVariant,
+        @Suppress("DEPRECATION") baseVariantOutput: com.android.build.gradle.api.BaseVariantOutput
+    ): AppLinkSettings {
+        val appLinkSettings = AppLinkSettings(variant.applicationId)
+
+        // XmlParser is not namespace aware because it makes querying nodes cumbersome.
+        // TODO(gmackall): Migrate to AGPs variant api.
+        //    https://github.com/flutter/flutter/issues/166550
+        @Suppress("DEPRECATION")
+        val manifest: Node =
+            groovy.xml.XmlParser(false, false).parse(findProcessResources(baseVariantOutput).manifestFile)
+        val applicationNode: Node? =
+            manifest.children().find { node ->
+                node is Node && node.name() == "application"
+            } as Node?
+        if (applicationNode == null) {
+            return appLinkSettings
+        }
+        val activities: List<Node> =
+            applicationNode.children().filterIsInstance<Node>().filter { item ->
+                item.name() == "activity"
+            }
+
+        activities.forEach { activity ->
+            val metaDataItems: List<Node> =
+                activity.children().filterIsInstance<Node>().filter { metaItem ->
+                    metaItem.name() == "meta-data"
+                }
+            metaDataItems.forEach { metaDataItem ->
+                val nameAttribute: Boolean =
+                    metaDataItem.attribute(MANIFEST_NAME_KEY) == "flutter_deeplinking_enabled"
+                val valueAttribute: Boolean =
+                    metaDataItem.attribute(MANIFEST_VALUE_KEY) == MANIFEST_VALUE_TRUE
+                if (nameAttribute && valueAttribute) {
+                    appLinkSettings.deeplinkingFlagEnabled = true
+                }
+            }
+            val intentFilterItems: List<Node> =
+                activity.children().filterIsInstance<Node>().filter { filterItem ->
+                    filterItem.name() == "intent-filter"
+                }
+            intentFilterItems.forEach { appLinkIntent ->
+                // Print out the host attributes in data tags.
+                val schemes: MutableSet<String?> = mutableSetOf()
+                val hosts: MutableSet<String?> = mutableSetOf()
+                val paths: MutableSet<String?> = mutableSetOf()
+                val intentFilterCheck = IntentFilterCheck()
+                if (appLinkIntent.attribute("android:autoVerify") == MANIFEST_VALUE_TRUE) {
+                    intentFilterCheck.hasAutoVerify = true
+                }
+
+                val actionItems: List<Node> =
+                    appLinkIntent.children().filterIsInstance<Node>().filter { item ->
+                        item.name() == "action"
+                    }
+                // Any action item causes intentFilterCheck to always be true
+                // and we keep looping instead of exiting out early.
+                // TODO: Exit out early per intent filter action view.
+                actionItems.forEach { action ->
+                    if (action.attribute(MANIFEST_NAME_KEY) == "android.intent.action.VIEW") {
+                        intentFilterCheck.hasActionView = true
+                    }
+                }
+                val categoryItems: List<Node> =
+                    appLinkIntent.children().filterIsInstance<Node>().filter { item ->
+                        item.name() == "category"
+                    }
+                categoryItems.forEach { category ->
+                    // TODO: Exit out early per intent filter default category.
+                    if (category.attribute(MANIFEST_NAME_KEY) == "android.intent.category.DEFAULT") {
+                        intentFilterCheck.hasDefaultCategory = true
+                    }
+                    // TODO: Exit out early per intent filter browsable category.
+                    if (category.attribute(MANIFEST_NAME_KEY) == "android.intent.category.BROWSABLE") {
+                        intentFilterCheck.hasBrowsableCategory =
+                            true
+                    }
+                }
+                val dataItems: List<Node> =
+                    appLinkIntent.children().filterIsInstance<Node>().filter { item ->
+                        item.name() == "data"
+                    }
+                dataItems.forEach { data ->
+                    data.attributes().forEach { entry ->
+                        when (entry.key) {
+                            "android:scheme" -> schemes.add(entry.value.toString())
+                            "android:host" -> hosts.add(entry.value.toString())
+                            // All path patterns add to paths.
+                            "android:pathAdvancedPattern" ->
+                                paths.add(
+                                    entry.value.toString()
+                                )
+
+                            "android:pathPattern" -> paths.add(entry.value.toString())
+                            "android:path" -> paths.add(entry.value.toString())
+                            "android:pathPrefix" -> paths.add(entry.value.toString() + ".*")
+                            "android:pathSuffix" -> paths.add(".*" + entry.value.toString())
+                        }
+                    }
+                }
+                if (hosts.isNotEmpty() || paths.isNotEmpty()) {
+                    if (schemes.isEmpty()) {
+                        schemes.add(null)
+                    }
+                    if (hosts.isEmpty()) {
+                        hosts.add(null)
+                    }
+                    if (paths.isEmpty()) {
+                        paths.add(".*")
+                    }
+                    // Sets are not ordered this could produce a bug.
+                    schemes.forEach { scheme ->
+                        hosts.forEach { host ->
+                            paths.forEach { path ->
+                                appLinkSettings.deeplinks.add(
+                                    Deeplink(
+                                        scheme,
+                                        host,
+                                        path,
+                                        intentFilterCheck
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return appLinkSettings
+    }
+}
+
+private data class PluginVersionPair(
+    val name: String,
+    val version: String
+)

--- a/packages/flutter_tools/gradle/bin/main/IntentFilterCheck.kt
+++ b/packages/flutter_tools/gradle/bin/main/IntentFilterCheck.kt
@@ -1,0 +1,25 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+class IntentFilterCheck {
+    // TODO(gmackall): Identify which of these can be val instead of var.
+    var hasAutoVerify = false
+    var hasActionView = false
+    var hasDefaultCategory = false
+    var hasBrowsableCategory = false
+
+    fun toJson(): JsonObject =
+        buildJsonObject {
+            put("hasAutoVerify", hasAutoVerify)
+            put("hasActionView", hasActionView)
+            put("hasDefaultCategory", hasDefaultCategory)
+            put("hasBrowsableCategory", hasBrowsableCategory)
+        }
+}

--- a/packages/flutter_tools/gradle/bin/main/NativePluginLoaderReflectionBridge.kt
+++ b/packages/flutter_tools/gradle/bin/main/NativePluginLoaderReflectionBridge.kt
@@ -1,0 +1,57 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import java.io.File
+
+// TODO(gmackall): Remove reflection after migrating to plugin style application in
+//  https://github.com/flutter/flutter/issues/166461.
+// New methods should not be added.
+
+/**
+ * Class to hide from Kotlin source the dangerous reflection being used to call methods defined
+ * in script gradle plugins.
+ */
+
+object NativePluginLoaderReflectionBridge {
+    /**
+     * An abstraction to hide reflection from calling sites. See ../scripts/native_plugin_loader.gradle.kts.
+     */
+    fun getPlugins(
+        extraProperties: ExtraPropertiesExtension,
+        flutterProjectRoot: File
+    ): List<Map<String?, Any?>> {
+        val nativePluginLoader = extraProperties.get("nativePluginLoader")!!
+
+        @Suppress("UNCHECKED_CAST")
+        val pluginList: List<Map<String?, Any?>> =
+            nativePluginLoader::class
+                .members
+                .firstOrNull { it.name == "getPlugins" }
+                ?.call(nativePluginLoader, flutterProjectRoot) as List<Map<String?, Any?>>
+
+        return pluginList
+    }
+
+    /**
+     * An abstraction to hide reflection from calling sites. See ../scripts/native_plugin_loader.gradle.kts.
+     */
+    fun getDependenciesMetadata(
+        extraProperties: ExtraPropertiesExtension,
+        flutterProjectRoot: File
+    ): Map<String, Any> {
+        val nativePluginLoader = extraProperties.get("nativePluginLoader")!!
+
+        @Suppress("UNCHECKED_CAST")
+        val dependenciesMetadata: Map<String, Any> =
+            nativePluginLoader::class
+                .members
+                .firstOrNull { it.name == "dependenciesMetadata" }
+                ?.call(nativePluginLoader, flutterProjectRoot) as Map<String, Any>
+
+        return dependenciesMetadata
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/VersionUtils.kt
+++ b/packages/flutter_tools/gradle/bin/main/VersionUtils.kt
@@ -1,0 +1,67 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import kotlin.math.max
+
+object VersionUtils {
+    /**
+     * Compares semantic versions ignoring labels.
+     *
+     * If the versions are equal (ignoring labels), returns one of the two strings arbitrarily. If
+     * minor or patch are omitted (non-conformant to semantic versioning), they are considered zero.
+     * If the provided versions in both are equal, the longest version string is returned. For
+     * example, "2.8.0" vs "2.8" will always consider "2.8.0" to be the most recent version. For
+     * another example, "8.7-rc-2" vs "8.7.2" will always consider "8.7.2" to be the most recent
+     * version.
+     */
+    @JvmStatic
+    fun mostRecentSemanticVersion(
+        version1: String,
+        version2: String
+    ): String {
+        val v1Parts = version1.split(".", "-")
+        val v2Parts = version2.split(".", "-")
+        val maxSize = max(v1Parts.size, v2Parts.size)
+
+        for (i in 0 until maxSize) {
+            val v1Part: String = v1Parts.getOrNull(i) ?: "0"
+            val v2Part: String = v2Parts.getOrNull(i) ?: "0"
+
+            val v1Num: Int? = v1Part.toIntOrNull()
+            val v2Num: Int? = v2Part.toIntOrNull()
+            when {
+                v1Num != null && v2Num != null -> { // Both are numbers
+                    if (v1Num != v2Num) {
+                        return if (v1Num > v2Num) version1 else version2
+                    }
+                }
+                v1Num != null && v2Num == null ->
+                    return version1 // v1 is a number, v2 is not, so v1 is newer.
+                v1Num == null && v2Num != null ->
+                    return version2 // v1 is not a number, v2 is, so v2 is newer.
+                else -> { // Both are not numbers (pre-release identifiers)
+                    if (v1Part != v2Part) {
+                        return if (comparePreReleaseIdentifiers(v1Part, v2Part)) version1 else version2
+                    }
+                }
+            }
+        }
+
+        // If versions are equal, return the longest version string
+        return if (version1.length >= version2.length) version1 else version2
+    }
+
+    /** Compares only non digits and returns true if v1Part is than v2Part. */
+    private fun comparePreReleaseIdentifiers(
+        v1Part: String,
+        v2Part: String
+    ): Boolean {
+        val digits = Regex("\\d")
+        val v1PreRelease = v1Part.replace(digits, "")
+        val v2PreRelease = v2Part.replace(digits, "")
+        return v1PreRelease < v2PreRelease
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/plugins/PluginHandler.kt
+++ b/packages/flutter_tools/gradle/bin/main/plugins/PluginHandler.kt
@@ -1,0 +1,326 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.plugins
+
+import androidx.annotation.VisibleForTesting
+import com.android.builder.model.BuildType
+import com.flutter.gradle.FlutterExtension
+import com.flutter.gradle.FlutterPluginUtils
+import com.flutter.gradle.FlutterPluginUtils.addApiDependencies
+import com.flutter.gradle.FlutterPluginUtils.buildModeFor
+import com.flutter.gradle.FlutterPluginUtils.getAndroidExtension
+import com.flutter.gradle.FlutterPluginUtils.getCompileSdkFromProject
+import com.flutter.gradle.FlutterPluginUtils.supportsBuildMode
+import com.flutter.gradle.NativePluginLoaderReflectionBridge
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import java.io.File
+import java.io.FileNotFoundException
+import java.nio.charset.StandardCharsets
+
+/**
+ * Handles interactions with the flutter plugins (not Gradle plugins) used by the Flutter project,
+ * such as retrieving them as a list and configuring them as Gradle dependencies of the main Gradle
+ * project.
+ */
+class PluginHandler(
+    val project: Project
+) {
+    private var pluginList: List<Map<String?, Any?>>? = null
+    private var pluginDependencies: List<Map<String?, Any?>>? = null
+
+    /**
+     * Gets the list of plugins (as map) that support the Android platform.
+     *
+     * The map contains the following key - value pairs:
+     *  `name` - the plugins name (String),
+     *  `path` - it's path (String),
+     *  `dependencies` - a list of its dependencies names (List<String>)
+     *  `dev_dependency` - a boolean indicating whether the plugin is a dev dependency (Boolean)
+     *  `native_build` - a boolean indicating whether the plugin has native code (Boolean)
+     *
+     * This format is defined in packages/flutter_tools/lib/src/flutter_plugins.dart, in the
+     * _createPluginMapOfPlatform method.
+     * See also [NativePluginLoader#getPlugins] in packages/flutter_tools/gradle/src/main/scripts/native_plugin_loader.gradle.kts
+     */
+    internal fun getPluginList(): List<Map<String?, Any?>> {
+        if (pluginList == null) {
+            pluginList =
+                NativePluginLoaderReflectionBridge.getPlugins(
+                    project.extraProperties,
+                    FlutterPluginUtils.getFlutterSourceDirectory(project)
+                )
+        }
+        return pluginList!!
+    }
+
+    // TODO(54566, 48918): Remove in favor of [getPluginList] only, see also
+    //  https://github.com/flutter/flutter/blob/1c90ed8b64d9ed8ce2431afad8bc6e6d9acc4556/packages/flutter_tools/lib/src/flutter_plugins.dart#L212
+
+    /** Gets the plugins dependencies from `.flutter-plugins-dependencies`. */
+    private fun getPluginDependencies(): List<Map<String?, Any?>> {
+        if (pluginDependencies == null) {
+            val meta: Map<String, Any> =
+                NativePluginLoaderReflectionBridge.getDependenciesMetadata(
+                    project.extraProperties,
+                    FlutterPluginUtils.getFlutterSourceDirectory(project)
+                )
+            check(meta["dependencyGraph"] is List<*>)
+            @Suppress("UNCHECKED_CAST")
+            pluginDependencies = meta["dependencyGraph"] as List<Map<String?, Any?>>
+        }
+        return pluginDependencies!!
+    }
+
+    // TODO(54566, 48918): Can remove once the issues are resolved.
+    //  This means all references to `.flutter-plugins` are then removed and
+    //  apps only depend exclusively on the `plugins` property in `.flutter-plugins-dependencies`.
+
+    /**
+     * Workaround to load non-native plugins for developers who may still use an
+     * old `settings.gradle` which includes all the plugins from the
+     * `.flutter-plugins` file, even if not made for Android.
+     * The settings.gradle then:
+     *     1) tries to add the android plugin implementation, which does not
+     *        exist at all, but is also not included successfully
+     *        (which does not throw an error and therefore isn't a problem), or
+     *     2) includes the plugin successfully as a valid android plugin
+     *        directory exists, even if the surrounding flutter package does not
+     *        support the android platform (see e.g. apple_maps_flutter: 1.0.1).
+     *        So as it's included successfully it expects to be added as API.
+     *        This is only possible by taking all plugins into account, which
+     *        only appear on the `dependencyGraph` and in the `.flutter-plugins` file.
+     * So in summary the plugins are currently selected from the `dependencyGraph`
+     * and filtered then with the [pluginSupportsAndroidPlatform] method instead of
+     * just using the `plugins.android` list.
+     */
+    private fun configureLegacyPluginEachProjects(engineVersionValue: String) {
+        try {
+            // Read the contents of the settings.gradle file.
+            // Remove block/line comments
+            var settingsText =
+                FlutterPluginUtils
+                    .getSettingsGradleFileFromProjectDir(
+                        project.projectDir,
+                        project.logger
+                    ).readText(StandardCharsets.UTF_8)
+            settingsText =
+                settingsText
+                    .replace(Regex("""(?s)/\*.*?\*/"""), "")
+                    .replace(Regex("""(?m)//.*$"""), "")
+            if (!settingsText.contains("'.flutter-plugins'")) {
+                return
+            }
+        } catch (ignored: FileNotFoundException) {
+            throw GradleException(
+                "settings.gradle/settings.gradle.kts does not exist: " +
+                    FlutterPluginUtils
+                        .getSettingsGradleFileFromProjectDir(
+                            project.projectDir,
+                            project.logger
+                        ).absolutePath
+            )
+        }
+        // TODO(matanlurey): https://github.com/flutter/flutter/issues/48918.
+        project.logger.quiet(
+            legacyFlutterPluginsWarning
+        )
+        val deps: List<Map<String?, Any?>> = getPluginDependencies()
+        val pluginsNameSet = HashSet<String>()
+        getPluginList().mapTo(pluginsNameSet) { plugin -> plugin["name"] as String }
+        deps.filterNot { plugin -> pluginsNameSet.contains(plugin["name"]) }
+        deps.forEach { plugin: Map<String?, Any?> ->
+            val pluginProject = project.rootProject.findProject(":${plugin["name"]}")
+            if (pluginProject == null) {
+                // Plugin was not included in `settings.gradle`, but is listed in `.flutter-plugins`.
+                project.logger.error(
+                    "Plugin project :${plugin["name"]} listed, but not found. Please fix your settings.gradle/settings.gradle.kts."
+                )
+            } else if (pluginSupportsAndroidPlatform(project)) {
+                // Plugin has a functioning `android` folder and is included successfully, although it's not supported.
+                // It must be configured nonetheless, to not throw an "Unresolved reference" exception.
+                configurePluginProject(project, plugin, engineVersionValue)
+            } else {
+                // Plugin has no or an empty `android` folder. No action required.
+            }
+        }
+    }
+
+    internal fun configurePlugins(engineVersionValue: String) {
+        configureLegacyPluginEachProjects(engineVersionValue)
+        val pluginList: List<Map<String?, Any?>> = getPluginList()
+        pluginList.forEach { plugin: Map<String?, Any?> ->
+            configurePluginProject(
+                project,
+                plugin,
+                engineVersionValue
+            )
+        }
+        pluginList.forEach { plugin: Map<String?, Any?> ->
+            configurePluginDependencies(project, plugin)
+        }
+    }
+
+    /**
+     * Gets the list of plugins (as map) that support the Android platform and are dependencies of the
+     * Android project excluding dev dependencies.
+     *
+     * The map value contains either the plugins `name` (String),
+     * its `path` (String), or its `dependencies` (List<String>).
+     * See [NativePluginLoader#getPlugins] in packages/flutter_tools/gradle/src/main/scripts/native_plugin_loader.gradle.kts
+     */
+    internal fun getPluginListWithoutDevDependencies(): List<Map<String?, Any?>> =
+        getPluginList().filter { pluginObject -> pluginObject["dev_dependency"] == false }
+
+    companion object {
+        /**
+         * Flutter Docs Website URLs for help messages.
+         */
+        private const val WEBSITE_DEPLOYMENT_ANDROID_BUILD_CONFIG = "https://flutter.dev/to/review-gradle-config"
+
+        @VisibleForTesting internal val legacyFlutterPluginsWarning =
+            """
+            Warning: This project is still reading the deprecated '.flutter-plugins. file.
+            In an upcoming stable release support for this file will be completely removed and your build will fail.
+            See https:/flutter.dev/to/flutter-plugins-configuration.
+            """.trimIndent()
+
+        /**
+         * Performs configuration related to the plugin's Gradle [Project], including
+         * 1. Adding the plugin itself as a dependency to the main project.
+         * 2. Adding the main project's build types to the plugin's build types.
+         * 3. Adding a dependency on the Flutter embedding to the plugin.
+         *
+         * Should only be called on plugins that support the Android platform.
+         */
+        private fun configurePluginProject(
+            project: Project,
+            pluginObject: Map<String?, Any?>,
+            engineVersion: String
+        ) {
+            val pluginName =
+                requireNotNull(pluginObject["name"] as? String) { "Plugin name must be a string for plugin object: $pluginObject" }
+            val pluginProject: Project = project.rootProject.findProject(":$pluginName") ?: return
+
+            // Apply the "flutter" Gradle extension to plugins so that they can use it's vended
+            // compile/target/min sdk values.
+            pluginProject.extensions.create("flutter", FlutterExtension::class.java)
+
+            // Add plugin dependency to the app project. We only want to add dependency
+            // for dev dependencies in non-release builds.
+            project.afterEvaluate {
+                getAndroidExtension(project).buildTypes.forEach { buildType ->
+                    if (!(pluginObject["dev_dependency"] as Boolean) || buildType.name != "release") {
+                        project.dependencies.add("${buildType.name}Api", pluginProject)
+                    }
+                }
+            }
+
+            // Wait until the Android plugin loaded.
+            pluginProject.afterEvaluate {
+                // Checks if there is a mismatch between the plugin compileSdkVersion and the project compileSdkVersion.
+                val projectCompileSdkVersion: String = getCompileSdkFromProject(project)
+                val pluginCompileSdkVersion: String = getCompileSdkFromProject(pluginProject)
+                // TODO(gmackall): This is doing a string comparison, which is odd and also can be wrong
+                //                 when comparing preview versions (against non preview, and also in the
+                //                 case of alphabet reset which happened with "Baklava".
+                if (pluginCompileSdkVersion > projectCompileSdkVersion) {
+                    project.logger.quiet(
+                        "Warning: The plugin $pluginName requires Android SDK version $pluginCompileSdkVersion or higher."
+                    )
+                    project.logger.quiet(
+                        "For more information about build configuration, see ${WEBSITE_DEPLOYMENT_ANDROID_BUILD_CONFIG}."
+                    )
+                }
+
+                getAndroidExtension(project).buildTypes.forEach { buildType ->
+                    addEmbeddingDependencyToPlugin(project, pluginProject, buildType, engineVersion)
+                }
+            }
+        }
+
+        private fun addEmbeddingDependencyToPlugin(
+            project: Project,
+            pluginProject: Project,
+            buildType: BuildType,
+            engineVersion: String
+        ) {
+            val flutterBuildMode: String = buildModeFor(buildType)
+            // TODO(gmackall): this should be safe to remove, as the minimum required AGP is well above
+            //                 3.5. We should try to remove it.
+            // In AGP 3.5, the embedding must be added as an API implementation,
+            // so java8 features are desugared against the runtime classpath.
+            // For more, see https://github.com/flutter/flutter/issues/40126
+            if (!supportsBuildMode(pluginProject, flutterBuildMode)) {
+                return
+            }
+            if (!pluginProject.hasProperty("android")) {
+                return
+            }
+
+            // Copy build types from the app to the plugin.
+            // This allows to build apps with plugins and custom build types or flavors.
+            getAndroidExtension(pluginProject).buildTypes.addAll(getAndroidExtension(project).buildTypes)
+
+            // The embedding is API dependency of the plugin, so the AGP is able to desugar
+            // default method implementations when the interface is implemented by a plugin.
+            //
+            // See https://issuetracker.google.com/139821726, and
+            // https://github.com/flutter/flutter/issues/72185 for more details.
+            addApiDependencies(pluginProject, buildType.name, "io.flutter:flutter_embedding_$flutterBuildMode:$engineVersion")
+        }
+
+        /**
+         * Returns `true` if the given project is a plugin project having an `android` directory
+         * containing a `build.gradle` or `build.gradle.kts` file.
+         */
+        internal fun pluginSupportsAndroidPlatform(project: Project): Boolean {
+            val buildGradle = File(File(project.projectDir.parentFile, "android"), "build.gradle")
+            val buildGradleKts =
+                File(File(project.projectDir.parentFile, "android"), "build.gradle.kts")
+            return buildGradle.exists() || buildGradleKts.exists()
+        }
+
+        /**
+         * Add the dependencies on other plugin projects to the plugin project.
+         * A plugin A can depend on plugin B. As a result, this dependency must be surfaced by
+         * making the Gradle plugin project A depend on the Gradle plugin project B.
+         */
+        private fun configurePluginDependencies(
+            project: Project,
+            pluginObject: Map<String?, Any?>
+        ) {
+            val pluginName: String =
+                requireNotNull(pluginObject["name"] as? String) {
+                    "Missing valid \"name\" property for plugin object: $pluginObject"
+                }
+            val pluginProject: Project = project.rootProject.findProject(":$pluginName") ?: return
+
+            getAndroidExtension(project).buildTypes.forEach { buildType ->
+                val flutterBuildMode: String = buildModeFor(buildType)
+                if (flutterBuildMode == "release" && (pluginObject["dev_dependency"] as? Boolean == true)) {
+                    // This plugin is a dev dependency will not be included in the
+                    // release build, so no need to add its dependencies.
+                    return@forEach
+                }
+                val dependencies = requireNotNull(pluginObject["dependencies"] as? List<*>)
+                dependencies.forEach innerForEach@{ pluginDependencyName ->
+                    check(pluginDependencyName is String)
+                    if (pluginDependencyName.isEmpty()) {
+                        return@innerForEach
+                    }
+
+                    val dependencyProject =
+                        project.rootProject.findProject(":$pluginDependencyName") ?: return@innerForEach
+                    pluginProject.afterEvaluate {
+                        // this.dependencies.add("implementation", dependencyProject)
+                        pluginProject.dependencies.add("implementation", dependencyProject)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/tasks/BaseFlutterTask.kt
+++ b/packages/flutter_tools/gradle/bin/main/tasks/BaseFlutterTask.kt
@@ -1,0 +1,148 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFiles
+import java.io.File
+
+// IMPORTANT: Do not add logic to the methods in this class directly,
+// instead add logic to [BaseFlutterTaskHelper].
+
+/**
+ * Base implementation of a Gradle task. Gradle tasks can not be instantiated for testing,
+ * so this class delegates all logic to [BaseFlutterTaskHelper].
+ */
+open class BaseFlutterTask : DefaultTask() {
+    @Internal
+    var flutterRoot: File? = null
+
+    @Internal
+    var flutterExecutable: File? = null
+
+    @Input
+    var buildMode: String? = null
+
+    @Input
+    var minSdkVersion: Int? = null
+
+    @Optional
+    @Input
+    var localEngine: String? = null
+
+    @Optional
+    @Input
+    var localEngineHost: String? = null
+
+    @Optional
+    @Input
+    var localEngineSrcPath: String? = null
+
+    @Optional
+    @Input
+    var fastStart: Boolean? = null
+
+    @Input
+    var targetPath: String? = null
+
+    @Optional
+    @Input
+    var verbose: Boolean? = null
+
+    @Optional
+    @Input
+    var fileSystemRoots: Array<String>? = null
+
+    @Optional
+    @Input
+    var fileSystemScheme: String? = null
+
+    @Input
+    var trackWidgetCreation: Boolean? = null
+
+    @Optional
+    @Input
+    var targetPlatformValues: List<String>? = null
+
+    @Internal
+    var sourceDir: File? = null
+
+    @Internal
+    var intermediateDir: File? = null
+
+    @Optional
+    @Input
+    var frontendServerStarterPath: String? = null
+
+    @Optional
+    @Input
+    var extraFrontEndOptions: String? = null
+
+    @Optional
+    @Input
+    var extraGenSnapshotOptions: String? = null
+
+    @Optional
+    @Input
+    var splitDebugInfo: String? = null
+
+    @Optional
+    @Input
+    var treeShakeIcons: Boolean? = null
+
+    @Optional
+    @Input
+    var dartObfuscation: Boolean? = null
+
+    @Optional
+    @Input
+    var dartDefines: String? = null
+
+    @Optional
+    @Input
+    var bundleSkSLPath: String? = null
+
+    @Optional
+    @Input
+    var codeSizeDirectory: String? = null
+
+    @Optional
+    @Input
+    var performanceMeasurementFile: String? = null
+
+    @Optional
+    @Input
+    var deferredComponents: Boolean? = null
+
+    @Optional
+    @Input
+    var validateDeferredComponents: Boolean? = null
+
+    @Optional
+    @Input
+    var skipDependencyChecks: Boolean? = null
+
+    @Optional
+    @Input
+    var flavor: String? = null
+
+    /**
+     * Gets the dependency file(s) by calling [com.flutter.gradle.tasks.BaseFlutterTaskHelper.getDependenciesFiles].
+     *
+     * @return the dependency file(s) based on the current intermediate directory path.
+     */
+    @OutputFiles
+    fun getDependenciesFiles() = BaseFlutterTaskHelper.getDependenciesFiles(baseFlutterTask = this)
+
+    /**
+     * Builds a Flutter Android application bundle by verifying the Flutter source directory,
+     * creating an intermediate build directory if necessary, and running flutter assemble by
+     * configuring and executing with a set of build configurations.
+     */
+    fun buildBundle() = BaseFlutterTaskHelper.buildBundle(baseFlutterTask = this)
+}

--- a/packages/flutter_tools/gradle/bin/main/tasks/BaseFlutterTaskHelper.kt
+++ b/packages/flutter_tools/gradle/bin/main/tasks/BaseFlutterTaskHelper.kt
@@ -1,0 +1,176 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.tasks
+
+import androidx.annotation.VisibleForTesting
+import org.gradle.api.Action
+import org.gradle.api.GradleException
+import org.gradle.api.file.FileCollection
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+import java.nio.file.Paths
+
+/**
+ * Stateless object to contain the logic used in [BaseFlutterTask]. Any required state should be stored
+ * on [BaseFlutterTask] instead, while any logic needed by [BaseFlutterTask] should be added here.
+ */
+object BaseFlutterTaskHelper {
+    @VisibleForTesting
+    internal fun getGradleErrorMessage(baseFlutterTask: BaseFlutterTask): String =
+        "Invalid Flutter source directory: ${baseFlutterTask.sourceDir}"
+
+    /**
+     * Gets the dependency file(s) that tracks the dependencies or input files used for a specific
+     * Flutter build step based on the current intermediate directory.
+     *
+     * @return the dependency file(s) based on the current intermediate directory.
+     */
+    @OutputFiles
+    @VisibleForTesting
+    internal fun getDependenciesFiles(baseFlutterTask: BaseFlutterTask): FileCollection {
+        var depfiles: FileCollection = baseFlutterTask.project.files()
+
+        // TODO(jesswon): During cleanup determine if .../flutter_build.d is ever a directory and refactor accordingly
+        // Includes all sources used in the flutter compilation.
+        depfiles += baseFlutterTask.project.files("${baseFlutterTask.intermediateDir}/flutter_build.d")
+        return depfiles
+    }
+
+    /**
+     * Checks precondition to ensures sourceDir is not null and is a directory. Also checks
+     * if intermediateDir is valid valid and creates it (and parent directories if needed) if invalid.
+     *
+     * @throws GradleException if sourceDir is null or is not a directory
+     */
+    @VisibleForTesting
+    internal fun checkPreConditions(baseFlutterTask: BaseFlutterTask) {
+        if (baseFlutterTask.sourceDir == null || !baseFlutterTask.sourceDir!!.isDirectory) {
+            throw GradleException(getGradleErrorMessage(baseFlutterTask))
+        }
+        baseFlutterTask.intermediateDir!!.mkdirs()
+    }
+
+    /**
+     * Computes the rule names for flutter assemble. To speed up builds that contain
+     * multiple ABIs, the target name is used to communicate which ones are required
+     * rather than the TargetPlatform. This allows multiple builds to share the same
+     * cache.
+     *
+     * @param baseFlutterTask is a BaseFlutterTask to access its properties
+     * @return the list of rule names for flutter assemble.
+     */
+    @VisibleForTesting
+    internal fun generateRuleNames(baseFlutterTask: BaseFlutterTask): List<String> {
+        val ruleNames: List<String> =
+            when {
+                baseFlutterTask.buildMode == "debug" -> listOf("debug_android_application")
+                baseFlutterTask.deferredComponents!! ->
+                    baseFlutterTask.targetPlatformValues!!
+                        .map {
+                            "android_aot_deferred_components_bundle_${baseFlutterTask.buildMode}_$it"
+                        }
+
+                else -> baseFlutterTask.targetPlatformValues!!.map { "android_aot_bundle_${baseFlutterTask.buildMode}_$it" }
+            }
+        return ruleNames
+    }
+
+    /**
+     * Creates and configures the build processes of an Android Flutter application to be executed.
+     * The configuration includes setting the executable to the Flutter command-line tool (Flutter CLI),
+     * setting the working directory to the Flutter project's source directory, adding command-line arguments and build rules
+     * to configure various build options.
+     *
+     * @return an Action<ExecSpec> of build processes and options to be executed.
+     */
+    internal fun createExecSpecActionFromTask(baseFlutterTask: BaseFlutterTask): Action<ExecSpec> =
+        Action<ExecSpec> {
+            executable(baseFlutterTask.flutterExecutable!!.absolutePath)
+            workingDir(baseFlutterTask.sourceDir)
+            baseFlutterTask.localEngine?.let {
+                args("--local-engine", it)
+                args("--local-engine-src-path", baseFlutterTask.localEngineSrcPath)
+            }
+            baseFlutterTask.localEngineHost?.let {
+                args("--local-engine-host", it)
+            }
+            if (baseFlutterTask.verbose == true) {
+                args("--verbose")
+            } else {
+                args("--quiet")
+            }
+            args("assemble")
+            args("--no-version-check")
+            args("--depfile", "${baseFlutterTask.intermediateDir}/flutter_build.d")
+            args("--output", "${baseFlutterTask.intermediateDir}")
+            baseFlutterTask.performanceMeasurementFile?.let {
+                args("--performance-measurement-file=$it")
+            }
+            if (!baseFlutterTask.fastStart!! || baseFlutterTask.buildMode != "debug") {
+                args("-dTargetFile=${baseFlutterTask.targetPath}")
+            } else {
+                args(
+                    "-dTargetFile=${
+                        Paths.get(
+                            baseFlutterTask.flutterRoot!!.absolutePath,
+                            "examples",
+                            "splash",
+                            "lib",
+                            "main.dart"
+                        )
+                    }"
+                )
+            }
+            args("-dTargetPlatform=android")
+            args("-dBuildMode=${baseFlutterTask.buildMode}")
+            baseFlutterTask.trackWidgetCreation?.let {
+                args("-dTrackWidgetCreation=$it")
+            }
+            baseFlutterTask.splitDebugInfo?.let {
+                args("-dSplitDebugInfo=$it")
+            }
+            if (baseFlutterTask.treeShakeIcons == true) {
+                args("-dTreeShakeIcons=true")
+            }
+            if (baseFlutterTask.dartObfuscation == true) {
+                args("-dDartObfuscation=true")
+            }
+            baseFlutterTask.dartDefines?.let {
+                args("--DartDefines=$it")
+            }
+            baseFlutterTask.bundleSkSLPath?.let {
+                args("-dBundleSkSLPath=$it")
+            }
+            baseFlutterTask.codeSizeDirectory?.let {
+                args("-dCodeSizeDirectory=$it")
+            }
+            baseFlutterTask.flavor?.let {
+                args("-dFlavor=$it")
+            }
+            baseFlutterTask.extraGenSnapshotOptions?.let {
+                args("--ExtraGenSnapshotOptions=$it")
+            }
+            baseFlutterTask.frontendServerStarterPath?.let {
+                args("-dFrontendServerStarterPath=$it")
+            }
+            baseFlutterTask.extraFrontEndOptions?.let {
+                args("--ExtraFrontEndOptions=$it")
+            }
+
+            args("-dAndroidArchs=${baseFlutterTask.targetPlatformValues!!.joinToString(" ")}")
+            args("-dMinSdkVersion=${baseFlutterTask.minSdkVersion}")
+            args(generateRuleNames(baseFlutterTask))
+        }
+
+    fun buildBundle(baseFlutterTask: BaseFlutterTask) {
+        checkPreConditions(baseFlutterTask)
+        baseFlutterTask.logging.captureStandardError(LogLevel.ERROR)
+        val execOps = baseFlutterTask.project.serviceOf<ExecOperations>()
+        execOps.exec(createExecSpecActionFromTask(baseFlutterTask = baseFlutterTask))
+    }
+}

--- a/packages/flutter_tools/gradle/bin/main/tasks/FlutterTask.kt
+++ b/packages/flutter_tools/gradle/bin/main/tasks/FlutterTask.kt
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.tasks
+
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFiles
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+// IMPORTANT: Do not add logic to the methods in this class directly,
+// instead add logic to [FlutterTaskHelper].
+
+/**
+ * Flutter's implementation of a Gradle task. Gradle tasks can not be instantiated for testing,
+ * so this class delegates all logic to [FlutterTaskHelper].
+ */
+abstract class FlutterTask : BaseFlutterTask() {
+    @get:OutputDirectory
+    val outputDirectory: File?
+        get() = FlutterTaskHelper.getOutputDirectory(flutterTask = this)
+
+    @get:Internal
+    val assetsDirectory: String
+        get() = FlutterTaskHelper.getAssetsDirectory(flutterTask = this)
+
+    @get:Internal
+    val assets: CopySpec
+        get() = FlutterTaskHelper.getAssets(project, flutterTask = this)
+
+    @get:Internal
+    val snapshots: CopySpec
+        get() = FlutterTaskHelper.getSnapshots(project, flutterTask = this)
+
+    @get:InputFiles
+    val sourceFiles: FileCollection
+        get() = FlutterTaskHelper.getSourceFiles(project, flutterTask = this)
+
+    @get:OutputFiles
+    val outputFiles: FileCollection
+        get() = FlutterTaskHelper.getOutputFiles(project, flutterTask = this)
+
+    @TaskAction
+    fun build() = FlutterTaskHelper.build(flutterTask = this)
+}

--- a/packages/flutter_tools/gradle/bin/main/tasks/FlutterTaskHelper.kt
+++ b/packages/flutter_tools/gradle/bin/main/tasks/FlutterTaskHelper.kt
@@ -1,0 +1,92 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.tasks
+
+import com.flutter.gradle.FlutterPluginConstants
+import org.gradle.api.Project
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileCollection
+import java.io.File
+
+/**
+ * Stateless object to contain the logic used in [FlutterTask]. Any required state should be stored
+ * on [FlutterTask] instead, while any logic needed by [FlutterTask] should be added here.
+ */
+object FlutterTaskHelper {
+    const val FLUTTER_ASSETS_INCLUDE_DIRECTORY = "flutter_assets/**"
+
+    internal fun getOutputDirectory(flutterTask: FlutterTask): File? = flutterTask.intermediateDir
+
+    internal fun getAssetsDirectory(flutterTask: FlutterTask): String = "${flutterTask.outputDirectory}/flutter_assets"
+
+    internal fun getAssets(
+        project: Project,
+        flutterTask: FlutterTask
+    ): CopySpec =
+        project.copySpec {
+            from("${flutterTask.intermediateDir}")
+            include(FLUTTER_ASSETS_INCLUDE_DIRECTORY) // the working dir and its files
+        }
+
+    internal fun getSnapshots(
+        project: Project,
+        flutterTask: FlutterTask
+    ): CopySpec =
+        project.copySpec {
+            from("${flutterTask.intermediateDir}")
+            if (flutterTask.buildMode == "release" || flutterTask.buildMode == "profile") {
+                flutterTask.targetPlatformValues!!.forEach { targetArch ->
+                    include("${FlutterPluginConstants.PLATFORM_ARCH_MAP[targetArch]}/app.so")
+                }
+            }
+        }
+
+    private fun readDependencies(
+        project: Project,
+        dependenciesFile: File,
+        inputs: Boolean
+    ): FileCollection {
+        if (dependenciesFile.exists()) {
+            // Dependencies file has Makefile syntax:
+            //   <target> <files>: <source> <files> <separated> <by> <non-escaped space>
+            val depText = dependenciesFile.readText()
+            // So we split list of files by non-escaped(by backslash) space,
+            val parts = depText.split(": ")
+            val fileString = parts[if (inputs) 1 else 0]
+            val matcher = Regex("""(\\ |\S)+""").findAll(fileString)
+            // then we replace all escaped spaces with regular spaces
+            val depList =
+                matcher.map { it.value.replace("\\\\ ", " ") }.toList()
+            return project.files(depList)
+        }
+        return project.files()
+    }
+
+    internal fun getSourceFiles(
+        project: Project,
+        flutterTask: FlutterTask
+    ): FileCollection {
+        var sources: FileCollection = project.files()
+        flutterTask.getDependenciesFiles().forEach { dependenciesFile ->
+            sources += readDependencies(project, dependenciesFile, true)
+        }
+        return sources + project.files("pubspec.yaml")
+    }
+
+    internal fun getOutputFiles(
+        project: Project,
+        flutterTask: FlutterTask
+    ): FileCollection {
+        var outputs: FileCollection = project.files()
+        flutterTask.getDependenciesFiles().forEach { dependenciesFile ->
+            outputs += readDependencies(project, dependenciesFile, false)
+        }
+        return outputs
+    }
+
+    internal fun build(flutterTask: FlutterTask) {
+        flutterTask.buildBundle()
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/AppLinkSettingsTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/AppLinkSettingsTest.kt
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+package com.flutter.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppLinkSettingsTest {
+    @Test
+    fun canCreateThenEditDeeplinks() {
+        val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+        val deeplink2 = Deeplink("scheme2", "host2", "path2", IntentFilterCheck())
+        val appLinkSettings = AppLinkSettings(applicationId = "testApplicationId")
+
+        appLinkSettings.deeplinks.add(deeplink1)
+        assert(appLinkSettings.deeplinks.contains(deeplink1))
+        // Check default value.
+        assertFalse(appLinkSettings.deeplinkingFlagEnabled)
+        // Can change the default value.
+        appLinkSettings.deeplinkingFlagEnabled = true
+
+        appLinkSettings.deeplinks.add(deeplink2)
+
+        assert(appLinkSettings.deeplinks.contains(deeplink1))
+        assert(appLinkSettings.deeplinks.contains(deeplink2))
+    }
+
+    @Test
+    fun canCreateAppLinkSettingsJson() {
+        val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+        val deeplink2 = Deeplink("scheme2", "host2", "path2", IntentFilterCheck())
+        val appLinkSettings = AppLinkSettings(applicationId = "testApplicationId")
+        appLinkSettings.deeplinkingFlagEnabled = true
+        appLinkSettings.deeplinks.addAll(listOf(deeplink1, deeplink2))
+
+        val settingsJson = appLinkSettings.toJson()
+
+        // Keys are not a reference because the key values are accessed
+        // across the gradle/dart boundery.
+        assertTrue(settingsJson.containsKey("applicationId"))
+        assertTrue(settingsJson.containsKey("deeplinkingFlagEnabled"))
+        assertTrue(settingsJson.containsKey("deeplinks"))
+        assertContains(settingsJson.toString(), deeplink1.toJson().toString())
+        assertContains(settingsJson.toString(), deeplink2.toJson().toString())
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/BaseApplicationNameHandlerTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/BaseApplicationNameHandlerTest.kt
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.api.dsl.ApplicationDefaultConfig
+import com.android.build.api.dsl.ApplicationExtension
+import com.flutter.gradle.BaseApplicationNameHandler.GRADLE_BASE_APPLICATION_NAME_PROPERTY
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.mockito.Mockito
+import kotlin.test.Test
+
+class BaseApplicationNameHandlerTest {
+    @Test
+    fun `setBaseName respects Flutter tool property`() {
+        val baseApplicationNamePassedByFlutterTool = "toolSetBaseApplicationName"
+
+        // Set up mocks.
+        val mockProject: Project = Mockito.mock(Project::class.java)
+        val mockAndroidComponentsExtension: ApplicationExtension = Mockito.mock(ApplicationExtension::class.java)
+        val mockExtensionContainer: ExtensionContainer = Mockito.mock(ExtensionContainer::class.java)
+        val mockDefaultConfig = Mockito.mock(ApplicationDefaultConfig::class.java)
+        val mockManifestPlaceholders = HashMap<String, Any>()
+
+        Mockito.`when`(mockProject.hasProperty(GRADLE_BASE_APPLICATION_NAME_PROPERTY)).thenReturn(true)
+        Mockito.`when`(mockProject.property(GRADLE_BASE_APPLICATION_NAME_PROPERTY)).thenReturn(baseApplicationNamePassedByFlutterTool)
+
+        Mockito.`when`(mockProject.extensions).thenReturn(mockExtensionContainer)
+        Mockito.`when`(mockExtensionContainer.findByType(ApplicationExtension::class.java)).thenReturn(mockAndroidComponentsExtension)
+        Mockito.`when`(mockAndroidComponentsExtension.defaultConfig).thenReturn(mockDefaultConfig)
+        Mockito.`when`(mockDefaultConfig.manifestPlaceholders).thenReturn(mockManifestPlaceholders)
+
+        // Call the base name handler.
+        BaseApplicationNameHandler.setBaseName(mockProject)
+
+        // Make sure we set the value passed by the tool.
+        assertEquals(mockManifestPlaceholders["applicationName"], baseApplicationNamePassedByFlutterTool)
+    }
+
+    @Test
+    fun `setBaseName defaults to correct value`() {
+        // Set up mocks.
+        val mockProject: Project = Mockito.mock(Project::class.java)
+        val mockAndroidComponentsExtension: ApplicationExtension = Mockito.mock(ApplicationExtension::class.java)
+        val mockExtensionContainer: ExtensionContainer = Mockito.mock(ExtensionContainer::class.java)
+        val mockDefaultConfig = Mockito.mock(ApplicationDefaultConfig::class.java)
+        val mockManifestPlaceholders = HashMap<String, Any>()
+
+        Mockito.`when`(mockProject.hasProperty(GRADLE_BASE_APPLICATION_NAME_PROPERTY)).thenReturn(false)
+
+        Mockito.`when`(mockProject.extensions).thenReturn(mockExtensionContainer)
+        Mockito.`when`(mockExtensionContainer.findByType(ApplicationExtension::class.java)).thenReturn(mockAndroidComponentsExtension)
+        Mockito.`when`(mockAndroidComponentsExtension.defaultConfig).thenReturn(mockDefaultConfig)
+        Mockito.`when`(mockDefaultConfig.manifestPlaceholders).thenReturn(mockManifestPlaceholders)
+
+        // Call the base name handler.
+        BaseApplicationNameHandler.setBaseName(mockProject)
+
+        // Make sure we default to the correct value.
+        assertEquals(mockManifestPlaceholders["applicationName"], BaseApplicationNameHandler.DEFAULT_BASE_APPLICATION_NAME)
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/DeeplinkTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/DeeplinkTest.kt
@@ -1,0 +1,62 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import org.gradle.internal.impldep.org.junit.Assert.assertThrows
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DeeplinkTest {
+    @Test
+    fun `equals should return true for equal objects`() {
+        val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+        val deeplink2 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+
+        assertTrue { deeplink1 == deeplink2 }
+    }
+
+    @Test
+    fun `equals should return false for unequal objects`() {
+        val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+        val deeplink2 = Deeplink("scheme2", "host2", "path2", IntentFilterCheck())
+
+        assertFalse { deeplink1 == deeplink2 }
+    }
+
+    @Test
+    fun `equals should return false for other of different type`() {
+        val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+        val notADeeplink = 5
+
+        assertFalse { deeplink1.equals(notADeeplink) }
+    }
+
+    @Suppress("UnusedEquals")
+    @Test
+    fun `equals should throw NullPointerException for null other`() {
+        val deeplink1 = Deeplink("scheme1", "host1", "path1", IntentFilterCheck())
+        val deeplink2 = null
+
+        assertThrows(NullPointerException::class.java, { deeplink1.equals(deeplink2) })
+    }
+
+    @Test
+    fun canCreateDeeplinkJsonWithIntentFilter() {
+        val intentFilterCheck = IntentFilterCheck()
+        intentFilterCheck.hasActionView = true
+        intentFilterCheck.hasDefaultCategory = true
+        val deeplink = Deeplink("scheme1", "host1", "path1", intentFilterCheck)
+        val linkJson = deeplink.toJson()
+        // Keys are not a reference because the key values are accessed
+        // across the gradle/dart boundery.
+        assertTrue(linkJson.containsKey("scheme"))
+        assertTrue(linkJson.containsKey("host"))
+        assertTrue(linkJson.containsKey("path"))
+        assertTrue(linkJson.containsKey("intentFilterCheck"))
+        assertContains(linkJson.toString(), intentFilterCheck.toJson().toString())
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/DependencyVersionCheckerTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/DependencyVersionCheckerTest.kt
@@ -1,0 +1,486 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.api.AndroidPluginVersion
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Variant
+import com.flutter.gradle.DependencyVersionChecker.AGP_NAME
+import com.flutter.gradle.DependencyVersionChecker.GRADLE_NAME
+import com.flutter.gradle.DependencyVersionChecker.JAVA_NAME
+import com.flutter.gradle.DependencyVersionChecker.KGP_NAME
+import com.flutter.gradle.DependencyVersionChecker.MIN_SDK_NAME
+import com.flutter.gradle.DependencyVersionChecker.OUT_OF_SUPPORT_RANGE_PROPERTY
+import com.flutter.gradle.DependencyVersionChecker.POTENTIAL_JAVA_FIX
+import com.flutter.gradle.DependencyVersionChecker.errorAGPVersion
+import com.flutter.gradle.DependencyVersionChecker.errorGradleVersion
+import com.flutter.gradle.DependencyVersionChecker.errorKGPVersion
+import com.flutter.gradle.DependencyVersionChecker.errorMinSdkVersion
+import com.flutter.gradle.DependencyVersionChecker.getErrorMessage
+import com.flutter.gradle.DependencyVersionChecker.getFlavorSpecificMessage
+import com.flutter.gradle.DependencyVersionChecker.getPotentialAGPFix
+import com.flutter.gradle.DependencyVersionChecker.getPotentialGradleFix
+import com.flutter.gradle.DependencyVersionChecker.getPotentialKGPFix
+import com.flutter.gradle.DependencyVersionChecker.getPotentialSDKFix
+import com.flutter.gradle.DependencyVersionChecker.getWarnMessage
+import com.flutter.gradle.DependencyVersionChecker.warnAGPVersion
+import com.flutter.gradle.DependencyVersionChecker.warnGradleVersion
+import com.flutter.gradle.DependencyVersionChecker.warnJavaVersion
+import com.flutter.gradle.DependencyVersionChecker.warnKGPVersion
+import com.flutter.gradle.DependencyVersionChecker.warnMinSdkVersion
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.JavaVersion
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.logging.Logger
+import org.gradle.api.plugins.ExtraPropertiesExtension
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.internal.extensions.core.extra
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+private const val FAKE_PROJECT_ROOT_DIR = "/fake/root/dir"
+
+// The following values will need to be modified when the corresponding "warn$DepName" versions
+// are updated in DependencyVersionChecker.kt
+private const val SUPPORTED_GRADLE_VERSION: String = "7.4.2"
+private val SUPPORTED_JAVA_VERSION: JavaVersion = JavaVersion.VERSION_11
+private val SUPPORTED_AGP_VERSION: AndroidPluginVersion = AndroidPluginVersion(8, 3, 0)
+private const val SUPPORTED_KGP_VERSION: String = "1.8.10"
+private val SUPPORTED_SDK_VERSION: MinSdkVersion = MinSdkVersion("release", 30)
+
+class DependencyVersionCheckerTest {
+    @Test
+    fun `AGP version in error range results in DependencyValidationException`() {
+        val exampleErrorAgpVersion = AndroidPluginVersion(4, 2, 0)
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleErrorAgpVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
+
+        val dependencyValidationException =
+            assertFailsWith<DependencyValidationException> { DependencyVersionChecker.checkDependencyVersions(mockProject) }
+        assert(
+            dependencyValidationException.message ==
+                getErrorMessage(
+                    AGP_NAME,
+                    exampleErrorAgpVersion.toString(),
+                    errorAGPVersion.toString(),
+                    getPotentialAGPFix(FAKE_PROJECT_ROOT_DIR)
+                )
+        )
+        verify { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    @Test
+    fun `AGP version in warn range results in warning logs`() {
+        val exampleWarnAgpVersion = AndroidPluginVersion(8, 2, 0)
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(agpVersion = exampleWarnAgpVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
+        val mockLogger = mockProject.logger
+        every { mockLogger.error(any()) } returns Unit
+
+        DependencyVersionChecker.checkDependencyVersions(mockProject)
+        verify {
+            mockLogger.error(
+                getWarnMessage(
+                    AGP_NAME,
+                    exampleWarnAgpVersion.toString(),
+                    warnAGPVersion.toString(),
+                    getPotentialAGPFix(FAKE_PROJECT_ROOT_DIR)
+                )
+            )
+        }
+        verify(exactly = 0) { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    @Test
+    fun `KGP version in error range results in DependencyValidationException`() {
+        val exampleErrorKgpVersion = "1.6.0"
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleErrorKgpVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
+
+        val dependencyValidationException =
+            assertFailsWith<DependencyValidationException> { DependencyVersionChecker.checkDependencyVersions(mockProject) }
+
+        println(dependencyValidationException.message)
+        assert(
+            dependencyValidationException.message ==
+                getErrorMessage(
+                    KGP_NAME,
+                    exampleErrorKgpVersion,
+                    errorKGPVersion.toString(),
+                    getPotentialKGPFix(FAKE_PROJECT_ROOT_DIR)
+                )
+        )
+        verify { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    @Test
+    fun `KGP version in warn range results in warning logs`() {
+        val exampleWarnKgpVersion = "1.8.0"
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(kgpVersion = exampleWarnKgpVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
+        val mockLogger = mockProject.logger
+        every { mockLogger.error(any()) } returns Unit
+
+        DependencyVersionChecker.checkDependencyVersions(mockProject)
+        verify {
+            mockLogger.error(
+                getWarnMessage(
+                    KGP_NAME,
+                    exampleWarnKgpVersion,
+                    warnKGPVersion.toString(),
+                    getPotentialKGPFix(FAKE_PROJECT_ROOT_DIR)
+                )
+            )
+        }
+        verify(exactly = 0) { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    // No test for Java version in error range, as the lowest supported Java version is also the
+    // lowest possible.
+
+    @Test
+    fun `Java version in warn range results in warning logs`() {
+        val exampleWarnJavaVersion = JavaVersion.VERSION_1_8
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(javaVersion = exampleWarnJavaVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
+        val mockLogger = mockProject.logger
+        every { mockLogger.error(any()) } returns Unit
+
+        DependencyVersionChecker.checkDependencyVersions(mockProject)
+        verify {
+            mockLogger.error(
+                getWarnMessage(
+                    JAVA_NAME,
+                    exampleWarnJavaVersion.toString(),
+                    warnJavaVersion.toString(),
+                    POTENTIAL_JAVA_FIX
+                )
+            )
+        }
+        verify(exactly = 0) { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    @Test
+    fun `Gradle version in error range results in DependencyValidationException`() {
+        val exampleErrorGradleVersion = "7.0.0"
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleErrorGradleVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
+
+        val dependencyValidationException =
+            assertFailsWith<DependencyValidationException> { DependencyVersionChecker.checkDependencyVersions(mockProject) }
+
+        assert(
+            dependencyValidationException.message ==
+                getErrorMessage(
+                    GRADLE_NAME,
+                    exampleErrorGradleVersion,
+                    errorGradleVersion.toString(),
+                    getPotentialGradleFix(FAKE_PROJECT_ROOT_DIR)
+                )
+        )
+        verify { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    @Test
+    fun `Gradle version in warn range results in warning logs`() {
+        val exampleWarnGradleVersion = "7.4.0"
+        val mockProject = MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(gradleVersion = exampleWarnGradleVersion)
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, false) } returns Unit
+        val mockLogger = mockProject.logger
+        every { mockLogger.error(any()) } returns Unit
+
+        DependencyVersionChecker.checkDependencyVersions(mockProject)
+        verify {
+            mockLogger.error(
+                getWarnMessage(
+                    GRADLE_NAME,
+                    exampleWarnGradleVersion,
+                    warnGradleVersion.toString(),
+                    getPotentialGradleFix(FAKE_PROJECT_ROOT_DIR)
+                )
+            )
+        }
+        verify(exactly = 0) { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
+    }
+
+    @Test
+    fun `min SDK version in warn range results in warning logs`() {
+        val exampleWarnSDKVersion = 19
+        val flavorName1 = "flavor1"
+        val flavorName2 = "flavor2"
+        val mockProject =
+            MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(
+                minSdkVersions =
+                    listOf(
+                        MinSdkVersion(flavorName1, exampleWarnSDKVersion),
+                        MinSdkVersion(flavorName2, exampleWarnSDKVersion)
+                    )
+            )
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        every {
+            mockExtraPropertiesExtension.set(
+                OUT_OF_SUPPORT_RANGE_PROPERTY,
+                false
+            )
+        } returns Unit
+        val mockLogger = mockProject.logger
+        every { mockLogger.error(any()) } returns Unit
+
+        DependencyVersionChecker.checkDependencyVersions(mockProject)
+        verify {
+            mockLogger.error(
+                getWarnMessage(
+                    getFlavorSpecificMessage(flavorName1, MIN_SDK_NAME),
+                    exampleWarnSDKVersion.toString(),
+                    warnMinSdkVersion.toString(),
+                    getPotentialSDKFix(FAKE_PROJECT_ROOT_DIR)
+                )
+            )
+            mockLogger.error(
+                getWarnMessage(
+                    getFlavorSpecificMessage(flavorName2, MIN_SDK_NAME),
+                    exampleWarnSDKVersion.toString(),
+                    warnMinSdkVersion.toString(),
+                    getPotentialSDKFix(FAKE_PROJECT_ROOT_DIR)
+                )
+            )
+        }
+        verify(exactly = 0) {
+            mockExtraPropertiesExtension.set(
+                OUT_OF_SUPPORT_RANGE_PROPERTY,
+                true
+            )
+        }
+    }
+
+    @Test
+    fun `min SDK version in error range results in DependencyValidationException`() {
+        val exampleErrorSDKVersion = 0
+        val flavorName = "flavor1"
+        val mockProject =
+            MockProjectFactory.createMockProjectWithSpecifiedDependencyVersions(
+                minSdkVersions =
+                    listOf(
+                        MinSdkVersion(flavorName, exampleErrorSDKVersion)
+                    )
+            )
+
+        val mockExtraPropertiesExtension = mockProject.extra
+        val mockLogger = mockProject.logger
+        every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
+        every { mockLogger.error(any()) } returns Unit
+
+        val dependencyValidationException =
+            assertFailsWith<DependencyValidationException> {
+                DependencyVersionChecker.checkDependencyVersions(
+                    mockProject
+                )
+            }
+
+        assert(
+            dependencyValidationException.message ==
+                getErrorMessage(
+                    getFlavorSpecificMessage(flavorName, MIN_SDK_NAME),
+                    exampleErrorSDKVersion.toString(),
+                    errorMinSdkVersion.toString(),
+                    getPotentialSDKFix(FAKE_PROJECT_ROOT_DIR)
+                )
+        )
+        verify(exactly = 1) {
+            mockExtraPropertiesExtension.set(
+                OUT_OF_SUPPORT_RANGE_PROPERTY,
+                true
+            )
+        }
+    }
+
+    @Test
+    fun `checkMinSdkVersion throws error when in error range for min SDK version`() {
+        val mockLogger = mockk<Logger>()
+        val mockExtraPropertiesExtension = mockk<ExtraPropertiesExtension>()
+        val projectDir = "projectDir"
+        val flavor = "flavor"
+        val version = 0
+
+        every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
+        every { mockLogger.error(any()) } returns Unit
+
+        val dependencyValidationException =
+            assertFailsWith<DependencyValidationException> {
+                DependencyVersionChecker.checkMinSdkVersion(
+                    minSdkVersion = MinSdkVersion(flavor, version),
+                    projectDirectory = projectDir,
+                    logger = mockLogger
+                )
+            }
+
+        assertEquals(
+            dependencyValidationException.message,
+            "Error: Your project's minimum Android SDK (flavor='flavor') version (0) is lower than " +
+                "Flutter's minimum supported version of 1. Please upgrade your minimum Android SDK " +
+                "(flavor='flavor') version. \n" +
+                "Alternatively, use the flag \"--android-skip-build-dependency-validation\" to " +
+                "bypass this check.\n" +
+                "\n" +
+                "Potential fix: Your project's minimum Android SDK version is typically defined in " +
+                "the android block of the app-level `build.gradle(.kts)` file " +
+                "(projectDir/app/build.gradle(.kts))."
+        )
+    }
+
+    @Test
+    fun `checkMinSdkVersion logs warning when in warning range for min SDK version`() {
+        val mockLogger = mockk<Logger>()
+        val mockExtraPropertiesExtension = mockk<ExtraPropertiesExtension>()
+        val projectDir = "projectDir"
+        val flavor = "flavor"
+        val version = 20
+
+        every { mockExtraPropertiesExtension.set(any(), any()) } returns Unit
+        every { mockLogger.error(any()) } returns Unit
+
+        DependencyVersionChecker.checkMinSdkVersion(
+            minSdkVersion = MinSdkVersion(flavor, version),
+            projectDirectory = projectDir,
+            logger = mockLogger
+        )
+
+        val warningMessageSlot = slot<String>()
+        verify {
+            mockLogger.error(capture(warningMessageSlot))
+        }
+
+        assertEquals(
+            warningMessageSlot.captured,
+            "Warning: Flutter support for your project's minimum Android SDK (flavor='flavor') " +
+                "version (20) will soon be dropped. Please upgrade your minimum Android SDK " +
+                "(flavor='flavor') version to a version of at least 21 soon.\n" +
+                "Alternatively, use the flag \"--android-skip-build-dependency-validation\" to " +
+                "bypass this check.\n" +
+                "\n" +
+                "Potential fix: Your project's minimum Android SDK version is typically defined in " +
+                "the android block of the app-level `build.gradle(.kts)` file " +
+                "(projectDir/app/build.gradle(.kts))."
+        )
+    }
+}
+
+// There isn't a way to create a real org.gradle.api.Project object for testing unfortunately, so
+// these tests rely heavily on mocking.
+//
+// TODO(gmackall): We should consider adding functional tests built on top of a testing framework
+//  perhaps like
+//  https://github.com/autonomousapps/dependency-analysis-gradle-plugin/tree/main/testkit
+//  as a way to fill this gap in testing (combined with moving functionality to individual tasks
+//  that can be tested independently).
+private object MockProjectFactory {
+    fun createMockProjectWithSpecifiedDependencyVersions(
+        javaVersion: JavaVersion = SUPPORTED_JAVA_VERSION,
+        gradleVersion: String = SUPPORTED_GRADLE_VERSION,
+        agpVersion: AndroidPluginVersion = SUPPORTED_AGP_VERSION,
+        kgpVersion: String = SUPPORTED_KGP_VERSION,
+        minSdkVersions: List<MinSdkVersion> = listOf(SUPPORTED_SDK_VERSION)
+    ): Project {
+        // Java
+        mockkStatic(JavaVersion::class)
+        every { JavaVersion.current() } returns javaVersion
+
+        // Gradle
+        val mockProject = mockk<Project>()
+        every { mockProject.gradle.gradleVersion } returns gradleVersion
+
+        // AGP
+        val mockAndroidComponentsExtension = mockk<AndroidComponentsExtension<*, *, *>>()
+        every { mockProject.extensions.findByType(AndroidComponentsExtension::class.java) } returns mockAndroidComponentsExtension
+        every { mockAndroidComponentsExtension.pluginVersion } returns agpVersion
+
+        // KGP
+        every { mockProject.hasProperty(eq("kotlin_version")) } returns true
+        every { mockProject.properties["kotlin_version"] } returns kgpVersion
+
+        // Logger
+        val mockLogger = mockk<Logger>()
+        every { mockProject.logger } returns mockLogger
+
+        // Extra properties extension
+        val mockExtraPropertiesExtension = mockk<ExtraPropertiesExtension>()
+        every { mockProject.extra } returns mockExtraPropertiesExtension
+
+        // Project path
+        every { mockProject.rootDir.path } returns FAKE_PROJECT_ROOT_DIR
+
+        // SDK
+        val actionSlot = slot<Action<Project>>()
+        every { mockProject.afterEvaluate(capture(actionSlot)) } answers {
+            actionSlot.captured.execute(mockProject)
+            return@answers Unit
+        }
+        val onVariantsFnSlot = slot<(Variant) -> Unit>()
+        every { mockAndroidComponentsExtension.selector() } returns
+            mockk {
+                every { all() } returns mockk()
+            }
+        every { mockProject.tasks } returns
+            mockk<TaskContainer> {
+                val registerTaskSlot = slot<Action<Task>>()
+                every { register(any(), capture(registerTaskSlot)) } answers registerAnswer@{
+                    registerTaskSlot.captured.execute(
+                        mockk {
+                            val doLastActionSlot = slot<Action<Task>>()
+                            every { doLast(capture(doLastActionSlot)) } answers doLastAnswer@{
+                                doLastActionSlot.captured.execute(mockk())
+                                return@doLastAnswer mockk()
+                            }
+                        }
+                    )
+                    return@registerAnswer mockk()
+                }
+
+                every { named(any<String>()) } returns
+                    mockk {
+                        every { configure(any<Action<Task>>()) } returns mockk()
+                    }
+            }
+        every {
+            mockAndroidComponentsExtension.onVariants(
+                any(),
+                capture(onVariantsFnSlot)
+            )
+        } answers {
+            minSdkVersions.forEach {
+                val variant = mockk<Variant>()
+                every { variant.name } returns it.flavor
+                every { variant.minSdk } returns mockk { every { apiLevel } returns it.version }
+                every { variant.minSdkVersion } returns mockk { every { apiLevel } returns it.version }
+                onVariantsFnSlot.captured.invoke(variant)
+            }
+            return@answers Unit
+        }
+
+        return mockProject
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/FlutterExtensionTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/FlutterExtensionTest.kt
@@ -1,0 +1,45 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import org.gradle.api.GradleException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class FlutterExtensionTest {
+    @Test
+    fun `getVersionCode() throws GradleException when flutterVersion is not set`() {
+        val flutterExtension: FlutterExtension = FlutterExtension()
+        assertFailsWith<GradleException> { flutterExtension.getVersionCode() }
+    }
+
+    @Test
+    fun `getVersionCode() throws GradleException when flutterVersion is not an integer`() {
+        val flutterExtension: FlutterExtension = FlutterExtension()
+        flutterExtension.flutterVersionCode = "not an integer"
+        assertFailsWith<GradleException> { flutterExtension.getVersionCode() }
+    }
+
+    @Test
+    fun `getVersionCode() returns flutterVersion without error when set and is a number`() {
+        val flutterExtension: FlutterExtension = FlutterExtension()
+        flutterExtension.flutterVersionCode = "123"
+        assertEquals(123, flutterExtension.getVersionCode())
+    }
+
+    @Test
+    fun `getVersionName() throws GradleException when flutterVersionName is not set`() {
+        val flutterExtension: FlutterExtension = FlutterExtension()
+        assertFailsWith<GradleException> { flutterExtension.getVersionName() }
+    }
+
+    @Test
+    fun `getVersionName() returns flutterVersionName without error when set`() {
+        val flutterExtension: FlutterExtension = FlutterExtension()
+        flutterExtension.flutterVersionName = "1.2.3"
+        assertEquals("1.2.3", flutterExtension.getVersionName())
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/FlutterPluginTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/FlutterPluginTest.kt
@@ -1,0 +1,78 @@
+package com.flutter.gradle
+
+import com.android.build.api.dsl.ApplicationDefaultConfig
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.gradle.AbstractAppExtension
+import com.android.build.gradle.BaseExtension
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import org.gradle.api.Project
+import org.gradle.api.file.Directory
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.writeText
+import kotlin.test.Test
+
+class FlutterPluginTest {
+    @Test
+    fun `FlutterPlugin apply() adds expected tasks`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("project-dir").resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+        val settingsFile = projectDir.parent.resolve("settings.gradle")
+        settingsFile.writeText("empty for now")
+        val fakeFlutterSdkDir = tempDir.resolve("fake-flutter-sdk")
+        fakeFlutterSdkDir.toFile().mkdirs()
+        val fakeCacheDir = fakeFlutterSdkDir.resolve("bin").resolve("cache")
+        fakeCacheDir.toFile().mkdirs()
+        val fakeEngineStampFile = fakeCacheDir.resolve("engine.stamp")
+        fakeEngineStampFile.writeText(FAKE_ENGINE_STAMP)
+        val fakeEngineRealmFile = fakeCacheDir.resolve("engine.realm")
+        fakeEngineRealmFile.writeText(FAKE_ENGINE_REALM)
+        val project = mockk<Project>(relaxed = true)
+        val mockAbstractAppExtension = mockk<AbstractAppExtension>(relaxed = true)
+        every { project.extensions.findByType(AbstractAppExtension::class.java) } returns mockAbstractAppExtension
+        every { project.extensions.getByType(AbstractAppExtension::class.java) } returns mockAbstractAppExtension
+        every { project.extensions.findByName("android") } returns mockAbstractAppExtension
+        every { project.projectDir } returns projectDir.toFile()
+        every { project.findProperty("flutter.sdk") } returns fakeFlutterSdkDir.toString()
+        every { project.file(fakeFlutterSdkDir.toString()) } returns fakeFlutterSdkDir.toFile()
+        val flutterExtension = FlutterExtension()
+        every { project.extensions.create("flutter", any<Class<*>>()) } returns flutterExtension
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns flutterExtension
+        val mockBaseExtension = mockk<BaseExtension>(relaxed = true)
+        every { project.extensions.findByType(BaseExtension::class.java) } returns mockBaseExtension
+        val mockApplicationExtension = mockk<ApplicationExtension>(relaxed = true)
+        every { project.extensions.findByType(ApplicationExtension::class.java) } returns mockApplicationExtension
+        val mockApplicationDefaultConfig = mockk<ApplicationDefaultConfig>(relaxed = true)
+        every { mockApplicationExtension.defaultConfig } returns mockApplicationDefaultConfig
+        every { project.rootProject } returns project
+        every { project.state.failure } returns null
+        val mockDirectory = mockk<Directory>(relaxed = true)
+        every { project.layout.buildDirectory.get() } returns mockDirectory
+        val mockAndroidSourceSet = mockk<com.android.build.gradle.api.AndroidSourceSet>(relaxed = true)
+        every { mockAbstractAppExtension.sourceSets.getByName("main") } returns mockAndroidSourceSet
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        mockkObject(NativePluginLoaderReflectionBridge)
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns
+            listOf()
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.file(flutterExtension.source!!) } returns mockk()
+        val flutterPlugin = FlutterPlugin()
+        flutterPlugin.apply(project)
+
+        verify { project.tasks.register("generateLockfiles", any()) }
+        verify { project.tasks.register("javaVersion", any()) }
+        verify { project.tasks.register("printBuildVariants", any()) }
+    }
+
+    companion object {
+        const val FAKE_ENGINE_STAMP = "901b0f1afe77c3555abee7b86a26aaa37f131379"
+        const val FAKE_ENGINE_REALM = "made_up_realm"
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/FlutterPluginUtilsTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/FlutterPluginUtilsTest.kt
@@ -1,0 +1,1217 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import com.android.build.gradle.AbstractAppExtension
+import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.ApplicationVariant
+import com.android.build.gradle.api.BaseVariantOutput
+import com.android.build.gradle.internal.dsl.CmakeOptions
+import com.android.build.gradle.internal.dsl.DefaultConfig
+import com.android.build.gradle.tasks.ProcessAndroidResources
+import com.android.builder.model.BuildType
+import com.flutter.gradle.plugins.PluginHandler
+import io.mockk.called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.DomainObjectCollection
+import org.gradle.api.DomainObjectSet
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.UnknownTaskException
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.logging.Logger
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import java.util.Properties
+import kotlin.io.path.createDirectory
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class FlutterPluginUtilsTest {
+    companion object {
+        const val EXAMPLE_ENGINE_VERSION = "1.0.0-e0676b47c7550ecdc0f0c4fa759201449b2c5f23"
+
+        val devDependency: Map<String?, Any?> =
+            mapOf(
+                Pair("name", "grays_fun_dev_dependency"),
+                Pair(
+                    "path",
+                    "/Users/someuser/.pub-cache/hosted/pub.dev/grays_fun_dev_dependency-1.1.1/"
+                ),
+                Pair("native_build", true),
+                Pair("dependencies", emptyList<String>()),
+                Pair("dev_dependency", true)
+            )
+
+        val cameraDependency: Map<String?, Any?> =
+            mapOf(
+                Pair("name", "camera_android_camerax"),
+                Pair(
+                    "path",
+                    "/Users/someuser/.pub-cache/hosted/pub.dev/camera_android_camerax-0.6.14+1/"
+                ),
+                Pair("native_build", true),
+                Pair("dependencies", emptyList<String>()),
+                Pair("dev_dependency", false)
+            )
+
+        val flutterPluginAndroidLifecycleDependency: Map<String?, Any?> =
+            mapOf(
+                Pair("name", "flutter_plugin_android_lifecycle"),
+                Pair(
+                    "path",
+                    "/Users/someuser/.pub-cache/hosted/pub.dev/flutter_plugin_android_lifecycle-2.0.27/"
+                ),
+                Pair("native_build", true),
+                Pair("dependencies", emptyList<String>()),
+                Pair("dev_dependency", false)
+            )
+
+        val pluginListWithoutDevDependency: List<Map<String?, Any?>> =
+            listOf(
+                cameraDependency,
+                flutterPluginAndroidLifecycleDependency,
+                mapOf(
+                    Pair("name", "in_app_purchase_android"),
+                    Pair(
+                        "path",
+                        "/Users/someuser/.pub-cache/hosted/pub.dev/in_app_purchase_android-0.4.0+1/"
+                    ),
+                    Pair("native_build", true),
+                    Pair("dependencies", emptyList<String>()),
+                    Pair("dev_dependency", false)
+                )
+            )
+
+        val pluginListWithDevDependency: List<Map<String?, Any?>> =
+            listOf(
+                cameraDependency,
+                flutterPluginAndroidLifecycleDependency,
+                devDependency,
+                mapOf(
+                    Pair("name", "in_app_purchase_android"),
+                    Pair(
+                        "path",
+                        "/Users/someuser/.pub-cache/hosted/pub.dev/in_app_purchase_android-0.4.0+1/"
+                    ),
+                    Pair("native_build", true),
+                    Pair("dependencies", emptyList<String>()),
+                    Pair("dev_dependency", false)
+                )
+            )
+        val manifestText =
+            """
+                <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+                    <!-- Permissions do not break parsing -->
+                    <uses-permission android:name="android.permission.INTERNET"/>
+
+                    <application android:label="Flutter Task Helper Test" android:icon="@mipmap/ic_launcher">
+                        <activity android:name="com.example.FlutterActivity1"
+                                  android:exported="true"
+                                  android:theme="@android:style/Theme.Black.NoTitleBar">
+                            <intent-filter>
+                                <action android:name="android.intent.action.MAIN"/>
+                                <category android:name="android.intent.category.LAUNCHER"/>
+                            </intent-filter>
+                        </activity>
+                        <activity android:name="com.example.FlutterActivity2"
+                                  android:exported="false"
+                                  android:theme="@android:style/Theme.Black.NoTitleBar">
+                            <intent-filter>
+                              <action android:name="android.intent.action.VIEW" />
+                              <category android:name="android.intent.category.DEFAULT" />
+                              <category android:name="android.intent.category.BROWSABLE" />
+                              <data
+                                android:scheme="poc"
+                                android:host="deeplink.flutter.dev"
+                                android:pathPrefix="some.prefix"
+                                />
+                            </intent-filter>
+                            <meta-data android:name="flutter_deeplinking_enabled" android:value="true" />
+                        </activity>
+                        <meta-data
+                            android:name="flutterEmbedding"
+                            android:value="2" />
+
+                    </application>
+            </manifest>
+            """.trimIndent()
+    }
+
+    // toCamelCase
+    @Test
+    fun `toCamelCase converts a list of strings to camel case`() {
+        val result = FlutterPluginUtils.toCamelCase(listOf("hello", "world"))
+        assertEquals("helloWorld", result)
+    }
+
+    @Test
+    fun `toCamelCase handles empty list`() {
+        val result = FlutterPluginUtils.toCamelCase(emptyList())
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `toCamelCase handles single-element list`() {
+        val result = FlutterPluginUtils.toCamelCase(listOf("hello"))
+        assertEquals("hello", result)
+    }
+
+    // compareVersionStrings
+    @Test
+    fun `compareVersionStrings compares last element of version string correctly`() {
+        val result = FlutterPluginUtils.compareVersionStrings("1.2.3", "1.2.4")
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun `compareVersionStrings compares middle element of version string correctly`() {
+        val result = FlutterPluginUtils.compareVersionStrings("1.2.3", "1.1.4")
+        assertEquals(1, result)
+    }
+
+    @Test
+    fun `compareVersionStrings compares first element of version string correctly`() {
+        val result = FlutterPluginUtils.compareVersionStrings("1.2.3", "2.2.4")
+        assertEquals(-1, result)
+    }
+
+    @Test
+    fun `compareVersionStrings considers rc candidates the same`() {
+        val result = FlutterPluginUtils.compareVersionStrings("1.2.3-rc", "1.2.3")
+        assertEquals(0, result)
+    }
+
+    // formatPlatformString
+    @Test
+    fun `formatPlatformString returns correct string`() {
+        val result = FlutterPluginUtils.formatPlatformString("android-arm64")
+        assertEquals("arm64_v8a", result)
+    }
+
+    // shouldShrinkResources
+    @Test
+    fun `shouldShrinkResources returns true by default`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(any()) } returns false
+        val result = FlutterPluginUtils.shouldShrinkResources(project)
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `shouldShrinkResources returns true when property is set to true`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_SHOULD_SHRINK_RESOURCES) } returns true
+        every { project.property(FlutterPluginUtils.PROP_SHOULD_SHRINK_RESOURCES) } returns true
+        val result = FlutterPluginUtils.shouldShrinkResources(project)
+        assertEquals(true, result)
+    }
+
+    // settingsGradleFile
+    @Test
+    fun `settingsGradleFile returns groovy settings gradle file when it exists`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+
+        val settingsGradle = File(projectDir.parent.toFile(), "settings.gradle")
+        settingsGradle.createNewFile()
+
+        val result =
+            FlutterPluginUtils.getSettingsGradleFileFromProjectDir(projectDir.toFile(), mockk())
+        assertEquals(settingsGradle, result)
+    }
+
+    @Test
+    fun `settingsGradleFile returns groovy settings file and logs when both groovy and kotlin exist`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+
+        val groovySettingsGradle = File(projectDir.parent.toFile(), "settings.gradle")
+        groovySettingsGradle.createNewFile()
+        val kotlinSettingsGradle = File(projectDir.parent.toFile(), "settings.gradle.kts")
+        kotlinSettingsGradle.createNewFile()
+
+        val mockLogger = mockk<Logger>()
+        every { mockLogger.error(any()) } returns Unit
+
+        val result =
+            FlutterPluginUtils.getSettingsGradleFileFromProjectDir(projectDir.toFile(), mockLogger)
+        assertEquals(groovySettingsGradle, result)
+        verify { mockLogger.error(any()) }
+    }
+
+    // buildGradleFile
+    @Test
+    fun `buildGradleFile returns groovy build gradle file when it exists`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+
+        val buildGradle = File(projectDir.parent.resolve("app").toFile(), "build.gradle")
+        buildGradle.createNewFile()
+
+        val result =
+            FlutterPluginUtils.getBuildGradleFileFromProjectDir(projectDir.toFile(), mockk())
+        assertEquals(buildGradle, result)
+    }
+
+    @Test
+    fun `buildGradleFile returns groovy build file and logs when both groovy and kotlin exist`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("android").resolve("app")
+        projectDir.toFile().mkdirs()
+
+        val groovyBuildGradle = File(projectDir.parent.resolve("app").toFile(), "build.gradle")
+        groovyBuildGradle.createNewFile()
+        val kotlinBuildGradle = File(projectDir.parent.resolve("app").toFile(), "build.gradle.kts")
+        kotlinBuildGradle.createNewFile()
+
+        val mockLogger = mockk<Logger>()
+        every { mockLogger.error(any()) } returns Unit
+
+        val result =
+            FlutterPluginUtils.getBuildGradleFileFromProjectDir(projectDir.toFile(), mockLogger)
+        assertEquals(groovyBuildGradle, result)
+        verify { mockLogger.error(any()) }
+    }
+
+    // shouldProjectSplitPerAbi
+    @Test
+    fun `shouldProjectSplitPerAbi returns false by default`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_SPLIT_PER_ABI) } returns null
+        val result = FlutterPluginUtils.shouldProjectSplitPerAbi(project)
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `shouldProjectSplitPerAbi returns true when property is set to true`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_SPLIT_PER_ABI) } returns "true"
+        val result = FlutterPluginUtils.shouldProjectSplitPerAbi(project)
+        assertEquals(true, result)
+    }
+
+    // shouldProjectUseLocalEngine skipped as it is a wrapper for a single getter
+
+    // isProjectVerbose
+    @Test
+    fun `isProjectVerbose returns false by default`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_IS_VERBOSE) } returns null
+        val result = FlutterPluginUtils.isProjectVerbose(project)
+        assertEquals(false, result)
+    }
+
+    // isProjectVerbose
+    @Test
+    fun `isProjectVerbose returns true when the property is set to true`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_IS_VERBOSE) } returns true
+        val result = FlutterPluginUtils.isProjectVerbose(project)
+        assertEquals(true, result)
+    }
+
+    // isProjectFastStart
+    @Test
+    fun `isProjectFastStart returns false by default`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_IS_FAST_START) } returns null
+        val result = FlutterPluginUtils.isProjectFastStart(project)
+        assertEquals(false, result)
+    }
+
+    @Test
+    fun `isProjectFastStart returns true when the property is set to true`() {
+        val project = mockk<Project>()
+        every { project.findProperty(FlutterPluginUtils.PROP_IS_FAST_START) } returns true
+        val result = FlutterPluginUtils.isProjectFastStart(project)
+        assertEquals(true, result)
+    }
+
+    // shouldConfigureFlutterTask
+    @Test
+    fun `shouldConfigureFlutterTask returns true for assemble task`() {
+        val project = mockk<Project>()
+        val assembleTask = mockk<Task>()
+
+        every { project.gradle.startParameter.taskNames } returns listOf("assemble")
+
+        val result = FlutterPluginUtils.shouldConfigureFlutterTask(project, assembleTask)
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `shouldConfigureFlutterTask returns true when taskname and assembleTask end with Release`() {
+        val project = mockk<Project>()
+        val assembleTask = mockk<Task>()
+
+        every { project.gradle.startParameter.taskNames } returns listOf("assembleRelease")
+        every { assembleTask.name } returns "assembleSomethingElseRelease"
+
+        val result = FlutterPluginUtils.shouldConfigureFlutterTask(project, assembleTask)
+        assertEquals(true, result)
+    }
+
+    // getFlutterSourceDirectory
+    @Test
+    fun `getFlutterSourceDirectory returns the flutter source directory`() {
+        val flutterExtension = FlutterExtension()
+        val project = mockk<Project>()
+
+        flutterExtension.source = "my/flutter/source/directory"
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns flutterExtension
+        every { project.file(any()) } returns mockk()
+
+        FlutterPluginUtils.getFlutterSourceDirectory(project)
+        verify { project.file("my/flutter/source/directory") }
+    }
+
+    @Test
+    fun `getFlutterSourceDirectory throws exception when flutter source directory is not set`() {
+        val flutterExtension = FlutterExtension()
+        val project = mockk<Project>()
+
+        flutterExtension.source = null
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns flutterExtension
+
+        assertThrows<GradleException> {
+            FlutterPluginUtils.getFlutterSourceDirectory(project)
+        }
+    }
+
+    // getFlutterTarget
+    @Test
+    fun `getFlutterTarget returns the target when the project property is set`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns true
+        every { project.property(FlutterPluginUtils.PROP_TARGET) } returns "my/target"
+
+        val result = FlutterPluginUtils.getFlutterTarget(project)
+        assertEquals("my/target", result)
+    }
+
+    @Test
+    fun `getFlutterTarget returns the target from the FlutterExtension when it is set and project property is not set`() {
+        val flutterExtension = FlutterExtension()
+        val project = mockk<Project>()
+        flutterExtension.target = "my/target"
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns false
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns flutterExtension
+
+        val result = FlutterPluginUtils.getFlutterTarget(project)
+        assertEquals(flutterExtension.target, result)
+    }
+
+    @Test
+    fun `getFlutterTarget returns the default target when it is not set`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET) } returns false
+        every { project.extensions.findByType(FlutterExtension::class.java)!!.target } returns null
+
+        val result = FlutterPluginUtils.getFlutterTarget(project)
+        assertEquals("lib/main.dart", result)
+    }
+
+    // isBuiltAsApp skipped as it is a wrapper for a single getter
+
+    // addApiDependencies
+    @Test
+    fun `addApiDependencies adds the dependency with the correct name when no UnknownTaskException`() {
+        val project = mockk<Project>()
+        val variantName = "debug"
+        val dependency = mockk<Any>()
+
+        every { project.configurations.named("api") } returns mockk()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+
+        FlutterPluginUtils.addApiDependencies(project, variantName, dependency)
+
+        verify { project.dependencies.add("debugApi", dependency) }
+    }
+
+    @Test
+    fun `addApiDependencies adds the dependency with the correct name when UnknownTaskException`() {
+        val project = mockk<Project>()
+        val variantName = "debug"
+        val dependency = mockk<Any>()
+
+        every { project.configurations.named("api") } throws
+            UnknownTaskException(
+                "message",
+                mockk()
+            )
+        every { project.dependencies.add(any(), any()) } returns mockk()
+
+        FlutterPluginUtils.addApiDependencies(project, variantName, dependency)
+
+        verify { project.dependencies.add("debugCompile", dependency) }
+    }
+
+    // buildModeFor
+    @Test
+    fun `buildModeFor returns profile if the BuildType has name profile`() {
+        val buildType = mockk<BuildType>()
+        every { buildType.name } returns "profile"
+
+        val result = FlutterPluginUtils.buildModeFor(buildType)
+        assertEquals("profile", result)
+    }
+
+    @Test
+    fun `buildModeFor returns debug if the BuildType is debuggable`() {
+        val buildType = mockk<BuildType>()
+        every { buildType.name } returns "something random"
+        every { buildType.isDebuggable } returns true
+
+        val result = FlutterPluginUtils.buildModeFor(buildType)
+        assertEquals("debug", result)
+    }
+
+    @Test
+    fun `buildModeFor returns release if the BuildType is not debuggable and not named profile`() {
+        val buildType = mockk<BuildType>()
+        every { buildType.isDebuggable } returns false
+        every { buildType.name } returns "something random"
+
+        val result = FlutterPluginUtils.buildModeFor(buildType)
+        assertEquals("release", result)
+    }
+
+    // supportsBuildMode
+    @Test
+    fun `supportsBuildMode returns true if project should not use local engine`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_LOCAL_ENGINE_REPO) } returns false
+        val result = FlutterPluginUtils.supportsBuildMode(project, "debug")
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `supportsBuildMode returns false if project should use local engine and build mode does not match`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_LOCAL_ENGINE_REPO) } returns true
+        every { project.hasProperty(FlutterPluginUtils.PROP_LOCAL_ENGINE_BUILD_MODE) } returns true
+        every { project.property(FlutterPluginUtils.PROP_LOCAL_ENGINE_BUILD_MODE) } returns "debug"
+
+        val result = FlutterPluginUtils.supportsBuildMode(project, "release")
+        assertEquals(false, result)
+    }
+
+    // getTargetPlatforms
+    @Test
+    fun `getTargetPlatforms the default if property is not set`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET_PLATFORM) } returns false
+        val result = FlutterPluginUtils.getTargetPlatforms(project)
+        assertEquals(listOf("android-arm", "android-arm64", "android-x64"), result)
+    }
+
+    @Test
+    fun `getTargetPlatforms the value if property is set`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET_PLATFORM) } returns true
+        every { project.property(FlutterPluginUtils.PROP_TARGET_PLATFORM) } returns "android-arm64,android-arm"
+        val result = FlutterPluginUtils.getTargetPlatforms(project)
+        assertEquals(listOf("android-arm64", "android-arm"), result)
+    }
+
+    @Test
+    fun `getTargetPlatforms throws GradleException if property is set to invalid value`() {
+        val project = mockk<Project>()
+        every { project.hasProperty(FlutterPluginUtils.PROP_TARGET_PLATFORM) } returns true
+        every { project.property(FlutterPluginUtils.PROP_TARGET_PLATFORM) } returns "android-invalid"
+        val gradleException: GradleException =
+            assertThrows<GradleException> {
+                FlutterPluginUtils.getTargetPlatforms(project)
+            }
+        assertContains(gradleException.message!!, "android-invalid")
+    }
+
+    // readPropertiesIfExist
+    @Test
+    fun `readPropertiesIfExist returns empty Properties when file does not exist`(
+        @TempDir tempDir: Path
+    ) {
+        val propertiesFile = tempDir.resolve("file_that_doesnt_exist.properties")
+        val result = FlutterPluginUtils.readPropertiesIfExist(propertiesFile.toFile())
+        assertEquals(Properties(), result)
+    }
+
+    @Test
+    fun `readPropertiesIfExist returns Properties when file exists`(
+        @TempDir tempDir: Path
+    ) {
+        val propertiesFile = tempDir.resolve("file_that_exists.properties").toFile()
+        propertiesFile.writeText(
+            """
+            sdk.dir=/Users/someuser/Library/Android/sdk
+            flutter.sdk=/Users/someuser/development/flutter/flutter
+            flutter.buildMode=release
+            flutter.versionName=1.0.0
+            flutter.versionCode=1
+            """.trimIndent()
+        )
+
+        val result = FlutterPluginUtils.readPropertiesIfExist(propertiesFile)
+        assertEquals(5, result.size)
+        assertEquals("/Users/someuser/Library/Android/sdk", result["sdk.dir"])
+        assertEquals("/Users/someuser/development/flutter/flutter", result["flutter.sdk"])
+        assertEquals("release", result["flutter.buildMode"])
+        assertEquals("1.0.0", result["flutter.versionName"])
+        assertEquals("1", result["flutter.versionCode"])
+    }
+
+    // getCompileSdkFromProject
+    @Test
+    fun `getCompileSdkFromProject returns the compileSdk from the project`() {
+        val project = mockk<Project>()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        val result = FlutterPluginUtils.getCompileSdkFromProject(project)
+        assertEquals("35", result)
+    }
+
+    // detectLowCompileSdkVersionOrNdkVersion
+    @Test
+    fun `detectLowCompileSdkVersionOrNdkVersion logs no warnings when no plugins have higher sdk or ndk`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("app").toFile()
+
+        val project = mockk<Project>()
+        val mockLogger = mockk<Logger>()
+        every { project.logger } returns mockLogger
+        every { project.projectDir } returns projectDir
+        val cameraPluginProject = mockk<Project>()
+        val projectActionSlot = slot<Action<Project>>()
+        val cameraPluginProjectActionSlot = slot<Action<Project>>()
+        every { project.afterEvaluate(any<Action<Project>>()) } returns Unit
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { project.extensions.findByType(BaseExtension::class.java)!!.ndkVersion } returns "26.3.11579264"
+        every { project.rootProject.findProject(":${cameraDependency["name"]}") } returns cameraPluginProject
+        every { cameraPluginProject.afterEvaluate(capture(cameraPluginProjectActionSlot)) } returns Unit
+        every { cameraPluginProject.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { cameraPluginProject.extensions.findByType(BaseExtension::class.java)!!.ndkVersion } returns "26.3.11579264"
+
+        FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(project, listOf(cameraDependency))
+
+        verify { project.afterEvaluate(capture(projectActionSlot)) }
+        projectActionSlot.captured.execute(project)
+        verify { cameraPluginProject.afterEvaluate(capture(cameraPluginProjectActionSlot)) }
+        cameraPluginProjectActionSlot.captured.execute(cameraPluginProject)
+
+        verify { mockLogger wasNot called }
+    }
+
+    @Test
+    fun `detectLowCompileSdkVersionOrNdkVersion logs warnings when plugins have higher sdk and ndk`(
+        @TempDir tempDir: Path
+    ) {
+        val buildGradleFile =
+            tempDir
+                .resolve("app")
+                .createDirectory()
+                .resolve("build.gradle")
+                .toFile()
+        buildGradleFile.createNewFile()
+        val projectDir = tempDir.resolve("app").toFile()
+
+        val project = mockk<Project>()
+        val mockLogger = mockk<Logger>()
+        every { project.logger } returns mockLogger
+        every { mockLogger.error(any()) } returns Unit
+        every { project.projectDir } returns projectDir
+        val cameraPluginProject = mockk<Project>()
+        val flutterPluginAndroidLifecycleDependencyPluginProject = mockk<Project>()
+        val projectActionSlot = slot<Action<Project>>()
+        val cameraPluginProjectActionSlot = slot<Action<Project>>()
+        val flutterPluginAndroidLifecycleDependencyPluginProjectActionSlot = slot<Action<Project>>()
+        every { project.afterEvaluate(any<Action<Project>>()) } returns Unit
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-33"
+        every { project.extensions.findByType(BaseExtension::class.java)!!.ndkVersion } returns "24.3.11579264"
+        every { project.rootProject.findProject(":${cameraDependency["name"]}") } returns cameraPluginProject
+        every { project.rootProject.findProject(":${flutterPluginAndroidLifecycleDependency["name"]}") } returns
+            flutterPluginAndroidLifecycleDependencyPluginProject
+        every { cameraPluginProject.afterEvaluate(capture(cameraPluginProjectActionSlot)) } returns Unit
+        every { cameraPluginProject.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { cameraPluginProject.extensions.findByType(BaseExtension::class.java)!!.ndkVersion } returns "26.3.11579264"
+        every {
+            flutterPluginAndroidLifecycleDependencyPluginProject.afterEvaluate(
+                capture(
+                    flutterPluginAndroidLifecycleDependencyPluginProjectActionSlot
+                )
+            )
+        } returns Unit
+        every {
+            flutterPluginAndroidLifecycleDependencyPluginProject.extensions
+                .findByType(
+                    BaseExtension::class.java
+                )!!
+                .compileSdkVersion
+        } returns "android-34"
+        every {
+            flutterPluginAndroidLifecycleDependencyPluginProject.extensions
+                .findByType(
+                    BaseExtension::class.java
+                )!!
+                .ndkVersion
+        } returns "25.3.11579264"
+
+        val dependencyList: List<Map<String?, Any?>> =
+            listOf(cameraDependency, flutterPluginAndroidLifecycleDependency)
+        FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(
+            project,
+            dependencyList
+        )
+
+        verify { project.afterEvaluate(capture(projectActionSlot)) }
+        projectActionSlot.captured.execute(project)
+        verify { cameraPluginProject.afterEvaluate(capture(cameraPluginProjectActionSlot)) }
+        cameraPluginProjectActionSlot.captured.execute(cameraPluginProject)
+        verify {
+            flutterPluginAndroidLifecycleDependencyPluginProject.afterEvaluate(
+                capture(
+                    flutterPluginAndroidLifecycleDependencyPluginProjectActionSlot
+                )
+            )
+        }
+        flutterPluginAndroidLifecycleDependencyPluginProjectActionSlot.captured.execute(
+            flutterPluginAndroidLifecycleDependencyPluginProject
+        )
+
+        verify {
+            mockLogger.error(
+                "Your project is configured to compile against Android SDK 33, but the " +
+                    "following plugin(s) require to be compiled against a higher Android SDK version:"
+            )
+        }
+        verify {
+            mockLogger.error(
+                "- ${cameraDependency["name"]} compiles against Android SDK 35"
+            )
+        }
+        verify {
+            mockLogger.error(
+                "- ${flutterPluginAndroidLifecycleDependency["name"]} compiles against Android SDK 34"
+            )
+        }
+        verify {
+            mockLogger.error(
+                """
+                Fix this issue by compiling against the highest Android SDK version (they are backward compatible).
+                Add the following to ${buildGradleFile.path}:
+
+                    android {
+                        compileSdk = 35
+                        ...
+                    }
+                """.trimIndent()
+            )
+        }
+        verify {
+            mockLogger.error(
+                "Your project is configured with Android NDK 24.3.11579264, but the following plugin(s) depend on a different Android NDK version:"
+            )
+        }
+        verify {
+            mockLogger.error(
+                "- ${cameraDependency["name"]} requires Android NDK 26.3.11579264"
+            )
+        }
+        verify {
+            mockLogger.error(
+                "- ${flutterPluginAndroidLifecycleDependency["name"]} requires Android NDK 25.3.11579264"
+            )
+        }
+        verify {
+            mockLogger.error(
+                """
+                Fix this issue by using the highest Android NDK version (they are backward compatible).
+                Add the following to ${buildGradleFile.path}:
+
+                    android {
+                        ndkVersion = "26.3.11579264"
+                        ...
+                    }
+                """.trimIndent()
+            )
+        }
+    }
+
+    @Test
+    fun `detectLowCompileSdkVersionOrNdkVersion throws IllegalArgumentException when plugin has no name`() {
+        val project = mockk<Project>()
+        val projectActionSlot = slot<Action<Project>>()
+        every { project.afterEvaluate(any<Action<Project>>()) } returns Unit
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { project.extensions.findByType(BaseExtension::class.java)!!.ndkVersion } returns "26.3.11579264"
+
+        val pluginWithoutName: MutableMap<String?, Any?> = cameraDependency.toMutableMap()
+        pluginWithoutName.remove("name")
+
+        FlutterPluginUtils.detectLowCompileSdkVersionOrNdkVersion(
+            project,
+            listOf(pluginWithoutName)
+        )
+        verify { project.afterEvaluate(capture(projectActionSlot)) }
+        assertThrows<IllegalArgumentException> { projectActionSlot.captured.execute(project) }
+    }
+
+    // forceNdkDownload
+    @Test
+    fun `forceNdkDownload skips projects which are already configuring a native build`(
+        @TempDir tempDir: Path
+    ) {
+        val fakeCmakeFile = tempDir.resolve("CMakeLists.txt").toFile()
+        fakeCmakeFile.createNewFile()
+        val project = mockk<Project>()
+        val mockCmakeOptions = mockk<CmakeOptions>()
+        val mockDefaultConfig = mockk<DefaultConfig>()
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .externalNativeBuild.cmake
+        } returns mockCmakeOptions
+        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+
+        every { mockCmakeOptions.path } returns fakeCmakeFile
+
+        FlutterPluginUtils.forceNdkDownload(project, "ignored")
+
+        verify(exactly = 1) {
+            mockCmakeOptions.path
+        }
+        verify(exactly = 0) { mockCmakeOptions.setPath(any()) }
+        verify { mockDefaultConfig wasNot called }
+    }
+
+    @Test
+    fun `forceNdkDownload sets externalNativeBuild properties`() {
+        val project = mockk<Project>()
+        val mockCmakeOptions = mockk<CmakeOptions>()
+        val mockDefaultConfig = mockk<DefaultConfig>()
+        val mockDirectoryProperty = mockk<DirectoryProperty>()
+        val mockDirectory = mockk<Directory>()
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .externalNativeBuild.cmake
+        } returns mockCmakeOptions
+        every { project.extensions.findByType(BaseExtension::class.java)!!.defaultConfig } returns mockDefaultConfig
+
+        val basePath = "/base/path"
+        val fakeBuildPath = "/randomapp/build/app/"
+        every { mockCmakeOptions.path } returns null
+        every { mockCmakeOptions.path(any()) } returns Unit
+        every { mockDefaultConfig.externalNativeBuild.cmake.arguments(any(), any()) } returns Unit
+        every { mockCmakeOptions.buildStagingDirectory(any()) } returns Unit
+        every { project.layout.buildDirectory } returns mockDirectoryProperty
+        every { mockDirectoryProperty.dir(any<String>()) } returns mockDirectoryProperty
+        every { mockDirectoryProperty.get() } returns mockDirectory
+        every { mockDirectory.asFile.path } returns fakeBuildPath
+
+        FlutterPluginUtils.forceNdkDownload(project, basePath)
+
+        verify(exactly = 1) {
+            mockCmakeOptions.path
+        }
+        verify(exactly = 1) { mockCmakeOptions.path("$basePath/packages/flutter_tools/gradle/src/main/scripts/CMakeLists.txt") }
+        verify(exactly = 1) { mockCmakeOptions.buildStagingDirectory(any()) }
+        verify(exactly = 1) {
+            mockDefaultConfig.externalNativeBuild.cmake.arguments(
+                "-Wno-dev",
+                "--no-warn-unused-cli"
+            )
+        }
+    }
+
+    // isFlutterAppProject skipped as it is a wrapper for a single getter that we would have to mock
+
+    // addFlutterDependencies
+    @Test
+    fun `addFlutterDependencies returns early if buildMode is not supported`() {
+        val project = mockk<Project>()
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns pluginListWithoutDevDependency
+        val buildType: BuildType = mockk<BuildType>()
+        every { buildType.name } returns "debug"
+        every { buildType.isDebuggable } returns true
+        every { project.hasProperty("local-engine-repo") } returns true
+        every { project.hasProperty("local-engine-build-mode") } returns true
+        every { project.property("local-engine-build-mode") } returns "release"
+        every { project.logger.quiet(any()) } returns Unit
+
+        FlutterPluginUtils.addFlutterDependencies(
+            project = project,
+            buildType = buildType,
+            pluginHandler = pluginHandler,
+            engineVersion = "1.0.0-e0676b47c7550ecdc0f0c4fa759201449b2c5f23"
+        )
+
+        verify(exactly = 1) {
+            project.logger.quiet(
+                "Project does not support Flutter build mode: debug, " +
+                    "skipping adding flutter dependencies"
+            )
+        }
+    }
+
+    @Test
+    fun `addFlutterDependencies adds libflutter dependency but not embedding dependency when is a flutter app`() {
+        val project = mockk<Project>()
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns pluginListWithoutDevDependency
+        val buildType: BuildType = mockk<BuildType>()
+        val engineVersion = EXAMPLE_ENGINE_VERSION
+        every { buildType.name } returns "debug"
+        every { buildType.isDebuggable } returns true
+        every { project.hasProperty("local-engine-repo") } returns false
+        every { project.extensions.findByType(AbstractAppExtension::class.java) } returns mockk<AbstractAppExtension>()
+        every { project.hasProperty("target-platform") } returns false
+        every { project.configurations.named("api") } returns mockk()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+
+        FlutterPluginUtils.addFlutterDependencies(
+            project = project,
+            buildType = buildType,
+            pluginHandler = pluginHandler,
+            engineVersion = engineVersion
+        )
+
+        verify(exactly = 3) { project.dependencies.add(any(), any()) }
+        verify {
+            project.dependencies.add(
+                "debugApi",
+                "io.flutter:armeabi_v7a_debug:$engineVersion"
+            )
+        }
+        verify { project.dependencies.add("debugApi", "io.flutter:arm64_v8a_debug:$engineVersion") }
+        verify { project.dependencies.add("debugApi", "io.flutter:x86_64_debug:$engineVersion") }
+    }
+
+    @Test
+    fun `addFlutterDependencies adds libflutter and embedding dep when only dep is dev dep in release mode`() {
+        val project = mockk<Project>()
+        val pluginListWithSingleDevDependency = listOf(devDependency)
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns pluginListWithSingleDevDependency
+        val buildType: BuildType = mockk<BuildType>()
+        val engineVersion = EXAMPLE_ENGINE_VERSION
+        every { buildType.name } returns "release"
+        every { buildType.isDebuggable } returns false
+        every { project.hasProperty("local-engine-repo") } returns false
+        every { project.extensions.findByType(AbstractAppExtension::class.java) } returns mockk<AbstractAppExtension>()
+        every { project.hasProperty("target-platform") } returns false
+        every { project.configurations.named("api") } returns mockk()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+
+        FlutterPluginUtils.addFlutterDependencies(
+            project = project,
+            buildType = buildType,
+            pluginHandler = pluginHandler,
+            engineVersion = engineVersion
+        )
+
+        verify(exactly = 4) { project.dependencies.add(any(), any()) }
+        verify {
+            project.dependencies.add(
+                "releaseApi",
+                "io.flutter:flutter_embedding_release:$engineVersion"
+            )
+        }
+        verify {
+            project.dependencies.add(
+                "releaseApi",
+                "io.flutter:armeabi_v7a_release:$engineVersion"
+            )
+        }
+        verify {
+            project.dependencies.add(
+                "releaseApi",
+                "io.flutter:arm64_v8a_release:$engineVersion"
+            )
+        }
+        verify {
+            project.dependencies.add(
+                "releaseApi",
+                "io.flutter:x86_64_release:$engineVersion"
+            )
+        }
+    }
+
+    @Test
+    fun `addFlutterDependencies adds libflutter dep but not embedding dep when only dep is dev dep in debug mode`() {
+        val project = mockk<Project>()
+        val pluginListWithSingleDevDependency = listOf(devDependency)
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns pluginListWithSingleDevDependency
+        val buildType: BuildType = mockk<BuildType>()
+        val engineVersion = EXAMPLE_ENGINE_VERSION
+        every { buildType.name } returns "debug"
+        every { buildType.isDebuggable } returns true
+        every { project.hasProperty("local-engine-repo") } returns false
+        every { project.extensions.findByType(AbstractAppExtension::class.java) } returns mockk<AbstractAppExtension>()
+        every { project.hasProperty("target-platform") } returns false
+        every { project.configurations.named("api") } returns mockk()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+
+        FlutterPluginUtils.addFlutterDependencies(
+            project = project,
+            buildType = buildType,
+            pluginHandler = pluginHandler,
+            engineVersion = engineVersion
+        )
+
+        verify(exactly = 3) { project.dependencies.add(any(), any()) }
+        verify {
+            project.dependencies.add(
+                "debugApi",
+                "io.flutter:armeabi_v7a_debug:$engineVersion"
+            )
+        }
+        verify {
+            project.dependencies.add(
+                "debugApi",
+                "io.flutter:arm64_v8a_debug:$engineVersion"
+            )
+        }
+        verify {
+            project.dependencies.add(
+                "debugApi",
+                "io.flutter:x86_64_debug:$engineVersion"
+            )
+        }
+    }
+
+    // addTaskForJavaVersion
+    @Test
+    fun `addTaskForJavaVersion adds task for Java version`() {
+        val project = mockk<Project>()
+        every { project.tasks.register(any(), any<Action<Task>>()) } returns mockk()
+        val captureSlot = slot<Action<Task>>()
+        FlutterPluginUtils.addTaskForJavaVersion(project)
+        verify { project.tasks.register("javaVersion", capture(captureSlot)) }
+
+        val mockTask = mockk<Task>()
+        every { mockTask.description = any() } returns Unit
+        every { mockTask.doLast(any<Action<Task>>()) } returns mockk()
+        captureSlot.captured.execute(mockTask)
+        verify {
+            mockTask.description = "Print the current java version used by gradle. see: " +
+                "https://docs.gradle.org/current/javadoc/org/gradle/api/JavaVersion.html"
+        }
+    }
+
+    // addTaskForPrintBuildVariants
+    @Test
+    fun `addTaskForPrintBuildVariants adds task for printing build variants`() {
+        val project = mockk<Project>()
+        every { project.extensions.getByType(AbstractAppExtension::class.java) } returns mockk()
+        every { project.tasks.register(any(), any<Action<Task>>()) } returns mockk()
+        val captureSlot = slot<Action<Task>>()
+
+        FlutterPluginUtils.addTaskForPrintBuildVariants(project)
+
+        verify { project.tasks.register("printBuildVariants", capture(captureSlot)) }
+        val mockTask = mockk<Task>()
+        every { mockTask.description = any() } returns Unit
+        every { mockTask.doLast(any<Action<Task>>()) } returns mockk()
+
+        captureSlot.captured.execute(mockTask)
+
+        verify {
+            mockTask.description = "Prints out all build variants for this Android project"
+        }
+    }
+
+    @Test
+    fun addTasksForOutputsAppLinkSettingsActual(
+        @TempDir tempDir: Path
+    ) {
+        val variants: MutableList<ApplicationVariant> = mutableListOf()
+        val registerTaskList = mutableListOf<Task>()
+        val descriptionSlot = slot<String>()
+        // vars so variables can be overridden below.
+        var mockLogger = mockk<Logger>()
+        var variantWithLinks = mockk<ApplicationVariant>()
+
+        val mockProject =
+            mockk<Project> {
+                every { logger } returns
+                    mockk {
+                        mockLogger = this
+                        every { info(any()) } returns Unit
+                        every { warn(any()) } returns Unit
+                    }
+                every { extensions.findByName("android") } returns
+                    mockk<AbstractAppExtension> {
+                        val variant1 =
+                            mockk<ApplicationVariant> {
+                                every { name } returns "one"
+                                every { applicationId } returns "com.example.FlutterActivity1"
+                            }
+                        variants.add(variant1)
+                        mockk<ApplicationVariant> {
+                            variantWithLinks = this
+                            every { name } returns "two"
+                            every { applicationId } returns "com.example.FlutterActivity2"
+                        }
+                        variants.add(variantWithLinks)
+                        // Capture the "action" that needs to be run for each variant.
+                        val actionSlot = slot<Action<ApplicationVariant>>()
+                        every { applicationVariants } returns
+                            mockk<DomainObjectSet<ApplicationVariant>> {
+                                every { configureEach(capture(actionSlot)) } answers {
+                                    // Execute the action for each variant.
+                                    variants.forEach { variant ->
+                                        actionSlot.captured.execute(variant)
+                                    }
+                                }
+                            }
+                    }
+
+                val registerTaskSlot = slot<Action<Task>>()
+                every { tasks } returns
+                    mockk<TaskContainer> {
+                        val registerTaskNameSlot = slot<String>()
+                        every {
+                            register(
+                                capture(registerTaskNameSlot),
+                                capture(registerTaskSlot)
+                            )
+                        } answers registerAnswer@{
+                            val mockRegisterTask =
+                                mockk<Task> {
+                                    every { name } returns registerTaskNameSlot.captured
+                                    every {
+                                        description = capture(descriptionSlot)
+                                    } returns Unit
+                                    every { dependsOn(any<ProcessAndroidResources>()) } returns mockk()
+                                    val doLastActionSlot = slot<Action<Task>>()
+                                    every { doLast(capture(doLastActionSlot)) } answers doLastAnswer@{
+                                        // We need to capture the task as well
+                                        doLastActionSlot.captured.execute(mockk())
+                                        return@doLastAnswer mockk()
+                                    }
+                                }
+                            registerTaskList.add(mockRegisterTask)
+                            registerTaskSlot.captured.execute(mockRegisterTask)
+                            return@registerAnswer mockk()
+                        }
+
+                        every { named(any<String>()) } returns
+                            mockk {
+                                every { configure(any<Action<Task>>()) } returns mockk()
+                            }
+                    }
+            }
+
+        variants.forEach { variant ->
+            val testOutputs: DomainObjectCollection<BaseVariantOutput> =
+                mockk<DomainObjectCollection<BaseVariantOutput>>()
+            val baseVariantSlot = slot<Action<BaseVariantOutput>>()
+            val baseVariantOutput = mockk<BaseVariantOutput>()
+            // Create a real file in a temp directory.
+            val manifest =
+                tempDir
+                    .resolve("${tempDir.toAbsolutePath()}/AndroidManifest.xml")
+                    .toFile()
+            manifest.writeText(manifestText)
+            val mockProcessResourcesProvider = mockk<TaskProvider<ProcessAndroidResources>>()
+            val mockProcessResources = mockk<ProcessAndroidResources>()
+            every {
+                mockProcessResourcesProvider.hint(ProcessAndroidResources::class).get()
+            } returns mockProcessResources
+            every { baseVariantOutput.processResourcesProvider } returns mockProcessResourcesProvider
+            // Fallback processing.
+            every { mockProcessResources.manifestFile } returns manifest
+
+            every { testOutputs.configureEach(capture(baseVariantSlot)) } answers {
+                // Execute the action for each output.
+                baseVariantSlot.captured.execute(baseVariantOutput)
+            }
+            every { variant.outputs } returns testOutputs
+        }
+        val outputFile =
+            tempDir
+                .resolve("${tempDir.toAbsolutePath()}/app-link-settings-build-variant.json")
+                .toFile()
+        every { mockProject.property("outputPath") } returns outputFile
+
+        FlutterPluginUtils.addTasksForOutputsAppLinkSettings(mockProject)
+
+        verify(exactly = 0) { mockLogger.info(any()) }
+        assert(descriptionSlot.captured.contains("stores app links settings for the given build variant"))
+        assertEquals(variants.size, registerTaskList.size)
+        for (i in 0 until variants.size) {
+            assertEquals(
+                "output${FlutterPluginUtils.capitalize(variants[i].name)}AppLinkSettings",
+                registerTaskList[i].name
+            )
+            verify(exactly = 1) { registerTaskList[i].dependsOn(any<ProcessAndroidResources>()) }
+        }
+        // Output assertions are minimal which ensures code is running but is not exhaustive testing.
+        // Integration test for more exhaustive behavior is defined in
+        // flutter/flutter/packages/flutter_tools/test/integration.shard/android_gradle_outputs_app_link_settings_test.dart
+        val outputFileText = outputFile.readText()
+        // Only variant2 since that one has app links.
+        assertContains(outputFileText, variantWithLinks.applicationId)
+        // Host.
+        assertContains(outputFileText, "deeplink.flutter.dev")
+        // pathPrefix used in variant2 combined with prefix logic.
+        assertContains(outputFileText, "some.prefix.*")
+        // Deep linking
+        assertContains(outputFileText, "deeplinkingFlagEnabled\":true")
+    }
+
+    @Test
+    fun addTasksForOutputsAppLinkSettingsNoAndroid(
+        @TempDir tempDir: Path
+    ) {
+        val mockProject = mockk<Project>()
+        val mockLogger = mockk<Logger>()
+        every { mockProject.logger } returns mockLogger
+        every { mockLogger.info(any()) } returns Unit
+        every { mockProject.extensions.findByName("android") } returns null
+
+        FlutterPluginUtils.addTasksForOutputsAppLinkSettings(mockProject)
+        verify(exactly = 1) { mockLogger.info("addTasksForOutputsAppLinkSettings called on project without android extension.") }
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/IntentFilterCheckTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/IntentFilterCheckTest.kt
@@ -1,0 +1,32 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class IntentFilterCheckTest {
+    @Test
+    fun canCreateIntentFilterJson() {
+        val intentFilterCheck = IntentFilterCheck()
+        intentFilterCheck.hasActionView = true
+        intentFilterCheck.hasDefaultCategory = true
+
+        val intentJson = intentFilterCheck.toJson()
+
+        // Keys are not a reference because the key values are accessed
+        // across the gradle/dart boundery.
+        assertTrue(intentJson.containsKey("hasAutoVerify"))
+        assertTrue(intentJson.containsKey("hasActionView"))
+        assertTrue(intentJson.containsKey("hasDefaultCategory"))
+        assertTrue(intentJson.containsKey("hasBrowsableCategory"))
+
+        assertEquals("false", intentJson.get(key = "hasAutoVerify").toString())
+        assertEquals("true", intentJson.get(key = "hasActionView").toString())
+        assertEquals("true", intentJson.get(key = "hasDefaultCategory").toString())
+        assertEquals("false", intentJson.get(key = "hasBrowsableCategory").toString())
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/VersionUtilsTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/VersionUtilsTest.kt
@@ -1,0 +1,40 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class VersionUtilsTest {
+    @Test
+    fun handles_documenation_examples() {
+        versionComparison("2.8.0", "2.8", expected = "2.8.0")
+        versionComparison("8.7-rc-2", "8.7.2", expected = "8.7.2")
+    }
+
+    @Test
+    fun expanded_examples() {
+        versionComparison("1.2", "1.2.0", expected = "1.2.0")
+        versionComparison("1.0", "1", expected = "1.0")
+        versionComparison("1.2.0-alpha", "1.2", expected = "1.2")
+        versionComparison("1.2.3", "1.2.3", expected = "1.2.3")
+        versionComparison("1.2.3-beta", "1.2.3", expected = "1.2.3")
+        versionComparison("1.2.3", "1.2.3.4", expected = "1.2.3.4")
+        versionComparison("rc-2", "rc-1", expected = "rc-2")
+        versionComparison("8.7-rc-1", "8.7", expected = "8.7")
+        versionComparison("8.7-rc-1", "8.7.2", expected = "8.7.2")
+        versionComparison("8.7.2", "8.7.1", expected = "8.7.2")
+        versionComparison("7.0.2", "8.7.1", expected = "8.7.1")
+        versionComparison("8.1", "7.5", expected = "8.1")
+    }
+
+    fun versionComparison(
+        version1: String,
+        version2: String,
+        expected: String
+    ) {
+        assertEquals(expected, VersionUtils.mostRecentSemanticVersion(version1, version2))
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/plugins/PluginHandlerTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/plugins/PluginHandlerTest.kt
@@ -1,0 +1,443 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.plugins
+
+import com.android.build.gradle.BaseExtension
+import com.flutter.gradle.FlutterExtension
+import com.flutter.gradle.FlutterPluginUtilsTest.Companion.EXAMPLE_ENGINE_VERSION
+import com.flutter.gradle.FlutterPluginUtilsTest.Companion.cameraDependency
+import com.flutter.gradle.FlutterPluginUtilsTest.Companion.flutterPluginAndroidLifecycleDependency
+import com.flutter.gradle.FlutterPluginUtilsTest.Companion.pluginListWithDevDependency
+import com.flutter.gradle.FlutterPluginUtilsTest.Companion.pluginListWithoutDevDependency
+import com.flutter.gradle.NativePluginLoaderReflectionBridge
+import io.mockk.called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PluginHandlerTest {
+    // getPluginListWithoutDevDependencies
+    @Test
+    fun `getPluginListWithoutDevDependencies removes dev dependencies from list`() {
+        val project = mockk<Project>()
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        every {
+            NativePluginLoaderReflectionBridge.getPlugins(
+                any(),
+                any()
+            )
+        } returns pluginListWithDevDependency
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+
+        val result = pluginHandler.getPluginListWithoutDevDependencies()
+        assertEquals(pluginListWithoutDevDependency, result)
+    }
+
+    @Test
+    fun `getPluginListWithoutDevDependencies does not modify list without dev dependencies`() {
+        val project = mockk<Project>()
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        every {
+            NativePluginLoaderReflectionBridge.getPlugins(
+                any(),
+                any()
+            )
+        } returns pluginListWithoutDevDependency
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+
+        val result = pluginHandler.getPluginListWithoutDevDependencies()
+        assertEquals(pluginListWithoutDevDependency, result)
+    }
+
+    // getPluginList skipped as it is a wrapper around a single reflection call
+
+    // pluginSupportsAndroidPlatform
+    @Test
+    fun `pluginSupportsAndroidPlatform returns true when android directory exists with gradle build file`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("my-plugin")
+        projectDir.toFile().mkdirs()
+
+        val androidDir = tempDir.resolve("android")
+        androidDir.toFile().mkdirs()
+        File(androidDir.toFile(), "build.gradle").createNewFile()
+
+        val mockProject =
+            mockk<Project> {
+                every { this@mockk.projectDir } returns projectDir.toFile()
+            }
+
+        assertTrue {
+            PluginHandler.pluginSupportsAndroidPlatform(mockProject)
+        } // Replace YourClass with the actual class containing the method
+    }
+
+    @Test
+    fun `pluginSupportsAndroidPlatform returns false when gradle build file does not exist`(
+        @TempDir tempDir: Path
+    ) {
+        val projectDir = tempDir.resolve("my-plugin")
+        projectDir.toFile().mkdirs()
+
+        val mockProject =
+            mockk<Project> {
+                every { this@mockk.projectDir } returns projectDir.toFile()
+            }
+
+        assertFalse {
+            PluginHandler.pluginSupportsAndroidPlatform(mockProject)
+        }
+    }
+
+    @Test
+    fun `configurePlugins throws IllegalArgumentException when plugin has no name`(
+        @TempDir tempDir: Path
+    ) {
+        val project = mockk<Project>()
+
+        // configuration for configureLegacyPluginEachProjects
+        val projectDir = tempDir.resolve("my-plugin")
+        projectDir.toFile().mkdirs()
+        every { project.projectDir } returns projectDir.toFile()
+        val settingsGradle = File(projectDir.parent.toFile(), "settings.gradle")
+        settingsGradle.createNewFile()
+        val mockLogger = mockk<Logger>()
+        every { project.logger } returns mockLogger
+
+        val pluginWithoutName: MutableMap<String?, Any?> = cameraDependency.toMutableMap()
+        pluginWithoutName.remove("name")
+
+        mockkObject(NativePluginLoaderReflectionBridge)
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns
+            listOf(
+                pluginWithoutName
+            )
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+
+        val pluginHandler = PluginHandler(project)
+        assertThrows<IllegalArgumentException> {
+            pluginHandler.configurePlugins(
+                engineVersionValue = EXAMPLE_ENGINE_VERSION
+            )
+        }
+    }
+
+    @Test
+    fun `configurePlugins adds plugin project and configures its dependencies`(
+        @TempDir tempDir: Path
+    ) {
+        val project = mockk<Project>()
+
+        // configuration for configureLegacyPluginEachProjects
+        val projectDir = tempDir.resolve("my-plugin")
+        projectDir.toFile().mkdirs()
+        every { project.projectDir } returns projectDir.toFile()
+        val settingsGradle = File(projectDir.parent.toFile(), "settings.gradle")
+        settingsGradle.createNewFile()
+        val mockLogger = mockk<Logger>()
+        every { project.logger } returns mockLogger
+
+        val pluginProject = mockk<Project>()
+        val pluginDependencyProject = mockk<Project>()
+        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
+        every { pluginProject.hasProperty("local-engine-repo") } returns false
+        every { pluginProject.hasProperty("android") } returns true
+        every { mockBuildType.name } returns "debug"
+        every { mockBuildType.isDebuggable } returns true
+        every { project.rootProject.findProject(":${cameraDependency["name"]}") } returns pluginProject
+        every { project.rootProject.findProject(":${flutterPluginAndroidLifecycleDependency["name"]}") } returns pluginDependencyProject
+        every { pluginProject.extensions.create(any(), any<Class<Any>>()) } returns mockk()
+        val captureActionSlot = slot<Action<Project>>()
+        val capturePluginActionSlot = mutableListOf<Action<Project>>()
+        every { project.afterEvaluate(any<Action<Project>>()) } returns Unit
+        every { pluginProject.afterEvaluate(any<Action<Project>>()) } returns Unit
+
+        val mockProjectBuildTypes =
+            mockk<NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        val mockPluginProjectBuildTypes =
+            mockk<NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.buildTypes } returns mockProjectBuildTypes
+        every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.buildTypes } returns mockPluginProjectBuildTypes
+        every { mockPluginProjectBuildTypes.addAll(any()) } returns true
+        every { pluginProject.configurations.named(any<String>()) } returns mockk()
+        every { pluginProject.dependencies.add(any(), any()) } returns mockk()
+
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .buildTypes
+                .iterator()
+        } returns
+            mutableListOf(
+                mockBuildType
+            ).iterator() andThen
+            mutableListOf( // can't return the same iterator as it is stateful
+                mockBuildType
+            ).iterator() andThen
+            mutableListOf( // and again
+                mockBuildType
+            ).iterator()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        val pluginWithDependencies: MutableMap<String?, Any?> = cameraDependency.toMutableMap()
+        pluginWithDependencies["dependencies"] =
+            listOf(flutterPluginAndroidLifecycleDependency["name"])
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns
+            listOf(
+                pluginWithDependencies
+            )
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+
+        pluginHandler.configurePlugins(
+            engineVersionValue = EXAMPLE_ENGINE_VERSION
+        )
+
+        verify { project.afterEvaluate(capture(captureActionSlot)) }
+        verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
+        captureActionSlot.captured.execute(project)
+        capturePluginActionSlot[0].execute(pluginProject)
+        capturePluginActionSlot[1].execute(pluginProject)
+        verify { pluginProject.extensions.create("flutter", FlutterExtension::class.java) }
+        verify {
+            pluginProject.dependencies.add(
+                "debugApi",
+                "io.flutter:flutter_embedding_debug:$EXAMPLE_ENGINE_VERSION"
+            )
+        }
+        verify { project.dependencies.add("debugApi", pluginProject) }
+        verify { mockLogger wasNot called }
+        verify { mockPluginProjectBuildTypes.addAll(project.extensions.findByType(BaseExtension::class.java)!!.buildTypes) }
+
+        verify { pluginProject.dependencies.add("implementation", pluginDependencyProject) }
+    }
+
+    @Test
+    fun `configurePlugins throws IllegalArgumentException when plugin has null dependencies`(
+        @TempDir tempDir: Path
+    ) {
+        val project = mockk<Project>()
+
+        // configuration for configureLegacyPluginEachProjects
+        val projectDir = tempDir.resolve("my-plugin")
+        projectDir.toFile().mkdirs()
+        every { project.projectDir } returns projectDir.toFile()
+        val settingsGradle = File(projectDir.parent.toFile(), "settings.gradle")
+        settingsGradle.createNewFile()
+        val mockLogger = mockk<Logger>()
+        every { project.logger } returns mockLogger
+
+        val pluginProject = mockk<Project>()
+        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
+        every { pluginProject.hasProperty("local-engine-repo") } returns false
+        every { pluginProject.hasProperty("android") } returns true
+        every { mockBuildType.name } returns "debug"
+        every { mockBuildType.isDebuggable } returns true
+        val pluginWithNullDependencies: MutableMap<String?, Any?> = cameraDependency.toMutableMap()
+        pluginWithNullDependencies["dependencies"] = null
+        every { project.rootProject.findProject(":${pluginWithNullDependencies["name"]}") } returns pluginProject
+        every { pluginProject.extensions.create(any(), any<Class<Any>>()) } returns mockk()
+        every { project.afterEvaluate(any<Action<Project>>()) } returns Unit
+        every { pluginProject.afterEvaluate(any<Action<Project>>()) } returns Unit
+
+        val mockProjectBuildTypes =
+            mockk<NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        val mockPluginProjectBuildTypes =
+            mockk<NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.buildTypes } returns mockProjectBuildTypes
+        every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.buildTypes } returns mockPluginProjectBuildTypes
+        every { mockPluginProjectBuildTypes.addAll(any()) } returns true
+        every { pluginProject.configurations.named(any<String>()) } returns mockk()
+        every { pluginProject.dependencies.add(any(), any()) } returns mockk()
+
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .buildTypes
+                .iterator()
+        } returns
+            mutableListOf(
+                mockBuildType
+            ).iterator() andThen
+            mutableListOf( // can't return the same iterator as it is stateful
+                mockBuildType
+            ).iterator() andThen
+            mutableListOf( // and again
+                mockBuildType
+            ).iterator()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns
+            listOf(
+                pluginWithNullDependencies
+            )
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+
+        assertThrows<IllegalArgumentException> {
+            pluginHandler.configurePlugins(
+                engineVersionValue = EXAMPLE_ENGINE_VERSION
+            )
+        }
+    }
+
+    @Test
+    fun `configurePlugins works for old flutter-plugins file`(
+        @TempDir tempDir: Path
+    ) {
+        val project = mockk<Project>()
+
+        // configuration for configureLegacyPluginEachProjects
+        val projectDir = tempDir.resolve("my-plugin")
+        projectDir.toFile().mkdirs()
+        every { project.projectDir } returns projectDir.toFile()
+        val settingsGradle = File(projectDir.parent.toFile(), "settings.gradle")
+        settingsGradle.createNewFile()
+        settingsGradle.writeText("def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')")
+        val mockLogger = mockk<Logger>()
+        every { project.logger } returns mockLogger
+        every { mockLogger.quiet(any()) } returns Unit
+
+        val pluginProject = mockk<Project>()
+        val pluginDependencyProject = mockk<Project>()
+        val mockBuildType = mockk<com.android.build.gradle.internal.dsl.BuildType>()
+        every { pluginProject.hasProperty("local-engine-repo") } returns false
+        every { pluginProject.hasProperty("android") } returns true
+        every { mockBuildType.name } returns "debug"
+        every { mockBuildType.isDebuggable } returns true
+        every { project.rootProject.findProject(":${cameraDependency["name"]}") } returns pluginProject
+        every { project.rootProject.findProject(":${flutterPluginAndroidLifecycleDependency["name"]}") } returns pluginDependencyProject
+        every { pluginProject.extensions.create(any(), any<Class<Any>>()) } returns mockk()
+        val captureActionSlot = slot<Action<Project>>()
+        val capturePluginActionSlot = mutableListOf<Action<Project>>()
+        every { project.afterEvaluate(any<Action<Project>>()) } returns Unit
+        every { pluginProject.afterEvaluate(any<Action<Project>>()) } returns Unit
+
+        val mockProjectBuildTypes =
+            mockk<NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        val mockPluginProjectBuildTypes =
+            mockk<NamedDomainObjectContainer<com.android.build.gradle.internal.dsl.BuildType>>()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.buildTypes } returns mockProjectBuildTypes
+        every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.buildTypes } returns mockPluginProjectBuildTypes
+        every { mockPluginProjectBuildTypes.addAll(any()) } returns true
+        every { pluginProject.configurations.named(any<String>()) } returns mockk()
+        every { pluginProject.dependencies.add(any(), any()) } returns mockk()
+
+        every {
+            project.extensions
+                .findByType(BaseExtension::class.java)!!
+                .buildTypes
+                .iterator()
+        } returns
+            mutableListOf(
+                mockBuildType
+            ).iterator() andThen
+            mutableListOf( // can't return the same iterator as it is stateful
+                mockBuildType
+            ).iterator() andThen
+            mutableListOf( // and again
+                mockBuildType
+            ).iterator()
+        every { project.dependencies.add(any(), any()) } returns mockk()
+        every { project.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+        every { pluginProject.extensions.findByType(BaseExtension::class.java)!!.compileSdkVersion } returns "android-35"
+
+        val pluginHandler = PluginHandler(project)
+        mockkObject(NativePluginLoaderReflectionBridge)
+        // mock return of NativePluginLoaderReflectionBridge.getPlugins
+        val pluginWithDependencies: MutableMap<String?, Any?> = cameraDependency.toMutableMap()
+        pluginWithDependencies["dependencies"] =
+            listOf(flutterPluginAndroidLifecycleDependency["name"])
+        every { NativePluginLoaderReflectionBridge.getPlugins(any(), any()) } returns
+            listOf(
+                pluginWithDependencies
+            )
+        // mock method calls that are invoked by the args to NativePluginLoaderReflectionBridge.getPlugins
+        every { project.extraProperties } returns mockk()
+        every { project.extensions.findByType(FlutterExtension::class.java) } returns FlutterExtension()
+        every { project.file(any()) } returns mockk()
+
+        val dependencyGraph =
+            listOf<Map<String?, Any?>>(
+                mapOf(
+                    "name" to cameraDependency["name"],
+                    "dependencies" to listOf(flutterPluginAndroidLifecycleDependency["name"])
+                ),
+                mapOf(
+                    "name" to flutterPluginAndroidLifecycleDependency["name"],
+                    "dependencies" to listOf<String>()
+                )
+            )
+
+        every { NativePluginLoaderReflectionBridge.getDependenciesMetadata(any(), any()) } returns
+            mapOf("dependencyGraph" to dependencyGraph)
+
+        pluginHandler.configurePlugins(
+            engineVersionValue = EXAMPLE_ENGINE_VERSION
+        )
+
+        verify { project.afterEvaluate(capture(captureActionSlot)) }
+        verify { pluginProject.afterEvaluate(capture(capturePluginActionSlot)) }
+        captureActionSlot.captured.execute(project)
+        capturePluginActionSlot[0].execute(pluginProject)
+        capturePluginActionSlot[1].execute(pluginProject)
+        verify { pluginProject.extensions.create("flutter", FlutterExtension::class.java) }
+        verify {
+            pluginProject.dependencies.add(
+                "debugApi",
+                "io.flutter:flutter_embedding_debug:$EXAMPLE_ENGINE_VERSION"
+            )
+        }
+        verify { project.dependencies.add("debugApi", pluginProject) }
+        verify { mockPluginProjectBuildTypes.addAll(project.extensions.findByType(BaseExtension::class.java)!!.buildTypes) }
+
+        verify { pluginProject.dependencies.add("implementation", pluginDependencyProject) }
+        verify { mockLogger.quiet(PluginHandler.legacyFlutterPluginsWarning) }
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/tasks/BaseFlutterTaskHelperTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/tasks/BaseFlutterTaskHelperTest.kt
@@ -1,0 +1,591 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.tasks
+
+import com.flutter.gradle.DependencyVersionChecker
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.logging.LoggingManager
+import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecSpec
+import org.gradle.process.ProcessForkOptions
+import org.junit.jupiter.api.assertDoesNotThrow
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class BaseFlutterTaskHelperTest {
+    object BaseFlutterTaskPropertiesTest {
+        internal const val LOCAL_ENGINE_TEST = "android_debug_arm64"
+        internal const val LOCAL_ENGINE_HOST_TEST = "host_debug"
+        internal const val DART_DEFINES_TEST = "ENVIRONMENT=development"
+        internal const val FLAVOR_TEST = "dev"
+        internal const val EXTRA_FRONTEND_OPTIONS_TEST = "--enable-asserts"
+        internal const val EXTRA_GEN_SNAPSHOT_OPTIONS_TEST = "--debugger"
+        internal const val TARGET_PLATFORM_VALUES_JOINED_LIST = "android linux"
+        val MIN_SDK_VERSION_TEST = DependencyVersionChecker.warnMinSdkVersion
+
+        // Using File.separator to ensure all paths use platform-specific separators
+        internal val FLUTTER_ROOT_ABSOLUTE_PATH_TEST = "/path/to/flutter".replace("/", File.separator)
+        internal val FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST = "/path/to/flutter/bin/flutter".replace("/", File.separator)
+        internal val LOCAL_ENGINE_SRC_PATH_TEST = "/path/to/flutter/engine/src".replace("/", File.separator)
+        internal val PERFORMANCE_MEASUREMENT_FILE_TEST = "/path/to/build/performance_file".replace("/", File.separator)
+        internal val FRONTEND_SERVER_STARTER_PATH_TEST = "/path/to/starter/script_file".replace("/", File.separator)
+        internal val SPLIT_DEBUG_INFO_TEST = "/path/to/build/debug_info_directory".replace("/", File.separator)
+        internal val CODE_SIZE_DIRECTORY_TEST = "/path/to/build/code_size_directory".replace("/", File.separator)
+
+        internal val BUNDLE_SK_SL_PATH_TEST = "/path/to/custom/shaders".replace("/", File.separator)
+        internal val FLUTTER_TARGET_FILE_PATH = "/path/to/flutter/examples/splash/lib/main.dart".replace("/", File.separator)
+        internal val FLUTTER_TARGET_PATH = "/path/to/main.dart".replace("/", File.separator)
+
+        internal val sourceDirTest = File("/path/to/working_directory".replace("/", File.separator))
+        internal val flutterRootTest = File("/path/to/flutter".replace("/", File.separator))
+        internal val flutterExecutableTest = File("/path/to/flutter/bin/flutter".replace("/", File.separator))
+        internal val intermediateDirFileTest = File("/path/to/build/app/intermediates/flutter/release".replace("/", File.separator))
+        internal val targetPlatformValuesList = listOf("android", "linux")
+    }
+
+    @Test
+    fun `checkPreConditions throws a GradleException when sourceDir is null`() {
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        every { baseFlutterTask.sourceDir } returns null
+
+        val gradleException =
+            assertFailsWith<GradleException> { BaseFlutterTaskHelper.checkPreConditions(baseFlutterTask) }
+        assert(
+            gradleException.message ==
+                BaseFlutterTaskHelper.getGradleErrorMessage(baseFlutterTask)
+        )
+    }
+
+    @Test
+    fun `checkPreConditions throws a GradleException when sourceDir is not a directory`() {
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        every { baseFlutterTask.sourceDir!!.isDirectory } returns false
+
+        val gradleException =
+            assertFailsWith<GradleException> { BaseFlutterTaskHelper.checkPreConditions(baseFlutterTask) }
+        assert(
+            gradleException.message ==
+                BaseFlutterTaskHelper.getGradleErrorMessage(baseFlutterTask)
+        )
+    }
+
+    // TODO(jesswon): Add a test for intermediateDir is not valid during cleanup for handling NPEs.
+    @Test
+    fun `checkPreConditions does not throw a GradleException and intermediateDir is valid`() {
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        every { baseFlutterTask.sourceDir!!.isDirectory } returns true
+
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+        // There is already an intermediate directory, so there is no need to create it.
+        every { baseFlutterTask.intermediateDir!!.mkdirs() } returns false
+
+        assertDoesNotThrow { BaseFlutterTaskHelper.checkPreConditions(baseFlutterTask) }
+    }
+
+    @Test
+    fun `generateRuleNames returns correct rule names when buildMode is debug`() {
+        val buildModeString = "debug"
+
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        every { baseFlutterTask.buildMode } returns buildModeString
+
+        val ruleNamesList = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        assertEquals(ruleNamesList, listOf("debug_android_application"))
+    }
+
+    @Test
+    fun `generateRuleNames returns correct rule names when buildMode is not debug and deferredComponents is true`() {
+        val buildModeString = "release"
+
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        every { baseFlutterTask.buildMode } returns buildModeString
+        every { baseFlutterTask.deferredComponents } returns true
+        every { baseFlutterTask.targetPlatformValues } returns BaseFlutterTaskPropertiesTest.targetPlatformValuesList
+
+        val ruleNamesList = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        assertEquals(
+            ruleNamesList,
+            listOf(
+                "android_aot_deferred_components_bundle_release_android",
+                "android_aot_deferred_components_bundle_release_linux"
+            )
+        )
+    }
+
+    @Test
+    fun `generateRuleNames returns correct rule names when buildMode is not debug and deferredComponents is false`() {
+        val buildModeString = "release"
+
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        every { baseFlutterTask.buildMode } returns buildModeString
+        every { baseFlutterTask.deferredComponents } returns false
+        every { baseFlutterTask.targetPlatformValues } returns BaseFlutterTaskPropertiesTest.targetPlatformValuesList
+
+        val ruleNamesList = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        assertEquals(
+            ruleNamesList,
+            listOf(
+                "android_aot_bundle_release_android",
+                "android_aot_bundle_release_linux"
+            )
+        )
+    }
+
+    @Test
+    fun `createSpecActionFromTask creates the correct build configurations when properties are non-null`() {
+        val buildModeString = "debug"
+
+        // Create necessary mocks.
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        val mockExecSpec = mockk<ExecSpec>()
+        val mockProcessForkOptions = mockk<ProcessForkOptions>()
+
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        val execSpecActionFromTask = BaseFlutterTaskHelper.createExecSpecActionFromTask(baseFlutterTask)
+
+        // Mock return values of properties.
+        every { baseFlutterTask.flutterExecutable } returns BaseFlutterTaskPropertiesTest.flutterExecutableTest
+        every {
+            baseFlutterTask.flutterExecutable!!.absolutePath
+        } returns BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST
+
+        every { baseFlutterTask.localEngine } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_TEST
+        every { baseFlutterTask.localEngineSrcPath } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_SRC_PATH_TEST
+
+        every { baseFlutterTask.localEngineHost } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_HOST_TEST
+        every { baseFlutterTask.verbose } returns true
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+        every { baseFlutterTask.performanceMeasurementFile } returns BaseFlutterTaskPropertiesTest.PERFORMANCE_MEASUREMENT_FILE_TEST
+
+        every { baseFlutterTask.fastStart } returns true
+        every { baseFlutterTask.buildMode } returns buildModeString
+        every { baseFlutterTask.flutterRoot } returns BaseFlutterTaskPropertiesTest.flutterRootTest
+        every { baseFlutterTask.flutterRoot!!.absolutePath } returns BaseFlutterTaskPropertiesTest.FLUTTER_ROOT_ABSOLUTE_PATH_TEST
+
+        every { baseFlutterTask.trackWidgetCreation } returns true
+        every { baseFlutterTask.splitDebugInfo } returns BaseFlutterTaskPropertiesTest.SPLIT_DEBUG_INFO_TEST
+        every { baseFlutterTask.treeShakeIcons } returns true
+
+        every { baseFlutterTask.dartObfuscation } returns true
+        every { baseFlutterTask.dartDefines } returns BaseFlutterTaskPropertiesTest.DART_DEFINES_TEST
+        every { baseFlutterTask.bundleSkSLPath } returns BaseFlutterTaskPropertiesTest.BUNDLE_SK_SL_PATH_TEST
+
+        every { baseFlutterTask.codeSizeDirectory } returns BaseFlutterTaskPropertiesTest.CODE_SIZE_DIRECTORY_TEST
+        every { baseFlutterTask.flavor } returns BaseFlutterTaskPropertiesTest.FLAVOR_TEST
+        every { baseFlutterTask.extraGenSnapshotOptions } returns BaseFlutterTaskPropertiesTest.EXTRA_GEN_SNAPSHOT_OPTIONS_TEST
+
+        every { baseFlutterTask.frontendServerStarterPath } returns BaseFlutterTaskPropertiesTest.FRONTEND_SERVER_STARTER_PATH_TEST
+        every { baseFlutterTask.extraFrontEndOptions } returns BaseFlutterTaskPropertiesTest.EXTRA_FRONTEND_OPTIONS_TEST
+
+        every { baseFlutterTask.targetPlatformValues } returns BaseFlutterTaskPropertiesTest.targetPlatformValuesList
+
+        every { baseFlutterTask.minSdkVersion } returns BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST
+
+        // Mock the method calls. We collapse all the args mock calls into four calls.
+        every { mockExecSpec.executable(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.workingDir(any()) } returns mockProcessForkOptions
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.args(any<List<String>>()) } returns mockExecSpec
+
+        // Generate rule names for verification and can only be generated after buildMode is mocked.
+        val ruleNamesList: List<String> = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        // The exec function will be deprecated in gradle 8.11 and will be removed in gradle 9.0
+        // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/-kotlin-script/exec.html?query=abstract%20fun%20exec(configuration:%20Action%3CExecSpec%3E):%20ExecResult
+        // The actions are executed.
+        execSpecActionFromTask.execute(mockExecSpec)
+
+        // After execution, we verify the functions are actually being
+        // called with the expected argument passed in.
+        verify { mockExecSpec.executable(BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST) }
+        verify { mockExecSpec.workingDir(BaseFlutterTaskPropertiesTest.sourceDirTest) }
+        verify { mockExecSpec.args("--local-engine", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_TEST) }
+        verify { mockExecSpec.args("--local-engine-src-path", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_SRC_PATH_TEST) }
+        verify { mockExecSpec.args("--local-engine-host", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_HOST_TEST) }
+        verify { mockExecSpec.args("--verbose") }
+        verify { mockExecSpec.args("assemble") }
+        verify { mockExecSpec.args("--no-version-check") }
+        verify { mockExecSpec.args("--depfile", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}/flutter_build.d") }
+        verify { mockExecSpec.args("--output", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}") }
+        verify { mockExecSpec.args("--performance-measurement-file=${BaseFlutterTaskPropertiesTest.PERFORMANCE_MEASUREMENT_FILE_TEST}") }
+        verify { mockExecSpec.args("-dTargetFile=${BaseFlutterTaskPropertiesTest.FLUTTER_TARGET_FILE_PATH}") }
+        verify { mockExecSpec.args("-dTargetPlatform=android") }
+        verify { mockExecSpec.args("-dBuildMode=$buildModeString") }
+        verify { mockExecSpec.args("-dTrackWidgetCreation=${true}") }
+        verify { mockExecSpec.args("-dSplitDebugInfo=${BaseFlutterTaskPropertiesTest.SPLIT_DEBUG_INFO_TEST}") }
+        verify { mockExecSpec.args("-dTreeShakeIcons=true") }
+        verify { mockExecSpec.args("-dDartObfuscation=true") }
+        verify { mockExecSpec.args("--DartDefines=${BaseFlutterTaskPropertiesTest.DART_DEFINES_TEST}") }
+        verify { mockExecSpec.args("-dBundleSkSLPath=${BaseFlutterTaskPropertiesTest.BUNDLE_SK_SL_PATH_TEST}") }
+        verify { mockExecSpec.args("-dCodeSizeDirectory=${BaseFlutterTaskPropertiesTest.CODE_SIZE_DIRECTORY_TEST}") }
+        verify { mockExecSpec.args("-dFlavor=${BaseFlutterTaskPropertiesTest.FLAVOR_TEST}") }
+        verify { mockExecSpec.args("--ExtraGenSnapshotOptions=${BaseFlutterTaskPropertiesTest.EXTRA_GEN_SNAPSHOT_OPTIONS_TEST}") }
+        verify { mockExecSpec.args("-dFrontendServerStarterPath=${BaseFlutterTaskPropertiesTest.FRONTEND_SERVER_STARTER_PATH_TEST}") }
+        verify { mockExecSpec.args("--ExtraFrontEndOptions=${BaseFlutterTaskPropertiesTest.EXTRA_FRONTEND_OPTIONS_TEST}") }
+        verify { mockExecSpec.args("-dAndroidArchs=${BaseFlutterTaskPropertiesTest.TARGET_PLATFORM_VALUES_JOINED_LIST}") }
+        verify { mockExecSpec.args("-dMinSdkVersion=${BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST}") }
+        verify { mockExecSpec.args(ruleNamesList) }
+    }
+
+    @Test
+    fun `createSpecActionFromTask creates the correct build configurations when properties are null`() {
+        val buildModeString = "debug"
+
+        // Create necessary mocks.
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        val mockExecSpec = mockk<ExecSpec>()
+        val mockProcessForkOptions = mockk<ProcessForkOptions>()
+
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        val execSpecActionFromTask = BaseFlutterTaskHelper.createExecSpecActionFromTask(baseFlutterTask)
+
+        // Mock return values of properties.
+        every { baseFlutterTask.flutterExecutable } returns BaseFlutterTaskPropertiesTest.flutterExecutableTest
+        every {
+            baseFlutterTask.flutterExecutable!!.absolutePath
+        } returns BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST
+
+        every { baseFlutterTask.localEngine } returns null
+        every { baseFlutterTask.localEngineSrcPath } returns null
+
+        every { baseFlutterTask.localEngineHost } returns null
+        every { baseFlutterTask.verbose } returns true
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+        every { baseFlutterTask.performanceMeasurementFile } returns null
+
+        every { baseFlutterTask.fastStart } returns true
+        every { baseFlutterTask.buildMode } returns buildModeString
+        every { baseFlutterTask.flutterRoot } returns BaseFlutterTaskPropertiesTest.flutterRootTest
+        every { baseFlutterTask.flutterRoot!!.absolutePath } returns BaseFlutterTaskPropertiesTest.FLUTTER_ROOT_ABSOLUTE_PATH_TEST
+
+        every { baseFlutterTask.trackWidgetCreation } returns null
+        every { baseFlutterTask.splitDebugInfo } returns null
+        every { baseFlutterTask.treeShakeIcons } returns null
+
+        every { baseFlutterTask.dartObfuscation } returns null
+        every { baseFlutterTask.dartDefines } returns null
+        every { baseFlutterTask.bundleSkSLPath } returns null
+
+        every { baseFlutterTask.codeSizeDirectory } returns null
+        every { baseFlutterTask.flavor } returns null
+        every { baseFlutterTask.extraGenSnapshotOptions } returns null
+
+        every { baseFlutterTask.frontendServerStarterPath } returns null
+        every { baseFlutterTask.extraFrontEndOptions } returns null
+
+        every { baseFlutterTask.targetPlatformValues } returns BaseFlutterTaskPropertiesTest.targetPlatformValuesList
+
+        every { baseFlutterTask.minSdkVersion } returns BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST
+
+        // Mock the method calls. We collapse all the args mock calls into four calls.
+        every { mockExecSpec.executable(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.workingDir(any()) } returns mockProcessForkOptions
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.args(any<List<String>>()) } returns mockExecSpec
+
+        // Generate rule names for verification and can only be generated after buildMode is mocked.
+        val ruleNamesList: List<String> = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        // The exec function will be deprecated in gradle 8.11 and will be removed in gradle 9.0
+        // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/-kotlin-script/exec.html?query=abstract%20fun%20exec(configuration:%20Action%3CExecSpec%3E):%20ExecResult
+        // The actions are executed.
+        execSpecActionFromTask.execute(mockExecSpec)
+
+        // After execution, we verify the functions are actually being
+        // called with the expected argument passed in.
+        verify { mockExecSpec.executable(BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST) }
+        verify { mockExecSpec.workingDir(BaseFlutterTaskPropertiesTest.sourceDirTest) }
+        verify { mockExecSpec.args("--verbose") }
+        verify { mockExecSpec.args("assemble") }
+        verify { mockExecSpec.args("--no-version-check") }
+        verify { mockExecSpec.args("--depfile", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}/flutter_build.d") }
+        verify { mockExecSpec.args("--output", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}") }
+        verify { mockExecSpec.args("-dTargetFile=${BaseFlutterTaskPropertiesTest.FLUTTER_TARGET_FILE_PATH}") }
+        verify { mockExecSpec.args("-dTargetPlatform=android") }
+        verify { mockExecSpec.args("-dBuildMode=$buildModeString") }
+        verify { mockExecSpec.args("-dAndroidArchs=${BaseFlutterTaskPropertiesTest.TARGET_PLATFORM_VALUES_JOINED_LIST}") }
+        verify { mockExecSpec.args("-dMinSdkVersion=${BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST}") }
+        verify { mockExecSpec.args(ruleNamesList) }
+    }
+
+    @Test
+    fun `createSpecActionFromTask creates the correct build configurations when verbose is false and fastStart is false`() {
+        val buildModeString = "debug"
+
+        // Create necessary mocks.
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        val mockExecSpec = mockk<ExecSpec>()
+        val mockProcessForkOptions = mockk<ProcessForkOptions>()
+
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        val execSpecActionFromTask = BaseFlutterTaskHelper.createExecSpecActionFromTask(baseFlutterTask)
+
+        // Mock return values of properties.
+        every { baseFlutterTask.flutterExecutable } returns BaseFlutterTaskPropertiesTest.flutterExecutableTest
+        every {
+            baseFlutterTask.flutterExecutable!!.absolutePath
+        } returns BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST
+
+        every { baseFlutterTask.localEngine } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_TEST
+        every { baseFlutterTask.localEngineSrcPath } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_SRC_PATH_TEST
+
+        every { baseFlutterTask.localEngineHost } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_HOST_TEST
+        every { baseFlutterTask.verbose } returns false
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+        every { baseFlutterTask.performanceMeasurementFile } returns BaseFlutterTaskPropertiesTest.PERFORMANCE_MEASUREMENT_FILE_TEST
+
+        every { baseFlutterTask.fastStart } returns false
+        every { baseFlutterTask.buildMode } returns buildModeString
+        every { baseFlutterTask.targetPath } returns BaseFlutterTaskPropertiesTest.FLUTTER_TARGET_PATH
+
+        every { baseFlutterTask.trackWidgetCreation } returns true
+        every { baseFlutterTask.splitDebugInfo } returns BaseFlutterTaskPropertiesTest.SPLIT_DEBUG_INFO_TEST
+        every { baseFlutterTask.treeShakeIcons } returns true
+
+        every { baseFlutterTask.dartObfuscation } returns true
+        every { baseFlutterTask.dartDefines } returns BaseFlutterTaskPropertiesTest.DART_DEFINES_TEST
+        every { baseFlutterTask.bundleSkSLPath } returns BaseFlutterTaskPropertiesTest.BUNDLE_SK_SL_PATH_TEST
+
+        every { baseFlutterTask.codeSizeDirectory } returns BaseFlutterTaskPropertiesTest.CODE_SIZE_DIRECTORY_TEST
+        every { baseFlutterTask.flavor } returns BaseFlutterTaskPropertiesTest.FLAVOR_TEST
+        every { baseFlutterTask.extraGenSnapshotOptions } returns BaseFlutterTaskPropertiesTest.EXTRA_GEN_SNAPSHOT_OPTIONS_TEST
+
+        every { baseFlutterTask.frontendServerStarterPath } returns BaseFlutterTaskPropertiesTest.FRONTEND_SERVER_STARTER_PATH_TEST
+        every { baseFlutterTask.extraFrontEndOptions } returns BaseFlutterTaskPropertiesTest.EXTRA_FRONTEND_OPTIONS_TEST
+
+        every { baseFlutterTask.targetPlatformValues } returns BaseFlutterTaskPropertiesTest.targetPlatformValuesList
+
+        every { baseFlutterTask.minSdkVersion } returns BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST
+
+        // Mock the method calls. We collapse all the args mock calls into four calls.
+        every { mockExecSpec.executable(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.workingDir(any()) } returns mockProcessForkOptions
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.args(any<List<String>>()) } returns mockExecSpec
+
+        // Generate rule names for verification and can only be generated after buildMode is mocked.
+        val ruleNamesList: List<String> = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        // The exec function will be deprecated in gradle 8.11 and will be removed in gradle 9.0
+        // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/-kotlin-script/exec.html?query=abstract%20fun%20exec(configuration:%20Action%3CExecSpec%3E):%20ExecResult
+        // The actions are executed.
+        execSpecActionFromTask.execute(mockExecSpec)
+
+        // After execution, we verify the functions are actually being
+        // called with the expected argument passed in.
+        verify { mockExecSpec.executable(BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST) }
+        verify { mockExecSpec.workingDir(BaseFlutterTaskPropertiesTest.sourceDirTest) }
+        verify { mockExecSpec.args("--local-engine", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_TEST) }
+        verify { mockExecSpec.args("--local-engine-src-path", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_SRC_PATH_TEST) }
+        verify { mockExecSpec.args("--local-engine-host", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_HOST_TEST) }
+        verify { mockExecSpec.args("--quiet") }
+        verify { mockExecSpec.args("assemble") }
+        verify { mockExecSpec.args("--no-version-check") }
+        verify { mockExecSpec.args("--depfile", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}/flutter_build.d") }
+        verify { mockExecSpec.args("--output", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}") }
+        verify { mockExecSpec.args("--performance-measurement-file=${BaseFlutterTaskPropertiesTest.PERFORMANCE_MEASUREMENT_FILE_TEST}") }
+        verify { mockExecSpec.args("-dTargetFile=${BaseFlutterTaskPropertiesTest.FLUTTER_TARGET_PATH}") }
+        verify { mockExecSpec.args("-dTargetPlatform=android") }
+        verify { mockExecSpec.args("-dBuildMode=$buildModeString") }
+        verify { mockExecSpec.args("-dTrackWidgetCreation=${true}") }
+        verify { mockExecSpec.args("-dSplitDebugInfo=${BaseFlutterTaskPropertiesTest.SPLIT_DEBUG_INFO_TEST}") }
+        verify { mockExecSpec.args("-dTreeShakeIcons=true") }
+        verify { mockExecSpec.args("-dDartObfuscation=true") }
+        verify { mockExecSpec.args("--DartDefines=${BaseFlutterTaskPropertiesTest.DART_DEFINES_TEST}") }
+        verify { mockExecSpec.args("-dBundleSkSLPath=${BaseFlutterTaskPropertiesTest.BUNDLE_SK_SL_PATH_TEST}") }
+        verify { mockExecSpec.args("-dCodeSizeDirectory=${BaseFlutterTaskPropertiesTest.CODE_SIZE_DIRECTORY_TEST}") }
+        verify { mockExecSpec.args("-dFlavor=${BaseFlutterTaskPropertiesTest.FLAVOR_TEST}") }
+        verify { mockExecSpec.args("--ExtraGenSnapshotOptions=${BaseFlutterTaskPropertiesTest.EXTRA_GEN_SNAPSHOT_OPTIONS_TEST}") }
+        verify { mockExecSpec.args("-dFrontendServerStarterPath=${BaseFlutterTaskPropertiesTest.FRONTEND_SERVER_STARTER_PATH_TEST}") }
+        verify { mockExecSpec.args("--ExtraFrontEndOptions=${BaseFlutterTaskPropertiesTest.EXTRA_FRONTEND_OPTIONS_TEST}") }
+        verify { mockExecSpec.args("-dAndroidArchs=${BaseFlutterTaskPropertiesTest.TARGET_PLATFORM_VALUES_JOINED_LIST}") }
+        verify { mockExecSpec.args("-dMinSdkVersion=${BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST}") }
+        verify { mockExecSpec.args(ruleNamesList) }
+    }
+
+    @Test
+    fun `createSpecActionFromTask creates the correct build configurations when fastStart is true and buildMode is not debug`() {
+        val buildModeString = "release"
+
+        // Create necessary mocks.
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        val mockExecSpec = mockk<ExecSpec>()
+        val mockProcessForkOptions = mockk<ProcessForkOptions>()
+
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+        val execSpecActionFromTask = BaseFlutterTaskHelper.createExecSpecActionFromTask(baseFlutterTask)
+
+        // Mock return values of properties.
+        every { baseFlutterTask.flutterExecutable } returns BaseFlutterTaskPropertiesTest.flutterExecutableTest
+        every {
+            baseFlutterTask.flutterExecutable!!.absolutePath
+        } returns BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST
+
+        every { baseFlutterTask.localEngine } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_TEST
+        every { baseFlutterTask.localEngineSrcPath } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_SRC_PATH_TEST
+
+        every { baseFlutterTask.localEngineHost } returns BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_HOST_TEST
+        every { baseFlutterTask.verbose } returns true
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+        every { baseFlutterTask.performanceMeasurementFile } returns BaseFlutterTaskPropertiesTest.PERFORMANCE_MEASUREMENT_FILE_TEST
+
+        every { baseFlutterTask.fastStart } returns true
+        every { baseFlutterTask.buildMode } returns buildModeString
+        every { baseFlutterTask.targetPath } returns BaseFlutterTaskPropertiesTest.FLUTTER_TARGET_PATH
+
+        every { baseFlutterTask.trackWidgetCreation } returns true
+        every { baseFlutterTask.splitDebugInfo } returns BaseFlutterTaskPropertiesTest.SPLIT_DEBUG_INFO_TEST
+        every { baseFlutterTask.treeShakeIcons } returns true
+
+        every { baseFlutterTask.dartObfuscation } returns true
+        every { baseFlutterTask.dartDefines } returns BaseFlutterTaskPropertiesTest.DART_DEFINES_TEST
+        every { baseFlutterTask.bundleSkSLPath } returns BaseFlutterTaskPropertiesTest.BUNDLE_SK_SL_PATH_TEST
+
+        every { baseFlutterTask.codeSizeDirectory } returns BaseFlutterTaskPropertiesTest.CODE_SIZE_DIRECTORY_TEST
+        every { baseFlutterTask.flavor } returns BaseFlutterTaskPropertiesTest.FLAVOR_TEST
+        every { baseFlutterTask.extraGenSnapshotOptions } returns BaseFlutterTaskPropertiesTest.EXTRA_GEN_SNAPSHOT_OPTIONS_TEST
+
+        every { baseFlutterTask.frontendServerStarterPath } returns BaseFlutterTaskPropertiesTest.FRONTEND_SERVER_STARTER_PATH_TEST
+        every { baseFlutterTask.extraFrontEndOptions } returns BaseFlutterTaskPropertiesTest.EXTRA_FRONTEND_OPTIONS_TEST
+
+        every { baseFlutterTask.deferredComponents } returns true
+        every { baseFlutterTask.targetPlatformValues } returns BaseFlutterTaskPropertiesTest.targetPlatformValuesList
+
+        every { baseFlutterTask.minSdkVersion } returns BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST
+
+        // Mock the method calls. We collapse all the args mock calls into four calls.
+        every { mockExecSpec.executable(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.workingDir(any()) } returns mockProcessForkOptions
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>(), any()) } returns mockExecSpec
+        every { mockExecSpec.args(any<String>()) } returns mockExecSpec
+        every { mockExecSpec.args(any<List<String>>()) } returns mockExecSpec
+
+        // Generate rule names for verification and can only be generated after buildMode is mocked.
+        val ruleNamesList: List<String> = BaseFlutterTaskHelper.generateRuleNames(baseFlutterTask)
+
+        // The exec function will be deprecated in gradle 8.11 and will be removed in gradle 9.0
+        // https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.kotlin.dsl/-kotlin-script/exec.html?query=abstract%20fun%20exec(configuration:%20Action%3CExecSpec%3E):%20ExecResult
+        // The actions are executed.
+        execSpecActionFromTask.execute(mockExecSpec)
+
+        // After execution, we verify the functions are actually being
+        // called with the expected argument passed in.
+        verify { mockExecSpec.executable(BaseFlutterTaskPropertiesTest.FLUTTER_EXECUTABLE_ABSOLUTE_PATH_TEST) }
+        verify { mockExecSpec.workingDir(BaseFlutterTaskPropertiesTest.sourceDirTest) }
+        verify { mockExecSpec.args("--local-engine", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_TEST) }
+        verify { mockExecSpec.args("--local-engine-src-path", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_SRC_PATH_TEST) }
+        verify { mockExecSpec.args("--local-engine-host", BaseFlutterTaskPropertiesTest.LOCAL_ENGINE_HOST_TEST) }
+        verify { mockExecSpec.args("--verbose") }
+        verify { mockExecSpec.args("assemble") }
+        verify { mockExecSpec.args("--no-version-check") }
+        verify { mockExecSpec.args("--depfile", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}/flutter_build.d") }
+        verify { mockExecSpec.args("--output", "${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}") }
+        verify { mockExecSpec.args("--performance-measurement-file=${BaseFlutterTaskPropertiesTest.PERFORMANCE_MEASUREMENT_FILE_TEST}") }
+        verify { mockExecSpec.args("-dTargetFile=${BaseFlutterTaskPropertiesTest.FLUTTER_TARGET_PATH}") }
+        verify { mockExecSpec.args("-dTargetPlatform=android") }
+        verify { mockExecSpec.args("-dBuildMode=$buildModeString") }
+        verify { mockExecSpec.args("-dTrackWidgetCreation=${true}") }
+        verify { mockExecSpec.args("-dSplitDebugInfo=${BaseFlutterTaskPropertiesTest.SPLIT_DEBUG_INFO_TEST}") }
+        verify { mockExecSpec.args("-dTreeShakeIcons=true") }
+        verify { mockExecSpec.args("-dDartObfuscation=true") }
+        verify { mockExecSpec.args("--DartDefines=${BaseFlutterTaskPropertiesTest.DART_DEFINES_TEST}") }
+        verify { mockExecSpec.args("-dBundleSkSLPath=${BaseFlutterTaskPropertiesTest.BUNDLE_SK_SL_PATH_TEST}") }
+        verify { mockExecSpec.args("-dCodeSizeDirectory=${BaseFlutterTaskPropertiesTest.CODE_SIZE_DIRECTORY_TEST}") }
+        verify { mockExecSpec.args("-dFlavor=${BaseFlutterTaskPropertiesTest.FLAVOR_TEST}") }
+        verify { mockExecSpec.args("--ExtraGenSnapshotOptions=${BaseFlutterTaskPropertiesTest.EXTRA_GEN_SNAPSHOT_OPTIONS_TEST}") }
+        verify { mockExecSpec.args("-dFrontendServerStarterPath=${BaseFlutterTaskPropertiesTest.FRONTEND_SERVER_STARTER_PATH_TEST}") }
+        verify { mockExecSpec.args("--ExtraFrontEndOptions=${BaseFlutterTaskPropertiesTest.EXTRA_FRONTEND_OPTIONS_TEST}") }
+        verify { mockExecSpec.args("-dAndroidArchs=${BaseFlutterTaskPropertiesTest.TARGET_PLATFORM_VALUES_JOINED_LIST}") }
+        verify { mockExecSpec.args("-dMinSdkVersion=${BaseFlutterTaskPropertiesTest.MIN_SDK_VERSION_TEST}") }
+        verify { mockExecSpec.args(ruleNamesList) }
+    }
+
+    @Test
+    fun `buildBundle calls the correct methods`() {
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        val mockLoggingManager = mockk<LoggingManager>()
+        val mockFile = mockk<File>()
+        // Mocking the serviceOf() extension below requires us to specify this internal type
+        // unfortunately.
+        val mockProject = mockk<org.gradle.api.internal.project.ProjectInternal>()
+
+        // When baseFlutterTask.sourceDir is null, an exception is thrown. We mock its return value
+        // before creating a BaseFlutterTaskHelper object.
+        every { baseFlutterTask.sourceDir } returns mockFile
+        every { mockFile.isDirectory } returns true
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+        every { baseFlutterTask.logging } returns mockLoggingManager
+        every { mockLoggingManager.captureStandardError(any()) } returns mockLoggingManager
+        every { baseFlutterTask.project } returns mockProject
+        val mockExecOperations = mockk<ExecOperations>()
+        every {
+            mockProject.serviceOf<ExecOperations>()
+        } returns mockExecOperations
+        every { mockExecOperations.exec(any<Action<ExecSpec>>()) } returns mockk()
+
+        BaseFlutterTaskHelper.buildBundle(baseFlutterTask)
+    }
+
+    @Test
+    fun `getDependencyFiles returns a FileCollection of dependency file(s)`() {
+        val baseFlutterTask = mockk<BaseFlutterTask>()
+        val project = mockk<Project>()
+        val configFileCollection = mockk<ConfigurableFileCollection>()
+        every { baseFlutterTask.sourceDir } returns BaseFlutterTaskPropertiesTest.sourceDirTest
+
+        every { baseFlutterTask.project } returns project
+        every { baseFlutterTask.intermediateDir } returns BaseFlutterTaskPropertiesTest.intermediateDirFileTest
+
+        val projectIntermediary = baseFlutterTask.project
+        val interDirFile = baseFlutterTask.intermediateDir
+
+        every { projectIntermediary.files() } returns configFileCollection
+        every { projectIntermediary.files("$interDirFile/flutter_build.d") } returns configFileCollection
+        every { configFileCollection.plus(configFileCollection) } returns configFileCollection
+
+        BaseFlutterTaskHelper.getDependenciesFiles(baseFlutterTask)
+        verify { projectIntermediary.files() }
+        verify { projectIntermediary.files("${BaseFlutterTaskPropertiesTest.intermediateDirFileTest}/flutter_build.d") }
+    }
+}

--- a/packages/flutter_tools/gradle/bin/test/tasks/FlutterTaskHelperTest.kt
+++ b/packages/flutter_tools/gradle/bin/test/tasks/FlutterTaskHelperTest.kt
@@ -1,0 +1,179 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package com.flutter.gradle.tasks
+
+import com.flutter.gradle.FlutterPluginConstants
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.CopySpec
+import org.gradle.api.file.FileCollection
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.Test
+
+class FlutterTaskHelperTest {
+    @Test
+    fun `getAssetsDirectory returns correct path`() {
+        val flutterTask = mockk<FlutterTask>()
+        val mockFile = mockk<File>()
+        val flutterTaskOutputDirectory = "/path/to/assets"
+        val expectedPath = "$flutterTaskOutputDirectory/flutter_assets"
+
+        every { flutterTask.outputDirectory } returns mockFile
+        every { mockFile.toString() } returns flutterTaskOutputDirectory
+        val result = FlutterTaskHelper.getAssetsDirectory(flutterTask)
+        assert(result == expectedPath)
+    }
+
+    @Test
+    fun `getAssets returns correct CopySpec`() {
+        val project = mockk<Project>()
+        val flutterTask = mockk<FlutterTask>()
+        val mockFile = mockk<File>()
+        val mockCopySpec = mockk<CopySpec>()
+        val copySpecActionSlot = slot<Action<in CopySpec>>()
+        val fakeFromPath = "/path/to/intermediate"
+
+        every { flutterTask.intermediateDir } returns mockFile
+        every { mockFile.toString() } returns fakeFromPath
+        every { project.copySpec(capture(copySpecActionSlot)) } returns mockk()
+
+        FlutterTaskHelper.getAssets(project, flutterTask)
+        every { mockCopySpec.from(fakeFromPath) } returns mockCopySpec
+        every { mockCopySpec.include(FlutterTaskHelper.FLUTTER_ASSETS_INCLUDE_DIRECTORY) } returns mockCopySpec
+        copySpecActionSlot.captured.execute(mockCopySpec)
+        verify { mockCopySpec.from(fakeFromPath) }
+        verify { mockCopySpec.include(FlutterTaskHelper.FLUTTER_ASSETS_INCLUDE_DIRECTORY) }
+    }
+
+    @Test
+    fun `getSnapshots returns correct CopySpec for release build`() {
+        val project = mockk<Project>()
+        val flutterTask = mockk<FlutterTask>()
+        val mockCopySpec = mockk<CopySpec>()
+        val copySpecActionSlot = slot<Action<in CopySpec>>()
+        val fakeIntermediateDirectory = mockk<File>()
+        val fakeIntermediateDirectoryPath = "/path/to/intermediate"
+
+        every { flutterTask.intermediateDir } returns fakeIntermediateDirectory
+        every { flutterTask.buildMode } returns "release"
+        every { flutterTask.targetPlatformValues } returns listOf("arm64-v8a", "x64")
+        every { fakeIntermediateDirectory.toString() } returns fakeIntermediateDirectoryPath
+        every { project.copySpec(capture(copySpecActionSlot)) } returns mockk()
+
+        FlutterTaskHelper.getSnapshots(project, flutterTask)
+        every { mockCopySpec.from(fakeIntermediateDirectoryPath) } returns mockCopySpec
+        every { mockCopySpec.include(any<String>()) } returns mockCopySpec
+        copySpecActionSlot.captured.execute(mockCopySpec)
+
+        verify { mockCopySpec.from(fakeIntermediateDirectoryPath) }
+        verify { mockCopySpec.include("${FlutterPluginConstants.PLATFORM_ARCH_MAP["arm64-v8a"]}/app.so") }
+        verify { mockCopySpec.include("${FlutterPluginConstants.PLATFORM_ARCH_MAP["x64"]}/app.so") }
+    }
+
+    @Test
+    fun `getSnapshots returns correct CopySpec for debug build`() {
+        val project = mockk<Project>()
+        val flutterTask = mockk<FlutterTask>()
+        val mockCopySpec = mockk<CopySpec>()
+        val copySpecActionSlot = slot<Action<in CopySpec>>()
+        val fakeIntermediateDirectory = mockk<File>()
+        val fakeIntermediateDirectoryPath = "/path/to/intermediate"
+
+        every { flutterTask.intermediateDir } returns fakeIntermediateDirectory
+        every { flutterTask.buildMode } returns "debug"
+        every { flutterTask.targetPlatformValues } returns listOf("arm64-v8a", "x64")
+        every { fakeIntermediateDirectory.toString() } returns fakeIntermediateDirectoryPath
+        every { project.copySpec(capture(copySpecActionSlot)) } returns mockk()
+
+        FlutterTaskHelper.getSnapshots(project, flutterTask)
+        every { mockCopySpec.from(fakeIntermediateDirectoryPath) } returns mockCopySpec
+        every { mockCopySpec.include(any<String>()) } returns mockCopySpec
+        copySpecActionSlot.captured.execute(mockCopySpec)
+
+        verify { mockCopySpec.from(fakeIntermediateDirectoryPath) }
+        verify(exactly = 0) { mockCopySpec.include(any<String>()) }
+    }
+
+    @Test
+    fun `getSourceFiles returns files when dependenciesFile exists`(
+        @TempDir tempDir: Path
+    ) {
+        val mockProjectFileCollection = mockk<ConfigurableFileCollection>(relaxed = true)
+        val mockDependenciesFileCollection = mockk<FileCollection>()
+        val project = mockk<Project>()
+        val mockFlutterTask = mockk<FlutterTask>()
+
+        every { project.files() } returns mockProjectFileCollection
+        every { project.files(any()) } returns mockProjectFileCollection
+
+        every { mockFlutterTask.intermediateDir } returns tempDir.toFile()
+        every { mockFlutterTask.getDependenciesFiles() } returns mockDependenciesFileCollection
+        val dependenciesFile =
+            tempDir
+                .resolve("${mockFlutterTask.intermediateDir}/flutter_build.d")
+                .toFile()
+        dependenciesFile.writeText(
+            " ${tempDir.toFile().path}/pre/delimiter/one ${tempDir.toFile().path}/pre/delimiter/two: ${tempDir.toFile().path}/post/delimiter/one ${tempDir.toFile().path}/post/delimiter/two"
+        )
+        every { mockDependenciesFileCollection.iterator() } returns (mutableListOf(dependenciesFile).iterator())
+
+        FlutterTaskHelper.getSourceFiles(project, mockFlutterTask)
+
+        verify {
+            project.files(
+                listOf(
+                    "${tempDir.toFile().path}/post/delimiter/one",
+                    "${tempDir.toFile().path}/post/delimiter/two"
+                )
+            )
+        }
+
+        verify { project.files("pubspec.yaml") }
+    }
+
+    @Test
+    fun `getOutputFiles returns files when dependenciesFile exists`(
+        @TempDir tempDir: Path
+    ) {
+        val mockProjectFileCollection = mockk<ConfigurableFileCollection>(relaxed = true)
+        val mockDependenciesFileCollection = mockk<FileCollection>()
+        val project = mockk<Project>()
+        val mockFlutterTask = mockk<FlutterTask>()
+
+        every { project.files() } returns mockProjectFileCollection
+        every { project.files(any()) } returns mockProjectFileCollection
+
+        every { mockFlutterTask.intermediateDir } returns tempDir.toFile()
+        every { mockFlutterTask.getDependenciesFiles() } returns mockDependenciesFileCollection
+        val dependenciesFile =
+            tempDir
+                .resolve("${mockFlutterTask.intermediateDir}/flutter_build.d")
+                .toFile()
+        dependenciesFile.writeText(
+            " ${tempDir.toFile().path}/pre/delimiter/one ${tempDir.toFile().path}/pre/delimiter/two: ${tempDir.toFile().path}/post/delimiter/one ${tempDir.toFile().path}/post/delimiter/two"
+        )
+        every { mockDependenciesFileCollection.iterator() } returns (mutableListOf(dependenciesFile).iterator())
+
+        FlutterTaskHelper.getOutputFiles(project, mockFlutterTask)
+
+        verify {
+            project.files(
+                listOf(
+                    "${tempDir.toFile().path}/pre/delimiter/one",
+                    "${tempDir.toFile().path}/pre/delimiter/two"
+                )
+            )
+        }
+
+        verify(exactly = 0) { project.files("pubspec.yaml") }
+    }
+}


### PR DESCRIPTION
- Implement comprehensive unit tests for BaseFlutterTaskHelper, covering pre-condition checks, rule name generation, and execution specifications.
- Add tests for FlutterTaskHelper to validate asset directory retrieval, snapshot handling for different build modes, and source/output file management based on dependencies.
- Utilize mocking frameworks to simulate project and task behaviors, ensuring robust test coverage for various scenarios.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
