### PR TITLE
[a11y-app] Fix NavigationRail leading and trailing labels

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/navigation_rail.dart
+++ b/dev/a11y_assessments/lib/use_cases/navigation_rail.dart
@@ -51,6 +51,7 @@ class _NavRailExampleState extends State<NavRailExample> {
             labelType: labelType,
             leading: showLeading
                 ? FloatingActionButton(
+                    tooltip: 'Add',
                     elevation: 0,
                     onPressed: () {
                       // Add your onPressed code here!
@@ -60,6 +61,7 @@ class _NavRailExampleState extends State<NavRailExample> {
                 : const SizedBox(),
             trailing: showTrailing
                 ? IconButton(
+                    tooltip: 'More',
                     onPressed: () {
                       // Add your onPressed code here!
                     },

--- a/dev/a11y_assessments/test/navigation_rail_test.dart
+++ b/dev/a11y_assessments/test/navigation_rail_test.dart
@@ -14,4 +14,34 @@ void main() {
 
     expect(find.byType(NavigationRail), findsExactly(1));
   });
+
+  testWidgets('navigation rail can show/hide leading', (WidgetTester tester) async {
+    await pumpsUseCase(tester, NavigationRailUseCase());
+    final Finder findLeading = find.byTooltip('Add');
+
+    expect(findLeading, findsNothing);
+
+    await tester.tap(find.text('Show Leading'));
+    await tester.pump();
+    expect(findLeading, findsOne);
+
+    await tester.tap(find.text('Hide Leading'));
+    await tester.pump();
+    expect(findLeading, findsNothing);
+  });
+
+  testWidgets('navigation rail can show/hide trailing', (WidgetTester tester) async {
+    await pumpsUseCase(tester, NavigationRailUseCase());
+    final Finder findTrailing = find.byTooltip('More');
+
+    expect(findTrailing, findsNothing);
+
+    await tester.tap(find.text('Show Trailing'));
+    await tester.pump();
+    expect(findTrailing, findsOne);
+
+    await tester.tap(find.text('Hide Trailing'));
+    await tester.pump();
+    expect(findTrailing, findsNothing);
+  });
 }


### PR DESCRIPTION
## Description

This PR adds a11y labels for the heading and trailing buttons of the NavigationRail use case (for the A11y assessments app).

## Related Issue

Part of [[VPAT][A11y][a11y-app] controls in a11y assessment missing label](https://github.com/flutter/flutter/issues/173051)

## Tests

Adds 1 test.