### PR TITLE
Make sure that a DropdownMenuFormField doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -1224,4 +1224,19 @@ void main() {
     await tester.pump();
     expect(onSelectedCallCount, 1);
   });
+
+  testWidgets('DropdownMenuFormField does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox.shrink(
+              child: DropdownMenuFormField<MenuItem>(dropdownMenuEntries: menuEntries),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(DropdownMenuFormField<MenuItem>)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the DropdownMenuFormField widget.