### PR TITLE
Update ImageReaderSurfaceProducer.MAX_IMAGES to include the maximum number of retained dequeued images

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -413,7 +413,6 @@ public class FlutterRenderer implements TextureRegistry {
           TextureRegistry.ImageConsumer,
           TextureRegistry.OnTrimMemoryListener {
     private static final String TAG = "ImageReaderSurfaceProducer";
-    private static final int MAX_IMAGES = 6;
     // The ImageReaderSurfaceProducer must not close images until the renderer,
     // either Skia OpenGL, Impeller OpenGL, or Impeller Vulkan is done reading
     // from them. The Vulkan renderer allows up to two frames in flight before
@@ -422,6 +421,7 @@ public class FlutterRenderer implements TextureRegistry {
     // the frame that references them has finished rendering can result in
     // tearing or other incorrect rendering.
     private static final int MAX_DEQUEUED_IMAGES = 2;
+    private static final int MAX_IMAGES = 5 + MAX_DEQUEUED_IMAGES;
 
     // Flip when debugging to see verbose logs.
     private static final boolean VERBOSE_LOGS = false;


### PR DESCRIPTION
MAX_IMAGES was set to 5 by https://github.com/flutter/engine/commit/7a58dac0b1c8efb6e9cfcaf743a8ab2f6c02a796 in order to fix "client tried to acquire more than maxImages buffers" warnings from ImageReader_JNI.

https://github.com/flutter/flutter/commit/696251d25a0a90d1bdc84fa7f7b5884ac632be2d then converted lastDequeuedImage into a queue that retains up to MAX_DEQUEUED_IMAGES in-flight images plus the latest dequeued image.  MAX_DEQUEUED_IMAGES was set to 2, but MAX_IMAGES was only incremented by 1.  So the ImageReader_JNI warning may reappear in some cases.

This PR ensures that MAX_IMAGES provides enough capacity in the ImageReader for the total number of images that may be in use.