### PR TITLE
Define a concept for UniqueObjectTraits.

### DIFF
--- a/engine/src/flutter/fml/unique_object.h
+++ b/engine/src/flutter/fml/unique_object.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_FML_UNIQUE_OBJECT_H_
 #define FLUTTER_FML_UNIQUE_OBJECT_H_
 
+#include <concepts>
 #include <utility>
 
 #include "flutter/fml/logging.h"
@@ -12,18 +13,20 @@
 
 namespace fml {
 
-// struct UniqueFooTraits {
-//   // This function should be fast and inline.
-//   static int InvalidValue() { return 0; }
-//
-//   // This function should be fast and inline.
-//   static bool IsValid(const T& value) { return value != InvalidValue(); }
-//
-//   // This free function will not be called if f == InvalidValue()!
-//   static void Free(int f) { ::FreeFoo(f); }
-// };
+template <typename T, typename Traits>
+concept UniqueObjectTraits = requires {
+  // |InvalidValue| should be fast and inline.
+  { Traits::InvalidValue() } -> std::same_as<T>;
+
+  // |IsValid| function should be fast and inline.
+  { Traits::IsValid(T{}) } -> std::same_as<bool>;
+
+  // |Free| function will not be called if value == InvalidValue()!
+  { Traits::Free(T{}) };
+};
 
 template <typename T, typename Traits>
+  requires UniqueObjectTraits<T, Traits>
 class UniqueObject {
  private:
   // This must be first since it's used inline below.

--- a/engine/src/flutter/fml/unique_object.h
+++ b/engine/src/flutter/fml/unique_object.h
@@ -19,10 +19,10 @@ concept UniqueObjectTraits = requires {
   { Traits::InvalidValue() } -> std::same_as<T>;
 
   // |IsValid| function should be fast and inline.
-  { Traits::IsValid(T{}) } -> std::same_as<bool>;
+  { Traits::IsValid(std::declval<T>()) } -> std::same_as<bool>;
 
   // |Free| function will not be called if value == InvalidValue()!
-  { Traits::Free(T{}) };
+  { Traits::Free(std::declval<T>()) };
 };
 
 template <typename T, typename Traits>

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_config_builder.h
@@ -18,7 +18,7 @@ struct UniqueEngineTraits {
 
   static bool IsValid(const FlutterEngine& value) { return value != nullptr; }
 
-  static void Free(FlutterEngine& engine) {
+  static void Free(FlutterEngine engine) {
     auto result = FlutterEngineShutdown(engine);
     FML_CHECK(result == kSuccess);
   }


### PR DESCRIPTION
Earlier, it was just a comment. If you didn't do what the comment said, you'd get a mysterious compiler error when the template was instantiated at the point where the trait method was invoked. This would be extremely far away from where the template was instantiated and typically in `fml/unique_object.h`.

Now, the exact reason and where a fix would go is printed in the compiler error. For instance, if I delete the Free method in `UniqueDirTraits`, I get (among other output):

```
no member named 'Free' in 'fml::internal::os_unix::UniqueDirTraits'
```
