### PR TITLE
docs(ListView): add example for removing bottom padding

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1253,6 +1253,44 @@ abstract class BoxScrollView extends ScrollView {
 ///  * Cookbook: [Create a horizontal list](https://docs.flutter.dev/cookbook/lists/horizontal-list)
 ///  * Cookbook: [Create lists with different types of items](https://docs.flutter.dev/cookbook/lists/mixed-list)
 ///  * Cookbook: [Implement swipe to dismiss](https://docs.flutter.dev/cookbook/gestures/dismissible)
+/// /// * Cookbook: [Implement swipe to dismiss](https://docs.flutter.dev/cookbook/gestures/dismissible)
+///
+/// ### Removing default bottom padding
+///
+/// By default, `ListView` and `ListView.builder` add bottom padding to account
+/// for system UI elements like the Android navigation bar or iOS home indicator.
+///
+/// If you want to remove this padding, wrap the `ListView` with
+/// `MediaQuery.removePadding` and set `removeBottom: true`.
+///
+/// ```dart
+/// MediaQuery.removePadding(
+///   context: context,
+///   removeBottom: true,
+///   child: ListView.builder(
+///     padding: EdgeInsets.zero, // also removes any default list padding
+///     itemCount: 20,
+///     itemBuilder: (context, index) {
+///       return ListTile(title: Text('Item \$index'));
+///     },
+///   ),
+/// )
+/// ```
+///
+/// Alternatively, you can also wrap your list in a `SafeArea` if you want to
+/// respect the top inset (status bar, notch) but ignore the bottom inset:
+///
+/// ```dart
+/// SafeArea(
+///   bottom: false,
+///   child: ListView.builder(
+///     itemCount: 20,
+///     itemBuilder: (context, index) {
+///       return ListTile(title: Text('Item \$index'));
+///     },
+///   ),
+/// )
+/// ```
 class ListView extends BoxScrollView {
   /// Creates a scrollable, linear array of widgets from an explicit [List].
   ///

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -1256,7 +1256,6 @@ abstract class BoxScrollView extends ScrollView {
 /// /// * Cookbook: [Implement swipe to dismiss](https://docs.flutter.dev/cookbook/gestures/dismissible)
 ///
 /// ### Removing default bottom padding
-///
 /// By default, `ListView` and `ListView.builder` add bottom padding to account
 /// for system UI elements like the Android navigation bar or iOS home indicator.
 ///
@@ -1289,8 +1288,7 @@ abstract class BoxScrollView extends ScrollView {
 ///       return ListTile(title: Text('Item \$index'));
 ///     },
 ///   ),
-/// )
-/// ```
+/// )```
 class ListView extends BoxScrollView {
   /// Creates a scrollable, linear array of widgets from an explicit [List].
   ///


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

### Summary

Added documentation example to `ListView` showing how to remove the default bottom padding caused by system UI elements (Android navigation bar, iOS home indicator).

This addresses a common confusion developers face when using `ListView.builder`, where unexpected extra space appears at the bottom.

### Before
The `ListView` docs did not mention why extra bottom padding appears or how to remove it.

### After
The docs now include examples showing:
- Using `MediaQuery.removePadding(removeBottom: true)` to remove the padding.
- Using `SafeArea(bottom: false)` as an alternative.

### Issue Fixed
Fixes #174983

---

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt]. (docs-only, so test-exempt)
- [x] I followed the [breaking change policy].
- [x] All existing and new tests are passing. (docs-only change, so no new tests needed)
