### PR TITLE
Fix InputDecoration does not apply errorStyle to error

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -401,8 +401,11 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
 
   Widget _buildError() {
     assert(widget.error != null || widget.errorText != null);
-    final Widget? capturedError = widget.error;
     final String? capturedErrorText = widget.errorText;
+    Widget? capturedError = widget.error;
+    if (capturedError != null && widget.errorStyle != null) {
+      capturedError = DefaultTextStyle(style: widget.errorStyle!, child: capturedError);
+    }
     return Builder(
       builder: (BuildContext context) {
         return Semantics(

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6210,6 +6210,21 @@ void main() {
           );
         }, throwsAssertionError);
       });
+
+      // Regression test for https://github.com/flutter/flutter/issues/174784.
+      testWidgets('InputDecorator error widget text style defaults to errorStyle', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          buildInputDecorator(decoration: const InputDecoration(error: Text(errorText))),
+        );
+
+        expect(findError(), findsOneWidget);
+        final ThemeData theme = Theme.of(tester.element(findDecorator()));
+        final Color expectedColor = theme.colorScheme.error;
+        final TextStyle expectedStyle = theme.textTheme.bodySmall!.copyWith(color: expectedColor);
+        expect(getErrorStyle(tester), expectedStyle);
+      });
     });
 
     testWidgets('InputDecorator with counter does not crash when given a 0 size', (


### PR DESCRIPTION
## Description

This PR fixes `InpuDecorator` not applying `InputDecoration.errorStyle` to `InputDecoration.error`.

## Before

Text from `InputDecoration.error` is not styled correctly:

<img width="239" height="75" alt="image" src="https://github.com/user-attachments/assets/9b27e029-f431-4448-9d2c-9a28f52087f8" />


## After

Text from `InputDecoration.error` is styled correctly:

<img width="239" height="75" alt="image" src="https://github.com/user-attachments/assets/9b0ac7da-4933-4ee8-a3ae-d7b4db7ca218" />



## Related Issue

Fixes [InputDecorator does not apply errorStyle to error](https://github.com/flutter/flutter/issues/174784) 

## Tests

Adds 1 test.