### PR TITLE
Revert "Check GTK calls are done on the same thread."

### DIFF
--- a/engine/src/flutter/shell/platform/linux/testing/mock_gtk.cc
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_gtk.cc
@@ -24,15 +24,9 @@ static void fl_mock_keymap_class_init(FlMockKeymapClass* klass) {
 
 static void fl_mock_keymap_init(FlMockKeymap* self) {}
 
-// Override GdkKeymap
-GType gdk_keymap_get_type() {
-  return fl_mock_keymap_get_type();
-}
-
 static MockGtk* mock = nullptr;
 
 MockGtk::MockGtk() {
-  thread = g_thread_self();
   mock = this;
 }
 
@@ -42,15 +36,7 @@ MockGtk::~MockGtk() {
   }
 }
 
-// Check we are running on the GTK thread.
-static void check_thread() {
-  if (mock != nullptr) {
-    EXPECT_EQ(mock->thread, g_thread_self());
-  }
-}
-
 GdkKeymap* gdk_keymap_get_for_display(GdkDisplay* display) {
-  check_thread();
   FlMockKeymap* keymap =
       FL_MOCK_KEYMAP(g_object_new(fl_mock_keymap_get_type(), nullptr));
   (void)FL_IS_MOCK_KEYMAP(keymap);
@@ -58,115 +44,53 @@ GdkKeymap* gdk_keymap_get_for_display(GdkDisplay* display) {
 }
 
 guint gdk_keymap_lookup_key(GdkKeymap* keymap, const GdkKeymapKey* key) {
-  check_thread();
   return mock->gdk_keymap_lookup_key(keymap, key);
 }
 
 GdkDisplay* gdk_display_get_default() {
-  check_thread();
   return GDK_DISPLAY(g_object_new(gdk_wayland_display_get_type(), nullptr));
 }
 
-void gdk_display_beep(GdkDisplay* display) {
-  check_thread();
-}
+void gdk_display_beep(GdkDisplay* display) {}
 
 int gdk_window_get_width(GdkWindow* window) {
-  check_thread();
   return 100;
 }
 
 int gdk_window_get_height(GdkWindow* window) {
-  check_thread();
   return 100;
 }
 
 gint gdk_window_get_scale_factor(GdkWindow* window) {
-  check_thread();
   return 1;
 }
 
 GdkWindowState gdk_window_get_state(GdkWindow* window) {
-  check_thread();
   return mock->gdk_window_get_state(window);
 }
 
 GdkDisplay* gdk_window_get_display(GdkWindow* window) {
-  check_thread();
   return GDK_DISPLAY(g_object_new(gdk_wayland_display_get_type(), nullptr));
 }
 
 int gdk_display_get_n_monitors(GdkDisplay* display) {
-  check_thread();
   return 1;
 }
 
 GdkMonitor* gdk_display_get_monitor(GdkDisplay* display, int n) {
-  check_thread();
   return GDK_MONITOR(g_object_new(gdk_monitor_get_type(), nullptr));
 }
 
 GdkMonitor* gdk_display_get_monitor_at_window(GdkDisplay* display,
                                               GdkWindow* window) {
-  check_thread();
   return nullptr;
-}
-
-void gdk_monitor_get_geometry(GdkMonitor* monitor, GdkRectangle* geometry) {
-  check_thread();
-}
-
-int gdk_monitor_get_refresh_rate(GdkMonitor* monitor) {
-  check_thread();
-  return 60000;
-}
-
-int gdk_monitor_get_scale_factor(GdkMonitor* monitor) {
-  check_thread();
-  return 1;
 }
 
 GdkCursor* gdk_cursor_new_from_name(GdkDisplay* display, const gchar* name) {
-  check_thread();
   return nullptr;
 }
 
-void gdk_window_set_cursor(GdkWindow* window, GdkCursor* cursor) {
-  check_thread();
-}
-
-GdkGLContext* gdk_window_create_gl_context(GdkWindow* window, GError** error) {
-  check_thread();
-  return nullptr;
-}
-
-void gdk_cairo_draw_from_gl(cairo_t* cr,
-                            GdkWindow* window,
-                            int source,
-                            int source_type,
-                            int buffer_scale,
-                            int x,
-                            int y,
-                            int width,
-                            int height) {
-  check_thread();
-}
-
-void gdk_cairo_set_source_rgba(cairo_t* cr, const GdkRGBA* rgba) {
-  check_thread();
-}
-
-void gdk_gl_context_realize(GdkGLContext* context) {
-  check_thread();
-}
-
-void gdk_gl_context_clear_current(GdkGLContext* context) {
-  check_thread();
-}
-
-void gdk_gl_context_make_current(GdkGLContext* context) {
-  check_thread();
-}
+void gdk_window_set_cursor(GdkWindow* window, GdkCursor* cursor) {}
 
 void gdk_cairo_draw_from_gl(cairo_t* cr,
                             GdkWindow* window,
@@ -179,19 +103,16 @@ void gdk_cairo_draw_from_gl(cairo_t* cr,
                             int height) {}
 
 GtkWidget* gtk_window_new(GtkWindowType type) {
-  check_thread();
   GtkWindow* window = GTK_WINDOW(g_object_new(gtk_window_get_type(), nullptr));
   mock->gtk_window_new(window, type);
   return GTK_WIDGET(window);
 }
 
 void gtk_window_set_default_size(GtkWindow* window, gint width, gint height) {
-  check_thread();
   mock->gtk_window_set_default_size(window, width, height);
 }
 
 void gtk_window_set_title(GtkWindow* window, const gchar* title) {
-  check_thread();
   mock->gtk_window_set_title(window, title);
 }
 
@@ -199,85 +120,42 @@ void gtk_window_set_geometry_hints(GtkWindow* window,
                                    GtkWidget* widget,
                                    GdkGeometry* geometry,
                                    GdkWindowHints geometry_mask) {
-  check_thread();
   mock->gtk_window_set_geometry_hints(window, widget, geometry, geometry_mask);
 }
 
 void gtk_window_resize(GtkWindow* window, gint width, gint height) {
-  check_thread();
   mock->gtk_window_resize(window, width, height);
 }
 
 void gtk_window_maximize(GtkWindow* window) {
-  check_thread();
   mock->gtk_window_maximize(window);
 }
 
 void gtk_window_unmaximize(GtkWindow* window) {
-  check_thread();
   mock->gtk_window_unmaximize(window);
 }
 
 gboolean gtk_window_is_maximized(GtkWindow* window) {
-  check_thread();
   return mock->gtk_window_is_maximized(window);
 }
 
 void gtk_window_iconify(GtkWindow* window) {
-  check_thread();
   mock->gtk_window_iconify(window);
 }
 
 void gtk_window_deiconify(GtkWindow* window) {
-  check_thread();
   mock->gtk_window_deiconify(window);
 }
 
-void gtk_widget_add_events(GtkWidget* widget, gint events) {
-  check_thread();
-}
+void gtk_widget_realize(GtkWidget* widget) {}
 
-void gtk_widget_class_set_accessible_type(GtkWidget* widget, GType type) {
-  check_thread();
-}
-
-void gtk_widget_get_allocation(GtkWidget* widget, GtkAllocation* allocation) {
-  check_thread();
-  allocation->x = 0;
-  allocation->y = 0;
-  allocation->width = 100;
-  allocation->height = 100;
-}
-
-GdkDisplay* gtk_widget_get_display(GtkWidget* widget) {
-  check_thread();
-  return nullptr;
-}
-
-gint gtk_widget_get_scale_factor(GtkWidget* widget) {
-  check_thread();
-  return 1;
-}
-
-void gtk_widget_realize(GtkWidget* widget) {
-  check_thread();
-}
-
-void gtk_widget_show(GtkWidget* widget) {
-  check_thread();
-}
-
-void gtk_widget_queue_draw(GtkWidget* widget) {
-  check_thread();
-}
+void gtk_widget_show(GtkWidget* widget) {}
 
 void gtk_widget_destroy(GtkWidget* widget) {
-  check_thread();
   mock->gtk_widget_destroy(widget);
 }
 
 void fl_gtk_widget_destroy(GtkWidget* widget) {
-  check_thread();
   void (*destroy)(GtkWidget*) = reinterpret_cast<void (*)(GtkWidget*)>(
       dlsym(RTLD_NEXT, "gtk_widget_destroy"));
   destroy(widget);
@@ -289,7 +167,6 @@ gboolean gtk_widget_translate_coordinates(GtkWidget* src_widget,
                                           gint src_y,
                                           gint* dest_x,
                                           gint* dest_y) {
-  check_thread();
   if (mock == nullptr) {
     *dest_x = src_x;
     *dest_y = src_y;
@@ -301,18 +178,11 @@ gboolean gtk_widget_translate_coordinates(GtkWidget* src_widget,
 }
 
 GtkWidget* gtk_widget_get_toplevel(GtkWidget* widget) {
-  check_thread();
   return widget;
-}
-
-GdkWindow* gtk_widget_get_window(GtkWidget* widget) {
-  check_thread();
-  return nullptr;
 }
 
 void gtk_im_context_set_client_window(GtkIMContext* context,
                                       GdkWindow* window) {
-  check_thread();
   if (mock != nullptr) {
     mock->gtk_im_context_set_client_window(context, window);
   }
@@ -322,7 +192,6 @@ void gtk_im_context_get_preedit_string(GtkIMContext* context,
                                        gchar** str,
                                        PangoAttrList** attrs,
                                        gint* cursor_pos) {
-  check_thread();
   if (mock != nullptr) {
     mock->gtk_im_context_get_preedit_string(context, str, attrs, cursor_pos);
   }
@@ -330,7 +199,6 @@ void gtk_im_context_get_preedit_string(GtkIMContext* context,
 
 gboolean gtk_im_context_filter_keypress(GtkIMContext* context,
                                         GdkEventKey* event) {
-  check_thread();
   if (mock == nullptr) {
     return TRUE;
   }
@@ -339,14 +207,12 @@ gboolean gtk_im_context_filter_keypress(GtkIMContext* context,
 }
 
 void gtk_im_context_focus_in(GtkIMContext* context) {
-  check_thread();
   if (mock != nullptr) {
     mock->gtk_im_context_focus_in(context);
   }
 }
 
 void gtk_im_context_focus_out(GtkIMContext* context) {
-  check_thread();
   if (mock != nullptr) {
     mock->gtk_im_context_focus_out(context);
   }
@@ -354,7 +220,6 @@ void gtk_im_context_focus_out(GtkIMContext* context) {
 
 void gtk_im_context_set_cursor_location(GtkIMContext* context,
                                         const GdkRectangle* area) {
-  check_thread();
   if (mock != nullptr) {
     mock->gtk_im_context_set_cursor_location(context, area);
   }
@@ -364,25 +229,7 @@ void gtk_im_context_set_surrounding(GtkIMContext* context,
                                     const gchar* text,
                                     gint len,
                                     gint cursor_index) {
-  check_thread();
   if (mock != nullptr) {
     mock->gtk_im_context_set_surrounding(context, text, len, cursor_index);
   }
-}
-
-GtkClipboard* gtk_clipboard_get_default(GdkDisplay* display) {
-  check_thread();
-  return nullptr;
-}
-
-void gtk_clipboard_set_text(GtkClipboard* clipboard,
-                            const gchar* text,
-                            gint len) {
-  check_thread();
-}
-
-void gtk_clipboard_request_text(GtkClipboard* clipboard,
-                                GtkClipboardTextReceivedFunc callback,
-                                gpointer user_data) {
-  check_thread();
 }

--- a/engine/src/flutter/shell/platform/linux/testing/mock_gtk.h
+++ b/engine/src/flutter/shell/platform/linux/testing/mock_gtk.h
@@ -74,8 +74,6 @@ class MockGtk {
       void,
       gtk_im_context_set_surrounding,
       (GtkIMContext * context, const gchar* text, gint len, gint cursor_index));
-
-  GThread* thread;
 };
 
 }  // namespace testing


### PR DESCRIPTION
Reverts flutter/flutter#174488

It is causing failures in testing:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8705343407724739553/+/u/build_ci_host_release_benchmarks_flutter_build_dart:copy_dart_sdk_flutter_display_list:display_list_benchmarks_flutter_display_list:display_list_builder_benchmarks_flutter_display_list:display_list_region_benchmarks_flutter_display_list:display_list_transform_benchmarks_flutter_fml:fml_benchmarks_flutter_impeller_geometry:geometry_benchmarks_flutter_lib_ui:ui_benchmarks_flutter_shell_common:shell_benchmarks_flutter_shell_testing_flutter_txt:txt_benchmarks_flutter_tools_path_ops_flutter_build_archives:flutter_patched_sdk_flutter:unittests/stdout