### PR TITLE
ListTile show tile color even a Container wraps it

### DIFF
--- a/examples/api/test/material/popup_menu/popup_menu.2_test.dart
+++ b/examples/api/test/material/popup_menu/popup_menu.2_test.dart
@@ -18,18 +18,18 @@ void main() {
     // Advance the animation by half of the default duration.
     await tester.pump(const Duration(milliseconds: 100));
 
-    expect(
-      tester.getSize(find.byType(Material).last),
-      within(distance: 0.1, from: const Size(224.0, 130.0)),
-    );
+    Finder findMenu() {
+      return find.byWidgetPredicate((Widget widget) {
+        return widget.runtimeType.toString() == '_PopupMenu<Menu?>';
+      });
+    }
+
+    expect(tester.getSize(findMenu()), within(distance: 0.1, from: const Size(224.0, 130.0)));
 
     // Let the animation finish.
     await tester.pumpAndSettle();
 
-    expect(
-      tester.getSize(find.byType(Material).last),
-      within(distance: 0.1, from: const Size(224.0, 312.0)),
-    );
+    expect(tester.getSize(findMenu()), within(distance: 0.1, from: const Size(224.0, 312.0)));
 
     // Tap outside the popup menu to close it.
     await tester.tapAt(const Offset(1, 1));
@@ -44,18 +44,12 @@ void main() {
     // Advance the animation by one third of the custom duration.
     await tester.pump(const Duration(milliseconds: 1000));
 
-    expect(
-      tester.getSize(find.byType(Material).last),
-      within(distance: 0.1, from: const Size(224.0, 312.0)),
-    );
+    expect(tester.getSize(findMenu()), within(distance: 0.1, from: const Size(224.0, 312.0)));
 
     // Let the animation finish.
     await tester.pumpAndSettle();
 
-    expect(
-      tester.getSize(find.byType(Material).last),
-      within(distance: 0.1, from: const Size(224.0, 312.0)),
-    );
+    expect(tester.getSize(findMenu()), within(distance: 0.1, from: const Size(224.0, 312.0)));
 
     // Tap outside the popup menu to close it.
     await tester.tapAt(const Offset(1, 1));
@@ -70,9 +64,6 @@ void main() {
     await tester.pump();
 
     // The popup menu is shown immediately.
-    expect(
-      tester.getSize(find.byType(Material).last),
-      within(distance: 0.1, from: const Size(224.0, 312.0)),
-    );
+    expect(tester.getSize(findMenu()), within(distance: 0.1, from: const Size(224.0, 312.0)));
   });
 }

--- a/examples/api/test/material/reorderable_list/reorderable_list_view.1_test.dart
+++ b/examples/api/test/material/reorderable_list/reorderable_list_view.1_test.dart
@@ -19,7 +19,10 @@ void main() {
     await tester.pump(kLongPressTimeout + kPressTimeout);
     await tester.pumpAndSettle();
     final Material material = tester.widget<Material>(
-      find.ancestor(of: find.text('Item 1'), matching: find.byType(Material)),
+      find.ancestor(
+        of: find.text('Item 1'),
+        matching: find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
+      ),
     );
     expect(material.color, theme.colorScheme.secondary);
 

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -31,6 +31,7 @@ import 'icon_button_theme.dart';
 import 'ink_decoration.dart';
 import 'ink_well.dart';
 import 'list_tile_theme.dart';
+import 'material.dart';
 import 'material_state.dart';
 import 'text_theme.dart';
 import 'theme.dart';
@@ -969,29 +970,27 @@ class ListTile extends StatelessWidget {
             ? ListTileTitleAlignment.threeLine
             : ListTileTitleAlignment.titleHeight);
 
-    return InkWell(
-      customBorder: shape ?? tileTheme.shape,
-      onTap: enabled ? onTap : null,
-      onLongPress: enabled ? onLongPress : null,
-      onFocusChange: onFocusChange,
-      mouseCursor: effectiveMouseCursor,
-      canRequestFocus: enabled,
-      focusNode: focusNode,
-      focusColor: focusColor,
-      hoverColor: hoverColor,
-      splashColor: splashColor,
-      autofocus: autofocus,
-      enableFeedback: enableFeedback ?? tileTheme.enableFeedback ?? true,
-      statesController: statesController,
-      child: Semantics(
-        button: internalAddSemanticForOnTap && (onTap != null || onLongPress != null),
-        selected: selected,
-        enabled: enabled,
-        child: Ink(
-          decoration: ShapeDecoration(
-            shape: shape ?? tileTheme.shape ?? const Border(),
-            color: _tileBackgroundColor(theme, tileTheme, defaults),
-          ),
+    return Material(
+      shape: shape ?? tileTheme.shape ?? const Border(),
+      color: _tileBackgroundColor(theme, tileTheme, defaults),
+      child: InkWell(
+        customBorder: shape ?? tileTheme.shape,
+        onTap: enabled ? onTap : null,
+        onLongPress: enabled ? onLongPress : null,
+        onFocusChange: onFocusChange,
+        mouseCursor: effectiveMouseCursor,
+        canRequestFocus: enabled,
+        focusNode: focusNode,
+        focusColor: focusColor,
+        hoverColor: hoverColor,
+        splashColor: splashColor,
+        autofocus: autofocus,
+        enableFeedback: enableFeedback ?? tileTheme.enableFeedback ?? true,
+        statesController: statesController,
+        child: Semantics(
+          button: internalAddSemanticForOnTap && (onTap != null || onLongPress != null),
+          selected: selected,
+          enabled: enabled,
           child: SafeArea(
             top: false,
             bottom: false,

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -55,7 +55,7 @@ void main() {
     }
 
     RenderBox getCheckboxListTileRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(CheckboxListTile));
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame(null));
@@ -92,7 +92,7 @@ void main() {
     }
 
     RenderBox getCheckboxListTileRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(CheckboxListTile));
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame(null));
@@ -136,17 +136,17 @@ void main() {
       );
     }
 
-    RenderBox getCheckboxListTileRenderer() {
-      return tester.renderObject<RenderBox>(find.byType(CheckboxListTile));
+    RenderBox getCheckboxRenderer() {
+      return tester.renderObject<RenderBox>(find.byType(Checkbox));
     }
 
     await tester.pumpWidget(buildFrame(const Color(0xFF000000), null));
     await tester.pumpAndSettle();
-    expect(getCheckboxListTileRenderer(), paints..path(color: const Color(0xFF000000)));
+    expect(getCheckboxRenderer(), paints..path(color: const Color(0xFF000000)));
 
     await tester.pumpWidget(buildFrame(const Color(0xFF000000), const Color(0xFFFFFFFF)));
     await tester.pumpAndSettle();
-    expect(getCheckboxListTileRenderer(), paints..path(color: const Color(0xFFFFFFFF)));
+    expect(getCheckboxRenderer(), paints..path(color: const Color(0xFFFFFFFF)));
   });
 
   testWidgets('CheckboxListTile can autofocus unless disabled.', (WidgetTester tester) async {
@@ -324,7 +324,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: tileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
+    );
   });
 
   testWidgets('CheckboxListTile respects selectedTileColor', (WidgetTester tester) async {
@@ -344,7 +347,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: selectedTileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: selectedTileColor),
+    );
   });
 
   testWidgets('CheckboxListTile selected item text Color', (WidgetTester tester) async {

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -56,7 +56,10 @@ void main() {
 
   Material getMaterial(WidgetTester tester) {
     return tester.widget<Material>(
-      find.descendant(of: find.byType(ExpansionTile), matching: find.byType(Material)),
+      find.descendant(
+        of: find.byType(ExpansionTile),
+        matching: find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
+      ),
     );
   }
 

--- a/packages/flutter/test/material/expansion_tile_theme_test.dart
+++ b/packages/flutter/test/material/expansion_tile_theme_test.dart
@@ -50,7 +50,10 @@ class TestTextState extends State<TestText> {
 void main() {
   Material getMaterial(WidgetTester tester) {
     return tester.widget<Material>(
-      find.descendant(of: find.byType(ExpansionTile), matching: find.byType(Material)),
+      find.descendant(
+        of: find.byType(ExpansionTile),
+        matching: find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
+      ),
     );
   }
 

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -965,29 +965,17 @@ void main() {
     await tester.pumpAndSettle();
     expect(focusNode.hasPrimaryFocus, isTrue);
     expect(
-      find.byType(Material),
+      find.byType(ListTile),
       paints
-        ..rect()
-        ..rect(color: Colors.orange[500], rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
-        ..rect(
-          color: const Color(0xffffffff),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        ),
+        ..path()
+        ..rect(color: Colors.orange[500], rect: const Rect.fromLTRB(0, 0, 100, 100)),
     );
 
     // Check when the list tile is disabled.
     await tester.pumpWidget(buildApp(enabled: false));
     await tester.pumpAndSettle();
     expect(focusNode.hasPrimaryFocus, isFalse);
-    expect(
-      find.byType(Material),
-      paints
-        ..rect()
-        ..rect(
-          color: const Color(0xffffffff),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        ),
-    );
+    expect(find.byType(ListTile), paints..path(color: Colors.transparent));
 
     focusNode.dispose();
   });
@@ -1021,19 +1009,7 @@ void main() {
 
     await tester.pump();
     await tester.pumpAndSettle();
-    expect(
-      find.byType(Material),
-      paints
-        ..rect()
-        ..rect(
-          color: const Color(0x1f000000),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        )
-        ..rect(
-          color: const Color(0xffffffff),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        ),
-    );
+    expect(find.byType(ListTile), paints..path(color: Colors.transparent));
 
     // Start hovering
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -1043,36 +1019,17 @@ void main() {
     await tester.pump();
     await tester.pumpAndSettle();
     expect(
-      find.byType(Material),
+      find.byType(ListTile),
       paints
-        ..rect()
-        ..rect(
-          color: const Color(0x1f000000),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        )
-        ..rect(color: Colors.orange[500], rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0))
-        ..rect(
-          color: const Color(0xffffffff),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        ),
+        ..path()
+        ..rect(color: const Color(0x1f000000), rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0))
+        ..rect(color: Colors.orange[500], rect: const Rect.fromLTRB(0.0, 0.0, 100.0, 100.0)),
     );
 
     await tester.pumpWidget(buildApp(enabled: false));
     await tester.pump();
     await tester.pumpAndSettle();
-    expect(
-      find.byType(Material),
-      paints
-        ..rect()
-        ..rect(
-          color: Colors.orange[500]!.withAlpha(0),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        )
-        ..rect(
-          color: const Color(0xffffffff),
-          rect: const Rect.fromLTRB(350.0, 250.0, 450.0, 350.0),
-        ),
-    );
+    expect(find.byType(ListTile), paints..path(color: Colors.transparent));
   });
 
   testWidgets('ListTile can be splashed and has correct splash color', (WidgetTester tester) async {
@@ -1095,7 +1052,10 @@ void main() {
       tester.getRect(find.byType(ListTile)).center,
     );
     await tester.pump(const Duration(milliseconds: 200));
-    expect(find.byType(Material), paints..circle(x: 50, y: 50, color: const Color(0xff88ff88)));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..circle(x: 50, y: 50, color: const Color(0xff88ff88)),
+    );
     await gesture.up();
   });
 
@@ -1197,25 +1157,31 @@ void main() {
 
     // Test rectangle shape
     await tester.pumpWidget(buildListTile(rectShape));
-    Rect rect = tester.getRect(find.byType(ListTile));
-
-    // Check if a rounded rectangle was painted with the correct color and shape
-    expect(find.byType(Material), paints..rect(color: tileColor, rect: rect));
-
-    // Test stadium shape
-    await tester.pumpWidget(buildListTile(stadiumShape));
-    rect = tester.getRect(find.byType(ListTile));
 
     // Check if a rounded rectangle was painted with the correct color and shape
     expect(
-      find.byType(Material),
-      paints
-        ..clipRect()
-        ..rrect(
-          color: tileColor,
-          rrect: RRect.fromRectAndRadius(rect, Radius.circular(rect.shortestSide / 2.0)),
-        ),
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
     );
+
+    final Material materialWidget = tester.widget<Material>(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+    );
+    expect(materialWidget.shape, rectShape);
+
+    // Test stadium shape
+    await tester.pumpWidget(buildListTile(stadiumShape));
+
+    // Check if a rounded rectangle was painted with the correct color and shape
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
+    );
+
+    final Material materialWidget2 = tester.widget<Material>(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+    );
+    expect(materialWidget2.shape, stadiumShape);
   });
 
   testWidgets('ListTile changes mouse cursor when hovered', (WidgetTester tester) async {
@@ -1359,14 +1325,20 @@ void main() {
     );
 
     // Initially, when isSelected is false, the ListTile should respect tileColor.
-    expect(find.byType(Material), paints..rect(color: tileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
+    );
 
     // Tap on tile to change isSelected.
     await tester.tap(find.byType(ListTile));
     await tester.pumpAndSettle();
 
     // When isSelected is true, the ListTile should respect selectedTileColor.
-    expect(find.byType(Material), paints..rect(color: selectedTileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: selectedTileColor),
+    );
   });
 
   testWidgets('ListTile shows Material ripple effects on top of tileColor', (
@@ -1387,7 +1359,10 @@ void main() {
     );
 
     // Before ListTile is tapped, it should be tileColor
-    expect(find.byType(Material), paints..rect(color: tileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
+    );
 
     // Tap on tile to trigger ink effect and wait for it to be underway.
     await tester.tap(find.byType(ListTile));
@@ -1395,9 +1370,9 @@ void main() {
 
     // After tap, the tile could be drawn in tileColor, with the ripple (circle) on top
     expect(
-      find.byType(Material),
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
       paints
-        ..rect(color: tileColor)
+        ..path(color: tileColor)
         ..circle(),
     );
   });
@@ -1428,13 +1403,19 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: defaultColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: defaultColor),
+    );
 
     // Tap on tile to change isSelected.
     await tester.tap(find.byType(ListTile));
     await tester.pumpAndSettle();
 
-    expect(find.byType(Material), paints..rect(color: defaultColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: defaultColor),
+    );
   });
 
   testWidgets('Default tile color when ListTile is wrapped with an elevated widget', (
@@ -1468,28 +1449,34 @@ void main() {
     );
 
     expect(
-      find.byType(Material),
+      find.byType(Card),
       paints
         ..path(color: const Color(0xff000000))
         ..path(color: const Color(0xfff7f2fa))
         ..save()
         ..save(),
     );
-    expect(find.byType(Material), paints..rect(color: defaultColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: defaultColor),
+    );
 
     // Tap on tile to change isSelected.
     await tester.tap(find.byType(ListTile));
     await tester.pumpAndSettle();
 
     expect(
-      find.byType(Material),
+      find.byType(Card),
       paints
         ..path(color: const Color(0xff000000))
         ..path(color: const Color(0xfff7f2fa))
         ..save()
         ..save(),
     );
-    expect(find.byType(Material), paints..rect(color: defaultColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: defaultColor),
+    );
   });
 
   testWidgets('ListTile layout at zero size', (WidgetTester tester) async {
@@ -4225,13 +4212,19 @@ void main() {
         ),
       );
 
-      expect(find.byType(Material), paints..rect(color: defaultColor));
+      expect(
+        find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+        paints..path(color: defaultColor),
+      );
 
       // Tap on tile to change isSelected.
       await tester.tap(find.byType(ListTile));
       await tester.pumpAndSettle();
 
-      expect(find.byType(Material), paints..rect(color: defaultColor));
+      expect(
+        find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+        paints..path(color: defaultColor),
+      );
     });
 
     testWidgets('titleAlignment position with title widget', (WidgetTester tester) async {

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -705,13 +705,19 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: theme.tileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: theme.tileColor),
+    );
 
     // Tap on tile to change isSelected.
     await tester.tap(find.byType(ListTile));
     await tester.pumpAndSettle();
 
-    expect(find.byType(Material), paints..rect(color: theme.selectedTileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: theme.selectedTileColor),
+    );
   });
 
   testWidgets(
@@ -746,13 +752,19 @@ void main() {
         ),
       );
 
-      expect(find.byType(Material), paints..rect(color: tileColor));
+      expect(
+        find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+        paints..path(color: tileColor),
+      );
 
       // Tap on tile to change isSelected.
       await tester.tap(find.byType(ListTile));
       await tester.pumpAndSettle();
 
-      expect(find.byType(Material), paints..rect(color: selectedTileColor));
+      expect(
+        find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+        paints..path(color: selectedTileColor),
+      );
     },
   );
 

--- a/packages/flutter/test/material/popup_menu_theme_test.dart
+++ b/packages/flutter/test/material/popup_menu_theme_test.dart
@@ -185,7 +185,10 @@ void main() {
     /// that is of type Material, this code retrieves the built
     /// [PopupMenuButton].
     final Material button = tester.widget<Material>(
-      find.descendant(of: find.byKey(popupButtonApp), matching: find.byType(Material)).last,
+      find.descendant(
+        of: find.byKey(popupButtonApp),
+        matching: find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
+      ),
     );
     expect(button.color, theme.colorScheme.surfaceContainer);
     expect(button.shadowColor, theme.colorScheme.shadow);
@@ -306,7 +309,10 @@ void main() {
     /// that is of type Material, this code retrieves the built
     /// [PopupMenuButton].
     final Material button = tester.widget<Material>(
-      find.descendant(of: find.byKey(popupButtonApp), matching: find.byType(Material)).last,
+      find.descendant(
+        of: find.byKey(popupButtonApp),
+        matching: find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
+      ),
     );
     expect(button.color, Colors.orange);
     expect(button.surfaceTintColor, const Color(0xff00ff00));
@@ -432,7 +438,10 @@ void main() {
     /// that is of type Material, this code retrieves the built
     /// [PopupMenuButton].
     final Material button = tester.widget<Material>(
-      find.descendant(of: find.byKey(popupButtonApp), matching: find.byType(Material)).last,
+      find.descendant(
+        of: find.byKey(popupButtonApp),
+        matching: find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
+      ),
     );
     expect(button.color, color);
     expect(button.shape, shape);

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -679,7 +679,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: tileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
+    );
   });
 
   testWidgets('RadioListTile respects selectedTileColor', (WidgetTester tester) async {
@@ -699,7 +702,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: selectedTileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: selectedTileColor),
+    );
   });
 
   testWidgets('RadioListTile selected item text Color', (WidgetTester tester) async {
@@ -934,7 +940,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: Colors.transparent)
         ..circle(color: activeEnabledFillColor)
         ..circle(color: activeEnabledFillColor),
@@ -947,7 +952,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: Colors.transparent)
         ..circle(color: inactiveEnabledFillColor, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
@@ -959,7 +963,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: Colors.transparent)
         ..circle(color: activeDisabledFillColor)
         ..circle(color: activeDisabledFillColor),
@@ -972,7 +975,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: Colors.transparent)
         ..circle(color: inactiveDisabledFillColor, style: PaintingStyle.stroke, strokeWidth: 2.0),
     );
@@ -1066,7 +1068,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: Colors.transparent)
         ..circle(color: theme.colorScheme.primary)
         ..circle(color: theme.colorScheme.primary),
@@ -1084,7 +1085,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: hoverColor)
         ..circle(color: Colors.transparent),
     );
@@ -1097,7 +1097,6 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
       paints
-        ..rect()
         ..circle(color: Colors.transparent)
         ..circle(color: theme.colorScheme.onSurface.withOpacity(0.38))
         ..circle(color: theme.colorScheme.onSurface.withOpacity(0.38)),
@@ -1148,9 +1147,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      Material.of(tester.element(find.byType(Radio<bool>))),
+      find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
       paints
-        ..rect(color: const Color(0x00000000))
+        ..path(color: const Color(0x00000000))
         ..rect(color: const Color(0x66bcbcbc))
         ..circle(color: fillColor.withAlpha(kRadialReactionAlpha), radius: 20.0),
       reason: 'Default inactive pressed Radio should have overlay color from fillColor',
@@ -1161,9 +1160,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      Material.of(tester.element(find.byType(Radio<bool>))),
+      find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
       paints
-        ..rect(color: const Color(0x00000000))
+        ..path(color: const Color(0x00000000))
         ..rect(color: const Color(0x66bcbcbc))
         ..circle(color: fillColor.withAlpha(kRadialReactionAlpha), radius: 20.0),
       reason: 'Default active pressed Radio should have overlay color from fillColor',
@@ -1174,9 +1173,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      Material.of(tester.element(find.byType(Radio<bool>))),
+      find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
       paints
-        ..rect(color: const Color(0x00000000))
+        ..path(color: const Color(0x00000000))
         ..rect(color: const Color(0x66bcbcbc))
         ..circle(color: inactivePressedOverlayColor, radius: 20.0),
       reason: 'Inactive pressed Radio should have overlay color: $inactivePressedOverlayColor',
@@ -1187,9 +1186,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      Material.of(tester.element(find.byType(Radio<bool>))),
+      find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
       paints
-        ..rect(color: const Color(0x00000000))
+        ..path(color: const Color(0x00000000))
         ..rect(color: const Color(0x66bcbcbc))
         ..circle(color: activePressedOverlayColor, radius: 20.0),
       reason: 'Active pressed Radio should have overlay color: $activePressedOverlayColor',
@@ -1206,9 +1205,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      Material.of(tester.element(find.byType(Radio<bool>))),
+      find.ancestor(of: find.byType(ListTile), matching: find.byType(Material)),
       paints
-        ..rect(color: const Color(0x00000000))
+        ..path(color: const Color(0x00000000))
         ..rect(color: const Color(0x0a000000))
         ..circle(color: hoverOverlayColor, radius: 20.0),
       reason: 'Hovered Radio should use overlay color $hoverOverlayColor over $hoverColor',
@@ -1526,7 +1525,6 @@ void main() {
       expect(
         Material.of(tester.element(find.byType(Radio<int>))),
         paints
-          ..rect()
           ..circle(color: Colors.transparent)
           ..circle(color: const Color(0xff2196f3))
           ..circle(color: const Color(0xff2196f3)),
@@ -1544,7 +1542,6 @@ void main() {
       expect(
         Material.of(tester.element(find.byType(Radio<int>))),
         paints
-          ..rect()
           ..circle(color: hoverColor)
           ..circle(color: Colors.transparent),
       );
@@ -1557,7 +1554,6 @@ void main() {
       expect(
         Material.of(tester.element(find.byType(Radio<int>))),
         paints
-          ..rect()
           ..circle(color: Colors.transparent)
           ..circle(color: const Color(0x61000000))
           ..circle(color: const Color(0x61000000)),
@@ -2189,9 +2185,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
-      paints
-        ..rect()
-        ..circle(color: activeEnabledBackgroundColor),
+      paints..circle(color: activeEnabledBackgroundColor),
     );
 
     // Check when the radio isn't selected.
@@ -2200,9 +2194,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
-      paints
-        ..rect()
-        ..circle(color: inactiveEnabledBackgroundColor),
+      paints..circle(color: inactiveEnabledBackgroundColor),
     );
 
     // Check when the radio is selected, but disabled.
@@ -2211,9 +2203,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
-      paints
-        ..rect()
-        ..circle(color: activeDisabledBackgroundColor),
+      paints..circle(color: activeDisabledBackgroundColor),
     );
 
     // Check when the radio is unselected and disabled.
@@ -2222,9 +2212,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(
       Material.of(tester.element(find.byType(Radio<int>))),
-      paints
-        ..rect()
-        ..circle(color: inactiveDisabledBackgroundColor),
+      paints..circle(color: inactiveDisabledBackgroundColor),
     );
   });
 

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -480,7 +480,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: tileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: tileColor),
+    );
   });
 
   testWidgets('SwitchListTile respects selectedTileColor', (WidgetTester tester) async {
@@ -500,7 +503,10 @@ void main() {
       ),
     );
 
-    expect(find.byType(Material), paints..rect(color: selectedTileColor));
+    expect(
+      find.descendant(of: find.byType(ListTile), matching: find.byType(Material)),
+      paints..path(color: selectedTileColor),
+    );
   });
 
   testWidgets('SwitchListTile selected item text Color', (WidgetTester tester) async {
@@ -723,7 +729,7 @@ void main() {
       Material.of(tester.element(find.byKey(key))),
       paints
         ..rect()
-        ..rect(color: Colors.orange[500], rect: const Rect.fromLTRB(150.0, 250.0, 650.0, 350.0)),
+        ..rect(color: Colors.orange[500], rect: const Rect.fromLTRB(0.0, 0.0, 500.0, 100.0)),
     );
   });
 


### PR DESCRIPTION
Fixes #174366 so that the tile background color wouldn't be hidden behind parent containers.

This PR is to replace `Ink` with `Material` and moved the original `Ink.shape` and `Ink.color` to `Material.shape` and `Material.color`.

Set `selectedTileColor: Colors.blueAccent,` to `ListTile` and use `Container` with purple background to wrap the `ListTile`.
Before:

https://github.com/user-attachments/assets/09e1ad0e-1051-4d4d-b834-82f9a662ab4b

After:


https://github.com/user-attachments/assets/14b4f8dc-9035-4f9d-bb09-2e17b0c0b3e5




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
