### PR TITLE
Depend on operator overload synthesis for three-way and equality comparisons.

### DIFF
--- a/engine/src/flutter/display_list/display_list.h
+++ b/engine/src/flutter/display_list/display_list.h
@@ -243,9 +243,6 @@ class SaveLayerOptions {
   bool operator==(const SaveLayerOptions& other) const {
     return flags_ == other.flags_;
   }
-  bool operator!=(const SaveLayerOptions& other) const {
-    return flags_ != other.flags_;
-  }
 
  private:
   union {

--- a/engine/src/flutter/display_list/dl_color.h
+++ b/engine/src/flutter/display_list/dl_color.h
@@ -181,9 +181,6 @@ struct DlColor {
            green_ == other.green_ && blue_ == other.blue_ &&
            color_space_ == other.color_space_;
   }
-  bool operator!=(DlColor const& other) const {
-    return !this->operator==(other);
-  }
 
  private:
   DlScalar alpha_;

--- a/engine/src/flutter/display_list/dl_paint.h
+++ b/engine/src/flutter/display_list/dl_paint.h
@@ -203,7 +203,6 @@ class DlPaint {
   }
 
   bool operator==(DlPaint const& other) const;
-  bool operator!=(DlPaint const& other) const { return !(*this == other); }
 
  private:
 #define ASSERT_ENUM_FITS(last_enum, num_bits)                    \

--- a/engine/src/flutter/display_list/dl_vertices.h
+++ b/engine/src/flutter/display_list/dl_vertices.h
@@ -231,8 +231,6 @@ class DlVertices {
 
   bool operator==(DlVertices const& other) const;
 
-  bool operator!=(DlVertices const& other) const { return !(*this == other); }
-
  private:
   // Constructors are designed to encapsulate arrays sequentially in memory
   // which means they can only be called by intantiations that use the

--- a/engine/src/flutter/display_list/geometry/dl_path.h
+++ b/engine/src/flutter/display_list/geometry/dl_path.h
@@ -92,7 +92,6 @@ class DlPath : public impeller::PathSource {
   DlPathFillType GetFillType() const override;
 
   bool operator==(const DlPath& other) const;
-  bool operator!=(const DlPath& other) const { return !(*this == other); }
 
   bool IsVolatile() const;
   bool IsConvex() const override;

--- a/engine/src/flutter/flow/embedded_views.h
+++ b/engine/src/flutter/flow/embedded_views.h
@@ -56,10 +56,6 @@ class ImageFilterMutation {
     return *filter_ == *other.filter_ && filter_rect_ == other.filter_rect_;
   }
 
-  bool operator!=(const ImageFilterMutation& other) const {
-    return !operator==(other);
-  }
-
  private:
   std::shared_ptr<DlImageFilter> filter_;
   const DlRect filter_rect_;
@@ -106,8 +102,6 @@ class Mutator {
   float GetAlphaFloat() const { return DlColor::toOpacity(GetAlpha()); }
 
   bool operator==(const Mutator& other) const { return data_ == other.data_; }
-
-  bool operator!=(const Mutator& other) const { return !operator==(other); }
 
   bool IsClipType() {
     switch (GetType()) {

--- a/engine/src/flutter/flow/raster_cache_key.h
+++ b/engine/src/flutter/flow/raster_cache_key.h
@@ -64,10 +64,6 @@ class RasterCacheKeyID {
            GetHash() == other.GetHash() && child_ids_ == other.child_ids_;
   }
 
-  bool operator!=(const RasterCacheKeyID& other) const {
-    return !operator==(other);
-  }
-
  private:
   const uint64_t unique_id_;
   const RasterCacheKeyType type_;

--- a/engine/src/flutter/fml/command_line.h
+++ b/engine/src/flutter/fml/command_line.h
@@ -66,7 +66,6 @@ class CommandLine final {
     bool operator==(const Option& other) const {
       return name == other.name && value == other.value;
     }
-    bool operator!=(const Option& other) const { return !operator==(other); }
 
     std::string name;
     std::string value;
@@ -103,7 +102,6 @@ class CommandLine final {
            options_ == other.options_ &&
            positional_args_ == other.positional_args_;
   }
-  bool operator!=(const CommandLine& other) const { return !operator==(other); }
 
   // Returns true if this command line has the option |name| (and if |index| is
   // non-null, sets |*index| to the index of the *last* occurrence of the given

--- a/engine/src/flutter/fml/time/time_delta.h
+++ b/engine/src/flutter/fml/time/time_delta.h
@@ -96,12 +96,7 @@ class TimeDelta {
     return TimeDelta::FromNanoseconds(delta_ % other.delta_);
   }
 
-  bool operator==(TimeDelta other) const { return delta_ == other.delta_; }
-  bool operator!=(TimeDelta other) const { return delta_ != other.delta_; }
-  bool operator<(TimeDelta other) const { return delta_ < other.delta_; }
-  bool operator<=(TimeDelta other) const { return delta_ <= other.delta_; }
-  bool operator>(TimeDelta other) const { return delta_ > other.delta_; }
-  bool operator>=(TimeDelta other) const { return delta_ >= other.delta_; }
+  constexpr auto operator<=>(const TimeDelta& other) const = default;
 
   static constexpr TimeDelta FromTimespec(struct timespec ts) {
     return TimeDelta::FromSeconds(ts.tv_sec) +

--- a/engine/src/flutter/fml/time/time_point.h
+++ b/engine/src/flutter/fml/time/time_point.h
@@ -49,26 +49,23 @@ class TimePoint {
     return TimePoint(ticks);
   }
 
-  TimeDelta ToEpochDelta() const { return TimeDelta::FromNanoseconds(ticks_); }
+  constexpr TimeDelta ToEpochDelta() const {
+    return TimeDelta::FromNanoseconds(ticks_);
+  }
 
   // Compute the difference between two time points.
-  TimeDelta operator-(TimePoint other) const {
+  constexpr TimeDelta operator-(TimePoint other) const {
     return TimeDelta::FromNanoseconds(ticks_ - other.ticks_);
   }
 
-  TimePoint operator+(TimeDelta duration) const {
+  constexpr TimePoint operator+(TimeDelta duration) const {
     return TimePoint(ticks_ + duration.ToNanoseconds());
   }
-  TimePoint operator-(TimeDelta duration) const {
+  constexpr TimePoint operator-(TimeDelta duration) const {
     return TimePoint(ticks_ - duration.ToNanoseconds());
   }
 
-  bool operator==(TimePoint other) const { return ticks_ == other.ticks_; }
-  bool operator!=(TimePoint other) const { return ticks_ != other.ticks_; }
-  bool operator<(TimePoint other) const { return ticks_ < other.ticks_; }
-  bool operator<=(TimePoint other) const { return ticks_ <= other.ticks_; }
-  bool operator>(TimePoint other) const { return ticks_ > other.ticks_; }
-  bool operator>=(TimePoint other) const { return ticks_ >= other.ticks_; }
+  constexpr auto operator<=>(const TimePoint& other) const = default;
 
  private:
   explicit constexpr TimePoint(int64_t ticks) : ticks_(ticks) {}

--- a/engine/src/flutter/fml/unique_object.h
+++ b/engine/src/flutter/fml/unique_object.h
@@ -92,8 +92,6 @@ class UniqueObject {
 
   bool operator==(const T& value) const { return data_.generic == value; }
 
-  bool operator!=(const T& value) const { return data_.generic != value; }
-
   Traits& get_traits() { return data_; }
   const Traits& get_traits() const { return data_; }
 

--- a/engine/src/flutter/impeller/base/allocation_size.h
+++ b/engine/src/flutter/impeller/base/allocation_size.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_BASE_ALLOCATION_SIZE_H_
 
 #include <cmath>
+#include <compare>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -91,32 +92,9 @@ class AllocationSize {
     return AllocationSize{GetByteSize(), FromBytesTag::kFromBytes};
   }
 
-  // The following relational operators can be replaced with a defaulted
-  // spaceship operator post C++20.
+  // Comparison operators.
 
-  constexpr bool operator<(const AllocationSize& other) const {
-    return bytes_ < other.bytes_;
-  }
-
-  constexpr bool operator>(const AllocationSize& other) const {
-    return bytes_ > other.bytes_;
-  }
-
-  constexpr bool operator>=(const AllocationSize& other) const {
-    return bytes_ >= other.bytes_;
-  }
-
-  constexpr bool operator<=(const AllocationSize& other) const {
-    return bytes_ <= other.bytes_;
-  }
-
-  constexpr bool operator==(const AllocationSize& other) const {
-    return bytes_ == other.bytes_;
-  }
-
-  constexpr bool operator!=(const AllocationSize& other) const {
-    return bytes_ != other.bytes_;
-  }
+  constexpr auto operator<=>(const AllocationSize& other) const = default;
 
   // Explicit casts.
 

--- a/engine/src/flutter/impeller/base/mask.h
+++ b/engine/src/flutter/impeller/base/mask.h
@@ -51,32 +51,9 @@ struct Mask {
 
   explicit constexpr operator bool() const { return !!mask_; }
 
-  // The following relational operators can be replaced with a defaulted
-  // spaceship operator post C++20.
+  // Comparison operators.
 
-  constexpr bool operator<(const Mask<EnumType>& other) const {
-    return mask_ < other.mask_;
-  }
-
-  constexpr bool operator>(const Mask<EnumType>& other) const {
-    return mask_ > other.mask_;
-  }
-
-  constexpr bool operator>=(const Mask<EnumType>& other) const {
-    return mask_ >= other.mask_;
-  }
-
-  constexpr bool operator<=(const Mask<EnumType>& other) const {
-    return mask_ <= other.mask_;
-  }
-
-  constexpr bool operator==(const Mask<EnumType>& other) const {
-    return mask_ == other.mask_;
-  }
-
-  constexpr bool operator!=(const Mask<EnumType>& other) const {
-    return mask_ != other.mask_;
-  }
+  constexpr auto operator<=>(const Mask<EnumType>& other) const = default;
 
   // Logical operators.
 
@@ -180,49 +157,13 @@ inline constexpr Mask<EnumType> operator^(const EnumType& lhs,
   return Mask<EnumType>{lhs} ^ rhs;
 }
 
-// Relational operators with EnumType promotion. These can be replaced by a
-// defaulted spaceship operator post C++20.
+// Relational operators with EnumType promotion.
 
 template <typename EnumType,
           typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
-inline constexpr bool operator<(const EnumType& lhs,
-                                const Mask<EnumType>& rhs) {
-  return Mask<EnumType>{lhs} < rhs;
-}
-
-template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
-inline constexpr bool operator>(const EnumType& lhs,
-                                const Mask<EnumType>& rhs) {
-  return Mask<EnumType>{lhs} > rhs;
-}
-
-template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
-inline constexpr bool operator<=(const EnumType& lhs,
-                                 const Mask<EnumType>& rhs) {
-  return Mask<EnumType>{lhs} <= rhs;
-}
-
-template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
-inline constexpr bool operator>=(const EnumType& lhs,
-                                 const Mask<EnumType>& rhs) {
-  return Mask<EnumType>{lhs} >= rhs;
-}
-
-template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
-inline constexpr bool operator==(const EnumType& lhs,
-                                 const Mask<EnumType>& rhs) {
-  return Mask<EnumType>{lhs} == rhs;
-}
-
-template <typename EnumType,
-          typename std::enable_if_t<MaskTraits<EnumType>::kIsMask, bool> = true>
-inline constexpr bool operator!=(const EnumType& lhs,
-                                 const Mask<EnumType>& rhs) {
-  return Mask<EnumType>{lhs} != rhs;
+inline constexpr auto operator<=>(const EnumType& lhs,
+                                  const Mask<EnumType>& rhs) {
+  return Mask<EnumType>{lhs} <=> rhs;
 }
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/base/version.h
+++ b/engine/src/flutter/impeller/base/version.h
@@ -29,10 +29,10 @@ struct Version {
   static std::optional<Version> FromVector(const std::vector<size_t>& version);
 
   constexpr bool IsAtLeast(const Version& other) const {
-    return std::tie(major_version, minor_version, patch_version) >=
-           std::tie(other.major_version, other.minor_version,
-                    other.patch_version);
+    return *this >= other;
   }
+
+  constexpr auto operator<=>(const Version&) const = default;
 
   std::string ToString() const;
 };

--- a/engine/src/flutter/impeller/core/texture_descriptor.h
+++ b/engine/src/flutter/impeller/core/texture_descriptor.h
@@ -80,20 +80,7 @@ struct TextureDescriptor {
     return IsMultisampleCapable(type) ? count > 1 : count == 1;
   }
 
-  constexpr bool operator==(const TextureDescriptor& other) const {
-    return size == other.size &&                          //
-           storage_mode == other.storage_mode &&          //
-           format == other.format &&                      //
-           usage == other.usage &&                        //
-           sample_count == other.sample_count &&          //
-           type == other.type &&                          //
-           compression_type == other.compression_type &&  //
-           mip_count == other.mip_count;
-  }
-
-  constexpr bool operator!=(const TextureDescriptor& other) const {
-    return !(*this == other);
-  }
+  constexpr bool operator==(const TextureDescriptor& other) const = default;
 
   constexpr bool IsValid() const {
     return format != PixelFormat::kUnknown &&  //

--- a/engine/src/flutter/impeller/geometry/half.h
+++ b/engine/src/flutter/impeller/geometry/half.h
@@ -52,8 +52,6 @@ struct Half {
   constexpr Half(InternalHalf x) : x(x) {}
 
   constexpr bool operator==(const Half& v) const { return v.x == x; }
-
-  constexpr bool operator!=(const Half& v) const { return v.x != x; }
 };
 
 /// @brief A storage only class for half precision floating point vector 4.

--- a/engine/src/flutter/impeller/geometry/rational.cc
+++ b/engine/src/flutter/impeller/geometry/rational.cc
@@ -25,10 +25,6 @@ bool Rational::operator==(const Rational& that) const {
   }
 }
 
-bool Rational::operator!=(const Rational& that) const {
-  return !(*this == that);
-}
-
 bool Rational::operator<(const Rational& that) const {
   if (den_ == that.den_) {
     return num_ < that.num_;

--- a/engine/src/flutter/impeller/geometry/rational.h
+++ b/engine/src/flutter/impeller/geometry/rational.h
@@ -22,8 +22,6 @@ class Rational {
 
   bool operator==(const Rational& that) const;
 
-  bool operator!=(const Rational& that) const;
-
   bool operator<(const Rational& that) const;
 
   uint64_t GetHash() const;

--- a/engine/src/flutter/impeller/geometry/rect.h
+++ b/engine/src/flutter/impeller/geometry/rect.h
@@ -199,10 +199,6 @@ struct TRect {
            bottom_ == r.bottom_;
   }
 
-  [[nodiscard]] constexpr bool operator!=(const TRect& r) const {
-    return !(*this == r);
-  }
-
   [[nodiscard]] constexpr TRect Scale(Type scale) const {
     return TRect(left_ * scale,   //
                  top_ * scale,    //

--- a/engine/src/flutter/impeller/geometry/round_rect.h
+++ b/engine/src/flutter/impeller/geometry/round_rect.h
@@ -128,10 +128,6 @@ struct RoundRect {
     return bounds_ == rr.bounds_ && radii_ == rr.radii_;
   }
 
-  [[nodiscard]] constexpr bool operator!=(const RoundRect& r) const {
-    return !(*this == r);
-  }
-
  private:
   constexpr RoundRect(const Rect& bounds, const RoundingRadii& radii)
       : bounds_(bounds), radii_(radii) {}

--- a/engine/src/flutter/impeller/geometry/round_superellipse.h
+++ b/engine/src/flutter/impeller/geometry/round_superellipse.h
@@ -123,10 +123,6 @@ struct RoundSuperellipse {
     return bounds_ == rr.bounds_ && radii_ == rr.radii_;
   }
 
-  [[nodiscard]] constexpr bool operator!=(const RoundSuperellipse& r) const {
-    return !(*this == r);
-  }
-
   // Approximates a rounded superellipse with a round rectangle to the
   // best practical accuracy.
   //

--- a/engine/src/flutter/impeller/geometry/rounding_radii.h
+++ b/engine/src/flutter/impeller/geometry/rounding_radii.h
@@ -84,10 +84,6 @@ struct RoundingRadii {
            bottom_left == rr.bottom_left &&  //
            bottom_right == rr.bottom_right;
   }
-
-  [[nodiscard]] constexpr bool operator!=(const RoundingRadii& rr) const {
-    return !(*this == rr);
-  }
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/scalar.h
+++ b/engine/src/flutter/impeller/geometry/scalar.h
@@ -60,17 +60,7 @@ struct Radians {
     return Radians{radians - r.radians};
   }
 
-  constexpr bool operator>(Radians r) { return radians > r.radians; }
-
-  constexpr bool operator>=(Radians r) { return radians >= r.radians; }
-
-  constexpr bool operator==(Radians r) { return radians == r.radians; }
-
-  constexpr bool operator!=(Radians r) { return radians != r.radians; }
-
-  constexpr bool operator<=(Radians r) { return radians <= r.radians; }
-
-  constexpr bool operator<(Radians r) { return radians < r.radians; }
+  constexpr auto operator<=>(const Radians& r) const = default;
 };
 
 struct Degrees {
@@ -96,17 +86,7 @@ struct Degrees {
     return Degrees{degrees - d.degrees};
   }
 
-  constexpr bool operator>(Degrees d) { return degrees > d.degrees; }
-
-  constexpr bool operator>=(Degrees d) { return degrees >= d.degrees; }
-
-  constexpr bool operator==(Degrees d) { return degrees == d.degrees; }
-
-  constexpr bool operator!=(Degrees d) { return degrees != d.degrees; }
-
-  constexpr bool operator<=(Degrees d) { return degrees <= d.degrees; }
-
-  constexpr bool operator<(Degrees d) { return degrees < d.degrees; }
+  constexpr auto operator<=>(const Degrees& d) const = default;
 
   constexpr Degrees GetPositive() const {
     Scalar deg = std::fmod(degrees, 360.0f);

--- a/engine/src/flutter/impeller/geometry/shear.h
+++ b/engine/src/flutter/impeller/geometry/shear.h
@@ -26,8 +26,6 @@ struct Shear {
   bool operator==(const Shear& o) const {
     return xy == o.xy && xz == o.xz && yz == o.yz;
   }
-
-  bool operator!=(const Shear& o) const { return !(*this == o); }
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/geometry/stroke_parameters.h
+++ b/engine/src/flutter/impeller/geometry/stroke_parameters.h
@@ -31,14 +31,7 @@ struct StrokeParameters {
   Join join = Join::kMiter;
   Scalar miter_limit = 4.0f;
 
-  constexpr bool operator==(const StrokeParameters& parameters) const {
-    return parameters.width == width && parameters.cap == cap &&
-           parameters.join == join && parameters.miter_limit == miter_limit;
-  }
-
-  constexpr bool operator!=(const StrokeParameters& parameters) const {
-    return !(*this == parameters);
-  }
+  constexpr bool operator==(const StrokeParameters& parameters) const = default;
 };
 
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/vma.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/vma.h
@@ -38,13 +38,7 @@ struct PoolVMA {
   VmaAllocator allocator = {};
   VmaPool pool = {};
 
-  constexpr bool operator==(const PoolVMA& other) const {
-    return allocator == other.allocator && pool == other.pool;
-  }
-
-  constexpr bool operator!=(const PoolVMA& other) const {
-    return !(*this == other);
-  }
+  constexpr bool operator==(const PoolVMA& other) const = default;
 };
 
 struct PoolVMATraits {

--- a/engine/src/flutter/impeller/toolkit/android/hardware_buffer.h
+++ b/engine/src/flutter/impeller/toolkit/android/hardware_buffer.h
@@ -73,13 +73,7 @@ struct HardwareBufferDescriptor {
   ///
   bool IsAllocatable() const;
 
-  constexpr bool operator==(const HardwareBufferDescriptor& o) const {
-    return format == o.format && size == o.size && usage == o.usage;
-  }
-
-  constexpr bool operator!=(const HardwareBufferDescriptor& o) const {
-    return !(*this == o);
-  }
+  constexpr bool operator==(const HardwareBufferDescriptor& o) const = default;
 };
 
 //------------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/toolkit/android/surface_transaction.h
+++ b/engine/src/flutter/impeller/toolkit/android/surface_transaction.h
@@ -31,10 +31,6 @@ struct WrappedSurfaceTransaction {
   constexpr bool operator==(const WrappedSurfaceTransaction& other) const {
     return other.tx == tx;
   }
-
-  constexpr bool operator!=(const WrappedSurfaceTransaction& other) const {
-    return !(*this == other);
-  }
 };
 
 //------------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/toolkit/egl/image.h
+++ b/engine/src/flutter/impeller/toolkit/egl/image.h
@@ -15,13 +15,7 @@ struct EGLImageWithDisplay {
   EGLImage image = EGL_NO_IMAGE;
   EGLDisplay display = EGL_NO_DISPLAY;
 
-  constexpr bool operator==(const EGLImageWithDisplay& other) const {
-    return image == other.image && display == other.display;
-  }
-
-  constexpr bool operator!=(const EGLImageWithDisplay& other) const {
-    return !(*this == other);
-  }
+  constexpr bool operator==(const EGLImageWithDisplay& other) const = default;
 };
 
 struct EGLImageWithDisplayTraits {
@@ -46,13 +40,8 @@ struct EGLImageKHRWithDisplay {
   EGLImageKHR image = EGL_NO_IMAGE_KHR;
   EGLDisplay display = EGL_NO_DISPLAY;
 
-  constexpr bool operator==(const EGLImageKHRWithDisplay& other) const {
-    return image == other.image && display == other.display;
-  }
-
-  constexpr bool operator!=(const EGLImageKHRWithDisplay& other) const {
-    return !(*this == other);
-  }
+  constexpr bool operator==(const EGLImageKHRWithDisplay& other) const =
+      default;
 };
 
 struct EGLImageKHRWithDisplayTraits {

--- a/engine/src/flutter/impeller/toolkit/gles/texture.h
+++ b/engine/src/flutter/impeller/toolkit/gles/texture.h
@@ -14,13 +14,7 @@ namespace impeller {
 struct GLTexture {
   GLuint texture_name;
 
-  constexpr bool operator==(const GLTexture& other) const {
-    return texture_name == other.texture_name;
-  }
-
-  constexpr bool operator!=(const GLTexture& other) const {
-    return !(*this == other);
-  }
+  constexpr bool operator==(const GLTexture& other) const = default;
 };
 
 struct GLTextureTraits {

--- a/engine/src/flutter/shell/platform/common/geometry.h
+++ b/engine/src/flutter/shell/platform/common/geometry.h
@@ -44,10 +44,7 @@ class Size {
   double width() const { return width_; }
   double height() const { return height_; }
 
-  bool operator==(const Size& other) const {
-    return width_ == other.width_ && height_ == other.height_;
-  }
-  bool operator!=(const Size& other) const { return !(*this == other); }
+  bool operator==(const Size& other) const = default;
 
  private:
   double width_ = 0.0;

--- a/engine/src/flutter/shell/platform/common/text_editing_delta.h
+++ b/engine/src/flutter/shell/platform/common/text_editing_delta.h
@@ -44,12 +44,7 @@ struct TextEditingDelta {
   /// Get the delta_end_ value.
   int delta_end() const { return delta_end_; }
 
-  bool operator==(const TextEditingDelta& rhs) const {
-    return old_text_ == rhs.old_text_ && delta_text_ == rhs.delta_text_ &&
-           delta_start_ == rhs.delta_start_ && delta_end_ == rhs.delta_end_;
-  }
-
-  bool operator!=(const TextEditingDelta& rhs) const { return !(*this == rhs); }
+  bool operator==(const TextEditingDelta& rhs) const = default;
 
   TextEditingDelta(const TextEditingDelta& other) = default;
 

--- a/engine/src/flutter/third_party/accessibility/ax/ax_event_intent.cc
+++ b/engine/src/flutter/third_party/accessibility/ax/ax_event_intent.cc
@@ -28,10 +28,6 @@ bool operator==(const AXEventIntent& a, const AXEventIntent& b) {
          a.move_direction == b.move_direction;
 }
 
-bool operator!=(const AXEventIntent& a, const AXEventIntent& b) {
-  return !(a == b);
-}
-
 std::string AXEventIntent::ToString() const {
   return std::string("AXEventIntent(") + ui::ToString(command) + ',' +
          ui::ToString(text_boundary) + ',' + ui::ToString(move_direction) + ')';

--- a/engine/src/flutter/third_party/accessibility/ax/ax_event_intent.h
+++ b/engine/src/flutter/third_party/accessibility/ax/ax_event_intent.h
@@ -27,8 +27,6 @@ struct AX_BASE_EXPORT AXEventIntent final {
 
   friend AX_BASE_EXPORT bool operator==(const AXEventIntent& a,
                                         const AXEventIntent& b);
-  friend AX_BASE_EXPORT bool operator!=(const AXEventIntent& a,
-                                        const AXEventIntent& b);
 
   ax::mojom::Command command = ax::mojom::Command::kType;
   // TODO(nektar): Split TextBoundary into TextUnit and TextBoundary.

--- a/engine/src/flutter/txt/src/txt/text_shadow.cc
+++ b/engine/src/flutter/txt/src/txt/text_shadow.cc
@@ -11,23 +11,7 @@ TextShadow::TextShadow() {}
 TextShadow::TextShadow(SkColor color, SkPoint offset, double blur_sigma)
     : color(color), offset(offset), blur_sigma(blur_sigma) {}
 
-bool TextShadow::operator==(const TextShadow& other) const {
-  if (color != other.color) {
-    return false;
-  }
-  if (offset != other.offset) {
-    return false;
-  }
-  if (blur_sigma != other.blur_sigma) {
-    return false;
-  }
-
-  return true;
-}
-
-bool TextShadow::operator!=(const TextShadow& other) const {
-  return !(*this == other);
-}
+bool TextShadow::operator==(const TextShadow& other) const = default;
 
 bool TextShadow::hasShadow() const {
   if (!offset.isZero()) {

--- a/engine/src/flutter/txt/src/txt/text_shadow.h
+++ b/engine/src/flutter/txt/src/txt/text_shadow.h
@@ -22,8 +22,6 @@ class TextShadow {
 
   bool operator==(const TextShadow& other) const;
 
-  bool operator!=(const TextShadow& other) const;
-
   bool hasShadow() const;
 };
 


### PR DESCRIPTION
This depends on the implicitly generated `operator!=` from `operator==` in a few cases (see the exceptions below) and add `operator<=>` in some of the more obvious instances.

I've tried to be extremely conservative in this first pass. There are a few more candidates that were not converted because:

* `operator!=` was different from `!operator=.` For instance, if it had early returns. Not sure how the compiler generated those and didn't want the behavior or performance characteristics to change.
* They were virtual.
* `operator==` didn't actually compare all struct members. Dubious but I didn't want to change existing behavior.
* There were template parameters.
