### PR TITLE
[native assets] Roll dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/update_packages_pins.dart
+++ b/packages/flutter_tools/lib/src/update_packages_pins.dart
@@ -22,16 +22,16 @@ const kManuallyPinnedDependencies = <String, String>{
   // Add pinned packages here. Please leave a comment explaining why.
   'archive': '3.6.1', // https://github.com/flutter/flutter/issues/115660
   'code_assets':
-      '0.19.4', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
+      '0.19.6', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'dds':
       '5.0.3', // 5.0.4 contains bugs described in https://github.com/Dart-Code/Dart-Code/issues/4678.
   'flutter_gallery_assets': '1.0.2', // Tests depend on the exact version.
   'flutter_template_images': '5.0.0', // Must always exactly match flutter_tools template.
   'google_mobile_ads': '5.1.0', // https://github.com/flutter/flutter/issues/156912
   'hooks':
-      '0.19.5', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
+      '0.20.1', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'hooks_runner':
-      '0.21.0', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
+      '0.22.1', // Under active development with breaking changes until 1.0.0. Manually rolled by @dcharkes.
   'material_color_utilities': '0.11.1', // Keep pinned to latest until 1.0.0.
 };
 

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -58,9 +58,9 @@ dependencies:
   pubspec_parse: 1.5.0
 
   graphs: 2.3.2
-  hooks_runner: 0.21.0
-  hooks: 0.19.5
-  code_assets: 0.19.4
+  hooks_runner: 0.22.1
+  hooks: 0.20.1
+  code_assets: 0.19.6
 
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
@@ -126,4 +126,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: 8e4gs4
+# PUBSPEC CHECKSUM: b2c0vq

--- a/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/package_ffi/pubspec.yaml.tmpl
@@ -6,10 +6,10 @@ environment:
   sdk: {{dartSdkVersionBounds}}
 
 dependencies:
-  code_assets: ^0.19.4
-  hooks: ^0.19.5
+  code_assets: ^0.19.6
+  hooks: ^0.20.1
   logging: ^1.3.0
-  native_toolchain_c: ^0.16.3
+  native_toolchain_c: ^0.17.1
 
 dev_dependencies:
   ffi: ^2.1.3

--- a/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
+++ b/packages/flutter_tools/test/general.shard/isolated/fake_native_assets_build_runner.dart
@@ -77,7 +77,11 @@ class FakeFlutterNativeAssetsBuildRunner implements FlutterNativeAssetsBuildRunn
           outputDirectoryShared: Uri.parse('build-out-dir-shared'),
           outputFile: Uri.file('output.json'),
         )
-        ..setupLink(assets: buildResult.encodedAssets, recordedUsesFile: null);
+        ..setupLink(
+          assets: buildResult.encodedAssets,
+          recordedUsesFile: null,
+          assetsFromLinking: [],
+        );
       for (final extension in extensions) {
         extension.setupLinkInput(input);
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,10 +126,10 @@ packages:
     dependency: "direct main"
     description:
       name: code_assets
-      sha256: dd7ed641b7f642092092969f2dcd5845ab31c9f3efead0c06ca437bf9ce8a8b2
+      sha256: "3b182b03a2f263ad6ab47cdadf9b64daa1d2d72ac941a277f685fb77ba96cbd5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.4"
+    version: "0.19.6"
   collection:
     dependency: "direct main"
     description:
@@ -350,10 +350,10 @@ packages:
     dependency: "direct main"
     description:
       name: hooks
-      sha256: "75363eae6c0c2db051c4f6b3b1fcdea8a09c4a596cc83bfff847661da6e80dfc"
+      sha256: "22abd27b650a571e53576abe732e4d9053aacaaa6dee23e9ff106c63e3e5b96c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.5"
+    version: "0.20.1"
   html:
     dependency: "direct main"
     description:
@@ -510,10 +510,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_toolchain_c
-      sha256: "74a0c80d877c519bc6bde2c4e27b6b01c1f93c9b480f65ceae8bedd3aba3c086"
+      sha256: "7e8358a4f6ec69a4f2d366bb971af298aca50d6c2e8a07be7c12d7f6d40460aa"
       url: "https://pub.dev"
     source: hosted
-    version: "0.16.8"
+    version: "0.17.1"
   nested:
     dependency: "direct main"
     description:
@@ -1096,5 +1096,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.9.0-21.0.dev <4.0.0"
+  dart: ">=3.9.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -90,7 +90,7 @@ dependencies:
   checked_yaml: 2.0.4
   cli_config: 0.2.0
   clock: 1.1.2
-  code_assets: 0.19.4
+  code_assets: 0.19.6
   collection: 1.19.1
   convert: 3.1.2
   coverage: 1.15.0
@@ -114,7 +114,7 @@ dependencies:
   google_mobile_ads: 5.1.0
   googleapis: 12.0.0
   googleapis_auth: 1.6.0
-  hooks: 0.19.5
+  hooks: 0.20.1
   html: 0.15.6
   http: 1.5.0
   http_multi_server: 3.2.2
@@ -133,7 +133,7 @@ dependencies:
   meta: 1.17.0
   metrics_center: 1.0.13
   mime: 2.0.0
-  native_toolchain_c: 0.16.8
+  native_toolchain_c: 0.17.1
   nested: 1.0.0
   node_preamble: 2.0.2
   package_config: 2.2.0
@@ -212,4 +212,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.2
-# PUBSPEC CHECKSUM: jbcfui
+# PUBSPEC CHECKSUM: n0dh93


### PR DESCRIPTION
Rolls the dependencies to the once published today.

Covered by existing integration tests.