### PR TITLE
[Impeller] Disable the render target cache when creating a snapshot in DlImageImpeller::MakeFromYUVTextures

### DIFF
--- a/engine/src/flutter/impeller/entity/render_target_cache.cc
+++ b/engine/src/flutter/impeller/entity/render_target_cache.cc
@@ -96,12 +96,14 @@ RenderTarget RenderTargetCache::CreateOffscreen(
   if (!created_target.IsValid()) {
     return created_target;
   }
-  render_target_data_.push_back(RenderTargetData{
-      .used_this_frame = true,                            //
-      .keep_alive_frame_count = keep_alive_frame_count_,  //
-      .config = config,                                   //
-      .render_target = created_target                     //
-  });
+  if (CacheEnabled()) {
+    render_target_data_.push_back(RenderTargetData{
+        .used_this_frame = true,                            //
+        .keep_alive_frame_count = keep_alive_frame_count_,  //
+        .config = config,                                   //
+        .render_target = created_target                     //
+    });
+  }
   return created_target;
 }
 
@@ -152,12 +154,14 @@ RenderTarget RenderTargetCache::CreateOffscreenMSAA(
   if (!created_target.IsValid()) {
     return created_target;
   }
-  render_target_data_.push_back(RenderTargetData{
-      .used_this_frame = true,                            //
-      .keep_alive_frame_count = keep_alive_frame_count_,  //
-      .config = config,                                   //
-      .render_target = created_target                     //
-  });
+  if (CacheEnabled()) {
+    render_target_data_.push_back(RenderTargetData{
+        .used_this_frame = true,                            //
+        .keep_alive_frame_count = keep_alive_frame_count_,  //
+        .config = config,                                   //
+        .render_target = created_target                     //
+    });
+  }
   return created_target;
 }
 


### PR DESCRIPTION
Also avoid inserting newly created render targets into the cache if the cache is disabled.  (Previously disabling the cache would skip lookups of existing cache entries but would still add new entries to the cache)

The image created by DlImageImpeller::MakeFromYUVTextures should not reuse a texture from the cache, and its texture should not be reused by other operations.

Fixes https://github.com/flutter/flutter/issues/174794