### PR TITLE
[Impeller] Fix overdraw in DrawRect geometry

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -35,6 +35,86 @@ TEST_P(AiksTest, CanRenderColoredRect) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, CanRenderWideStrokedRectWithoutOverlap) {
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  builder.DrawColor(DlColor::kWhite(), DlBlendMode::kSrc);
+
+  DlPaint paint;
+  paint.setColor(DlColor::kBlue().withAlphaF(0.5));
+  paint.setDrawStyle(DlDrawStyle::kStroke);
+  paint.setStrokeWidth(30.0f);
+
+  paint.setStrokeJoin(DlStrokeJoin::kBevel);
+  builder.DrawRect(DlRect::MakeXYWH(100.0f, 100.0f, 100.0f, 100.0f), paint);
+  builder.DrawRect(DlRect::MakeXYWH(250.0f, 100.0f, 10.0f, 100.0f), paint);
+  builder.DrawRect(DlRect::MakeXYWH(100.0f, 250.0f, 100.0f, 10.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kRound);
+  builder.DrawRect(DlRect::MakeXYWH(350.0f, 100.0f, 100.0f, 100.0f), paint);
+  builder.DrawRect(DlRect::MakeXYWH(500.0f, 100.0f, 10.0f, 100.0f), paint);
+  builder.DrawRect(DlRect::MakeXYWH(350.0f, 250.0f, 100.0f, 10.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kMiter);
+  builder.DrawRect(DlRect::MakeXYWH(600.0f, 100.0f, 100.0f, 100.0f), paint);
+  builder.DrawRect(DlRect::MakeXYWH(750.0f, 100.0f, 10.0f, 100.0f), paint);
+  builder.DrawRect(DlRect::MakeXYWH(600.0f, 250.0f, 100.0f, 10.0f), paint);
+
+  // And now with a stroke width that overlaps in the middle.
+  paint.setStrokeWidth(110.0f);
+
+  paint.setStrokeJoin(DlStrokeJoin::kBevel);
+  builder.DrawRect(DlRect::MakeXYWH(100.0f, 400.0f, 100.0f, 100.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kRound);
+  builder.DrawRect(DlRect::MakeXYWH(350.0f, 400.0f, 100.0f, 100.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kMiter);
+  builder.DrawRect(DlRect::MakeXYWH(600.0f, 400.0f, 100.0f, 100.0f), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_P(AiksTest, CanRenderWideStrokedRectPathWithoutOverlap) {
+  DisplayListBuilder builder;
+  builder.Scale(GetContentScale().x, GetContentScale().y);
+  builder.DrawColor(DlColor::kWhite(), DlBlendMode::kSrc);
+
+  DlPaint paint;
+  paint.setColor(DlColor::kBlue().withAlphaF(0.5));
+  paint.setDrawStyle(DlDrawStyle::kStroke);
+  paint.setStrokeWidth(30.0f);
+
+  paint.setStrokeJoin(DlStrokeJoin::kBevel);
+  builder.DrawPath(DlPath::MakeRectXYWH(100.0f, 100.0f, 100.0f, 100.0f), paint);
+  builder.DrawPath(DlPath::MakeRectXYWH(250.0f, 100.0f, 10.0f, 100.0f), paint);
+  builder.DrawPath(DlPath::MakeRectXYWH(100.0f, 250.0f, 100.0f, 10.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kRound);
+  builder.DrawPath(DlPath::MakeRectXYWH(350.0f, 100.0f, 100.0f, 100.0f), paint);
+  builder.DrawPath(DlPath::MakeRectXYWH(500.0f, 100.0f, 10.0f, 100.0f), paint);
+  builder.DrawPath(DlPath::MakeRectXYWH(350.0f, 250.0f, 100.0f, 10.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kMiter);
+  builder.DrawPath(DlPath::MakeRectXYWH(600.0f, 100.0f, 100.0f, 100.0f), paint);
+  builder.DrawPath(DlPath::MakeRectXYWH(750.0f, 100.0f, 10.0f, 100.0f), paint);
+  builder.DrawPath(DlPath::MakeRectXYWH(600.0f, 250.0f, 100.0f, 10.0f), paint);
+
+  // And now with a stroke width that overlaps in the middle.
+  paint.setStrokeWidth(110.0f);
+
+  paint.setStrokeJoin(DlStrokeJoin::kBevel);
+  builder.DrawPath(DlPath::MakeRectXYWH(100.0f, 400.0f, 100.0f, 100.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kRound);
+  builder.DrawPath(DlPath::MakeRectXYWH(350.0f, 400.0f, 100.0f, 100.0f), paint);
+
+  paint.setStrokeJoin(DlStrokeJoin::kMiter);
+  builder.DrawPath(DlPath::MakeRectXYWH(600.0f, 400.0f, 100.0f, 100.0f), paint);
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(AiksTest, CanRenderImage) {
   DisplayListBuilder builder;
   DlPaint paint;

--- a/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_basic_unittests.cc
@@ -39,7 +39,6 @@ namespace {
 using DrawRectProc =
     std::function<void(DisplayListBuilder&, const DlRect&, const DlPaint&)>;
 
-[[maybe_unused]]
 sk_sp<DisplayList> MakeWideStrokedRects(Point scale,
                                         const DrawRectProc& draw_rect) {
   DisplayListBuilder builder;

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
@@ -68,10 +68,12 @@ GeometryResult StrokeRectGeometry::GetPositionBuffer(
   }
 
   Scalar min_size = kMinStrokeSize / max_basis;
-  Scalar half_stroke_width = std::max(stroke_width_, min_size) * 0.5f;
+  Scalar stroke_width = std::max(stroke_width_, min_size);
+  Scalar half_stroke_width = stroke_width * 0.5f;
 
   auto& data_host_buffer = renderer.GetTransientsDataBuffer();
   const Rect& rect = rect_;
+  bool interior_empty = (stroke_width >= rect.GetSize().MinDimension());
 
   switch (stroke_join_) {
     case Join::kRound: {
@@ -134,7 +136,7 @@ GeometryResult StrokeRectGeometry::GetPositionBuffer(
     }
 
     case Join::kBevel: {
-      if (half_stroke_width * 2.0f >= rect.GetSize().MinDimension()) {
+      if (interior_empty) {
         return GeometryResult{
             .type = PrimitiveType::kTriangleStrip,
             .vertex_buffer =
@@ -202,7 +204,7 @@ GeometryResult StrokeRectGeometry::GetPositionBuffer(
     }
 
     case Join::kMiter: {
-      if (half_stroke_width * 2.0f >= rect.GetSize().MinDimension()) {
+      if (interior_empty) {
         return GeometryResult{
             .type = PrimitiveType::kTriangleStrip,
             .vertex_buffer =

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
@@ -288,7 +288,7 @@ GeometryResult StrokeRectGeometry::GetPositionBuffer(
                           Scalar right = rect.GetRight();
                           Scalar bottom = rect.GetBottom();
                           auto vertices = reinterpret_cast<Point*>(buffer);
-                          // Zig-zag pattern: UL, UR, LL, LR
+
                           vertices[0] = Point(left - hsw, top - hsw);
                           vertices[1] = Point(right + hsw, top - hsw);
                           vertices[2] = Point(left - hsw, bottom + hsw);

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.cc
@@ -339,13 +339,6 @@ std::optional<Rect> StrokeRectGeometry::GetCoverage(
   return rect_.TransformBounds(transform);
 }
 
-GeometryResult::Mode StrokeRectGeometry::GetResultMode() const {
-  // Most(all?) of our geometry is produced in full with an explicit mode
-  // specified in the returned GeometryResult, but just in case we missed
-  // a case, the safest mode to return here is kPreventOverdraw.
-  return GeometryResult::Mode::kPreventOverdraw;
-}
-
 Join StrokeRectGeometry::AdjustStrokeJoin(const StrokeParameters& stroke) {
   return (stroke.join == Join::kMiter && stroke.miter_limit < kSqrt2)
              ? Join::kBevel

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
@@ -48,8 +48,6 @@ class StrokeRectGeometry final : public Geometry {
   // |Geometry|
   std::optional<Rect> GetCoverage(const Matrix& transform) const override;
 
-  virtual GeometryResult::Mode GetResultMode() const override;
-
  private:
   const Rect rect_;
   const Scalar stroke_width_;

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
@@ -48,6 +48,8 @@ class StrokeRectGeometry final : public Geometry {
   // |Geometry|
   std::optional<Rect> GetCoverage(const Matrix& transform) const override;
 
+  virtual GeometryResult::Mode GetResultMode() const override;
+
  private:
   const Rect rect_;
   const Scalar stroke_width_;

--- a/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
+++ b/engine/src/flutter/impeller/entity/geometry/rect_geometry.h
@@ -56,11 +56,6 @@ class StrokeRectGeometry final : public Geometry {
   const Join stroke_join_;
 
   static Join AdjustStrokeJoin(const StrokeParameters& stroke);
-
-  static Point* AppendRoundCornerJoin(Point* buffer,
-                                      Point corner,
-                                      Vector2 offset,
-                                      const Tessellator::Trigs& trigs);
 };
 
 }  // namespace impeller


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/174579

Vertex lists for stroked rects were fixed by being more careful about the creation of the vertices so that they have no inherent overdraw. These operations continue to use the fastest kNormal vertex mode but no longer create rendering artifacts due to multiple triangles covering the same area.