### PR TITLE
Fix empty adaptive text selection toolbars building.

### DIFF
--- a/packages/flutter/lib/src/cupertino/adaptive_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/adaptive_text_selection_toolbar.dart
@@ -209,7 +209,9 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // If there aren't any buttons to build, build an empty toolbar.
-    if ((children?.isEmpty ?? false) || (buttonItems?.isEmpty ?? false)) {
+    if ((children == null && buttonItems == null) ||
+        (children?.isEmpty ?? false) ||
+        (buttonItems?.isEmpty ?? false)) {
       return const SizedBox.shrink();
     }
 

--- a/packages/flutter/lib/src/cupertino/adaptive_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/adaptive_text_selection_toolbar.dart
@@ -209,9 +209,7 @@ class CupertinoAdaptiveTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // If there aren't any buttons to build, build an empty toolbar.
-    if ((children == null && buttonItems == null) ||
-        (children?.isEmpty ?? false) ||
-        (buttonItems?.isEmpty ?? false)) {
+    if ((children ?? buttonItems)?.isEmpty ?? true) {
       return const SizedBox.shrink();
     }
 

--- a/packages/flutter/lib/src/material/adaptive_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/adaptive_text_selection_toolbar.dart
@@ -297,9 +297,7 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // If there aren't any buttons to build, build an empty toolbar.
-    if ((children == null && buttonItems == null) ||
-        (children?.isEmpty ?? false) ||
-        (buttonItems?.isEmpty ?? false)) {
+    if ((children ?? buttonItems)?.isEmpty ?? true) {
       return const SizedBox.shrink();
     }
 

--- a/packages/flutter/lib/src/material/adaptive_text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/adaptive_text_selection_toolbar.dart
@@ -297,7 +297,9 @@ class AdaptiveTextSelectionToolbar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // If there aren't any buttons to build, build an empty toolbar.
-    if ((children != null && children!.isEmpty) || (buttonItems != null && buttonItems!.isEmpty)) {
+    if ((children == null && buttonItems == null) ||
+        (children?.isEmpty ?? false) ||
+        (buttonItems?.isEmpty ?? false)) {
       return const SizedBox.shrink();
     }
 

--- a/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/adaptive_text_selection_toolbar_test.dart
@@ -270,4 +270,25 @@ void main() {
         expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsOneWidget);
     }
   }, variant: TargetPlatformVariant.all());
+
+  testWidgets(
+    'Builds empty toolbar when children and buttonItems are null',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const CupertinoApp(
+          home: Center(
+            child: CupertinoAdaptiveTextSelectionToolbar(
+              anchors: TextSelectionToolbarAnchors(primaryAnchor: Offset.zero),
+              children: null,
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(CupertinoAdaptiveTextSelectionToolbar)), Size.zero);
+      expect(tester.takeException(), isNull);
+    },
+    skip: isBrowser, // [intended] see https://github.com/flutter/flutter/issues/108382
+    variant: TargetPlatformVariant.all(),
+  );
 }

--- a/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
+++ b/packages/flutter/test/material/adaptive_text_selection_toolbar_test.dart
@@ -270,6 +270,27 @@ void main() {
     variant: TargetPlatformVariant.all(),
   );
 
+  testWidgets(
+    'Builds empty toolbar when children and buttonItems are null',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Center(
+            child: AdaptiveTextSelectionToolbar(
+              anchors: TextSelectionToolbarAnchors(primaryAnchor: Offset.zero),
+              children: null,
+            ),
+          ),
+        ),
+      );
+
+      expect(tester.getSize(find.byType(AdaptiveTextSelectionToolbar)), Size.zero);
+      expect(tester.takeException(), isNull);
+    },
+    skip: isBrowser, // [intended] on web the browser handles the context menu.
+    variant: TargetPlatformVariant.all(),
+  );
+
   group('buttonItems', () {
     testWidgets(
       'getEditableTextButtonItems builds the correct button items per-platform',


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/174649

This PR fixes `AdaptiveTextSelectionToolbar` and `CupertinoAdaptiveTextSelectionToolbar` building when `children` and `buttonItems` are both `null`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
