### PR TITLE
fix: :bug: Add equality and hashCode implementations to ScrollAwareImageProvider

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
+++ b/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
@@ -43,6 +43,7 @@ import 'scrollable.dart';
 /// The [Image] widget wraps its incoming providers with this provider to avoid
 /// overutilization of resources for images that would never appear on screen or
 /// only be visible for a very brief period.
+@immutable
 @optionalTypeArgs
 class ScrollAwareImageProvider<T extends Object> extends ImageProvider<T> {
   /// Creates a [ScrollAwareImageProvider].
@@ -114,4 +115,20 @@ class ScrollAwareImageProvider<T extends Object> extends ImageProvider<T> {
 
   @override
   Future<T> obtainKey(ImageConfiguration configuration) => imageProvider.obtainKey(configuration);
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is ScrollAwareImageProvider &&
+        context == other.context &&
+        imageProvider == other.imageProvider;
+  }
+
+  @override
+  int get hashCode => Object.hash(context, imageProvider);
 }

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -39,6 +39,128 @@ void main() {
     return Scrollable.of(find.byType(TestWidget).evaluate().first).position;
   }
 
+  Future<DisposableBuildContext> createContext(WidgetTester tester) async {
+    final GlobalKey<TestWidgetState> key = GlobalKey<TestWidgetState>();
+    await tester.pumpWidget(TestWidget(key));
+    final DisposableBuildContext context = DisposableBuildContext(key.currentState!);
+    addTearDown(context.dispose);
+    return context;
+  }
+
+  group('equality and hashCode', () {
+    testWidgets('Two identical instances should be equal and have same hashCode', (
+      WidgetTester tester,
+    ) async {
+      final DisposableBuildContext context = await createContext(tester);
+
+      final ui.Image image = testImage.clone();
+      final TestImageProvider testImageProvider = TestImageProvider(image);
+
+      final ScrollAwareImageProvider<TestImageProvider> imageProvider1 =
+          ScrollAwareImageProvider<TestImageProvider>(
+            context: context,
+            imageProvider: testImageProvider,
+          );
+
+      final ScrollAwareImageProvider<TestImageProvider> imageProvider2 =
+          ScrollAwareImageProvider<TestImageProvider>(
+            context: context,
+            imageProvider: testImageProvider,
+          );
+
+      testImageProvider.complete();
+      image.dispose();
+
+      expect(imageProvider1 == imageProvider2, isTrue);
+      expect(imageProvider1.hashCode, equals(imageProvider2.hashCode));
+    });
+
+    testWidgets(
+      'ScrollAwareImageProvider instances with same context but different images should not be equal',
+      (WidgetTester tester) async {
+        final DisposableBuildContext context = await createContext(tester);
+
+        final ui.Image image1 = testImage.clone();
+        final ui.Image image2 = testImage.clone();
+
+        final TestImageProvider testImageProvider1 = TestImageProvider(image1);
+        final TestImageProvider testImageProvider2 = TestImageProvider(image2);
+
+        final ScrollAwareImageProvider<TestImageProvider> imageProvider1 =
+            ScrollAwareImageProvider<TestImageProvider>(
+              context: context,
+              imageProvider: testImageProvider1,
+            );
+
+        final ScrollAwareImageProvider<TestImageProvider> imageProvider2 =
+            ScrollAwareImageProvider<TestImageProvider>(
+              context: context,
+              imageProvider: testImageProvider2,
+            );
+
+        testImageProvider1.complete();
+        testImageProvider2.complete();
+        image1.dispose();
+        image2.dispose();
+
+        expect(imageProvider1 == imageProvider2, isFalse);
+        expect(imageProvider1.hashCode, isNot(equals(imageProvider2.hashCode)));
+      },
+    );
+
+    testWidgets('ScrollAwareImageProvider instance should be equal to itself', (
+      WidgetTester tester,
+    ) async {
+      final DisposableBuildContext context = await createContext(tester);
+
+      final ui.Image image = testImage.clone();
+      final TestImageProvider testImageProvider = TestImageProvider(image);
+
+      final ScrollAwareImageProvider<TestImageProvider> imageProvider =
+          ScrollAwareImageProvider<TestImageProvider>(
+            context: context,
+            imageProvider: testImageProvider,
+          );
+
+      testImageProvider.complete();
+      image.dispose();
+
+      expect(imageProvider == imageProvider, isTrue);
+    });
+
+    testWidgets('ScrollAwareImageProvider instances with different contexts should not be equal', (
+      WidgetTester tester,
+    ) async {
+      final DisposableBuildContext context1 = await createContext(tester);
+      final DisposableBuildContext context2 = await createContext(tester);
+
+      final ui.Image image1 = testImage.clone();
+      final ui.Image image2 = testImage.clone();
+
+      final TestImageProvider testImageProvider1 = TestImageProvider(image1);
+      final TestImageProvider testImageProvider2 = TestImageProvider(image2);
+
+      final ScrollAwareImageProvider<TestImageProvider> imageProvider1 =
+          ScrollAwareImageProvider<TestImageProvider>(
+            context: context1,
+            imageProvider: testImageProvider1,
+          );
+
+      final ScrollAwareImageProvider<TestImageProvider> imageProvider2 =
+          ScrollAwareImageProvider<TestImageProvider>(
+            context: context2,
+            imageProvider: testImageProvider2,
+          );
+
+      testImageProvider1.complete();
+      testImageProvider2.complete();
+      image1.dispose();
+      image2.dispose();
+
+      expect(imageProvider1 == imageProvider2, isFalse);
+    });
+  });
+
   testWidgets('ScrollAwareImageProvider does not delay if widget is not in scrollable', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION

### Description
This PR adds `==` and `hashCode` implementations to **`ScrollAwareImageProvider`**.

According to the [`ImageProvider` documentation](https://api.flutter.dev/flutter/painting/ImageProvider-class.html):

> It should be immutable and implement the [==](https://api.flutter.dev/flutter/painting/dart-core/Object/operator_equals.html) operator and the [hashCode](https://api.flutter.dev/flutter/painting/dart-core/Object/hashCode.html) getter.

`ScrollAwareImageProvider` did not previously override these, which could result in instances with identical configuration being treated as unequal. This behavior can negatively impact image caching and equality checks.  

With this change, `ScrollAwareImageProvider` now conforms to the `ImageProvider` contract.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
