### PR TITLE
fix: Displaying the Flutter context menu in the Android browser

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1954,6 +1954,19 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
 
     addCompositionEventHandlers(activeDomElement);
 
+    // See https://github.com/flutter/flutter/issues/174005#issuecomment-3200375688
+    // On Android browsers, the browser's ContextMenu cannot be displayed properly,
+    // so as a workaround, Flutter's context menu is displayed.
+    subscriptions.add(
+      DomSubscription(
+        activeDomElement,
+        'contextmenu',
+        createDomEventListener((DomEvent event) {
+          event.preventDefault();
+        }),
+      ),
+    );
+
     preventDefaultForMouseEvents();
   }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2508,7 +2508,20 @@ class EditableTextState extends State<EditableText>
   ({TextEditingValue value, Rect selectionBounds})? _dataWhenToolbarShowScheduled;
   bool _listeningToScrollNotificationObserver = false;
 
-  bool get _webContextMenuEnabled => kIsWeb && BrowserContextMenu.enabled;
+  bool get _webContextMenuEnabled {
+    if (!kIsWeb) {
+      return false;
+    }
+
+    // See https://github.com/flutter/flutter/issues/174005#issuecomment-3200375688
+    // On Android browsers, the browser's ContextMenu cannot be displayed properly,
+    // so as a workaround, Flutter's context menu is displayed.
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      return false;
+    }
+
+    return BrowserContextMenu.enabled;
+  }
 
   final GlobalKey _scrollableKey = GlobalKey();
   ScrollController? _internalScrollController;

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -26,6 +26,8 @@ void main() {
     await Clipboard.setData(const ClipboardData(text: 'Clipboard data'));
   });
 
+  final bool isWebExceptAndroid = kIsWeb && defaultTargetPlatform != TargetPlatform.android;
+
   testWidgets(
     'Builds the right toolbar on each platform, including web, and shows buttonItems',
     (WidgetTester tester) async {
@@ -159,7 +161,7 @@ void main() {
       controller.dispose();
       focusNode.dispose();
     },
-    skip: kIsWeb, // [intended] on web the browser handles the context menu.
+    skip: isWebExceptAndroid, // [intended] on web the browser handles the context menu except
     variant: TargetPlatformVariant.all(),
   );
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

As reproduced in https://github.com/flutter/flutter/issues/174005#issuecomment-3200375688, there are cases where the context menu cannot be displayed in the current stable version. This is a workaround to display Flutter's context menu instead of the browser's context menu.

If more detailed discussion is needed, I will create a new issue.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
