### PR TITLE
Fix DropdownMenuFormField does not clear text field content on reset …

### DIFF
--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -982,19 +982,24 @@ void main() {
         ),
       );
 
+      final TextField textField = tester.widget(find.byType(TextField));
+
       // Select menuItem1.
       await tester.tap(find.byType(DropdownMenu<MenuItem>));
       await tester.pump();
       await tester.tap(findMenuItem(MenuItem.menuItem1));
       await tester.pump();
       expect(fieldKey.currentState!.value, MenuItem.menuItem1);
+      expect(
+        textField.controller?.value,
+        const TextEditingValue(text: 'Item 1', selection: TextSelection.collapsed(offset: 6)),
+      );
 
       // After reset the text field content is cleared.
       fieldKey.currentState!.reset();
       await tester.pump();
 
       expect(fieldKey.currentState!.value, null);
-      final TextField textField = tester.widget(find.byType(TextField));
       expect(
         textField.controller?.value,
         const TextEditingValue(selection: TextSelection.collapsed(offset: 0)),
@@ -1032,6 +1037,10 @@ void main() {
       await tester.tap(findMenuItem(MenuItem.menuItem1));
       await tester.pump();
       expect(fieldKey.currentState!.value, MenuItem.menuItem1);
+      expect(
+        textField.controller?.value,
+        const TextEditingValue(text: 'Item 1', selection: TextSelection.collapsed(offset: 6)),
+      );
 
       // After reset the text field content is cleared.
       fieldKey.currentState!.reset();

--- a/packages/flutter/test/material/dropdown_menu_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_form_field_test.dart
@@ -506,12 +506,13 @@ void main() {
       ),
     );
 
-    // Check default value.
-    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
-    expect(dropdownMenu.controller, null);
-
     final TextEditingController controller = TextEditingController();
     addTearDown(controller.dispose);
+
+    // Check default value.
+    DropdownMenu<MenuItem> dropdownMenu = tester.widget(find.byType(DropdownMenu<MenuItem>));
+    expect(dropdownMenu.controller, isNotNull); // A default controller is created.
+    expect(dropdownMenu.controller, isNot(controller));
 
     await tester.pumpWidget(
       MaterialApp(
@@ -966,6 +967,83 @@ void main() {
 
     expect(fieldKey.currentState!.value, MenuItem.menuItem0);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/174578.
+  testWidgets(
+    'Inner text field is cleared on reset when initialSelection is null - Default controller',
+    (WidgetTester tester) async {
+      final GlobalKey<FormFieldState<MenuItem>> fieldKey = GlobalKey<FormFieldState<MenuItem>>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenuFormField<MenuItem>(key: fieldKey, dropdownMenuEntries: menuEntries),
+          ),
+        ),
+      );
+
+      // Select menuItem1.
+      await tester.tap(find.byType(DropdownMenu<MenuItem>));
+      await tester.pump();
+      await tester.tap(findMenuItem(MenuItem.menuItem1));
+      await tester.pump();
+      expect(fieldKey.currentState!.value, MenuItem.menuItem1);
+
+      // After reset the text field content is cleared.
+      fieldKey.currentState!.reset();
+      await tester.pump();
+
+      expect(fieldKey.currentState!.value, null);
+      final TextField textField = tester.widget(find.byType(TextField));
+      expect(
+        textField.controller?.value,
+        const TextEditingValue(selection: TextSelection.collapsed(offset: 0)),
+      );
+    },
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/174578.
+  testWidgets(
+    'Inner text field is cleared on reset when initialSelection is null - Custom controller',
+    (WidgetTester tester) async {
+      final GlobalKey<FormFieldState<MenuItem>> fieldKey = GlobalKey<FormFieldState<MenuItem>>();
+      final TextEditingController controller = TextEditingController();
+      addTearDown(controller.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenuFormField<MenuItem>(
+              key: fieldKey,
+              controller: controller,
+              dropdownMenuEntries: menuEntries,
+            ),
+          ),
+        ),
+      );
+
+      // Custom controller is correctly passed to the inner TextField.
+      final TextField textField = tester.widget(find.byType(TextField));
+      expect(textField.controller, controller);
+
+      // Select menuItem1.
+      await tester.tap(find.byType(DropdownMenu<MenuItem>));
+      await tester.pump();
+      await tester.tap(findMenuItem(MenuItem.menuItem1));
+      await tester.pump();
+      expect(fieldKey.currentState!.value, MenuItem.menuItem1);
+
+      // After reset the text field content is cleared.
+      fieldKey.currentState!.reset();
+      await tester.pump();
+
+      expect(fieldKey.currentState!.value, null);
+      expect(
+        controller.value,
+        const TextEditingValue(selection: TextSelection.collapsed(offset: 0)),
+      );
+    },
+  );
 
   testWidgets('isValid and hasError results are correct', (WidgetTester tester) async {
     final GlobalKey<FormFieldState<MenuItem>> fieldKey = GlobalKey<FormFieldState<MenuItem>>();


### PR DESCRIPTION
## Description

This PR fixes `DropdownMenuFormField` not clearing the text field value when the form is reset and DropdownMenuFormField.initialSelection is null.

## Related Issue

Fixes [DropdownMenuFormField does not reset when calling FormState.reset](https://github.com/flutter/flutter/issues/174578) 

## Tests

Adds 2 tests.