### PR TITLE
[CP-stable][Impeller] Flush the data written to the device buffer by RoundSuperellipseGeometry (#174316)

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/content_context.h
+++ b/engine/src/flutter/impeller/entity/contents/content_context.h
@@ -298,6 +298,12 @@ class ContentContext {
 
   TextShadowCache& GetTextShadowCache() const { return *text_shadow_cache_; }
 
+ protected:
+  // Visible for testing.
+  void SetTransientsBuffer(std::shared_ptr<HostBuffer> host_buffer) {
+    host_buffer_ = std::move(host_buffer);
+  }
+
  private:
   std::shared_ptr<Context> context_;
   std::shared_ptr<LazyGlyphAtlas> lazy_glyph_atlas_;

--- a/engine/src/flutter/impeller/entity/entity_playground.cc
+++ b/engine/src/flutter/impeller/entity/entity_playground.cc
@@ -20,6 +20,11 @@ void EntityPlayground::SetTypographerContext(
   typographer_context_ = std::move(typographer_context);
 }
 
+std::shared_ptr<TypographerContext> EntityPlayground::GetTypographerContext()
+    const {
+  return typographer_context_;
+}
+
 std::shared_ptr<ContentContext> EntityPlayground::GetContentContext() const {
   return std::make_shared<ContentContext>(GetContext(), typographer_context_);
 }

--- a/engine/src/flutter/impeller/entity/entity_playground.h
+++ b/engine/src/flutter/impeller/entity/entity_playground.h
@@ -25,6 +25,8 @@ class EntityPlayground : public PlaygroundTest {
   void SetTypographerContext(
       std::shared_ptr<TypographerContext> typographer_context);
 
+  std::shared_ptr<TypographerContext> GetTypographerContext() const;
+
   bool OpenPlaygroundHere(Entity entity);
 
   bool OpenPlaygroundHere(EntityPlaygroundCallback callback);

--- a/engine/src/flutter/impeller/entity/entity_unittests.cc
+++ b/engine/src/flutter/impeller/entity/entity_unittests.cc
@@ -2622,8 +2622,8 @@ class FlushTestAllocator : public Allocator {
     return std::make_shared<FlushTestDeviceBuffer>(desc);
   };
 
-  std::shared_ptr<Texture> OnCreateTexture(const TextureDescriptor& desc,
-                                           bool threadsafe) override {
+  std::shared_ptr<Texture> OnCreateTexture(
+      const TextureDescriptor& desc) override {
     return nullptr;
   }
 };

--- a/engine/src/flutter/impeller/entity/geometry/round_superellipse_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/round_superellipse_geometry.cc
@@ -421,6 +421,7 @@ GeometryResult RoundSuperellipseGeometry::GetPositionBuffer(
       reinterpret_cast<Point*>(vertex_buffer.GetBuffer()->OnGetContents() +
                                vertex_buffer.GetRange().offset);
   rearranger->RearrangeIntoTriangleStrip(vertex_data);
+  vertex_buffer.GetBuffer()->Flush(vertex_buffer.GetRange());
 
   return GeometryResult{
       .type = PrimitiveType::kTriangleStrip,


### PR DESCRIPTION
### Issue Link:

https://github.com/flutter/flutter/issues/174100

### Changelog Description:

Fixes errors seen when rendering superellipses on Impeller.

### Impact Description:

This affects apps like the one in https://github.com/flutter/flutter/issues/174100 that render Cupertino widgets which use superellipses.  The app may show flickering or other artifacts when rendered with Impeller (particularly on the GLES back end).

### Workaround:

Disable Impeller

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:

Run the app in https://github.com/flutter/flutter/issues/174100 on an Android device and select the Impeller GLES back end.  Confirm that it can scroll without flickering.