### PR TITLE
Ndk download is not a condition of the test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1194,7 +1194,6 @@ targets:
       task_name: linux_feature_flags_test
 
   - name: Linux_android_emu android_display_cutout
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/174500
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Unmarks https://github.com/flutter/flutter/issues/174500 passing condition of network not an issue of the test 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
