### PR TITLE
[web] Reuse chrome instance to run all flutter tests

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -580,7 +580,7 @@ class FlutterWebPlatform extends PlatformPlugin {
 
     final Runtime browser = platform.runtime;
     try {
-      _browserManager = await _launchBrowser(browser);
+      _browserManager ??= await _launchBrowser(browser);
     } on Error catch (_) {
       await _suiteLock.close();
       rethrow;
@@ -600,8 +600,6 @@ class FlutterWebPlatform extends PlatformPlugin {
       suiteConfig,
       message,
       onDone: () async {
-        await _browserManager!.close();
-        _browserManager = null;
         lockResource.release();
         if (_logger.isVerbose) {
           _logger.printTrace('Test suite $relativePath finished.');


### PR DESCRIPTION
Web test shards take a significant time to run in CI compared to their VM counterparts. One theory is that launching and shutting down Chrome repeatedly is a major part of the slowness.

This PR makes `flutter test --platform=chrome` reuse the same Chrome instance for all test files instead of launching a new one for each test file.

At first glance, it may seem like we aren't shutting down Chrome anymore, but we actually do in `closeEphemeral` and `close` methods.

Thanks @eyebrowsoffire for the idea!