### PR TITLE
fix(widgets): guard showPerformanceOverlay on web with no-op and debug message

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -232,7 +232,7 @@ Locale basicLocaleListResolution(
   // supported locale.
   final Locale resolvedLocale = matchesLanguageCode ?? matchesCountryCode ?? supportedLocales.first;
   return resolvedLocale;
-}
+      }
 
 /// The signature of [WidgetsApp.onGenerateTitle].
 ///
@@ -1415,7 +1415,7 @@ class WidgetsApp extends StatefulWidget {
 
   @override
   State<WidgetsApp> createState() => _WidgetsAppState();
-}
+      }
 
 class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
   // STATE LIFECYCLE
@@ -1734,11 +1734,11 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     result = Stack(
       children: <Widget>[
         result,
-        const Positioned(top: 0.0, left: 0.0, right: 0.0, child: PerformanceOverlay.allEnabled()),
+        Positioned(top: 0.0, left: 0.0, right: 0.0, child: PerformanceOverlay.allEnabled()),
       ],
     );
   }
-}
+      }
 
     if (widget.showSemanticsDebugger) {
       result = SemanticsDebugger(child: result);
@@ -1834,4 +1834,4 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
       ),
     );
   }
-}
+      }

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1721,13 +1721,24 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     }
 
     if (widget.showPerformanceOverlay || WidgetsApp.showPerformanceOverlayOverride) {
-      result = Stack(
-        children: <Widget>[
-          result,
-          Positioned(top: 0.0, left: 0.0, right: 0.0, child: PerformanceOverlay.allEnabled()),
-        ],
-      );
-    }
+  // On web, the engine does not support performance overlay layers.
+  // Avoid throwing and provide a debug message instead.
+  if (kIsWeb) {
+    assert(() {
+      FlutterError.reportError(FlutterErrorDetails(
+        exception: FlutterError('showPerformanceOverlay is not supported on web.'),
+      ));
+      return true;
+    }());
+  } else {
+    result = Stack(
+      children: <Widget>[
+        result,
+        const Positioned(top: 0.0, left: 0.0, right: 0.0, child: PerformanceOverlay.allEnabled()),
+      ],
+    );
+  }
+}
 
     if (widget.showSemanticsDebugger) {
       result = SemanticsDebugger(child: result);


### PR DESCRIPTION
Web currently throws an UnimplementedError when `showPerformanceOverlay` is
enabled (MaterialApp/WidgetsApp) because the engine does not implement the
performance overlay layer. This change makes the framework:

- No-op on web (do not insert PerformanceOverlay), and
- In debug mode, emit a single error report message explaining it is not
  supported on web.

This avoids a crash while providing a clearer signal to developers.

Tests: platform-specific (web) behavior; existing non-web overlay tests remain
valid. Requesting test exemption for the web-only path.

Refs: flutter/flutter#172405