### PR TITLE
Add `showToolbar` and `toggleToolbar` to `TextSelectionDelegate`

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1235,12 +1235,22 @@ mixin TextSelectionDelegate {
   ///   updating the text editing state.
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause);
 
+  /// Shows the text selection toolbar.
+  void showToolbar();
+
   /// Hides the text selection toolbar.
   ///
   /// By default, hideHandles is true, and the toolbar is hidden along with its
   /// handles. If hideHandles is set to false, then the toolbar will be hidden
   /// but the handles will remain.
   void hideToolbar([bool hideHandles = true]);
+
+  /// Toggles the visibility of the toolbar.
+  ///
+  /// If the toolbar is hidden calling this method should show the toolbar.
+  ///
+  /// If the toolbar is visible calling this method should hide the toolbar.
+  void toggleToolbar();
 
   /// Brings the provided [TextPosition] into the visible area of the text
   /// input.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1247,9 +1247,11 @@ mixin TextSelectionDelegate {
 
   /// Toggles the visibility of the toolbar.
   ///
-  /// If the toolbar is hidden calling this method should show the toolbar.
+  /// If the toolbar is hidden calling this method shows the toolbar.
   ///
-  /// If the toolbar is visible calling this method should hide the toolbar.
+  /// If the toolbar is visible calling this method hides the toolbar.
+  ///
+  /// The handles will remain visible if they were already visible.
   void toggleToolbar();
 
   /// Brings the provided [TextPosition] into the visible area of the text

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4995,6 +4995,7 @@ class EditableTextState extends State<EditableText>
   }
 
   /// Toggles the visibility of the toolbar.
+  @override
   void toggleToolbar([bool hideHandles = true]) {
     final TextSelectionOverlay selectionOverlay = _selectionOverlay ??= _createSelectionOverlay();
     if (selectionOverlay.toolbarIsVisible) {

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -895,11 +895,11 @@ class SelectableRegionState extends State<SelectableRegion>
       case TargetPlatform.fuchsia:
         if (shouldShowSelectionOverlayOnMobile) {
           _showHandles();
-          _showToolbar();
+          showToolbar();
         }
       case TargetPlatform.iOS:
         if (shouldShowSelectionOverlayOnMobile) {
-          _showToolbar();
+          showToolbar();
         }
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
@@ -917,12 +917,7 @@ class SelectableRegionState extends State<SelectableRegion>
         _positionIsOnActiveSelection(globalPosition: details.globalPosition)) {
       // On iOS when the tap occurs on the previous selection, instead of
       // moving the selection, the context menu will be toggled.
-      final bool toolbarIsVisible = _selectionOverlay?.toolbarIsVisible ?? false;
-      if (toolbarIsVisible) {
-        hideToolbar(false);
-      } else {
-        _showToolbar();
-      }
+      toggleToolbar();
       return;
     }
     switch (_getEffectiveConsecutiveTapCount(details.consecutiveTapCount)) {
@@ -948,7 +943,7 @@ class SelectableRegionState extends State<SelectableRegion>
               // On Android, a double tap will only show the selection overlay after
               // the following tap up when the pointer device kind is not precise.
               _showHandles();
-              _showToolbar();
+              showToolbar();
             }
           case TargetPlatform.iOS:
             if (!isPointerPrecise) {
@@ -958,7 +953,7 @@ class SelectableRegionState extends State<SelectableRegion>
               }
               // On iOS, a double tap will only show the selection toolbar after
               // the following tap up when the pointer device kind is not precise.
-              _showToolbar();
+              showToolbar();
             }
           case TargetPlatform.macOS:
           case TargetPlatform.linux:
@@ -1007,7 +1002,7 @@ class SelectableRegionState extends State<SelectableRegion>
     _finalizeSelection();
     _updateSelectedContentIfNeeded();
     _finalizeSelectableRegionStatus();
-    _showToolbar();
+    showToolbar();
     if (defaultTargetPlatform == TargetPlatform.android) {
       _showHandles();
     }
@@ -1043,7 +1038,7 @@ class SelectableRegionState extends State<SelectableRegion>
           // accesses contextMenuAnchors.
           _lastSecondaryTapDownPosition = details.globalPosition;
           _showHandles();
-          _showToolbar(location: _lastSecondaryTapDownPosition);
+          showToolbar(location: _lastSecondaryTapDownPosition);
           _updateSelectedContentIfNeeded();
           return;
         }
@@ -1076,7 +1071,7 @@ class SelectableRegionState extends State<SelectableRegion>
     // accesses contextMenuAnchors.
     _lastSecondaryTapDownPosition = details.globalPosition;
     _showHandles();
-    _showToolbar(location: _lastSecondaryTapDownPosition);
+    showToolbar(location: _lastSecondaryTapDownPosition);
     _updateSelectedContentIfNeeded();
   }
 
@@ -1347,7 +1342,8 @@ class SelectableRegionState extends State<SelectableRegion>
   /// [Overlay].
   ///
   /// Returns true if the toolbar is shown, false if the toolbar can't be shown.
-  bool _showToolbar({Offset? location}) {
+  @override
+  bool showToolbar({Offset? location}) {
     if (!_hasSelectionOverlayGeometry && _selectionOverlay == null) {
       return false;
     }
@@ -1380,6 +1376,16 @@ class SelectableRegionState extends State<SelectableRegion>
       },
     );
     return true;
+  }
+
+  @override
+  void toggleToolbar() {
+    final bool toolbarIsVisible = _selectionOverlay?.toolbarIsVisible ?? false;
+    if (toolbarIsVisible) {
+      hideToolbar(false);
+    } else {
+      showToolbar();
+    }
   }
 
   /// Sets or updates selection end edge to the `offset` location.
@@ -1833,7 +1839,7 @@ class SelectableRegionState extends State<SelectableRegion>
     clearSelection();
     _selectable?.dispatchSelectionEvent(const SelectAllSelectionEvent());
     if (cause == SelectionChangedCause.toolbar) {
-      _showToolbar();
+      showToolbar();
       _showHandles();
     }
     _updateSelectedContentIfNeeded();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1038,7 +1038,7 @@ class SelectableRegionState extends State<SelectableRegion>
           // accesses contextMenuAnchors.
           _lastSecondaryTapDownPosition = details.globalPosition;
           _showHandles();
-          showToolbar(location: _lastSecondaryTapDownPosition);
+          _showToolbar(location: _lastSecondaryTapDownPosition);
           _updateSelectedContentIfNeeded();
           return;
         }
@@ -1071,7 +1071,7 @@ class SelectableRegionState extends State<SelectableRegion>
     // accesses contextMenuAnchors.
     _lastSecondaryTapDownPosition = details.globalPosition;
     _showHandles();
-    showToolbar(location: _lastSecondaryTapDownPosition);
+    _showToolbar(location: _lastSecondaryTapDownPosition);
     _updateSelectedContentIfNeeded();
   }
 
@@ -1336,14 +1336,25 @@ class SelectableRegionState extends State<SelectableRegion>
 
   /// Shows the text selection toolbar.
   ///
-  /// If the parameter `location` is set, the toolbar will be shown at the
-  /// location. Otherwise, the toolbar location will be calculated based on the
-  /// handles' locations. The `location` is in the coordinates system of the
-  /// [Overlay].
+  /// The toolbar location will be calculated based on the
+  /// location of the selection endpoints.
   ///
   /// Returns true if the toolbar is shown, false if the toolbar can't be shown.
   @override
-  bool showToolbar({Offset? location}) {
+  bool showToolbar() {
+    return _showToolbar();
+  }
+
+  /// Shows the text selection toolbar.
+  ///
+  /// When using [TextSelectionControls] to build the toolbar `location` will
+  /// be where the toolbar is shown. Otherwise, the toolbar location will be
+  /// calculated based on the selection endpoints locations. The `location` is
+  /// in the coordinates system of the [Overlay].
+  ///
+  /// Returns true if the toolbar is shown, false if the toolbar can't be shown.
+  // TODO(Renzo-Olivares): Update this method when TextSelectionControls is removed from the framework.
+  bool _showToolbar({Offset? location}) {
     if (!_hasSelectionOverlayGeometry && _selectionOverlay == null) {
       return false;
     }

--- a/packages/flutter/test/rendering/editable_intrinsics_test.dart
+++ b/packages/flutter/test/rendering/editable_intrinsics_test.dart
@@ -111,7 +111,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
+  void showToolbar() {}
+
+  @override
   void hideToolbar([bool hideHandles = true]) {}
+
+  @override
+  void toggleToolbar() {}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -44,7 +44,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
+  void showToolbar() {}
+
+  @override
   void hideToolbar([bool hideHandles = true]) {}
+
+  @override
+  void toggleToolbar() {}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -3946,6 +3946,96 @@ void main() {
       variant: TargetPlatformVariant.only(TargetPlatform.macOS),
     );
 
+    testWidgets('can show the toolbar programmatically', (WidgetTester tester) async {
+      final GlobalKey<SelectionAreaState> selectionAreaKey = GlobalKey<SelectionAreaState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SelectionArea(key: selectionAreaKey, child: const Text('abc')),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final SelectionAreaState selectionAreaState = selectionAreaKey.currentState!;
+      final SelectableRegionState selectableRegionState = selectionAreaState.selectableRegion;
+
+      // The toolbar should not be visible initially.
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+      expect(selectableRegionState.selectionOverlay, isNull);
+
+      // Tap to set the selection.
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text('abc'), matching: find.byType(RichText)),
+      );
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 1));
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Programmatically show the toolbar.
+      selectableRegionState.showToolbar();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      expect(selectableRegionState.selectionOverlay?.toolbarIsVisible, isTrue);
+    }, skip: kIsWeb); // [intended] Web uses its native context menu.
+
+    testWidgets('can toggle the toolbar programmatically', (WidgetTester tester) async {
+      final GlobalKey<SelectionAreaState> selectionAreaKey = GlobalKey<SelectionAreaState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: SelectionArea(key: selectionAreaKey, child: const Text('abc')),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final SelectionAreaState selectionAreaState = selectionAreaKey.currentState!;
+      final SelectableRegionState selectableRegionState = selectionAreaState.selectableRegion;
+
+      // The toolbar should not be visible initially.
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+      expect(selectableRegionState.selectionOverlay, isNull);
+
+      // Tap to set the selection.
+      final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(
+        find.descendant(of: find.text('abc'), matching: find.byType(RichText)),
+      );
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 1));
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      // Programmatically show the toolbar.
+      selectableRegionState.showToolbar();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      expect(selectableRegionState.selectionOverlay?.toolbarIsVisible, isTrue);
+
+      // Programatically toggle the toolbar, should hide it.
+      selectableRegionState.toggleToolbar();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+      expect(selectableRegionState.selectionOverlay?.toolbarIsVisible, isFalse);
+
+      // Programatically toggle the toolbar, should show it.
+      selectableRegionState.toggleToolbar();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+      expect(selectableRegionState.selectionOverlay?.toolbarIsVisible, isTrue);
+    }, skip: kIsWeb); // [intended] Web uses its native context menu.
+
     testWidgets(
       'can select word when a selectables rect is completely inside of another selectables rect',
       (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/text_scaler_backward_compatibility_test.dart
+++ b/packages/flutter/test/widgets/text_scaler_backward_compatibility_test.dart
@@ -239,7 +239,13 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextSelection? selection;
 
   @override
+  void showToolbar() {}
+
+  @override
   void hideToolbar([bool hideHandles = true]) {}
+
+  @override
+  void toggleToolbar() {}
 
   @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) {


### PR DESCRIPTION
Currently `TextSelectionDelegate` only provides access to `hideToolbar` through its interface to hide the selection toolbar. `showToolbar` is a method on `TextInputClient`, this PR adds `showToolbar` to the `TextSelectionDelegate` as well as `toggleToolbar`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.