### PR TITLE
feat(widgets): add semanticIndexOffset to SliverList/SliverGrid/Fixed/Varied builder constructors + tests

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -225,6 +225,7 @@ class SliverList extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 
@@ -349,6 +350,7 @@ class SliverList extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 
@@ -481,6 +483,7 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 
@@ -528,6 +531,7 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 
@@ -612,6 +616,7 @@ class SliverVariedExtentList extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 
@@ -637,6 +642,7 @@ class SliverVariedExtentList extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 
@@ -756,6 +762,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
            addAutomaticKeepAlives: addAutomaticKeepAlives,
            addRepaintBoundaries: addRepaintBoundaries,
            addSemanticIndexes: addSemanticIndexes,
+           semanticIndexOffset: semanticIndexOffset,
          ),
        );
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -216,6 +216,7 @@ class SliverList extends SliverMultiBoxAdaptorWidget {
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
+    int semanticIndexOffset = 0,
   }) : super(
          delegate: SliverChildBuilderDelegate(
            itemBuilder,
@@ -471,6 +472,7 @@ class SliverFixedExtentList extends SliverMultiBoxAdaptorWidget {
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
+    int semanticIndexOffset = 0,
   }) : super(
          delegate: SliverChildBuilderDelegate(
            itemBuilder,
@@ -601,6 +603,7 @@ class SliverVariedExtentList extends SliverMultiBoxAdaptorWidget {
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
+    int semanticIndexOffset = 0,
   }) : super(
          delegate: SliverChildBuilderDelegate(
            itemBuilder,
@@ -744,6 +747,7 @@ class SliverGrid extends SliverMultiBoxAdaptorWidget {
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
+    int semanticIndexOffset = 0,
   }) : super(
          delegate: SliverChildBuilderDelegate(
            itemBuilder,

--- a/packages/flutter/test/widgets/sliver_semantic_index_offset_more_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantic_index_offset_more_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('SliverGrid.builder applies semanticIndexOffset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverGrid.builder(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 2),
+              addSemanticIndexes: true,
+              semanticIndexOffset: 5,
+              itemBuilder: (BuildContext context, int index) {
+                return SizedBox(height: 50, child: Text('G$index'));
+              },
+              itemCount: 2,
+            ),
+          ],
+        ),
+      ),
+    );
+    final Finder semantics0 = find.bySemanticsLabel('G0');
+    expect(tester.getSemantics(semantics0).index, 5);
+  });
+
+  testWidgets('SliverFixedExtentList.builder applies semanticIndexOffset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverFixedExtentList.builder(
+              itemExtent: 20,
+              addSemanticIndexes: true,
+              semanticIndexOffset: 3,
+              itemBuilder: (BuildContext context, int index) => Text('F$index'),
+              itemCount: 1,
+            ),
+          ],
+        ),
+      ),
+    );
+    final Finder semantics0 = find.bySemanticsLabel('F0');
+    expect(tester.getSemantics(semantics0).index, 3);
+  });
+
+  testWidgets('SliverVariedExtentList.builder applies semanticIndexOffset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverVariedExtentList.builder(
+              itemExtentBuilder: (int index) => 30,
+              addSemanticIndexes: true,
+              semanticIndexOffset: 4,
+              itemBuilder: (BuildContext context, int index) => Text('V$index'),
+              itemCount: 1,
+            ),
+          ],
+        ),
+      ),
+    );
+    final Finder semantics0 = find.bySemanticsLabel('V0');
+    expect(tester.getSemantics(semantics0).index, 4);
+  });
+}

--- a/packages/flutter/test/widgets/sliver_semantic_index_offset_test.dart
+++ b/packages/flutter/test/widgets/sliver_semantic_index_offset_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('SliverList.builder applies semanticIndexOffset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverList.builder(
+              addSemanticIndexes: true,
+              semanticIndexOffset: 2,
+              itemBuilder: (BuildContext context, int index) {
+                return SizedBox(height: 50, child: Text('Item $index'));
+              },
+              itemCount: 3,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final Finder semantics0 = find.bySemanticsLabel('Item 0');
+    // IndexedSemantics should map first child to index 2
+    expect(tester.getSemantics(semantics0).index, 2);
+  });
+}


### PR DESCRIPTION
Expose `semanticIndexOffset` on builder constructors so apps using builder APIs
can offset semantics indices the same way list/extent constructors already do.

Changes:
- SliverList.builder: add `int semanticIndexOffset = 0` and plumb to SliverChildBuilderDelegate.
- SliverGrid.builder: same as above.
- SliverFixedExtentList.builder, SliverVariedExtentList.builder: same as above.

Tests:
- Add a widget test verifying that SliverList.builder with addSemanticIndexes
  true and `semanticIndexOffset: 2` yields IndexedSemantics starting at 2.