### PR TITLE
[CP-stable][ Tool ] Roll 24.4.0+2 hotfix release of package:dwds

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.0.3
-  dwds: 24.4.0+1
+  dwds: 24.4.0+2
   code_builder: 4.10.1
   collection: 1.19.1
   completion: 1.0.1
@@ -126,4 +126,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: ec23d4
+# PUBSPEC CHECKSUM: 62uco7


### PR DESCRIPTION
### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/174437

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

When running a Flutter web application in debug mode, the console is spammed with non-fatal error messages.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

When running a Flutter web application in debug mode, the console is spammed with `DebugService: Error serving requestsError: Unsupported operation: Cannot send Null`.

### Workaround:
Is there a workaround for this issue?

Manually patching `$PUB_CACHE/hosted/pub.dev/dwds-24.4.0+1/lib/src/services/debug_service.dart` as described in https://github.com/flutter/flutter/issues/174437#issuecomment-3228740745.

### Risk:
What is the risk level of this cherry-pick?

  - [X] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [X] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Run `flutter run -d chrome` and see that the console spam is gone.

