### PR TITLE
Fix slider crash in Table/TableRow

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -668,7 +668,6 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   FocusNode? _focusNode;
   FocusNode get focusNode => widget.focusNode ?? _focusNode!;
 
-  // Always keep the ValueIndicator visible on the Overlay; otherwise, it cannot be updated during the build phase.
   final OverlayPortalController _valueIndicatorOverlayPortalController = OverlayPortalController(
     debugLabel: 'Slider ValueIndicator',
   );

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -671,7 +671,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
   // Always keep the ValueIndicator visible on the Overlay; otherwise, it cannot be updated during the build phase.
   final OverlayPortalController _valueIndicatorOverlayPortalController = OverlayPortalController(
     debugLabel: 'Slider ValueIndicator',
-  )..show();
+  );
 
   @override
   void initState() {
@@ -714,6 +714,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         widget.onChanged!(_currentChangedValue!);
       }
     }
+    _valueIndicatorOverlayPortalController.show();
   }
 
   void _handleDragStart(double value) {
@@ -752,6 +753,7 @@ class _SliderState extends State<Slider> with TickerProviderStateMixin {
         _focused = focused;
       });
     }
+    _valueIndicatorOverlayPortalController.show();
   }
 
   bool _hovering = false;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -5419,7 +5419,7 @@ void main() {
     expect(log.last, const Offset(400.0, 300.0));
   });
 
-  // Regression test for hhttps://github.com/flutter/flutter/issues/161805
+  // Regression test for https://github.com/flutter/flutter/issues/161805
   testWidgets('Discrete Slider does not apply thumb padding in a non-rounded track shape', (
     WidgetTester tester,
   ) async {
@@ -5459,5 +5459,22 @@ void main() {
       material,
       paints..circle(x: 800.0 - sliderPadding, y: 300.0, color: theme.colorScheme.primary),
     );
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/174133
+  testWidgets('Value indicator crash', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Table(
+            children: const <TableRow>[
+              TableRow(children: <Widget>[Slider(value: 0.0, onChanged: null)]),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
Fixes [[3.35.1]: Slider in Table/TableRow crashes with error package:flutter/src/rendering/object.dart': Failed assertion: line 1982 pos 12: 'child.owner == owner': is not true.](https://github.com/flutter/flutter/issues/174133).

Crashes if I show the controller in `initState`/`build`.