### PR TITLE
Ensures initial semantics state is sent to engine

### DIFF
--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -40,6 +40,10 @@ mixin SemanticsBinding on BindingBase {
       };
     _handleSemanticsEnabledChanged();
     addSemanticsEnabledListener(_handleFrameworkSemanticsEnabledChanged);
+    // Ensure the initial value is set.
+    if (semanticsEnabled) {
+      _handleFrameworkSemanticsEnabledChanged();
+    }
   }
 
   /// The current [SemanticsBinding], if one has been created.

--- a/packages/flutter/test/semantics/semantics_binding_set_semantics_tree_enabled_1_test.dart
+++ b/packages/flutter/test/semantics/semantics_binding_set_semantics_tree_enabled_1_test.dart
@@ -19,9 +19,6 @@ void main() {
 
 class SemanticsTestBindingWithInitialEnabled extends AutomatedTestWidgetsFlutterBinding {
   @override
-  bool get semanticsEnabled => true;
-
-  @override
   TestPlatformDispatcherSpy get platformDispatcher => _platformDispatcherSpy;
   static final TestPlatformDispatcherSpy _platformDispatcherSpy = TestPlatformDispatcherSpy(
     platformDispatcher: PlatformDispatcher.instance,
@@ -35,4 +32,7 @@ class TestPlatformDispatcherSpy extends TestPlatformDispatcher {
   void setSemanticsTreeEnabled(bool enabled) {
     semanticsTreeEnabled = enabled;
   }
+
+  @override
+  bool get semanticsEnabled => true;
 }

--- a/packages/flutter/test/semantics/semantics_binding_set_semantics_tree_enabled_1_test.dart
+++ b/packages/flutter/test/semantics/semantics_binding_set_semantics_tree_enabled_1_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test(
+    'setSemanticsTreeEnabled calls when the semantics is enabled before binding initialized',
+    () async {
+      final SemanticsTestBindingWithInitialEnabled binding =
+          SemanticsTestBindingWithInitialEnabled();
+      expect(binding.platformDispatcher.semanticsTreeEnabled, isTrue);
+    },
+  );
+}
+
+class SemanticsTestBindingWithInitialEnabled extends AutomatedTestWidgetsFlutterBinding {
+  @override
+  bool get semanticsEnabled => true;
+
+  @override
+  TestPlatformDispatcherSpy get platformDispatcher => _platformDispatcherSpy;
+  static final TestPlatformDispatcherSpy _platformDispatcherSpy = TestPlatformDispatcherSpy(
+    platformDispatcher: PlatformDispatcher.instance,
+  );
+}
+
+class TestPlatformDispatcherSpy extends TestPlatformDispatcher {
+  TestPlatformDispatcherSpy({required super.platformDispatcher});
+  bool semanticsTreeEnabled = false;
+  @override
+  void setSemanticsTreeEnabled(bool enabled) {
+    semanticsTreeEnabled = enabled;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fixes https://github.com/flutter/flutter/issues/174842

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
