### PR TITLE
Patch .clang-format files to specify C++20.

### DIFF
--- a/engine/src/.clang-format
+++ b/engine/src/.clang-format
@@ -1,8 +1,5 @@
 # Defines the Chromium style for automatic reformatting.
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
-# This defaults to 'Auto'. Explicitly set it for a while, so that
-# 'vector<vector<int> >' in existing files gets formatted to
-# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
-# 'int>>' if the file already contains at least one such instance.)
-Standard: Cpp11
+# This defaults to 'Auto'.
+Standard: c++20

--- a/engine/src/flutter/.clang-format
+++ b/engine/src/flutter/.clang-format
@@ -5,7 +5,7 @@ BasedOnStyle: Chromium
 # 'vector<vector<int> >' in existing files gets formatted to
 # 'vector<vector<int>>'. ('Auto' means that clang-format will only use
 # 'int>>' if the file already contains at least one such instance.)
-Standard: Cpp11
+Standard: c++20
 SortIncludes: true
 ---
 Language: ObjC

--- a/engine/src/flutter/impeller/.clang-format
+++ b/engine/src/flutter/impeller/.clang-format
@@ -1,5 +1,5 @@
 # Defines the Chromium style for automatic reformatting.
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
-Standard: c++17
+Standard: c++20
 EmptyLineBeforeAccessModifier: Always

--- a/engine/src/flutter/txt/.clang-format
+++ b/engine/src/flutter/txt/.clang-format
@@ -1,8 +1,5 @@
 # Defines the Chromium style for automatic reformatting.
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
-# This defaults to 'Auto'. Explicitly set it for a while, so that
-# 'vector<vector<int> >' in existing files gets formatted to
-# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
-# 'int>>' if the file already contains at least one such instance.)
-Standard: Cpp11
+# This defaults to 'Auto'.
+Standard: c++20


### PR DESCRIPTION
Clang format will reject valid uses of C++ (like the spaceship operator definition) because they are not valid C++11. This tweaks how clang-format treats sources.

I tried to get rid of the redundant .clang-format files but they all specify other options and don't cascade. So just let the files be and only updated the version.
