### PR TITLE
[ Widget Preview ] Respond to IDE navigation events and show previews from the currently focused script

### DIFF
--- a/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
@@ -35,7 +35,8 @@ typedef PreviewDependencyGraph = Map<PreviewPath, LibraryPreviewNode>;
 class _PreviewVisitor extends RecursiveAstVisitor<void> {
   _PreviewVisitor({required LibraryElement2 lib})
     : packageName = lib.uri.scheme == 'package' ? lib.uri.pathSegments.first : null,
-      _context = lib.session.analysisContext;
+      _context = lib.session.analysisContext,
+      _currentScriptUri = null;
 
   late final String? packageName;
 

--- a/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
@@ -46,6 +46,12 @@ class _PreviewVisitor extends RecursiveAstVisitor<void> {
   ConstructorDeclaration? _currentConstructor;
   MethodDeclaration? _currentMethod;
 
+  Uri? _currentScriptUri;
+
+  void findPreviewsInResolvedUnitResult(ResolvedUnitResult unit) {
+    _scopedVisitChildren(unit.unit, (_) => _currentScriptUri = unit.file.toUri());
+  }
+
   /// Handles previews defined on top-level functions.
   @override
   void visitFunctionDeclaration(FunctionDeclaration node) {
@@ -104,6 +110,7 @@ class _PreviewVisitor extends RecursiveAstVisitor<void> {
           if (returnType.isWidget || returnType.isWidgetBuilder) {
             previewEntries.add(
               PreviewDetails(
+                scriptUri: _currentScriptUri!,
                 packageName: packageName,
                 functionName: _currentFunction!.name.toString(),
                 isBuilder: returnType.isWidgetBuilder,
@@ -118,6 +125,7 @@ class _PreviewVisitor extends RecursiveAstVisitor<void> {
         final Token? name = _currentConstructor!.name;
         previewEntries.add(
           PreviewDetails(
+            scriptUri: _currentScriptUri!,
             packageName: packageName,
             functionName: '$returnType${name == null ? '' : '.$name'}',
             isBuilder: false,
@@ -132,6 +140,7 @@ class _PreviewVisitor extends RecursiveAstVisitor<void> {
             final parentClass = _currentMethod!.parent! as ClassDeclaration;
             previewEntries.add(
               PreviewDetails(
+                scriptUri: _currentScriptUri!,
                 packageName: packageName,
                 functionName: '${parentClass.name}.${_currentMethod!.name}',
                 isBuilder: returnType.isWidgetBuilder,
@@ -210,9 +219,7 @@ final class LibraryPreviewNode {
   void findPreviews({required ResolvedLibraryResult lib}) {
     // Iterate over the compilation unit's AST to find previews.
     final visitor = _PreviewVisitor(lib: lib.element);
-    for (final ResolvedUnitResult libUnit in lib.units) {
-      libUnit.unit.visitChildren(visitor);
-    }
+    lib.units.forEach(visitor.findPreviewsInResolvedUnitResult);
     previews
       ..clear()
       ..addAll(visitor.previewEntries);

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -193,6 +193,7 @@ class PreviewCodeGenerator {
         // TODO(bkonyi): try to display the preview name, even if the preview can't be displayed.
         if (!libraryDetails.dependencyHasErrors &&
             !libraryDetails.hasErrors) ...<String, cb.Expression>{
+          PreviewDetails.kScriptUri: cb.literalString(preview.scriptUri.toString()),
           if (preview.packageName != null)
             PreviewDetails.kPackageName: cb.literalString(preview.packageName!),
           ...?_generateCodeFromAnalyzerExpression(

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -190,10 +190,10 @@ class PreviewCodeGenerator {
     return cb.refer(_kWidgetPreviewClass, _kWidgetPreviewLibraryUri).newInstance(
       <cb.Expression>[],
       <String, cb.Expression>{
+        PreviewDetails.kScriptUri: cb.literalString(preview.scriptUri.toString()),
         // TODO(bkonyi): try to display the preview name, even if the preview can't be displayed.
         if (!libraryDetails.dependencyHasErrors &&
             !libraryDetails.hasErrors) ...<String, cb.Expression>{
-          PreviewDetails.kScriptUri: cb.literalString(preview.scriptUri.toString()),
           if (preview.packageName != null)
             PreviewDetails.kPackageName: cb.literalString(preview.packageName!),
           ...?_generateCodeFromAnalyzerExpression(

--- a/packages/flutter_tools/lib/src/widget_preview/preview_details.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_details.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/constant/value.dart';
 /// Contains details related to a single preview instance.
 final class PreviewDetails {
   PreviewDetails({
+    required this.scriptUri,
     required this.packageName,
     required this.functionName,
     required this.isBuilder,
@@ -19,6 +20,7 @@ final class PreviewDetails {
        brightness = previewAnnotation.getField(kBrightness)!,
        localizations = previewAnnotation.getField(kLocalizations)!;
 
+  static const kScriptUri = 'scriptUri';
   static const kPackageName = 'packageName';
   static const kName = 'name';
   static const kSize = 'size';
@@ -27,6 +29,9 @@ final class PreviewDetails {
   static const kTheme = 'theme';
   static const kBrightness = 'brightness';
   static const kLocalizations = 'localizations';
+
+  /// The file:// URI pointing to the script in which the preview is defined.
+  final Uri scriptUri;
 
   /// The name of the package in which the preview was defined.
   ///

--- a/packages/flutter_tools/templates/template_manifest.json
+++ b/packages/flutter_tools/templates/template_manifest.json
@@ -348,6 +348,7 @@
     "templates/widget_preview_scaffold/lib/main.dart.tmpl",
     "templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl",
     "templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl",
+    "templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl",
     "templates/widget_preview_scaffold/lib/src/controls.dart.tmpl",
     "templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl",
     "templates/widget_preview_scaffold/lib/src/dtd/editor_service.dart.tmpl",

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/controls.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/controls.dart.tmpl
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:widget_preview_scaffold/src/dtd/dtd_services.dart';
+import 'widget_preview_scaffold_controller.dart';
 
 class _WidgetPreviewIconButton extends StatelessWidget {
   const _WidgetPreviewIconButton({
@@ -97,6 +97,85 @@ class ZoomControls extends StatelessWidget {
   }
 }
 
+class _ControlDecorator extends StatelessWidget {
+  const _ControlDecorator({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(8.0),
+      decoration: BoxDecoration(
+        color: Colors.grey[300],
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      child: child,
+    );
+  }
+}
+
+/// Allows for controlling the grid vs layout view in the preview environment.
+class LayoutTypeSelector extends StatelessWidget {
+  const LayoutTypeSelector({super.key, required this.controller});
+
+  final WidgetPreviewScaffoldController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ControlDecorator(
+      child: ValueListenableBuilder<LayoutType>(
+        valueListenable: controller.layoutTypeListenable,
+        builder: (context, selectedLayout, _) {
+          return Row(
+            children: [
+              IconButton(
+                onPressed: () => controller.layoutType = LayoutType.gridView,
+                icon: Icon(Icons.grid_on),
+                color: selectedLayout == LayoutType.gridView
+                    ? Colors.blue
+                    : Colors.black,
+              ),
+              IconButton(
+                onPressed: () => controller.layoutType = LayoutType.listView,
+                icon: Icon(Icons.view_list),
+                color: selectedLayout == LayoutType.listView
+                    ? Colors.blue
+                    : Colors.black,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A toggle button that enables / disables filtering previews by the currently
+/// selected source file.
+class FilterBySelectedFileToggle extends StatelessWidget {
+  const FilterBySelectedFileToggle({super.key, required this.controller});
+
+  final WidgetPreviewScaffoldController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ControlDecorator(
+      child: ValueListenableBuilder(
+        valueListenable: controller.filterBySelectedFileListenable,
+        builder: (context, value, child) {
+          return IconButton(
+            onPressed: controller.toggleFilterBySelectedFile,
+            icon: Icon(Icons.file_open),
+            color: value ? Colors.blue : Colors.black,
+            tooltip: 'Filter previews by selected file',
+          );
+        },
+      ),
+    );
+  }
+}
+
 /// A button that triggers a "soft" restart of a previewed widget.
 ///
 /// A soft restart removes the previewed widget from the widget tree for a frame before
@@ -129,16 +208,18 @@ class SoftRestartButton extends StatelessWidget {
 /// A button that triggers a restart of the widget previewer through a hot restart request made
 /// through DTD.
 class WidgetPreviewerRestartButton extends StatelessWidget {
-  const WidgetPreviewerRestartButton({super.key, required this.dtdServices});
+  const WidgetPreviewerRestartButton({super.key, required this.controller});
 
-  final WidgetPreviewScaffoldDtdServices dtdServices;
+  final WidgetPreviewScaffoldController controller;
 
   @override
   Widget build(BuildContext context) {
-    return IconButton.outlined(
-      tooltip: 'Restart the Widget Previewer',
-      onPressed: () => dtdServices.hotRestartPreviewer(),
-      icon: Icon(Icons.restart_alt),
+    return _ControlDecorator(
+      child: IconButton(
+        tooltip: 'Restart the Widget Previewer',
+        onPressed: controller.dtdServices.hotRestartPreviewer,
+        icon: Icon(Icons.restart_alt),
+      ),
     );
   }
 }

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
@@ -43,7 +43,9 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
   }
 
   /// Disposes the DTD connection.
+  @override
   Future<void> dispose() async {
+    super.dispose();
     await dtd.close();
   }
 

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/dtd_services.dart.tmpl
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:dtd/dtd.dart';
-import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'editor_service.dart';
 
 /// Provides services, streams, and RPC invocations to interact with Flutter developer tooling.
 class WidgetPreviewScaffoldDtdServices with DtdEditorService {
@@ -40,6 +40,11 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
     );
 
     await initializeEditorService();
+  }
+
+  /// Disposes the DTD connection.
+  Future<void> dispose() async {
+    await dtd.close();
   }
 
   Future<DTDResponse> _call(

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/editor_service.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/dtd/editor_service.dart.tmpl
@@ -40,6 +40,12 @@ mixin DtdEditorService {
     });
     await dtd.streamListen(kEditorService);
   }
+
+  @mustCallSuper
+  void dispose() {
+    _selectedSourceFile.dispose();
+    _editorTheme.dispose();
+  }
 }
 
 // TODO(bkonyi): much of the following code is copied from the DevTools codebase. We should publish

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/utils.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/utils.dart.tmpl
@@ -31,3 +31,44 @@ class VerticalSpacer extends StatelessWidget {
     return const SizedBox(height: 10);
   }
 }
+
+/// A basic horizontal spacer.
+class HorizontalSpacer extends StatelessWidget {
+  /// Creates a basic vertical spacer.
+  const HorizontalSpacer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(width: 10);
+  }
+}
+
+/// A widget that explicitly responds to hot reload events.
+///
+/// Hot reload will always result in [reassemble] being called.
+class HotReloadListener extends StatefulWidget {
+  const HotReloadListener({
+    super.key,
+    required this.onHotReload,
+    required this.child,
+  });
+
+  final VoidCallback onHotReload;
+  final Widget child;
+
+  @override
+  HotReloadListenerState createState() => HotReloadListenerState();
+}
+
+class HotReloadListenerState extends State<HotReloadListener> {
+  @override
+  void reassemble() {
+    super.reassemble();
+    widget.onHotReload();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl
@@ -8,19 +8,12 @@ import 'package:flutter/widgets.dart';
 
 /// Wraps a [Widget], initializing various state and properties to allow for
 /// previewing of the [Widget] in the widget previewer.
-///
-/// WARNING: This interface is not stable and **will change**.
-///
-/// See also:
-///
-///  * [Preview], an annotation class used to mark functions returning widget
-///    previews.
-// TODO(bkonyi): link to actual documentation when available.
 class WidgetPreview {
   /// Wraps [builder] in a [WidgetPreview] instance that applies some set of
   /// properties.
   const WidgetPreview({
     required this.builder,
+    required this.scriptUri,
     this.packageName,
     this.name,
     this.size,
@@ -29,6 +22,11 @@ class WidgetPreview {
     this.theme,
     this.localizations,
   });
+
+  /// The absolute file:// URI pointing to the script containing this preview.
+  ///
+  /// This matches the URI format sent by IDEs for active location change events.
+  final String scriptUri;
 
   /// The name of the package in which a preview was defined.
   ///

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -868,33 +868,28 @@ class WidgetPreviews extends StatelessWidget {
     return ValueListenableBuilder<List<WidgetPreview>>(
       valueListenable: controller.filteredPreviewSetListenable,
       builder: (context, previewList, _) {
-        Widget previewView;
         if (previewList.isEmpty) {
-          previewView = Column(
+          return Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[NoPreviewsDetectedWidget()],
           );
-        } else {
-          previewView = LayoutBuilder(
-            builder: (BuildContext context, BoxConstraints constraints) {
-              return WidgetPreviewerWindowConstraints(
-                constraints: constraints,
-                child: ValueListenableBuilder<LayoutType>(
-                  valueListenable: controller.layoutTypeListenable,
-                  builder: (context, selectedLayout, _) {
-                    return switch (selectedLayout) {
-                      LayoutType.gridView => _buildGridViewFlex(previewList),
-                      LayoutType.listView => _buildVerticalListView(
-                        previewList,
-                      ),
-                    };
-                  },
-                ),
-              );
-            },
-          );
         }
-        return previewView;
+        return LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return WidgetPreviewerWindowConstraints(
+              constraints: constraints,
+              child: ValueListenableBuilder<LayoutType>(
+                valueListenable: controller.layoutTypeListenable,
+                builder: (context, selectedLayout, _) {
+                  return switch (selectedLayout) {
+                    LayoutType.gridView => _buildGridViewFlex(previewList),
+                    LayoutType.listView => _buildVerticalListView(previewList),
+                  };
+                },
+              ),
+            );
+          },
+        );
       },
     );
   }

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -839,7 +839,7 @@ class WidgetPreviews extends StatelessWidget {
   static const _gridSpacing = 8.0;
   static const _gridRunSpacing = 8.0;
 
-  Widget _buildGridViewFlex(List<WidgetPreview> previewList) {
+  Widget _buildGridViewFlex(Iterable<WidgetPreview> previewList) {
     return SingleChildScrollView(
       child: Wrap(
         spacing: _gridSpacing,
@@ -853,7 +853,8 @@ class WidgetPreviews extends StatelessWidget {
     );
   }
 
-  Widget _buildVerticalListView(List<WidgetPreview> previewList) {
+  Widget _buildVerticalListView(Iterable<WidgetPreview> previews) {
+    final previewList = previews.toList();
     return ListView.builder(
       itemCount: previewList.length,
       itemBuilder: (context, index) {
@@ -865,7 +866,7 @@ class WidgetPreviews extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<List<WidgetPreview>>(
+    return ValueListenableBuilder<Iterable<WidgetPreview>>(
       valueListenable: controller.filteredPreviewSetListenable,
       builder: (context, previewList, _) {
         if (previewList.isEmpty) {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -1,0 +1,91 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'dtd/dtd_services.dart';
+import 'widget_preview.dart';
+
+/// Define the Enum for Layout Types
+enum LayoutType { gridView, listView }
+
+typedef PreviewsCallback = List<WidgetPreview> Function();
+
+/// Controller used to process events and determine which previews should be
+/// displayed and how they should be displayed in the [WidgetPreviewScaffold].
+class WidgetPreviewScaffoldController {
+  WidgetPreviewScaffoldController({
+    required PreviewsCallback previews,
+    @visibleForTesting WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
+  }) : _previews = previews,
+       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
+
+  /// Initializes the controller by establishing a connection to DTD and
+  /// listening for events.
+  Future<void> initialize() async {
+    await dtdServices.connect();
+    _registerListeners();
+  }
+
+  /// Cleanup internal controller state.
+  Future<void> dispose() async {
+    _cleanupListeners();
+    await dtdServices.dispose();
+  }
+
+  /// Update state after the project has been reassembled due to a hot reload.
+  void onHotReload() {
+    _handleSelectedSourceFileChanged();
+  }
+
+  /// The active DTD connection used to communicate with other developer tooling.
+  final WidgetPreviewScaffoldDtdServices dtdServices;
+
+  final List<WidgetPreview> Function() _previews;
+
+  /// Specifies how the previews should be laid out.
+  ValueListenable<LayoutType> get layoutTypeListenable => _layoutType;
+  final _layoutType = ValueNotifier<LayoutType>(LayoutType.gridView);
+
+  LayoutType get layoutType => _layoutType.value;
+  set layoutType(LayoutType type) => _layoutType.value = type;
+
+  ValueListenable<bool> get filterBySelectedFileListenable =>
+      _filterBySelectedFile;
+  final _filterBySelectedFile = ValueNotifier<bool>(true);
+
+  void toggleFilterBySelectedFile() {
+    _filterBySelectedFile.value = !_filterBySelectedFile.value;
+    _handleSelectedSourceFileChanged();
+  }
+
+  /// The current set of previews to be displayed.
+  ValueListenable<List<WidgetPreview>> get filteredPreviewSetListenable =>
+      _filteredPreviewSet;
+  final _filteredPreviewSet = ValueNotifier<List<WidgetPreview>>([]);
+
+  void _registerListeners() {
+    dtdServices.selectedSourceFile.addListener(
+      _handleSelectedSourceFileChanged,
+    );
+    // Set the initial state.
+    _handleSelectedSourceFileChanged();
+  }
+
+  void _cleanupListeners() {
+    dtdServices.selectedSourceFile.removeListener(
+      _handleSelectedSourceFileChanged,
+    );
+  }
+
+  void _handleSelectedSourceFileChanged() {
+    final selectedSourceFile = dtdServices.selectedSourceFile.value;
+    if (selectedSourceFile == null || !_filterBySelectedFile.value) {
+      _filteredPreviewSet.value = _previews();
+      return;
+    }
+    _filteredPreviewSet.value = _previews()
+        .where((preview) => preview.scriptUri == selectedSourceFile.uriAsString)
+        .toList();
+  }
+}

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -18,7 +18,7 @@ class WidgetPreviewScaffoldController {
     required PreviewsCallback previews,
     @visibleForTesting WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
   }) : _previews = previews,
-       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
+       _dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
 
   /// Initializes the controller by establishing a connection to DTD and
   /// listening for events.

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -63,7 +63,7 @@ class WidgetPreviewScaffoldController {
   }
 
   /// The current set of previews to be displayed.
-  ValueListenable<List<WidgetPreview>> get filteredPreviewSetListenable =>
+  ValueListenable<Iterable<WidgetPreview>> get filteredPreviewSetListenable =>
       _filteredPreviewSet;
   final _filteredPreviewSet = ValueNotifier<List<WidgetPreview>>([]);
 

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -39,7 +39,8 @@ class WidgetPreviewScaffoldController {
   }
 
   /// The active DTD connection used to communicate with other developer tooling.
-  final WidgetPreviewScaffoldDtdServices dtdServices;
+  WidgetPreviewScaffoldDtdServices get dtdServices => _dtdServices;
+  final WidgetPreviewScaffoldDtdServices _dtdServices;
 
   final List<WidgetPreview> Function() _previews;
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -240,19 +240,23 @@ import 'package:flutter/material.dart' as _i10;
 
 List<_i1.WidgetPreview> previews() => [
       _i1.WidgetPreview(
+        scriptUri: 'STRIPPED',
         packageName: 'foo_project',
         builder: () => _i2.preview(),
       ),
       _i1.WidgetPreview(
+        scriptUri: 'STRIPPED',
         packageName: 'foo_project',
         builder: () => _i3.barPreview1(),
       ),
       _i1.WidgetPreview(
+        scriptUri: 'STRIPPED',
         packageName: 'foo_project',
         brightness: _i4.brightnessConstant,
         builder: () => _i3.barPreview2(),
       ),
       _i1.WidgetPreview(
+        scriptUri: 'STRIPPED',
         packageName: 'foo_project',
         name: 'Foo',
         size: const _i5.Size(
@@ -266,14 +270,24 @@ List<_i1.WidgetPreview> previews() => [
         builder: () => _i8.wrapper(_i9.Builder(builder: _i3.barPreview3())),
       ),
       _i1.WidgetPreview(
-          builder: () =>
-              _i10.Text('package:foo_project/src/error.dart has errors!')),
+        scriptUri: 'STRIPPED',
+        builder: () =>
+            _i10.Text('package:foo_project/src/error.dart has errors!'),
+      ),
       _i1.WidgetPreview(
-          builder: () => _i10.Text(
-              'Dependency of package:foo_project/src/transitive_error.dart has errors!')),
+        scriptUri: 'STRIPPED',
+        builder: () => _i10.Text(
+            'Dependency of package:foo_project/src/transitive_error.dart has errors!'),
+      ),
     ];
 ''';
-        expect(generatedPreviewFile.readAsStringSync(), expectedGeneratedPreviewFileContents);
+        expect(
+          generatedPreviewFile.readAsStringSync().replaceAll(
+            RegExp(r"scriptUri:\s*'file:\/\/\/\S*',"),
+            "scriptUri: 'STRIPPED',",
+          ),
+          expectedGeneratedPreviewFileContents,
+        );
 
         // Regenerate the generated file with no previews.
         codeGenerator.populatePreviewsInGeneratedPreviewScaffold(

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -81,6 +81,11 @@ class FakeCustomBrowserDevice extends Fake implements ChromiumDevice {
   String get displayName => 'Dartium';
 }
 
+extension on String {
+  String get stripScriptUris =>
+      replaceAll(RegExp(r"scriptUri:\s*'file:\/\/\/\S*',"), "scriptUri: 'STRIPPED',");
+}
+
 void main() {
   late Directory originalCwd;
   late Directory tempDir;
@@ -324,6 +329,7 @@ import 'package:flutter_project/foo.dart' as _i2;
 
 List<_i1.WidgetPreview> previews() => [
       _i1.WidgetPreview(
+        scriptUri: 'STRIPPED',
         packageName: 'flutter_project',
         name: 'preview',
         builder: () => _i2.preview(),
@@ -348,7 +354,7 @@ List<_i1.WidgetPreview> previews() => [
         );
 
         await startWidgetPreview(rootProject: rootProject);
-        expect(generatedFile.readAsStringSync(), expectedGeneratedFileContents);
+        expect(generatedFile.readAsStringSync().stripScriptUris, expectedGeneratedFileContents);
         expectSinglePreviewLaunchTimingEvent();
       },
       overrides: <Type, Generator>{
@@ -386,7 +392,7 @@ List<_i1.WidgetPreview> previews() => [
         fs.currentDirectory = rootProject;
         await startWidgetPreview(rootProject: null);
 
-        expect(generatedFile.readAsStringSync(), expectedGeneratedFileContents);
+        expect(generatedFile.readAsStringSync().stripScriptUris, expectedGeneratedFileContents);
         expectSinglePreviewLaunchTimingEvent();
       },
       overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/controls.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/controls.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:widget_preview_scaffold/src/dtd/dtd_services.dart';
+import 'widget_preview_scaffold_controller.dart';
 
 class _WidgetPreviewIconButton extends StatelessWidget {
   const _WidgetPreviewIconButton({
@@ -97,6 +97,85 @@ class ZoomControls extends StatelessWidget {
   }
 }
 
+class _ControlDecorator extends StatelessWidget {
+  const _ControlDecorator({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(8.0),
+      decoration: BoxDecoration(
+        color: Colors.grey[300],
+        borderRadius: BorderRadius.circular(8.0),
+      ),
+      child: child,
+    );
+  }
+}
+
+/// Allows for controlling the grid vs layout view in the preview environment.
+class LayoutTypeSelector extends StatelessWidget {
+  const LayoutTypeSelector({super.key, required this.controller});
+
+  final WidgetPreviewScaffoldController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ControlDecorator(
+      child: ValueListenableBuilder<LayoutType>(
+        valueListenable: controller.layoutTypeListenable,
+        builder: (context, selectedLayout, _) {
+          return Row(
+            children: [
+              IconButton(
+                onPressed: () => controller.layoutType = LayoutType.gridView,
+                icon: Icon(Icons.grid_on),
+                color: selectedLayout == LayoutType.gridView
+                    ? Colors.blue
+                    : Colors.black,
+              ),
+              IconButton(
+                onPressed: () => controller.layoutType = LayoutType.listView,
+                icon: Icon(Icons.view_list),
+                color: selectedLayout == LayoutType.listView
+                    ? Colors.blue
+                    : Colors.black,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// A toggle button that enables / disables filtering previews by the currently
+/// selected source file.
+class FilterBySelectedFileToggle extends StatelessWidget {
+  const FilterBySelectedFileToggle({super.key, required this.controller});
+
+  final WidgetPreviewScaffoldController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ControlDecorator(
+      child: ValueListenableBuilder(
+        valueListenable: controller.filterBySelectedFileListenable,
+        builder: (context, value, child) {
+          return IconButton(
+            onPressed: controller.toggleFilterBySelectedFile,
+            icon: Icon(Icons.file_open),
+            color: value ? Colors.blue : Colors.black,
+            tooltip: 'Filter previews by selected file',
+          );
+        },
+      ),
+    );
+  }
+}
+
 /// A button that triggers a "soft" restart of a previewed widget.
 ///
 /// A soft restart removes the previewed widget from the widget tree for a frame before
@@ -129,16 +208,18 @@ class SoftRestartButton extends StatelessWidget {
 /// A button that triggers a restart of the widget previewer through a hot restart request made
 /// through DTD.
 class WidgetPreviewerRestartButton extends StatelessWidget {
-  const WidgetPreviewerRestartButton({super.key, required this.dtdServices});
+  const WidgetPreviewerRestartButton({super.key, required this.controller});
 
-  final WidgetPreviewScaffoldDtdServices dtdServices;
+  final WidgetPreviewScaffoldController controller;
 
   @override
   Widget build(BuildContext context) {
-    return IconButton.outlined(
-      tooltip: 'Restart the Widget Previewer',
-      onPressed: () => dtdServices.hotRestartPreviewer(),
-      icon: Icon(Icons.restart_alt),
+    return _ControlDecorator(
+      child: IconButton(
+        tooltip: 'Restart the Widget Previewer',
+        onPressed: controller.dtdServices.hotRestartPreviewer,
+        icon: Icon(Icons.restart_alt),
+      ),
     );
   }
 }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
@@ -43,7 +43,9 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
   }
 
   /// Disposes the DTD connection.
+  @override
   Future<void> dispose() async {
+    super.dispose();
     await dtd.close();
   }
 

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:dtd/dtd.dart';
-import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'editor_service.dart';
 
 /// Provides services, streams, and RPC invocations to interact with Flutter developer tooling.
 class WidgetPreviewScaffoldDtdServices with DtdEditorService {
@@ -40,6 +40,11 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
     );
 
     await initializeEditorService();
+  }
+
+  /// Disposes the DTD connection.
+  Future<void> dispose() async {
+    await dtd.close();
   }
 
   Future<DTDResponse> _call(

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/editor_service.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/editor_service.dart
@@ -40,6 +40,12 @@ mixin DtdEditorService {
     });
     await dtd.streamListen(kEditorService);
   }
+
+  @mustCallSuper
+  void dispose() {
+    _selectedSourceFile.dispose();
+    _editorTheme.dispose();
+  }
 }
 
 // TODO(bkonyi): much of the following code is copied from the DevTools codebase. We should publish

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/utils.dart
@@ -31,3 +31,44 @@ class VerticalSpacer extends StatelessWidget {
     return const SizedBox(height: 10);
   }
 }
+
+/// A basic horizontal spacer.
+class HorizontalSpacer extends StatelessWidget {
+  /// Creates a basic vertical spacer.
+  const HorizontalSpacer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox(width: 10);
+  }
+}
+
+/// A widget that explicitly responds to hot reload events.
+///
+/// Hot reload will always result in [reassemble] being called.
+class HotReloadListener extends StatefulWidget {
+  const HotReloadListener({
+    super.key,
+    required this.onHotReload,
+    required this.child,
+  });
+
+  final VoidCallback onHotReload;
+  final Widget child;
+
+  @override
+  HotReloadListenerState createState() => HotReloadListenerState();
+}
+
+class HotReloadListenerState extends State<HotReloadListener> {
+  @override
+  void reassemble() {
+    super.reassemble();
+    widget.onHotReload();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview.dart
@@ -8,19 +8,12 @@ import 'package:flutter/widgets.dart';
 
 /// Wraps a [Widget], initializing various state and properties to allow for
 /// previewing of the [Widget] in the widget previewer.
-///
-/// WARNING: This interface is not stable and **will change**.
-///
-/// See also:
-///
-///  * [Preview], an annotation class used to mark functions returning widget
-///    previews.
-// TODO(bkonyi): link to actual documentation when available.
 class WidgetPreview {
   /// Wraps [builder] in a [WidgetPreview] instance that applies some set of
   /// properties.
   const WidgetPreview({
     required this.builder,
+    required this.scriptUri,
     this.packageName,
     this.name,
     this.size,
@@ -29,6 +22,11 @@ class WidgetPreview {
     this.theme,
     this.localizations,
   });
+
+  /// The absolute file:// URI pointing to the script containing this preview.
+  ///
+  /// This matches the URI format sent by IDEs for active location change events.
+  final String scriptUri;
 
   /// The name of the package in which a preview was defined.
   ///

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -868,33 +868,28 @@ class WidgetPreviews extends StatelessWidget {
     return ValueListenableBuilder<List<WidgetPreview>>(
       valueListenable: controller.filteredPreviewSetListenable,
       builder: (context, previewList, _) {
-        Widget previewView;
         if (previewList.isEmpty) {
-          previewView = Column(
+          return Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[NoPreviewsDetectedWidget()],
           );
-        } else {
-          previewView = LayoutBuilder(
-            builder: (BuildContext context, BoxConstraints constraints) {
-              return WidgetPreviewerWindowConstraints(
-                constraints: constraints,
-                child: ValueListenableBuilder<LayoutType>(
-                  valueListenable: controller.layoutTypeListenable,
-                  builder: (context, selectedLayout, _) {
-                    return switch (selectedLayout) {
-                      LayoutType.gridView => _buildGridViewFlex(previewList),
-                      LayoutType.listView => _buildVerticalListView(
-                        previewList,
-                      ),
-                    };
-                  },
-                ),
-              );
-            },
-          );
         }
-        return previewView;
+        return LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            return WidgetPreviewerWindowConstraints(
+              constraints: constraints,
+              child: ValueListenableBuilder<LayoutType>(
+                valueListenable: controller.layoutTypeListenable,
+                builder: (context, selectedLayout, _) {
+                  return switch (selectedLayout) {
+                    LayoutType.gridView => _buildGridViewFlex(previewList),
+                    LayoutType.listView => _buildVerticalListView(previewList),
+                  };
+                },
+              ),
+            );
+          },
+        );
       },
     );
   }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -839,7 +839,7 @@ class WidgetPreviews extends StatelessWidget {
   static const _gridSpacing = 8.0;
   static const _gridRunSpacing = 8.0;
 
-  Widget _buildGridViewFlex(List<WidgetPreview> previewList) {
+  Widget _buildGridViewFlex(Iterable<WidgetPreview> previewList) {
     return SingleChildScrollView(
       child: Wrap(
         spacing: _gridSpacing,
@@ -853,7 +853,8 @@ class WidgetPreviews extends StatelessWidget {
     );
   }
 
-  Widget _buildVerticalListView(List<WidgetPreview> previewList) {
+  Widget _buildVerticalListView(Iterable<WidgetPreview> previews) {
+    final previewList = previews.toList();
     return ListView.builder(
       itemCount: previewList.length,
       itemBuilder: (context, index) {
@@ -865,7 +866,7 @@ class WidgetPreviews extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<List<WidgetPreview>>(
+    return ValueListenableBuilder<Iterable<WidgetPreview>>(
       valueListenable: controller.filteredPreviewSetListenable,
       builder: (context, previewList, _) {
         if (previewList.isEmpty) {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
@@ -1,0 +1,91 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'dtd/dtd_services.dart';
+import 'widget_preview.dart';
+
+/// Define the Enum for Layout Types
+enum LayoutType { gridView, listView }
+
+typedef PreviewsCallback = List<WidgetPreview> Function();
+
+/// Controller used to process events and determine which previews should be
+/// displayed and how they should be displayed in the [WidgetPreviewScaffold].
+class WidgetPreviewScaffoldController {
+  WidgetPreviewScaffoldController({
+    required PreviewsCallback previews,
+    @visibleForTesting WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
+  }) : _previews = previews,
+       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
+
+  /// Initializes the controller by establishing a connection to DTD and
+  /// listening for events.
+  Future<void> initialize() async {
+    await dtdServices.connect();
+    _registerListeners();
+  }
+
+  /// Cleanup internal controller state.
+  Future<void> dispose() async {
+    _cleanupListeners();
+    await dtdServices.dispose();
+  }
+
+  /// Update state after the project has been reassembled due to a hot reload.
+  void onHotReload() {
+    _handleSelectedSourceFileChanged();
+  }
+
+  /// The active DTD connection used to communicate with other developer tooling.
+  final WidgetPreviewScaffoldDtdServices dtdServices;
+
+  final List<WidgetPreview> Function() _previews;
+
+  /// Specifies how the previews should be laid out.
+  ValueListenable<LayoutType> get layoutTypeListenable => _layoutType;
+  final _layoutType = ValueNotifier<LayoutType>(LayoutType.gridView);
+
+  LayoutType get layoutType => _layoutType.value;
+  set layoutType(LayoutType type) => _layoutType.value = type;
+
+  ValueListenable<bool> get filterBySelectedFileListenable =>
+      _filterBySelectedFile;
+  final _filterBySelectedFile = ValueNotifier<bool>(true);
+
+  void toggleFilterBySelectedFile() {
+    _filterBySelectedFile.value = !_filterBySelectedFile.value;
+    _handleSelectedSourceFileChanged();
+  }
+
+  /// The current set of previews to be displayed.
+  ValueListenable<List<WidgetPreview>> get filteredPreviewSetListenable =>
+      _filteredPreviewSet;
+  final _filteredPreviewSet = ValueNotifier<List<WidgetPreview>>([]);
+
+  void _registerListeners() {
+    dtdServices.selectedSourceFile.addListener(
+      _handleSelectedSourceFileChanged,
+    );
+    // Set the initial state.
+    _handleSelectedSourceFileChanged();
+  }
+
+  void _cleanupListeners() {
+    dtdServices.selectedSourceFile.removeListener(
+      _handleSelectedSourceFileChanged,
+    );
+  }
+
+  void _handleSelectedSourceFileChanged() {
+    final selectedSourceFile = dtdServices.selectedSourceFile.value;
+    if (selectedSourceFile == null || !_filterBySelectedFile.value) {
+      _filteredPreviewSet.value = _previews();
+      return;
+    }
+    _filteredPreviewSet.value = _previews()
+        .where((preview) => preview.scriptUri == selectedSourceFile.uriAsString)
+        .toList();
+  }
+}

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
@@ -18,7 +18,7 @@ class WidgetPreviewScaffoldController {
     required PreviewsCallback previews,
     @visibleForTesting WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
   }) : _previews = previews,
-       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
+       _dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
 
   /// Initializes the controller by establishing a connection to DTD and
   /// listening for events.
@@ -39,7 +39,8 @@ class WidgetPreviewScaffoldController {
   }
 
   /// The active DTD connection used to communicate with other developer tooling.
-  final WidgetPreviewScaffoldDtdServices dtdServices;
+  WidgetPreviewScaffoldDtdServices get dtdServices => _dtdServices;
+  final WidgetPreviewScaffoldDtdServices _dtdServices;
 
   final List<WidgetPreview> Function() _previews;
 

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
@@ -63,7 +63,7 @@ class WidgetPreviewScaffoldController {
   }
 
   /// The current set of previews to be displayed.
-  ValueListenable<List<WidgetPreview>> get filteredPreviewSetListenable =>
+  ValueListenable<Iterable<WidgetPreview>> get filteredPreviewSetListenable =>
       _filteredPreviewSet;
   final _filteredPreviewSet = ValueNotifier<List<WidgetPreview>>([]);
 

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
@@ -25,7 +25,7 @@ void main() {
       WidgetPreview(builder: () => Text('widget2'), scriptUri: kScript2),
     ];
     final controller = FakeWidgetPreviewScaffoldController(
-      dtdServices: dtdServices,
+      dtdServicesOverride: dtdServices,
       previews: previews,
     );
     await controller.initialize();

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:widget_preview_scaffold/src/controls.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
+
+import 'utils/widget_preview_scaffold_test_utils.dart';
+
+void main() {
+  testWidgets('Filter previews based on currently selected file', (
+    tester,
+  ) async {
+    const kScript1 = 'file:///script1.dart';
+    const kScript2 = 'file:///script2.dart';
+
+    final FakeWidgetPreviewScaffoldDtdServices dtdServices =
+        FakeWidgetPreviewScaffoldDtdServices();
+    final previews = <WidgetPreview>[
+      WidgetPreview(builder: () => Text('widget1'), scriptUri: kScript1),
+      WidgetPreview(builder: () => Text('widget2'), scriptUri: kScript2),
+    ];
+    final controller = FakeWidgetPreviewScaffoldController(
+      dtdServices: dtdServices,
+      previews: previews,
+    );
+    await controller.initialize();
+    final WidgetPreviewScaffold widgetPreview = WidgetPreviewScaffold(
+      controller: controller,
+    );
+
+    // No file is selected, so all previews should be visible.
+    await tester.pumpWidget(widgetPreview);
+    expect(controller.filterBySelectedFileListenable.value, true);
+    expect(dtdServices.selectedSourceFile.value, isNull);
+    expect(controller.filteredPreviewSetListenable.value, hasLength(2));
+
+    // Select kScript1
+    dtdServices.selectedSourceFile.value = TextDocument(
+      uriAsString: kScript1,
+      version: 0,
+    );
+    await tester.pumpWidget(widgetPreview);
+
+    // Verify only previews from kScript1 are displayed.
+    expect(dtdServices.selectedSourceFile.value?.uriAsString, kScript1);
+    expect(
+      controller.filteredPreviewSetListenable.value.single.scriptUri,
+      kScript1,
+    );
+
+    // Select kScript2
+    dtdServices.selectedSourceFile.value = TextDocument(
+      uriAsString: kScript2,
+      version: 0,
+    );
+    await tester.pumpWidget(widgetPreview);
+
+    // Verify only previews from kScript2 are displayed.
+    expect(dtdServices.selectedSourceFile.value?.uriAsString, kScript2);
+    expect(
+      controller.filteredPreviewSetListenable.value.single.scriptUri,
+      kScript2,
+    );
+
+    final Finder filterBySelectedFileToggle = find.byType(
+      FilterBySelectedFileToggle,
+    );
+
+    // Press the "Filter by selected file" button and disable preview filtering.
+    expect(controller.filterBySelectedFileListenable.value, true);
+    await tester.tap(filterBySelectedFileToggle);
+    expect(controller.filterBySelectedFileListenable.value, false);
+    // Verify the currently selected source is still kScript2 but all previews are displayed.
+    expect(dtdServices.selectedSourceFile.value?.uriAsString, kScript2);
+    expect(controller.filteredPreviewSetListenable.value, previews);
+  });
+}

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/hot_restart_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/hot_restart_test.dart
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widget_preview_scaffold/src/controls.dart';
-import 'package:widget_preview_scaffold/src/widget_preview.dart';
 import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
 
 import 'utils/widget_preview_scaffold_test_utils.dart';
@@ -16,12 +14,10 @@ void main() {
     (tester) async {
       final FakeWidgetPreviewScaffoldDtdServices dtdServices =
           FakeWidgetPreviewScaffoldDtdServices();
-      const String kTestText = 'Foo';
       final WidgetPreviewScaffold widgetPreview = WidgetPreviewScaffold(
-        dtdServices: dtdServices,
-        previews: () => <WidgetPreview>[
-          WidgetPreview(builder: () => const Text(kTestText)),
-        ],
+        controller: FakeWidgetPreviewScaffoldController(
+          dtdServices: dtdServices,
+        ),
       );
 
       await tester.pumpWidget(widgetPreview);

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/hot_restart_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/hot_restart_test.dart
@@ -16,7 +16,7 @@ void main() {
           FakeWidgetPreviewScaffoldDtdServices();
       final WidgetPreviewScaffold widgetPreview = WidgetPreviewScaffold(
         controller: FakeWidgetPreviewScaffoldController(
-          dtdServices: dtdServices,
+          dtdServicesOverride: dtdServices,
         ),
       );
 

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/localizations_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/localizations_test.dart
@@ -35,6 +35,7 @@ WidgetPreviewerWidgetScaffolding previewForLocalizations({
   return WidgetPreviewerWidgetScaffolding(
     child: WidgetPreviewWidget(
       preview: WidgetPreview(
+        scriptUri: '',
         builder: () => Text('Foo', key: key),
         localizations: previewLocalizationsData,
       ),

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/soft_restart_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/soft_restart_test.dart
@@ -20,7 +20,10 @@ void main() {
       final WidgetPreviewerWidgetScaffolding widgetPreview =
           WidgetPreviewerWidgetScaffolding(
             child: WidgetPreviewWidget(
-              preview: WidgetPreview(builder: () => const Text(kTestText)),
+              preview: WidgetPreview(
+                scriptUri: '',
+                builder: () => const Text(kTestText),
+              ),
             ),
           );
 

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/theming_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/theming_test.dart
@@ -54,6 +54,7 @@ WidgetPreviewerWidgetScaffolding previewForBrightness({
     platformBrightness: platformBrightness ?? Brightness.light,
     child: WidgetPreviewWidget(
       preview: WidgetPreview(
+        scriptUri: '',
         builder: () => Text('Foo', key: key),
         theme: previewThemeData,
         brightness: brightness,

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/utils/widget_preview_scaffold_test_utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/utils/widget_preview_scaffold_test_utils.dart
@@ -63,7 +63,9 @@ class FakeWidgetPreviewScaffoldDtdServices extends Fake
   Future<void> connect({Uri? dtdUri}) async {}
 
   @override
-  Future<void> dispose() async {}
+  Future<void> dispose() async {
+    super.dispose();
+  }
 
   bool hotRestartInvoked = false;
 
@@ -81,11 +83,11 @@ class FakeWidgetPreviewScaffoldDtdServices extends Fake
 class FakeWidgetPreviewScaffoldController
     extends WidgetPreviewScaffoldController {
   FakeWidgetPreviewScaffoldController({
-    WidgetPreviewScaffoldDtdServices? dtdServices,
+    WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
     List<WidgetPreview>? previews,
-  }) : dtdServices = dtdServices ?? FakeWidgetPreviewScaffoldDtdServices(),
-       super(previews: () => previews ?? []);
-
-  @override
-  final WidgetPreviewScaffoldDtdServices dtdServices;
+  }) : super(
+         previews: () => previews ?? [],
+         dtdServicesOverride:
+             dtdServicesOverride ?? FakeWidgetPreviewScaffoldDtdServices(),
+       );
 }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/utils/widget_preview_scaffold_test_utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/utils/widget_preview_scaffold_test_utils.dart
@@ -2,10 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widget_preview_scaffold/src/dtd/dtd_services.dart';
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview.dart';
 import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_scaffold_controller.dart';
 
 class WidgetPreviewerWidgetScaffolding extends StatelessWidget {
   WidgetPreviewerWidgetScaffolding({
@@ -54,11 +58,35 @@ class WidgetPreviewerWidgetScaffolding extends StatelessWidget {
 }
 
 class FakeWidgetPreviewScaffoldDtdServices extends Fake
+    with DtdEditorService
     implements WidgetPreviewScaffoldDtdServices {
+  @override
+  Future<void> connect({Uri? dtdUri}) async {}
+
+  @override
+  Future<void> dispose() async {}
+
   bool hotRestartInvoked = false;
 
   @override
   Future<void> hotRestartPreviewer() async {
     hotRestartInvoked = true;
   }
+
+  /// The currently selected source file in the IDE.
+  @override
+  final ValueNotifier<TextDocument?> selectedSourceFile =
+      ValueNotifier<TextDocument?>(null);
+}
+
+class FakeWidgetPreviewScaffoldController
+    extends WidgetPreviewScaffoldController {
+  FakeWidgetPreviewScaffoldController({
+    WidgetPreviewScaffoldDtdServices? dtdServices,
+    List<WidgetPreview>? previews,
+  }) : dtdServices = dtdServices ?? FakeWidgetPreviewScaffoldDtdServices(),
+       super(previews: () => previews ?? []);
+
+  @override
+  final WidgetPreviewScaffoldDtdServices dtdServices;
 }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/utils/widget_preview_scaffold_test_utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/utils/widget_preview_scaffold_test_utils.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:widget_preview_scaffold/src/dtd/dtd_services.dart';

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_inspector_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/widget_inspector_test.dart
@@ -22,7 +22,10 @@ void main() {
               children: <Widget>[
                 for (int i = 0; i < kNumPreviewedWidgets; ++i)
                   WidgetPreviewWidget(
-                    preview: WidgetPreview(builder: () => Text('$kTestText$i')),
+                    preview: WidgetPreview(
+                      scriptUri: '',
+                      builder: () => Text('$kTestText$i'),
+                    ),
                   ),
               ],
             ),


### PR DESCRIPTION
This change allows for the widget previewer to react to `activeLocationChanged` events sent over the `Editor` DTD service to automatically filter the set of visible previews based on the currently selected file in the IDE. This functionality can be turned on or off depending on whether or not the developer wants to see all previews in the project at once.

This change also includes some minor refactoring and UI changes to move the widget preview environment controls to a reserved area at the bottom of the preview window.

**Demo:**

https://github.com/user-attachments/assets/c3b93826-8437-4655-8264-6beed6651fe7

Fixes https://github.com/flutter/flutter/issues/175661

