### PR TITLE
Fix: use 'exit' instead of 'return' for curlExitCode

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -155,7 +155,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     # 33  HTTP range error. The range "command" didn't work.
     # https://man7.org/linux/man-pages/man1/curl.1.html#EXIT_CODES
     if [ $curlExitCode != 33 ]; then
-      return $curlExitCode
+      exit $curlExitCode
     fi
     curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
   } || {

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -155,7 +155,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     # 33  HTTP range error. The range "command" didn't work.
     # https://man7.org/linux/man-pages/man1/curl.1.html#EXIT_CODES
     if [ $curlExitCode != 33 ]; then
-      exit $curlExitCode
+      exit "$curlExitCode"
     fi
     curl ${verbose_curl} --retry 3 --location --output "$DART_SDK_ZIP" "$DART_SDK_URL" 2>&1
   } || {


### PR DESCRIPTION
When updating Flutter using `flutter upgrade`, the following message appeared:
```
curl: (18) Transferred a partial file
/opt/flutter/bin/internal/update_dart_sdk.sh: 
158: return: can only `return' from a function or sourced script
```
An invalid syntax was used here(Line 158 of `flutter/bin/internal/update_dart_sdk.sh`):
```
if [ $curlExitCode != 33 ]; then
   return $curlExitCode
fi
```
I applied a simple fix: use `exit` instead of `return` for curlExitCode.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.