### PR TITLE
[ Device Lab ] Fix wakefulness check to only match log entries with string values

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -685,7 +685,7 @@ class AndroidDevice extends Device {
     final String powerInfo = await shellEval('dumpsys', <String>['power']);
     // A motoG4 phone returns `mWakefulness=Awake`.
     // A Samsung phone returns `getWakefullnessLocked()=Awake`.
-    final RegExp wakefulnessRegexp = RegExp(r'.*(mWakefulness|getWakefulnessLocked\(\))=[a-zA-Z]*');
+    final RegExp wakefulnessRegexp = RegExp(r'(?:mWakefulness|getWakefulnessLocked\(\))=[a-zA-Z]+');
     final String wakefulness = grep(wakefulnessRegexp, from: powerInfo).single.split('=')[1].trim();
     return wakefulness;
   }

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -685,7 +685,7 @@ class AndroidDevice extends Device {
     final String powerInfo = await shellEval('dumpsys', <String>['power']);
     // A motoG4 phone returns `mWakefulness=Awake`.
     // A Samsung phone returns `getWakefullnessLocked()=Awake`.
-    final RegExp wakefulnessRegexp = RegExp(r'.*(mWakefulness=|getWakefulnessLocked\(\)=).*');
+    final RegExp wakefulnessRegexp = RegExp(r'.*(mWakefulness|getWakefulnessLocked\(\))=[a-zA-Z]*');
     final String wakefulness = grep(wakefulnessRegexp, from: powerInfo).single.split('=')[1].trim();
     return wakefulness;
   }


### PR DESCRIPTION
Sometimes there can be multiple wakefulness log entries (e.g., 'mWakefulness=Awake' and 'mWakefulness=1'), but we only care about the entry with a string value.

Fixed https://github.com/flutter/flutter/issues/174948