### PR TITLE
[a11y-app] Fix form field label and error message

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/text_button.dart
+++ b/dev/a11y_assessments/lib/use_cases/text_button.dart
@@ -29,6 +29,7 @@ class MainWidget extends StatefulWidget {
 class MainWidgetState extends State<MainWidget> {
   String pageTitle = getUseCaseName(TextButtonUseCase());
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  static const String fieldLabel = 'City';
 
   @override
   Widget build(BuildContext context) {
@@ -50,6 +51,10 @@ class MainWidgetState extends State<MainWidget> {
                 }
                 return null;
               },
+              errorBuilder: (BuildContext context, String errorText) {
+                return Text(errorText, semanticsLabel: '$errorText in $fieldLabel');
+              },
+              decoration: const InputDecoration(labelText: fieldLabel),
             ),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 16),

--- a/dev/a11y_assessments/test/text_button_test.dart
+++ b/dev/a11y_assessments/test/text_button_test.dart
@@ -9,6 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'test_utils.dart';
 
 void main() {
+  testWidgets('text field label is visible', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextButtonUseCase());
+    expect(find.text('City'), findsOneWidget);
+  });
+
   testWidgets('text button can run', (WidgetTester tester) async {
     await pumpsUseCase(tester, TextButtonUseCase());
     expect(find.text('Submit'), findsOneWidget);
@@ -33,5 +38,16 @@ void main() {
     final Finder findHeadingLevelOnes = find.bySemanticsLabel('TextButton Demo');
     await tester.pumpAndSettle();
     expect(findHeadingLevelOnes, findsOne);
+  });
+
+  testWidgets('submit empty field causes error to show', (WidgetTester tester) async {
+    await pumpsUseCase(tester, TextButtonUseCase());
+    final Finder submitButton = find.text('Submit');
+
+    await tester.tap(submitButton);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Please enter some text'), findsOneWidget);
+    expect(find.bySemanticsLabel('Please enter some text in City'), findsOne);
   });
 }


### PR DESCRIPTION
## Description

This PR adds a label to the form field inside TextButton use case page (for the A11y assessments app). It also customises the error message.

## Related Issue

Fixes [[VPAT][A11y][a11y-app] fix form field in text button a11y assessment to have proper error message](https://github.com/flutter/flutter/issues/173007)  

## Tests

Adds 1 test.