### PR TITLE
[ios26]fix host engine compile error

### DIFF
--- a/engine/src/build/toolchain/darwin/swiftc.py
+++ b/engine/src/build/toolchain/darwin/swiftc.py
@@ -444,6 +444,14 @@ def invoke_swift_compiler(args, extras_args, build_cache_dir, output_file_map):
         args.file_prefix_map,
     ])
 
+  # Since iOS/macOS 26, building host engine requires setting -plugin-path for the `testing` plugin under XcodeDefault.xctoolchain.
+  testing_plugin_path = os.path.join(args.mac_host_toolchain_path, 'usr/lib/swift/host/plugins/testing')
+  if os.path.isdir(testing_plugin_path):
+    swiftc_args.extend([
+      '-plugin-path',
+      testing_plugin_path,
+    ])
+
   swift_toolchain_path = args.swift_toolchain_path
   if not swift_toolchain_path:
     swift_toolchain_path = os.path.join(os.path.dirname(args.sdk_path),
@@ -585,6 +593,10 @@ def main(args):
   parser.add_argument('--swift-toolchain-path',
                       default='',
                       help='path to the Swift toolchain to use')
+
+  parser.add_argument('--mac-host-toolchain-path',
+                      default='',
+                      help='path to the mac host toolchain to use')
 
   parser.add_argument('--whole-module-optimization',
                       default=False,

--- a/engine/src/build/toolchain/mac/BUILD.gn
+++ b/engine/src/build/toolchain/mac/BUILD.gn
@@ -277,6 +277,11 @@ template("mac_toolchain") {
                         rebase_path(swift_toolchain_path, root_build_dir)
       }
 
+      if (mac_host_toolchain_path != "") {
+        _extra_flags += " --mac-host-toolchain-path " +
+                        rebase_path(mac_host_toolchain_path, root_build_dir)
+      }
+
       if (swift_whole_module_optimization) {
         _extra_flags += " --whole-module-optimization"
       }


### PR DESCRIPTION
## What it does

This adds `-plugin-path` flag to `swiftc` cmd to fix a compile error related to missing swift plugin. The plugin is under `mac_host_toolchain_path`, which is only available on macs. However, we only build mac host engine on macs, so we are good. 

## About unit test

This swiftc.py file currently has no test coverage, but it should - I filed https://github.com/flutter/flutter/issues/174843. However, given there's a big fire (https://github.com/flutter/flutter/issues/174513) going on, and we are approaching iOS 26 release, I have to prioritize that one. 

I will manually verify the solution. 

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/172155


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
