### PR TITLE
[ Device Lab ] Add regression testing for flutter/flutter#174952

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -685,9 +685,11 @@ class AndroidDevice extends Device {
     final String powerInfo = await shellEval('dumpsys', <String>['power']);
     // A motoG4 phone returns `mWakefulness=Awake`.
     // A Samsung phone returns `getWakefullnessLocked()=Awake`.
-    final RegExp wakefulnessRegexp = RegExp(r'(?:mWakefulness|getWakefulnessLocked\(\))=[a-zA-Z]+');
-    final String wakefulness = grep(wakefulnessRegexp, from: powerInfo).single.split('=')[1].trim();
-    return wakefulness;
+    final RegExp wakefulnessRegexp = RegExp(
+      r'(?:mWakefulness|getWakefulnessLocked\(\))=\s*([a-zA-Z]+)',
+    );
+    final String wakefulnessEntry = grep(wakefulnessRegexp, from: powerInfo).single;
+    return wakefulnessRegexp.firstMatch(wakefulnessEntry)!.group(1)!;
   }
 
   Future<bool> isArm64() async {

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -688,8 +688,7 @@ class AndroidDevice extends Device {
     final RegExp wakefulnessRegexp = RegExp(
       r'(?:mWakefulness|getWakefulnessLocked\(\))=\s*([a-zA-Z]+)',
     );
-    final String wakefulnessEntry = grep(wakefulnessRegexp, from: powerInfo).single;
-    return wakefulnessRegexp.firstMatch(wakefulnessEntry)!.group(1)!;
+    return wakefulnessRegexp.allMatches(powerInfo).single.group(1)!;
   }
 
   Future<bool> isArm64() async {

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -325,19 +325,34 @@ class FakeDevice extends AndroidDevice {
   }
 
   static void pretendAwake() {
+    // Emit an integer value in addition to the state string to ensure only
+    // the state string is matched.
+    //
+    // Regression testing for https://github.com/flutter/flutter/issues/174952.
     output = '''
+      mWakefulness=1
       mWakefulness=Awake
     ''';
   }
 
   static void pretendAwakeSamsung() {
+    // Emit an integer value in addition to the state string to ensure only
+    // the state string is matched.
+    //
+    // Regression testing for https://github.com/flutter/flutter/issues/174952.
     output = '''
+      getWakefulnessLocked()=1
       getWakefulnessLocked()=Awake
     ''';
   }
 
   static void pretendAsleep() {
+    // Emit an integer value in addition to the state string to ensure only
+    // the state string is matched.
+    //
+    // Regression testing for https://github.com/flutter/flutter/issues/174952.
     output = '''
+      mWakefulness=0
       mWakefulness=Asleep
     ''';
   }

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -23,7 +23,9 @@ void main() {
       device = FakeDevice(deviceId: 'fakeDeviceId');
     });
 
-    tearDown(() {});
+    tearDown(() {
+      FakeDevice.resetLog();
+    });
 
     group('cpu check', () {
       test('arm64', () async {
@@ -332,6 +334,7 @@ class FakeDevice extends AndroidDevice {
     output = '''
       mWakefulness=1
       mWakefulness=Awake
+
     ''';
   }
 
@@ -343,6 +346,7 @@ class FakeDevice extends AndroidDevice {
     output = '''
       getWakefulnessLocked()=1
       getWakefulnessLocked()=Awake
+
     ''';
   }
 
@@ -354,6 +358,7 @@ class FakeDevice extends AndroidDevice {
     output = '''
       mWakefulness=0
       mWakefulness=Asleep
+
     ''';
   }
 


### PR DESCRIPTION
Also switches to using a regex group to match the device state instead of splitting the matched string on '='.

Fixes https://github.com/flutter/flutter/issues/174952