### PR TITLE
Remove legacy pkg:coverage from DEPS and use from dart-lang/tools

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -535,7 +535,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/brendan-duncan/archive.git' + '@' + 'f1d164f8f5d8aea0be620a9b1e8d300b75a29388', # 3.6.1
 
   'engine/src/flutter/third_party/pkg/coverage':
-  Var('flutter_git') + '/third_party/coverage.git' + '@' + 'bb0ab721ee4ceef1abfa413d8d6fd46013b583b9', # 1.7.2
+  Var('flutter_git') + '/third_party/coverage.git' + '@' + '1500539bc29006f7c29abe5f7f2e1ea92c692b67', # 1.15.0
 
   'engine/src/flutter/third_party/pkg/equatable':
   Var('flutter_git') + '/third_party/equatable.git' + '@' + '2117551ff3054f8edb1a58f63ffe1832a8d25623', # 2.0.5

--- a/DEPS
+++ b/DEPS
@@ -534,9 +534,6 @@ deps = {
   'engine/src/flutter/third_party/pkg/archive':
   Var('chromium_git') + '/external/github.com/brendan-duncan/archive.git' + '@' + 'f1d164f8f5d8aea0be620a9b1e8d300b75a29388', # 3.6.1
 
-  'engine/src/flutter/third_party/pkg/coverage':
-  Var('flutter_git') + '/third_party/coverage.git' + '@' + '1500539bc29006f7c29abe5f7f2e1ea92c692b67', # 1.15.0
-
   'engine/src/flutter/third_party/pkg/equatable':
   Var('flutter_git') + '/third_party/equatable.git' + '@' + '2117551ff3054f8edb1a58f63ffe1832a8d25623', # 2.0.5
 

--- a/engine/src/flutter/pubspec.yaml
+++ b/engine/src/flutter/pubspec.yaml
@@ -183,7 +183,7 @@ dependency_overrides:
   convert:
     path: ./third_party/dart/third_party/pkg/core/pkgs/convert
   coverage:
-    path: ./third_party/pkg/coverage
+    path: ./third_party/pkg/tools/pkgs/coverage
   crypto:
     path: ./third_party/dart/third_party/pkg/core/pkgs/crypto
   dart_mcp:

--- a/engine/src/flutter/pubspec.yaml
+++ b/engine/src/flutter/pubspec.yaml
@@ -178,6 +178,8 @@ dependency_overrides:
     path: ./third_party/dart/pkg/async_helper
   boolean_selector:
     path: ./third_party/dart/third_party/pkg/tools/pkgs/boolean_selector
+  cli_config:
+    path: ./third_party/dart/third_party/pkg/tools/pkgs/cli_config
   collection:
     path: ./third_party/dart/third_party/pkg/core/pkgs/collection
   convert:

--- a/engine/src/flutter/pubspec.yaml
+++ b/engine/src/flutter/pubspec.yaml
@@ -183,7 +183,7 @@ dependency_overrides:
   convert:
     path: ./third_party/dart/third_party/pkg/core/pkgs/convert
   coverage:
-    path: ./third_party/pkg/tools/pkgs/coverage
+    path: ./third_party/dart/third_party/pkg/tools/pkgs/coverage
   crypto:
     path: ./third_party/dart/third_party/pkg/core/pkgs/crypto
   dart_mcp:


### PR DESCRIPTION
This unblocks updating pkg:test in the Dart SDK which was originally bumped in https://dart-review.googlesource.com/c/sdk/+/444360 but had to be reverted because it failed to roll into Flutter because it uses new APIs from coverage 1.15.

https://ci.chromium.org/p/dart/builders/ci.sandbox/flutter-linux/12194:

```
../../flutter/third_party/dart/third_party/pkg/test/pkgs/test_core/lib/src/runner/coverage.dart:43:48: Error: The method 'filterIgnored' isn't defined for the type 'Map<String, HitMap>'.

'Map' is from 'dart:core'.
'HitMap' is from 'package:coverage/src/hitmap.dart' ('../../flutter/third_party/pkg/coverage/lib/src/hitmap.dart').
Try correcting the name to the name of an existing method, or defining a method named 'filterIgnored'.
final filteredCoverageData = allCoverageData.filterIgnored(
                                        ^^^^^^^^^^^^^
```

The coverage dep was added in https://github.com/flutter/flutter/commit/42daa3bb567b4a19b840792069af282091b202cb when coverage was in its own repo, but now it's in `tools` so this was referencing a stale version. This change removes it from DEPS and updates `engine/pubspec.yaml` to reference it from the existing `tools` checkout instead, and also adds `cli_config` which it depends on (it's already listed in the root `pubspec.yaml` just needs the path overriding here).