### PR TITLE
a11y(material): make AM/PM buttons live regions so state change is announced

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -809,6 +809,7 @@ class _AmPmButton extends StatelessWidget {
       checked: selected,
       inMutuallyExclusiveGroup: true,
       button: true,
+      liveRegion: true,
       child: Padding(
         padding: padding,
         child: Material(

--- a/packages/flutter/test/material/time_picker_live_region_test.dart
+++ b/packages/flutter/test/material/time_picker_live_region_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('AM/PM buttons are live regions', (WidgetTester tester) async {
+    // Build a simple TimePicker via showTimePicker
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (BuildContext context) {
+          return TextButton(
+            onPressed: () { showTimePicker(context: context, initialTime: const TimeOfDay(hour: 7, minute: 0)); },
+            child: const Text('Open'),
+          );
+        },
+      ),
+    ));
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final SemanticsTester semantics = SemanticsTester(tester);
+    // Expect AM node has live region flag (12-hour mode)
+    expect(
+      semantics,
+      includesNodeWith(label: 'AM', flags: <SemanticsFlag>[SemanticsFlag.isLiveRegion, SemanticsFlag.isButton]),
+    );
+    semantics.dispose();
+  });
+}


### PR DESCRIPTION
Improve accessibility of the Material TimePicker AM/PM control by marking the
AM/PM buttons as live regions so their state change is announced by screen
readers when toggled.

Details:
- In `_AmPmButton` (packages/flutter/lib/src/material/time_picker.dart), add
  `liveRegion: true` to the Semantics node wrapping the AM/PM button. The node
  already provides `button`, `inMutuallyExclusiveGroup`, and `checked` flags;
  making it a live region prompts an announcement when its checked state
  changes.

Tests:
- Existing semantics tests validate AM/PM semantics (label, flags, actions).
  This change augments semantics and should not break them. If preferred, I can
  add an extra assertion for the live region flag.

Refs: flutter/flutter#173302