### PR TITLE
Fix `Select All` button behavior on iOS System Context Menu

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1022,7 +1022,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                                                            _textInputClient];
                       }
                     }];
-        action.attributes = [keepsMenuPresented boolValue] ? UIMenuElementAttributesKeepsMenuPresented : 0;
+        action.attributes =
+            [keepsMenuPresented boolValue] ? UIMenuElementAttributesKeepsMenuPresented : 0;
         [items addObject:action];
       }
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1006,6 +1006,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     } else if ([type isEqualToString:@"custom"]) {
       NSString* callbackId = encodedItem[@"id"];
       NSString* title = encodedItem[@"title"];
+      NSString* keepsMenuPresented = encodedItem[@"keepsMenuPresented"];
       if (callbackId && title) {
         __weak FlutterTextInputView* weakSelf = self;
         UIAction* action = [UIAction
@@ -1021,6 +1022,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                                                            _textInputClient];
                       }
                     }];
+        action.attributes = [keepsMenuPresented boolValue] ? UIMenuElementAttributesKeepsMenuPresented : 0;
         [items addObject:action];
       }
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1012,7 +1012,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                        type:type
                                    selector:@selector(captureTextFromCamera:)
                               suggestedMenu:suggestedMenu
-                              attributes:attributes];
+                                 attributes:attributes];
       }
     } else if ([type isEqualToString:@"custom"]) {
       NSString* callbackId = encodedItem[@"id"];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1006,8 +1006,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
     } else if ([type isEqualToString:@"custom"]) {
       NSString* callbackId = encodedItem[@"id"];
       NSString* title = encodedItem[@"title"];
-      NSString* keepsMenuPresented = encodedItem[@"keepsMenuPresented"];
-      if (callbackId && title) {
+      NSNumber* attributes = encodedItem[@"attributes"];
+      if (callbackId && title && attributes) {
         __weak FlutterTextInputView* weakSelf = self;
         UIAction* action = [UIAction
             actionWithTitle:title
@@ -1022,8 +1022,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                                                            _textInputClient];
                       }
                     }];
-        action.attributes =
-            [keepsMenuPresented boolValue] ? UIMenuElementAttributesKeepsMenuPresented : 0;
+        action.attributes = [attributes intValue];
         [items addObject:action];
       }
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1012,7 +1012,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                        type:type
                                    selector:@selector(captureTextFromCamera:)
                               suggestedMenu:suggestedMenu
-                                 attributes:attributes];
+                              attributes:attributes];
       }
     } else if ([type isEqualToString:@"custom"]) {
       NSString* callbackId = encodedItem[@"id"];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -916,8 +916,10 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 - (void)addBasicEditingCommandToItems:(NSMutableArray*)items
                                  type:(NSString*)type
                              selector:(SEL)selector
-                        suggestedMenu:(UIMenu*)suggestedMenu {
+                        suggestedMenu:(UIMenu*)suggestedMenu
+                           attributes:(NSNumber*)attributes {
   UICommand* command = [self searchCommandWithSelector:selector element:suggestedMenu];
+  command.attributes = [attributes intValue];
   if (command) {
     [items addObject:command];
   } else {
@@ -932,11 +934,13 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                 selector:(SEL)selector
                              encodedItem:(NSDictionary<NSString*, id>*)encodedItem {
   NSString* title = encodedItem[@"title"];
+  NSNumber* attributes = encodedItem[@"attributes"];
   if (title) {
     UICommand* command = [UICommand commandWithTitle:title
                                                image:nil
                                               action:selector
                                         propertyList:nil];
+    command.attributes = [attributes intValue];
     [items addObject:command];
   } else {
     NSString* errorMessage =
@@ -956,31 +960,37 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   NSMutableArray* items = [NSMutableArray array];
   for (NSDictionary<NSString*, id>* encodedItem in _editMenuItems) {
     NSString* type = encodedItem[@"type"];
+    NSNumber* attributes = encodedItem[@"attributes"];
     if ([type isEqualToString:@"copy"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(copy:)
-                            suggestedMenu:suggestedMenu];
+                            suggestedMenu:suggestedMenu
+                               attributes:attributes];
     } else if ([type isEqualToString:@"paste"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(paste:)
-                            suggestedMenu:suggestedMenu];
+                            suggestedMenu:suggestedMenu
+                               attributes:attributes];
     } else if ([type isEqualToString:@"cut"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(cut:)
-                            suggestedMenu:suggestedMenu];
+                            suggestedMenu:suggestedMenu
+                               attributes:attributes];
     } else if ([type isEqualToString:@"delete"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(delete:)
-                            suggestedMenu:suggestedMenu];
+                            suggestedMenu:suggestedMenu
+                               attributes:attributes];
     } else if ([type isEqualToString:@"selectAll"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(selectAll:)
-                            suggestedMenu:suggestedMenu];
+                            suggestedMenu:suggestedMenu
+                               attributes:attributes];
     } else if ([type isEqualToString:@"searchWeb"]) {
       [self addAdditionalBasicCommandToItems:items
                                         type:type
@@ -1001,7 +1011,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
         [self addBasicEditingCommandToItems:items
                                        type:type
                                    selector:@selector(captureTextFromCamera:)
-                              suggestedMenu:suggestedMenu];
+                              suggestedMenu:suggestedMenu
+                              attributes:attributes];
       }
     } else if ([type isEqualToString:@"custom"]) {
       NSString* callbackId = encodedItem[@"id"];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -916,10 +916,8 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
 - (void)addBasicEditingCommandToItems:(NSMutableArray*)items
                                  type:(NSString*)type
                              selector:(SEL)selector
-                        suggestedMenu:(UIMenu*)suggestedMenu
-                           attributes:(NSNumber*)attributes {
+                        suggestedMenu:(UIMenu*)suggestedMenu {
   UICommand* command = [self searchCommandWithSelector:selector element:suggestedMenu];
-  command.attributes = [attributes intValue];
   if (command) {
     [items addObject:command];
   } else {
@@ -934,13 +932,11 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
                                 selector:(SEL)selector
                              encodedItem:(NSDictionary<NSString*, id>*)encodedItem {
   NSString* title = encodedItem[@"title"];
-  NSNumber* attributes = encodedItem[@"attributes"];
   if (title) {
     UICommand* command = [UICommand commandWithTitle:title
                                                image:nil
                                               action:selector
                                         propertyList:nil];
-    command.attributes = [attributes intValue];
     [items addObject:command];
   } else {
     NSString* errorMessage =
@@ -960,37 +956,31 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
   NSMutableArray* items = [NSMutableArray array];
   for (NSDictionary<NSString*, id>* encodedItem in _editMenuItems) {
     NSString* type = encodedItem[@"type"];
-    NSNumber* attributes = encodedItem[@"attributes"];
     if ([type isEqualToString:@"copy"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(copy:)
-                            suggestedMenu:suggestedMenu
-                               attributes:attributes];
+                            suggestedMenu:suggestedMenu];
     } else if ([type isEqualToString:@"paste"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(paste:)
-                            suggestedMenu:suggestedMenu
-                               attributes:attributes];
+                            suggestedMenu:suggestedMenu];
     } else if ([type isEqualToString:@"cut"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(cut:)
-                            suggestedMenu:suggestedMenu
-                               attributes:attributes];
+                            suggestedMenu:suggestedMenu];
     } else if ([type isEqualToString:@"delete"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(delete:)
-                            suggestedMenu:suggestedMenu
-                               attributes:attributes];
+                            suggestedMenu:suggestedMenu];
     } else if ([type isEqualToString:@"selectAll"]) {
       [self addBasicEditingCommandToItems:items
                                      type:type
                                  selector:@selector(selectAll:)
-                            suggestedMenu:suggestedMenu
-                               attributes:attributes];
+                            suggestedMenu:suggestedMenu];
     } else if ([type isEqualToString:@"searchWeb"]) {
       [self addAdditionalBasicCommandToItems:items
                                         type:type
@@ -1011,8 +1001,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
         [self addBasicEditingCommandToItems:items
                                        type:type
                                    selector:@selector(captureTextFromCamera:)
-                              suggestedMenu:suggestedMenu
-                              attributes:attributes];
+                              suggestedMenu:suggestedMenu];
       }
     } else if ([type isEqualToString:@"custom"]) {
       NSString* callbackId = encodedItem[@"id"];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1007,7 +1007,7 @@ static BOOL IsSelectionRectBoundaryCloserToPoint(CGPoint point,
       NSString* callbackId = encodedItem[@"id"];
       NSString* title = encodedItem[@"title"];
       NSNumber* attributes = encodedItem[@"attributes"];
-      if (callbackId && title && attributes) {
+      if (callbackId && title) {
         __weak FlutterTextInputView* weakSelf = self;
         UIAction* action = [UIAction
             actionWithTitle:title

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -3890,8 +3890,18 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
         @{@"x" : @(0), @"y" : @(0), @"width" : @(100), @"height" : @(50)};
 
     NSArray<NSDictionary*>* encodedItems = @[
-      @{@"type" : @"custom", @"id" : @"custom-action-1", @"title" : @"Custom Action 1"},
-      @{@"type" : @"custom", @"id" : @"custom-action-2", @"title" : @"Custom Action 2"},
+      @{
+        @"type" : @"custom",
+        @"id" : @"custom-action-1",
+        @"title" : @"Custom Action 1",
+        @"" : @"attributes" : @(1)
+      },
+      @{
+        @"type" : @"custom",
+        @"id" : @"custom-action-2",
+        @"title" : @"Custom Action 2",
+        @"" : @"attributes" : @(2)
+      },
     ];
 
     BOOL shownEditMenu =
@@ -3907,8 +3917,10 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
     UIAction* secondAction = (UIAction*)menu.children[1];
     XCTAssertEqualObjects(firstAction.title, @"Custom Action 1",
                           @"First action title should match");
+    XCTAssertEqual(firstAction.attributes, @(1), @"First action attributes should match");
     XCTAssertEqualObjects(secondAction.title, @"Custom Action 2",
                           @"Second action title should match");
+    XCTAssertEqual(secondAction.attributes, @(2), @"Second action attributes should match");
   }
 }
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3178,15 +3178,12 @@ final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   }
 
   @override
-  int get hashCode => _index.hashCode;
+  int get hashCode => Object.hash(_index);
 
-  @override
-  bool operator ==(Object other) {
-    if (other is! IOSSystemContextMenuItemCustomAttributes) {
-      return false;
-    }
-    return other._index == _index;
-  }
+  // @override
+  // bool operator ==(Object other) {
+  //   return (other is IOSSystemContextMenuItemCustomAttributes)._index == _index;
+  // }
 
   /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
   IOSSystemContextMenuItemCustomAttributes operator |(

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3120,10 +3120,12 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataCustom].
-  const IOSSystemContextMenuItemDataCustom({required this.title, required this.onPressed});
+  const IOSSystemContextMenuItemDataCustom({required this.title, required this.keepsMenuPresented, required this.onPressed});
 
   @override
   final String title;
+
+  final bool keepsMenuPresented;
 
   /// The callback to be executed when the item is selected.
   final VoidCallback onPressed;
@@ -3136,7 +3138,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
 
   @override
   Map<String, dynamic> get _json {
-    return <String, dynamic>{'id': callbackId, 'title': title, 'type': _jsonType};
+    return <String, dynamic>{'id': callbackId, 'title': title, 'type': _jsonType, 'keepsMenuPresented': keepsMenuPresented};
   }
 
   @override
@@ -3144,11 +3146,12 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
     properties.add(StringProperty('callbackId', callbackId));
+    properties.add(FlagProperty('keepsMenuPresented', value: keepsMenuPresented));
     properties.add(DiagnosticsProperty<VoidCallback>('onPressed', onPressed));
   }
 
   @override
-  int get hashCode => Object.hash(title, onPressed);
+  int get hashCode => Object.hash(title, keepsMenuPresented, onPressed);
 
   @override
   bool operator ==(Object other) {
@@ -3157,6 +3160,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     }
     return other is IOSSystemContextMenuItemDataCustom &&
         other.title == title &&
+        other.keepsMenuPresented == keepsMenuPresented &&
         other.onPressed == onPressed;
   }
 }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3111,8 +3111,8 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 ///
 ///  * <https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc>
 @immutable
-final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
-  const IOSSystemContextMenuItemCustomAttributes._(this._index);
+final class IOSSystemContextMenuItemAttributes with Diagnosticable {
+  const IOSSystemContextMenuItemAttributes._(this._index);
 
   /// The numerical value for this attribute.
   ///
@@ -3124,34 +3124,34 @@ final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDestructive value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/destructive?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes destructive =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 1);
+  static const IOSSystemContextMenuItemAttributes destructive =
+      IOSSystemContextMenuItemAttributes._(1 << 1);
 
   /// An attribute indicating that the menu item is disabled and cannot be selected.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDisabled value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/disabled?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes disabled =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 0);
+  static const IOSSystemContextMenuItemAttributes disabled =
+      IOSSystemContextMenuItemAttributes._(1 << 0);
 
   /// An attribute indicating that the menu should not display the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesHidden value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/hidden?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes hidden =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 2);
+  static const IOSSystemContextMenuItemAttributes hidden =
+      IOSSystemContextMenuItemAttributes._(1 << 2);
 
   /// An attribute indicating that the menu remains presented after pressing on
   /// the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesKeepsMenuPresented value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/keepsmenupresented?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes keepsMenuPresented =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 3);
+  static const IOSSystemContextMenuItemAttributes keepsMenuPresented =
+      IOSSystemContextMenuItemAttributes._(1 << 3);
 
   /// No attributes.
-  static const IOSSystemContextMenuItemCustomAttributes none =
-      IOSSystemContextMenuItemCustomAttributes._(0);
+  static const IOSSystemContextMenuItemAttributes none =
+      IOSSystemContextMenuItemAttributes._(0);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -3182,17 +3182,17 @@ final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    if (other is! IOSSystemContextMenuItemCustomAttributes) {
+    if (other is! IOSSystemContextMenuItemAttributes) {
       return false;
     }
     return other._index == _index;
   }
 
-  /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
-  IOSSystemContextMenuItemCustomAttributes operator |(
-    IOSSystemContextMenuItemCustomAttributes other,
+  /// Combines two [IOSSystemContextMenuItemAttributes] values using logical "or".
+  IOSSystemContextMenuItemAttributes operator |(
+    IOSSystemContextMenuItemAttributes other,
   ) {
-    return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
+    return IOSSystemContextMenuItemAttributes._(_index | other._index);
   }
 }
 
@@ -3220,9 +3220,9 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
   @override
   final String title;
 
-  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
+  /// The [IOSSystemContextMenuItemAttributes] indicating
   /// additional configurations for this menu item.
-  final IOSSystemContextMenuItemCustomAttributes attributes;
+  final IOSSystemContextMenuItemAttributes attributes;
 
   /// The callback to be executed when the item is selected.
   final VoidCallback onPressed;
@@ -3249,7 +3249,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     properties.add(StringProperty('title', title));
     properties.add(StringProperty('callbackId', callbackId));
     properties.add(
-      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
+      DiagnosticsProperty<IOSSystemContextMenuItemAttributes>('attributes', attributes),
     );
     properties.add(DiagnosticsProperty<VoidCallback>('onPressed', onPressed));
   }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2880,7 +2880,7 @@ class SystemContextMenuController with SystemContextMenuClient, Diagnosticable {
 ///    context menus.
 @immutable
 sealed class IOSSystemContextMenuItemData {
-  const IOSSystemContextMenuItemData({required this.attributes});
+  const IOSSystemContextMenuItemData();
 
   /// The text to display to the user.
   ///
@@ -2888,22 +2888,13 @@ sealed class IOSSystemContextMenuItemData {
   /// platform.
   String? get title => null;
 
-  /// The [IOSSystemContextMenuItemAttributes] indicating
-  /// additional configurations for this menu item.
-  final IOSSystemContextMenuItemAttributes attributes;
-
   /// The type string used when serialized to json, recognized by the engine.
   String get _jsonType;
 
   /// Returns json for use in method channel calls, specifically
   /// `ContextMenu.showSystemContextMenu`.
   Map<String, dynamic> get _json {
-    return <String, dynamic>{
-      'callbackId': hashCode,
-      'title': ?title,
-      'type': _jsonType,
-      'attributes': attributes._index,
-    };
+    return <String, dynamic>{'callbackId': hashCode, 'title': ?title, 'type': _jsonType};
   }
 
   @override
@@ -2933,7 +2924,7 @@ sealed class IOSSystemContextMenuItemData {
 ///    widget level.
 final class IOSSystemContextMenuItemDataCopy extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataCopy].
-  const IOSSystemContextMenuItemDataCopy({required super.attributes});
+  const IOSSystemContextMenuItemDataCopy();
 
   @override
   String get _jsonType => 'copy';
@@ -2951,7 +2942,7 @@ final class IOSSystemContextMenuItemDataCopy extends IOSSystemContextMenuItemDat
 ///    widget level.
 final class IOSSystemContextMenuItemDataCut extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataCut].
-  const IOSSystemContextMenuItemDataCut({required super.attributes});
+  const IOSSystemContextMenuItemDataCut();
 
   @override
   String get _jsonType => 'cut';
@@ -2969,7 +2960,7 @@ final class IOSSystemContextMenuItemDataCut extends IOSSystemContextMenuItemData
 ///    widget level.
 final class IOSSystemContextMenuItemDataPaste extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataPaste].
-  const IOSSystemContextMenuItemDataPaste({required super.attributes});
+  const IOSSystemContextMenuItemDataPaste();
 
   @override
   String get _jsonType => 'paste';
@@ -2988,7 +2979,7 @@ final class IOSSystemContextMenuItemDataPaste extends IOSSystemContextMenuItemDa
 ///    the widget level.
 final class IOSSystemContextMenuItemDataSelectAll extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataSelectAll].
-  const IOSSystemContextMenuItemDataSelectAll({required super.attributes});
+  const IOSSystemContextMenuItemDataSelectAll();
 
   @override
   String get _jsonType => 'selectAll';
@@ -3011,7 +3002,7 @@ final class IOSSystemContextMenuItemDataSelectAll extends IOSSystemContextMenuIt
 final class IOSSystemContextMenuItemDataLookUp extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataLookUp].
-  const IOSSystemContextMenuItemDataLookUp({required this.title, required super.attributes});
+  const IOSSystemContextMenuItemDataLookUp({required this.title});
 
   @override
   final String title;
@@ -3044,7 +3035,7 @@ final class IOSSystemContextMenuItemDataLookUp extends IOSSystemContextMenuItemD
 final class IOSSystemContextMenuItemDataSearchWeb extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataSearchWeb].
-  const IOSSystemContextMenuItemDataSearchWeb({required this.title, required super.attributes});
+  const IOSSystemContextMenuItemDataSearchWeb({required this.title});
 
   @override
   final String title;
@@ -3076,7 +3067,7 @@ final class IOSSystemContextMenuItemDataSearchWeb extends IOSSystemContextMenuIt
 final class IOSSystemContextMenuItemDataShare extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataShare].
-  const IOSSystemContextMenuItemDataShare({required this.title, required super.attributes});
+  const IOSSystemContextMenuItemDataShare({required this.title});
 
   @override
   final String title;
@@ -3108,7 +3099,7 @@ final class IOSSystemContextMenuItemDataShare extends IOSSystemContextMenuItemDa
 ///  * https://github.com/flutter/flutter/issues/169781
 final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataLiveText].
-  const IOSSystemContextMenuItemDataLiveText({required super.attributes});
+  const IOSSystemContextMenuItemDataLiveText();
 
   @override
   String get _jsonType => 'captureTextFromCamera';
@@ -3120,8 +3111,8 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 ///
 ///  * <https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc>
 @immutable
-final class IOSSystemContextMenuItemAttributes with Diagnosticable {
-  const IOSSystemContextMenuItemAttributes._(this._index);
+final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
+  const IOSSystemContextMenuItemCustomAttributes._(this._index);
 
   /// The numerical value for this attribute.
   ///
@@ -3133,35 +3124,34 @@ final class IOSSystemContextMenuItemAttributes with Diagnosticable {
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDestructive value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/destructive?language=objc).
-  static const IOSSystemContextMenuItemAttributes destructive =
-      IOSSystemContextMenuItemAttributes._(1 << 1);
+  static const IOSSystemContextMenuItemCustomAttributes destructive =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 1);
 
   /// An attribute indicating that the menu item is disabled and cannot be selected.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDisabled value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/disabled?language=objc).
-  static const IOSSystemContextMenuItemAttributes disabled = IOSSystemContextMenuItemAttributes._(
-    1 << 0,
-  );
+  static const IOSSystemContextMenuItemCustomAttributes disabled =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 0);
 
   /// An attribute indicating that the menu should not display the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesHidden value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/hidden?language=objc).
-  static const IOSSystemContextMenuItemAttributes hidden = IOSSystemContextMenuItemAttributes._(
-    1 << 2,
-  );
+  static const IOSSystemContextMenuItemCustomAttributes hidden =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 2);
 
   /// An attribute indicating that the menu remains presented after pressing on
   /// the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesKeepsMenuPresented value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/keepsmenupresented?language=objc).
-  static const IOSSystemContextMenuItemAttributes keepsMenuPresented =
-      IOSSystemContextMenuItemAttributes._(1 << 3);
+  static const IOSSystemContextMenuItemCustomAttributes keepsMenuPresented =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 3);
 
   /// No attributes.
-  static const IOSSystemContextMenuItemAttributes none = IOSSystemContextMenuItemAttributes._(0);
+  static const IOSSystemContextMenuItemCustomAttributes none =
+      IOSSystemContextMenuItemCustomAttributes._(0);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -3192,15 +3182,17 @@ final class IOSSystemContextMenuItemAttributes with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    if (other is! IOSSystemContextMenuItemAttributes) {
+    if (other is! IOSSystemContextMenuItemCustomAttributes) {
       return false;
     }
     return other._index == _index;
   }
 
-  /// Combines two [IOSSystemContextMenuItemAttributes] values using logical "or".
-  IOSSystemContextMenuItemAttributes operator |(IOSSystemContextMenuItemAttributes other) {
-    return IOSSystemContextMenuItemAttributes._(_index | other._index);
+  /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
+  IOSSystemContextMenuItemCustomAttributes operator |(
+    IOSSystemContextMenuItemCustomAttributes other,
+  ) {
+    return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
   }
 }
 
@@ -3221,12 +3213,16 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
   /// Creates an instance of [IOSSystemContextMenuItemDataCustom].
   const IOSSystemContextMenuItemDataCustom({
     required this.title,
-    required super.attributes,
+    required this.attributes,
     required this.onPressed,
   });
 
   @override
   final String title;
+
+  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
+  /// additional configurations for this menu item.
+  final IOSSystemContextMenuItemCustomAttributes attributes;
 
   /// The callback to be executed when the item is selected.
   final VoidCallback onPressed;
@@ -3253,7 +3249,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     properties.add(StringProperty('title', title));
     properties.add(StringProperty('callbackId', callbackId));
     properties.add(
-      DiagnosticsProperty<IOSSystemContextMenuItemAttributes>('attributes', attributes),
+      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
     );
     properties.add(DiagnosticsProperty<VoidCallback>('onPressed', onPressed));
   }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2880,7 +2880,7 @@ class SystemContextMenuController with SystemContextMenuClient, Diagnosticable {
 ///    context menus.
 @immutable
 sealed class IOSSystemContextMenuItemData {
-  const IOSSystemContextMenuItemData();
+  const IOSSystemContextMenuItemData({required this.attributes});
 
   /// The text to display to the user.
   ///
@@ -2888,13 +2888,22 @@ sealed class IOSSystemContextMenuItemData {
   /// platform.
   String? get title => null;
 
+  /// The [IOSSystemContextMenuItemAttributes] indicating
+  /// additional configurations for this menu item.
+  final IOSSystemContextMenuItemAttributes attributes;
+
   /// The type string used when serialized to json, recognized by the engine.
   String get _jsonType;
 
   /// Returns json for use in method channel calls, specifically
   /// `ContextMenu.showSystemContextMenu`.
   Map<String, dynamic> get _json {
-    return <String, dynamic>{'callbackId': hashCode, 'title': ?title, 'type': _jsonType};
+    return <String, dynamic>{
+      'callbackId': hashCode,
+      'title': ?title,
+      'type': _jsonType,
+      'attributes': attributes._index,
+    };
   }
 
   @override
@@ -2924,7 +2933,7 @@ sealed class IOSSystemContextMenuItemData {
 ///    widget level.
 final class IOSSystemContextMenuItemDataCopy extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataCopy].
-  const IOSSystemContextMenuItemDataCopy();
+  const IOSSystemContextMenuItemDataCopy({required super.attributes});
 
   @override
   String get _jsonType => 'copy';
@@ -2942,7 +2951,7 @@ final class IOSSystemContextMenuItemDataCopy extends IOSSystemContextMenuItemDat
 ///    widget level.
 final class IOSSystemContextMenuItemDataCut extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataCut].
-  const IOSSystemContextMenuItemDataCut();
+  const IOSSystemContextMenuItemDataCut({required super.attributes});
 
   @override
   String get _jsonType => 'cut';
@@ -2960,7 +2969,7 @@ final class IOSSystemContextMenuItemDataCut extends IOSSystemContextMenuItemData
 ///    widget level.
 final class IOSSystemContextMenuItemDataPaste extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataPaste].
-  const IOSSystemContextMenuItemDataPaste();
+  const IOSSystemContextMenuItemDataPaste({required super.attributes});
 
   @override
   String get _jsonType => 'paste';
@@ -2979,7 +2988,7 @@ final class IOSSystemContextMenuItemDataPaste extends IOSSystemContextMenuItemDa
 ///    the widget level.
 final class IOSSystemContextMenuItemDataSelectAll extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataSelectAll].
-  const IOSSystemContextMenuItemDataSelectAll();
+  const IOSSystemContextMenuItemDataSelectAll({required super.attributes});
 
   @override
   String get _jsonType => 'selectAll';
@@ -3002,7 +3011,7 @@ final class IOSSystemContextMenuItemDataSelectAll extends IOSSystemContextMenuIt
 final class IOSSystemContextMenuItemDataLookUp extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataLookUp].
-  const IOSSystemContextMenuItemDataLookUp({required this.title});
+  const IOSSystemContextMenuItemDataLookUp({required this.title, required super.attributes});
 
   @override
   final String title;
@@ -3035,7 +3044,7 @@ final class IOSSystemContextMenuItemDataLookUp extends IOSSystemContextMenuItemD
 final class IOSSystemContextMenuItemDataSearchWeb extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataSearchWeb].
-  const IOSSystemContextMenuItemDataSearchWeb({required this.title});
+  const IOSSystemContextMenuItemDataSearchWeb({required this.title, required super.attributes});
 
   @override
   final String title;
@@ -3067,7 +3076,7 @@ final class IOSSystemContextMenuItemDataSearchWeb extends IOSSystemContextMenuIt
 final class IOSSystemContextMenuItemDataShare extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataShare].
-  const IOSSystemContextMenuItemDataShare({required this.title});
+  const IOSSystemContextMenuItemDataShare({required this.title, required super.attributes});
 
   @override
   final String title;
@@ -3099,7 +3108,7 @@ final class IOSSystemContextMenuItemDataShare extends IOSSystemContextMenuItemDa
 ///  * https://github.com/flutter/flutter/issues/169781
 final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuItemData {
   /// Creates an instance of [IOSSystemContextMenuItemDataLiveText].
-  const IOSSystemContextMenuItemDataLiveText();
+  const IOSSystemContextMenuItemDataLiveText({required super.attributes});
 
   @override
   String get _jsonType => 'captureTextFromCamera';
@@ -3111,8 +3120,8 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 ///
 ///  * <https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc>
 @immutable
-final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
-  const IOSSystemContextMenuItemCustomAttributes._(this._index);
+final class IOSSystemContextMenuItemAttributes with Diagnosticable {
+  const IOSSystemContextMenuItemAttributes._(this._index);
 
   /// The numerical value for this attribute.
   ///
@@ -3124,34 +3133,35 @@ final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDestructive value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/destructive?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes destructive =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 1);
+  static const IOSSystemContextMenuItemAttributes destructive =
+      IOSSystemContextMenuItemAttributes._(1 << 1);
 
   /// An attribute indicating that the menu item is disabled and cannot be selected.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDisabled value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/disabled?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes disabled =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 0);
+  static const IOSSystemContextMenuItemAttributes disabled = IOSSystemContextMenuItemAttributes._(
+    1 << 0,
+  );
 
   /// An attribute indicating that the menu should not display the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesHidden value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/hidden?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes hidden =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 2);
+  static const IOSSystemContextMenuItemAttributes hidden = IOSSystemContextMenuItemAttributes._(
+    1 << 2,
+  );
 
   /// An attribute indicating that the menu remains presented after pressing on
   /// the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesKeepsMenuPresented value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/keepsmenupresented?language=objc).
-  static const IOSSystemContextMenuItemCustomAttributes keepsMenuPresented =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 3);
+  static const IOSSystemContextMenuItemAttributes keepsMenuPresented =
+      IOSSystemContextMenuItemAttributes._(1 << 3);
 
   /// No attributes.
-  static const IOSSystemContextMenuItemCustomAttributes none =
-      IOSSystemContextMenuItemCustomAttributes._(0);
+  static const IOSSystemContextMenuItemAttributes none = IOSSystemContextMenuItemAttributes._(0);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -3182,17 +3192,15 @@ final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
 
   @override
   bool operator ==(Object other) {
-    if (other is! IOSSystemContextMenuItemCustomAttributes) {
+    if (other is! IOSSystemContextMenuItemAttributes) {
       return false;
     }
     return other._index == _index;
   }
 
-  /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
-  IOSSystemContextMenuItemCustomAttributes operator |(
-    IOSSystemContextMenuItemCustomAttributes other,
-  ) {
-    return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
+  /// Combines two [IOSSystemContextMenuItemAttributes] values using logical "or".
+  IOSSystemContextMenuItemAttributes operator |(IOSSystemContextMenuItemAttributes other) {
+    return IOSSystemContextMenuItemAttributes._(_index | other._index);
   }
 }
 
@@ -3213,16 +3221,12 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
   /// Creates an instance of [IOSSystemContextMenuItemDataCustom].
   const IOSSystemContextMenuItemDataCustom({
     required this.title,
-    required this.attributes,
+    required super.attributes,
     required this.onPressed,
   });
 
   @override
   final String title;
-
-  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
-  /// additional configurations for this menu item.
-  final IOSSystemContextMenuItemCustomAttributes attributes;
 
   /// The callback to be executed when the item is selected.
   final VoidCallback onPressed;
@@ -3249,7 +3253,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     properties.add(StringProperty('title', title));
     properties.add(StringProperty('callbackId', callbackId));
     properties.add(
-      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
+      DiagnosticsProperty<IOSSystemContextMenuItemAttributes>('attributes', attributes),
     );
     properties.add(DiagnosticsProperty<VoidCallback>('onPressed', onPressed));
   }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2888,13 +2888,23 @@ sealed class IOSSystemContextMenuItemData {
   /// platform.
   String? get title => null;
 
+  /// The attributes to assign to the menu item.
+  ///
+  /// Not exposed for built-in menu items.
+  IOSSystemContextMenuItemAttributes? get attributes => null;
+
   /// The type string used when serialized to json, recognized by the engine.
   String get _jsonType;
 
   /// Returns json for use in method channel calls, specifically
   /// `ContextMenu.showSystemContextMenu`.
   Map<String, dynamic> get _json {
-    return <String, dynamic>{'callbackId': hashCode, 'title': ?title, 'type': _jsonType};
+    return <String, dynamic>{
+      'callbackId': hashCode,
+      'title': ?title,
+      'type': _jsonType,
+      'attributes': ?attributes?._index,
+    };
   }
 
   @override
@@ -3131,15 +3141,17 @@ final class IOSSystemContextMenuItemAttributes with Diagnosticable {
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDisabled value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/disabled?language=objc).
-  static const IOSSystemContextMenuItemAttributes disabled =
-      IOSSystemContextMenuItemAttributes._(1 << 0);
+  static const IOSSystemContextMenuItemAttributes disabled = IOSSystemContextMenuItemAttributes._(
+    1 << 0,
+  );
 
   /// An attribute indicating that the menu should not display the menu item.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesHidden value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/hidden?language=objc).
-  static const IOSSystemContextMenuItemAttributes hidden =
-      IOSSystemContextMenuItemAttributes._(1 << 2);
+  static const IOSSystemContextMenuItemAttributes hidden = IOSSystemContextMenuItemAttributes._(
+    1 << 2,
+  );
 
   /// An attribute indicating that the menu remains presented after pressing on
   /// the menu item.
@@ -3150,8 +3162,7 @@ final class IOSSystemContextMenuItemAttributes with Diagnosticable {
       IOSSystemContextMenuItemAttributes._(1 << 3);
 
   /// No attributes.
-  static const IOSSystemContextMenuItemAttributes none =
-      IOSSystemContextMenuItemAttributes._(0);
+  static const IOSSystemContextMenuItemAttributes none = IOSSystemContextMenuItemAttributes._(0);
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
@@ -3189,9 +3200,7 @@ final class IOSSystemContextMenuItemAttributes with Diagnosticable {
   }
 
   /// Combines two [IOSSystemContextMenuItemAttributes] values using logical "or".
-  IOSSystemContextMenuItemAttributes operator |(
-    IOSSystemContextMenuItemAttributes other,
-  ) {
+  IOSSystemContextMenuItemAttributes operator |(IOSSystemContextMenuItemAttributes other) {
     return IOSSystemContextMenuItemAttributes._(_index | other._index);
   }
 }
@@ -3222,6 +3231,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
 
   /// The [IOSSystemContextMenuItemAttributes] indicating
   /// additional configurations for this menu item.
+  @override
   final IOSSystemContextMenuItemAttributes attributes;
 
   /// The callback to be executed when the item is selected.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3110,7 +3110,8 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 /// See also:
 ///
 ///  * <https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc>
-class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
+@immutable
+final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   const IOSSystemContextMenuItemCustomAttributes._(this._index);
 
   /// The numerical value for this attribute.
@@ -3152,13 +3153,6 @@ class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   static const IOSSystemContextMenuItemCustomAttributes none =
       IOSSystemContextMenuItemCustomAttributes._(0);
 
-  /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
-  IOSSystemContextMenuItemCustomAttributes operator |(
-    IOSSystemContextMenuItemCustomAttributes other,
-  ) {
-    return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
-  }
-
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
@@ -3183,30 +3177,23 @@ class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
     );
   }
 
-  // @override
-  // String toString() {
-  //   if (_index == 0) {
-  //     return 'IOSSystemContextMenuItemCustomAttributes.none';
-  //   }
-  //   final List<String> parts = <String>[];
-  //   if ((_index & destructive._index) != 0) {
-  //     parts.add('IOSSystemContextMenuItemCustomAttributes.destructive');
-  //   }
-  //   if ((_index & disabled._index) != 0) {
-  //     parts.add('IOSSystemContextMenuItemCustomAttributes.disabled');
-  //   }
-  //   if ((_index & hidden._index) != 0) {
-  //     parts.add('IOSSystemContextMenuItemCustomAttributes.hidden');
-  //   }
-  //   if ((_index & keepsMenuPresented._index) != 0) {
-  //     parts.add('IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented');
-  //   }
-  //   if (parts.isEmpty) {
-  //     // This should not happen if _index is not 0 and constants are defined as powers of 2.
-  //     return 'IOSSystemContextMenuItemCustomAttributes(value: $_index)';
-  //   }
-  //   return parts.join(' | ');
-  // }
+  @override
+  int get hashCode => _index.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! IOSSystemContextMenuItemCustomAttributes) {
+      return false;
+    }
+    return other._index == _index;
+  }
+
+  /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
+  IOSSystemContextMenuItemCustomAttributes operator |(
+    IOSSystemContextMenuItemCustomAttributes other,
+  ) {
+    return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
+  }
 }
 
 /// An [IOSSystemContextMenuItemData] for custom action buttons defined by the developer.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3119,19 +3119,19 @@ class IOSSystemContextMenuItemCustomAttributes {
   final int _index;
 
   /// An attribute indicating that the menu item should be the displayed in a more
-  /// prominent style, such as with red text.
+  /// prominent style, with red text.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDestructive value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/destructive?language=objc).
   static const IOSSystemContextMenuItemCustomAttributes destructive =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 0);
+      IOSSystemContextMenuItemCustomAttributes._(1 << 1);
 
   /// An attribute indicating that the menu item is disabled and cannot be selected.
   ///
   /// This corresponds to the
   /// [UIMenuElementAttributesDisabled value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/disabled?language=objc).
   static const IOSSystemContextMenuItemCustomAttributes disabled =
-      IOSSystemContextMenuItemCustomAttributes._(1 << 1);
+      IOSSystemContextMenuItemCustomAttributes._(1 << 0);
 
   /// An attribute indicating that the menu should not display the menu item.
   ///
@@ -3152,7 +3152,10 @@ class IOSSystemContextMenuItemCustomAttributes {
   static const IOSSystemContextMenuItemCustomAttributes none =
       IOSSystemContextMenuItemCustomAttributes._(0);
 
-  IOSSystemContextMenuItemCustomAttributes operator |(IOSSystemContextMenuItemCustomAttributes other) {
+  /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
+  IOSSystemContextMenuItemCustomAttributes operator |(
+    IOSSystemContextMenuItemCustomAttributes other,
+  ) {
     return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
   }
 }
@@ -3172,11 +3175,17 @@ class IOSSystemContextMenuItemCustomAttributes {
 final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataCustom].
-  const IOSSystemContextMenuItemDataCustom({required this.title, required this.attributes, required this.onPressed});
+  const IOSSystemContextMenuItemDataCustom({
+    required this.title,
+    required this.attributes,
+    required this.onPressed,
+  });
 
   @override
   final String title;
 
+  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
+  /// additional configurations for this menu item.
   final IOSSystemContextMenuItemCustomAttributes attributes;
 
   /// The callback to be executed when the item is selected.
@@ -3190,7 +3199,12 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
 
   @override
   Map<String, dynamic> get _json {
-    return <String, dynamic>{'id': callbackId, 'title': title, 'type': _jsonType, 'attributes': attributes._index};
+    return <String, dynamic>{
+      'id': callbackId,
+      'title': title,
+      'type': _jsonType,
+      'attributes': attributes._index,
+    };
   }
 
   @override
@@ -3198,7 +3212,9 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
     properties.add(StringProperty('callbackId', callbackId));
-    // properties.add(FlagProperty('attributes', value: keepsMenuPresented));
+    properties.add(
+      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
+    );
     properties.add(DiagnosticsProperty<VoidCallback>('onPressed', onPressed));
   }
 

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3178,12 +3178,15 @@ final class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   }
 
   @override
-  int get hashCode => Object.hash(_index);
+  int get hashCode => _index.hashCode;
 
-  // @override
-  // bool operator ==(Object other) {
-  //   return (other is IOSSystemContextMenuItemCustomAttributes)._index == _index;
-  // }
+  @override
+  bool operator ==(Object other) {
+    if (other is! IOSSystemContextMenuItemCustomAttributes) {
+      return false;
+    }
+    return other._index == _index;
+  }
 
   /// Combines two [IOSSystemContextMenuItemCustomAttributes] values using logical "or".
   IOSSystemContextMenuItemCustomAttributes operator |(

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3105,6 +3105,58 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
   String get _jsonType => 'captureTextFromCamera';
 }
 
+/// Attributes that define additional configurations for a [IOSSystemContextMenuItem].
+///
+/// See also:
+///
+///  * <https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc>
+class IOSSystemContextMenuItemCustomAttributes {
+  const IOSSystemContextMenuItemCustomAttributes._(this._index);
+
+  /// The numerical value for this attribute.
+  ///
+  /// Each attribute has one bit set in this bit field.
+  final int _index;
+
+  /// An attribute indicating that the menu item should be the displayed in a more
+  /// prominent style, such as with red text.
+  ///
+  /// This corresponds to the
+  /// [UIMenuElementAttributesDestructive value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/destructive?language=objc).
+  static const IOSSystemContextMenuItemCustomAttributes destructive =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 0);
+
+  /// An attribute indicating that the menu item is disabled and cannot be selected.
+  ///
+  /// This corresponds to the
+  /// [UIMenuElementAttributesDisabled value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/disabled?language=objc).
+  static const IOSSystemContextMenuItemCustomAttributes disabled =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 1);
+
+  /// An attribute indicating that the menu should not display the menu item.
+  ///
+  /// This corresponds to the
+  /// [UIMenuElementAttributesHidden value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/hidden?language=objc).
+  static const IOSSystemContextMenuItemCustomAttributes hidden =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 2);
+
+  /// An attribute indicating that the menu remains presented after pressing on
+  /// the menu item.
+  ///
+  /// This corresponds to the
+  /// [UIMenuElementAttributesKeepsMenuPresented value of UIMenuElementAttributes](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/keepsmenupresented?language=objc).
+  static const IOSSystemContextMenuItemCustomAttributes keepsMenuPresented =
+      IOSSystemContextMenuItemCustomAttributes._(1 << 3);
+
+  /// No attributes.
+  static const IOSSystemContextMenuItemCustomAttributes none =
+      IOSSystemContextMenuItemCustomAttributes._(0);
+
+  IOSSystemContextMenuItemCustomAttributes operator |(IOSSystemContextMenuItemCustomAttributes other) {
+    return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
+  }
+}
+
 /// An [IOSSystemContextMenuItemData] for custom action buttons defined by the developer.
 ///
 /// Must specify a [title] and [onPressed].
@@ -3120,12 +3172,12 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemData
     with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemDataCustom].
-  const IOSSystemContextMenuItemDataCustom({required this.title, required this.keepsMenuPresented, required this.onPressed});
+  const IOSSystemContextMenuItemDataCustom({required this.title, required this.attributes, required this.onPressed});
 
   @override
   final String title;
 
-  final bool keepsMenuPresented;
+  final IOSSystemContextMenuItemCustomAttributes attributes;
 
   /// The callback to be executed when the item is selected.
   final VoidCallback onPressed;
@@ -3138,7 +3190,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
 
   @override
   Map<String, dynamic> get _json {
-    return <String, dynamic>{'id': callbackId, 'title': title, 'type': _jsonType, 'keepsMenuPresented': keepsMenuPresented};
+    return <String, dynamic>{'id': callbackId, 'title': title, 'type': _jsonType, 'attributes': attributes._index};
   }
 
   @override
@@ -3146,12 +3198,12 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
     properties.add(StringProperty('callbackId', callbackId));
-    properties.add(FlagProperty('keepsMenuPresented', value: keepsMenuPresented));
+    // properties.add(FlagProperty('attributes', value: keepsMenuPresented));
     properties.add(DiagnosticsProperty<VoidCallback>('onPressed', onPressed));
   }
 
   @override
-  int get hashCode => Object.hash(title, keepsMenuPresented, onPressed);
+  int get hashCode => Object.hash(title, attributes, onPressed);
 
   @override
   bool operator ==(Object other) {
@@ -3160,7 +3212,7 @@ final class IOSSystemContextMenuItemDataCustom extends IOSSystemContextMenuItemD
     }
     return other is IOSSystemContextMenuItemDataCustom &&
         other.title == title &&
-        other.keepsMenuPresented == keepsMenuPresented &&
+        other.attributes == attributes &&
         other.onPressed == onPressed;
   }
 }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -3110,7 +3110,7 @@ final class IOSSystemContextMenuItemDataLiveText extends IOSSystemContextMenuIte
 /// See also:
 ///
 ///  * <https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc>
-class IOSSystemContextMenuItemCustomAttributes {
+class IOSSystemContextMenuItemCustomAttributes with Diagnosticable {
   const IOSSystemContextMenuItemCustomAttributes._(this._index);
 
   /// The numerical value for this attribute.
@@ -3158,6 +3158,55 @@ class IOSSystemContextMenuItemCustomAttributes {
   ) {
     return IOSSystemContextMenuItemCustomAttributes._(_index | other._index);
   }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    if (_index == none._index) {
+      properties.add(StringProperty('attributes', 'no attributes', quoted: false));
+      return;
+    }
+
+    final List<String> flags = <String>[
+      if ((_index & destructive._index) != 0) 'destructive',
+      if ((_index & disabled._index) != 0) 'disabled',
+      if ((_index & hidden._index) != 0) 'hidden',
+      if ((_index & keepsMenuPresented._index) != 0) 'keepsMenuPresented',
+    ];
+
+    properties.add(
+      StringProperty(
+        'attributes',
+        flags.isEmpty ? 'no attributes' : flags.join(', '),
+        quoted: false,
+      ),
+    );
+  }
+
+  // @override
+  // String toString() {
+  //   if (_index == 0) {
+  //     return 'IOSSystemContextMenuItemCustomAttributes.none';
+  //   }
+  //   final List<String> parts = <String>[];
+  //   if ((_index & destructive._index) != 0) {
+  //     parts.add('IOSSystemContextMenuItemCustomAttributes.destructive');
+  //   }
+  //   if ((_index & disabled._index) != 0) {
+  //     parts.add('IOSSystemContextMenuItemCustomAttributes.disabled');
+  //   }
+  //   if ((_index & hidden._index) != 0) {
+  //     parts.add('IOSSystemContextMenuItemCustomAttributes.hidden');
+  //   }
+  //   if ((_index & keepsMenuPresented._index) != 0) {
+  //     parts.add('IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented');
+  //   }
+  //   if (parts.isEmpty) {
+  //     // This should not happen if _index is not 0 and constants are defined as powers of 2.
+  //     return 'IOSSystemContextMenuItemCustomAttributes(value: $_index)';
+  //   }
+  //   return parts.join(' | ');
+  // }
 }
 
 /// An [IOSSystemContextMenuItemData] for custom action buttons defined by the developer.

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -163,7 +163,7 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.selectAllEnabled)
         IOSSystemContextMenuItemCustom(
           title: 'Select All',
-          keepsMenuPresented: true,
+          attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented | IOSSystemContextMenuItemCustomAttributes.disabled,
           onPressed: () {
             editableTextState.selectAll(SelectionChangedCause.toolbar);
           },
@@ -171,29 +171,6 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.lookUpEnabled) const IOSSystemContextMenuItemLookUp(),
       if (editableTextState.searchWebEnabled) const IOSSystemContextMenuItemSearchWeb(),
       if (editableTextState.liveTextInputEnabled) const IOSSystemContextMenuItemLiveText(),
-      // if (editableTextState.copyEnabled) IOSSystemContextMenuItemCustom(
-      //   title: 'Copy',
-      //   onPressed: () => editableTextState.copySelection(SelectionChangedCause.toolbar),
-      // ),
-      // if (editableTextState.cutEnabled) IOSSystemContextMenuItemCustom(
-      //   title: 'Cut',
-      //   onPressed: () => editableTextState.cutSelection(SelectionChangedCause.toolbar),
-      // ),
-      // if (editableTextState.pasteEnabled) const IOSSystemContextMenuItemPaste(),
-      // if (editableTextState.selectAllEnabled) IOSSystemContextMenuItemCustom(
-      //   title: 'Select All',
-      //   onPressed: () => editableTextState.selectAll(SelectionChangedCause.toolbar),
-      // ),
-      // if (editableTextState.selectAllEnabled) const IOSSystemContextMenuItemSelectAll(),
-      // if (editableTextState.lookUpEnabled) IOSSystemContextMenuItemCustom(
-      //   title: 'Look Up',
-      //   onPressed: () => editableTextState.lookUpSelection(SelectionChangedCause.toolbar),
-      // ),
-      // if (editableTextState.searchWebEnabled) IOSSystemContextMenuItemCustom(
-      //   title: 'Search Web',
-      //   onPressed: () => editableTextState.searchWebForSelection(SelectionChangedCause.toolbar),
-      // ),
-      // if (editableTextState.liveTextInputEnabled) const IOSSystemContextMenuItemLiveText(),
     ];
   }
 
@@ -520,7 +497,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   const IOSSystemContextMenuItemCustom({
     required this.title,
     required this.onPressed,
-    this.keepsMenuPresented = false,
+    this.attributes = IOSSystemContextMenuItemCustomAttributes.none,
   });
 
   @override
@@ -529,19 +506,19 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   /// The callback that is called when the button is pressed.
   final VoidCallback onPressed;
 
-  final bool keepsMenuPresented;
+  final IOSSystemContextMenuItemCustomAttributes attributes;
 
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
     return IOSSystemContextMenuItemDataCustom(
       title: title,
-      keepsMenuPresented: keepsMenuPresented,
+      attributes: attributes,
       onPressed: onPressed,
     );
   }
 
   @override
-  int get hashCode => Object.hash(title, keepsMenuPresented, onPressed);
+  int get hashCode => Object.hash(title, attributes, onPressed);
 
   @override
   bool operator ==(Object other) {
@@ -550,7 +527,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
     }
     return other is IOSSystemContextMenuItemCustom &&
         other.title == title &&
-        other.keepsMenuPresented == keepsMenuPresented &&
+        other.attributes == attributes &&
         other.onPressed == onPressed;
   }
 
@@ -558,7 +535,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
-    properties.add(FlagProperty('keepsMenuPresented', value: keepsMenuPresented));
+    // properties.add(FlagProperty('attributes', value: attributes));
     properties.add(ObjectFlagProperty<VoidCallback>.has('onPressed', onPressed));
   }
 }

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -160,10 +160,40 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.copyEnabled) const IOSSystemContextMenuItemCopy(),
       if (editableTextState.cutEnabled) const IOSSystemContextMenuItemCut(),
       if (editableTextState.pasteEnabled) const IOSSystemContextMenuItemPaste(),
-      if (editableTextState.selectAllEnabled) const IOSSystemContextMenuItemSelectAll(),
+      if (editableTextState.selectAllEnabled)
+        IOSSystemContextMenuItemCustom(
+          title: 'Select All',
+          keepsMenuPresented: true,
+          onPressed: () {
+            editableTextState.selectAll(SelectionChangedCause.toolbar);
+          },
+        ),
       if (editableTextState.lookUpEnabled) const IOSSystemContextMenuItemLookUp(),
       if (editableTextState.searchWebEnabled) const IOSSystemContextMenuItemSearchWeb(),
       if (editableTextState.liveTextInputEnabled) const IOSSystemContextMenuItemLiveText(),
+      // if (editableTextState.copyEnabled) IOSSystemContextMenuItemCustom(
+      //   title: 'Copy',
+      //   onPressed: () => editableTextState.copySelection(SelectionChangedCause.toolbar),
+      // ),
+      // if (editableTextState.cutEnabled) IOSSystemContextMenuItemCustom(
+      //   title: 'Cut',
+      //   onPressed: () => editableTextState.cutSelection(SelectionChangedCause.toolbar),
+      // ),
+      // if (editableTextState.pasteEnabled) const IOSSystemContextMenuItemPaste(),
+      // if (editableTextState.selectAllEnabled) IOSSystemContextMenuItemCustom(
+      //   title: 'Select All',
+      //   onPressed: () => editableTextState.selectAll(SelectionChangedCause.toolbar),
+      // ),
+      // if (editableTextState.selectAllEnabled) const IOSSystemContextMenuItemSelectAll(),
+      // if (editableTextState.lookUpEnabled) IOSSystemContextMenuItemCustom(
+      //   title: 'Look Up',
+      //   onPressed: () => editableTextState.lookUpSelection(SelectionChangedCause.toolbar),
+      // ),
+      // if (editableTextState.searchWebEnabled) IOSSystemContextMenuItemCustom(
+      //   title: 'Search Web',
+      //   onPressed: () => editableTextState.searchWebForSelection(SelectionChangedCause.toolbar),
+      // ),
+      // if (editableTextState.liveTextInputEnabled) const IOSSystemContextMenuItemLiveText(),
     ];
   }
 
@@ -487,7 +517,11 @@ final class IOSSystemContextMenuItemLiveText extends IOSSystemContextMenuItem {
 @immutable
 class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemCustom].
-  const IOSSystemContextMenuItemCustom({required this.title, required this.onPressed});
+  const IOSSystemContextMenuItemCustom({
+    required this.title,
+    required this.onPressed,
+    this.keepsMenuPresented = false,
+  });
 
   @override
   final String title;
@@ -495,13 +529,19 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   /// The callback that is called when the button is pressed.
   final VoidCallback onPressed;
 
+  final bool keepsMenuPresented;
+
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
-    return IOSSystemContextMenuItemDataCustom(title: title, onPressed: onPressed);
+    return IOSSystemContextMenuItemDataCustom(
+      title: title,
+      keepsMenuPresented: keepsMenuPresented,
+      onPressed: onPressed,
+    );
   }
 
   @override
-  int get hashCode => Object.hash(title, onPressed);
+  int get hashCode => Object.hash(title, keepsMenuPresented, onPressed);
 
   @override
   bool operator ==(Object other) {
@@ -510,6 +550,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
     }
     return other is IOSSystemContextMenuItemCustom &&
         other.title == title &&
+        other.keepsMenuPresented == keepsMenuPresented &&
         other.onPressed == onPressed;
   }
 
@@ -517,6 +558,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
+    properties.add(FlagProperty('keepsMenuPresented', value: keepsMenuPresented));
     properties.add(ObjectFlagProperty<VoidCallback>.has('onPressed', onPressed));
   }
 }

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -163,7 +163,7 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.selectAllEnabled)
         IOSSystemContextMenuItemCustom(
           title: WidgetsLocalizations.of(editableTextState.context).selectAllButtonLabel,
-          attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented,
+          attributes: IOSSystemContextMenuItemAttributes.keepsMenuPresented,
           onPressed: () {
             editableTextState.selectAll(SelectionChangedCause.toolbar);
           },
@@ -497,7 +497,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   const IOSSystemContextMenuItemCustom({
     required this.title,
     required this.onPressed,
-    this.attributes = IOSSystemContextMenuItemCustomAttributes.none,
+    this.attributes = IOSSystemContextMenuItemAttributes.none,
   });
 
   @override
@@ -506,9 +506,9 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   /// The callback that is called when the button is pressed.
   final VoidCallback onPressed;
 
-  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
+  /// The [IOSSystemContextMenuItemAttributes] indicating
   /// additional configurations for this button.
-  final IOSSystemContextMenuItemCustomAttributes attributes;
+  final IOSSystemContextMenuItemAttributes attributes;
 
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
@@ -538,7 +538,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
     properties.add(
-      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
+      DiagnosticsProperty<IOSSystemContextMenuItemAttributes>('attributes', attributes),
     );
     properties.add(ObjectFlagProperty<VoidCallback>.has('onPressed', onPressed));
   }

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -163,7 +163,7 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.selectAllEnabled)
         IOSSystemContextMenuItemCustom(
           title: WidgetsLocalizations.of(editableTextState.context).selectAllButtonLabel,
-          attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented,
+          attributes: IOSSystemContextMenuItemAttributes.keepsMenuPresented,
           onPressed: () {
             editableTextState.selectAll(SelectionChangedCause.toolbar);
           },
@@ -223,13 +223,15 @@ class _SystemContextMenuState extends State<SystemContextMenu> {
 ///    context menus.
 @immutable
 sealed class IOSSystemContextMenuItem {
-  const IOSSystemContextMenuItem();
+  const IOSSystemContextMenuItem({required this.attributes});
 
   /// The text to display to the user.
   ///
   /// Not exposed for some built-in menu items whose title is always set by the
   /// platform.
   String? get title => null;
+
+  final IOSSystemContextMenuItemAttributes attributes;
 
   /// Returns the representation of this class used by method channels.
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations);
@@ -264,7 +266,7 @@ sealed class IOSSystemContextMenuItem {
 ///    the platform for this same button.
 final class IOSSystemContextMenuItemCopy extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemCopy].
-  const IOSSystemContextMenuItemCopy();
+  const IOSSystemContextMenuItemCopy({super.attributes = IOSSystemContextMenuItemAttributes.none});
 
   @override
   IOSSystemContextMenuItemDataCopy getData(WidgetsLocalizations localizations) {
@@ -287,11 +289,11 @@ final class IOSSystemContextMenuItemCopy extends IOSSystemContextMenuItem {
 ///    the platform for this same button.
 final class IOSSystemContextMenuItemCut extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemCut].
-  const IOSSystemContextMenuItemCut();
+  const IOSSystemContextMenuItemCut({super.attributes = IOSSystemContextMenuItemAttributes.none});
 
   @override
   IOSSystemContextMenuItemDataCut getData(WidgetsLocalizations localizations) {
-    return const IOSSystemContextMenuItemDataCut();
+    return const IOSSystemContextMenuItemDataCut(attributes: attributes);
   }
 }
 
@@ -310,7 +312,7 @@ final class IOSSystemContextMenuItemCut extends IOSSystemContextMenuItem {
 ///     to the platform for this same button.
 final class IOSSystemContextMenuItemPaste extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemPaste].
-  const IOSSystemContextMenuItemPaste();
+  const IOSSystemContextMenuItemPaste({super.attributes = IOSSystemContextMenuItemAttributes.none});
 
   @override
   IOSSystemContextMenuItemDataPaste getData(WidgetsLocalizations localizations) {
@@ -333,7 +335,9 @@ final class IOSSystemContextMenuItemPaste extends IOSSystemContextMenuItem {
 ///     sent to the platform for this same button.
 final class IOSSystemContextMenuItemSelectAll extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemSelectAll].
-  const IOSSystemContextMenuItemSelectAll();
+  const IOSSystemContextMenuItemSelectAll({
+    super.attributes = IOSSystemContextMenuItemAttributes.none,
+  });
 
   @override
   IOSSystemContextMenuItemDataSelectAll getData(WidgetsLocalizations localizations) {
@@ -360,7 +364,10 @@ final class IOSSystemContextMenuItemSelectAll extends IOSSystemContextMenuItem {
 ///    to the platform for this same button.
 final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemLookUp].
-  const IOSSystemContextMenuItemLookUp({this.title});
+  const IOSSystemContextMenuItemLookUp({
+    this.title,
+    super.attributes = IOSSystemContextMenuItemAttributes.none,
+  });
 
   @override
   final String? title;
@@ -396,7 +403,10 @@ final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem with
 ///    sent to the platform for this same button.
 final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemSearchWeb].
-  const IOSSystemContextMenuItemSearchWeb({this.title});
+  const IOSSystemContextMenuItemSearchWeb({
+    this.title,
+    super.attributes = IOSSystemContextMenuItemAttributes.none,
+  });
 
   @override
   final String? title;
@@ -434,7 +444,10 @@ final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem w
 ///    to the platform for this same button.
 final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemShare].
-  const IOSSystemContextMenuItemShare({this.title});
+  const IOSSystemContextMenuItemShare({
+    this.title,
+    super.attributes = IOSSystemContextMenuItemAttributes.none,
+  });
 
   @override
   final String? title;
@@ -464,7 +477,9 @@ final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem with 
 ///    to the platform for this same button.
 final class IOSSystemContextMenuItemLiveText extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemLiveText].
-  const IOSSystemContextMenuItemLiveText();
+  const IOSSystemContextMenuItemLiveText({
+    super.attributes = IOSSystemContextMenuItemAttributes.none,
+  });
 
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
@@ -497,7 +512,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   const IOSSystemContextMenuItemCustom({
     required this.title,
     required this.onPressed,
-    this.attributes = IOSSystemContextMenuItemCustomAttributes.none,
+    super.attributes = IOSSystemContextMenuItemAttributes.none,
   });
 
   @override
@@ -505,10 +520,6 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
 
   /// The callback that is called when the button is pressed.
   final VoidCallback onPressed;
-
-  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
-  /// additional configurations for this button.
-  final IOSSystemContextMenuItemCustomAttributes attributes;
 
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
@@ -538,7 +549,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
     properties.add(
-      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
+      DiagnosticsProperty<IOSSystemContextMenuItemAttributes>('attributes', attributes),
     );
     properties.add(ObjectFlagProperty<VoidCallback>.has('onPressed', onPressed));
   }

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -163,7 +163,7 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.selectAllEnabled)
         IOSSystemContextMenuItemCustom(
           title: 'Select All',
-          attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented | IOSSystemContextMenuItemCustomAttributes.disabled,
+          attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented,
           onPressed: () {
             editableTextState.selectAll(SelectionChangedCause.toolbar);
           },
@@ -506,6 +506,8 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   /// The callback that is called when the button is pressed.
   final VoidCallback onPressed;
 
+  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
+  /// additional configurations for this button.
   final IOSSystemContextMenuItemCustomAttributes attributes;
 
   @override
@@ -535,7 +537,9 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
-    // properties.add(FlagProperty('attributes', value: attributes));
+    properties.add(
+      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
+    );
     properties.add(ObjectFlagProperty<VoidCallback>.has('onPressed', onPressed));
   }
 }

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -163,7 +163,7 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.selectAllEnabled)
         IOSSystemContextMenuItemCustom(
           title: WidgetsLocalizations.of(editableTextState.context).selectAllButtonLabel,
-          attributes: IOSSystemContextMenuItemAttributes.keepsMenuPresented,
+          attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented,
           onPressed: () {
             editableTextState.selectAll(SelectionChangedCause.toolbar);
           },
@@ -223,15 +223,13 @@ class _SystemContextMenuState extends State<SystemContextMenu> {
 ///    context menus.
 @immutable
 sealed class IOSSystemContextMenuItem {
-  const IOSSystemContextMenuItem({required this.attributes});
+  const IOSSystemContextMenuItem();
 
   /// The text to display to the user.
   ///
   /// Not exposed for some built-in menu items whose title is always set by the
   /// platform.
   String? get title => null;
-
-  final IOSSystemContextMenuItemAttributes attributes;
 
   /// Returns the representation of this class used by method channels.
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations);
@@ -266,7 +264,7 @@ sealed class IOSSystemContextMenuItem {
 ///    the platform for this same button.
 final class IOSSystemContextMenuItemCopy extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemCopy].
-  const IOSSystemContextMenuItemCopy({super.attributes = IOSSystemContextMenuItemAttributes.none});
+  const IOSSystemContextMenuItemCopy();
 
   @override
   IOSSystemContextMenuItemDataCopy getData(WidgetsLocalizations localizations) {
@@ -289,11 +287,11 @@ final class IOSSystemContextMenuItemCopy extends IOSSystemContextMenuItem {
 ///    the platform for this same button.
 final class IOSSystemContextMenuItemCut extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemCut].
-  const IOSSystemContextMenuItemCut({super.attributes = IOSSystemContextMenuItemAttributes.none});
+  const IOSSystemContextMenuItemCut();
 
   @override
   IOSSystemContextMenuItemDataCut getData(WidgetsLocalizations localizations) {
-    return const IOSSystemContextMenuItemDataCut(attributes: attributes);
+    return const IOSSystemContextMenuItemDataCut();
   }
 }
 
@@ -312,7 +310,7 @@ final class IOSSystemContextMenuItemCut extends IOSSystemContextMenuItem {
 ///     to the platform for this same button.
 final class IOSSystemContextMenuItemPaste extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemPaste].
-  const IOSSystemContextMenuItemPaste({super.attributes = IOSSystemContextMenuItemAttributes.none});
+  const IOSSystemContextMenuItemPaste();
 
   @override
   IOSSystemContextMenuItemDataPaste getData(WidgetsLocalizations localizations) {
@@ -335,9 +333,7 @@ final class IOSSystemContextMenuItemPaste extends IOSSystemContextMenuItem {
 ///     sent to the platform for this same button.
 final class IOSSystemContextMenuItemSelectAll extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemSelectAll].
-  const IOSSystemContextMenuItemSelectAll({
-    super.attributes = IOSSystemContextMenuItemAttributes.none,
-  });
+  const IOSSystemContextMenuItemSelectAll();
 
   @override
   IOSSystemContextMenuItemDataSelectAll getData(WidgetsLocalizations localizations) {
@@ -364,10 +360,7 @@ final class IOSSystemContextMenuItemSelectAll extends IOSSystemContextMenuItem {
 ///    to the platform for this same button.
 final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemLookUp].
-  const IOSSystemContextMenuItemLookUp({
-    this.title,
-    super.attributes = IOSSystemContextMenuItemAttributes.none,
-  });
+  const IOSSystemContextMenuItemLookUp({this.title});
 
   @override
   final String? title;
@@ -403,10 +396,7 @@ final class IOSSystemContextMenuItemLookUp extends IOSSystemContextMenuItem with
 ///    sent to the platform for this same button.
 final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemSearchWeb].
-  const IOSSystemContextMenuItemSearchWeb({
-    this.title,
-    super.attributes = IOSSystemContextMenuItemAttributes.none,
-  });
+  const IOSSystemContextMenuItemSearchWeb({this.title});
 
   @override
   final String? title;
@@ -444,10 +434,7 @@ final class IOSSystemContextMenuItemSearchWeb extends IOSSystemContextMenuItem w
 ///    to the platform for this same button.
 final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem with Diagnosticable {
   /// Creates an instance of [IOSSystemContextMenuItemShare].
-  const IOSSystemContextMenuItemShare({
-    this.title,
-    super.attributes = IOSSystemContextMenuItemAttributes.none,
-  });
+  const IOSSystemContextMenuItemShare({this.title});
 
   @override
   final String? title;
@@ -477,9 +464,7 @@ final class IOSSystemContextMenuItemShare extends IOSSystemContextMenuItem with 
 ///    to the platform for this same button.
 final class IOSSystemContextMenuItemLiveText extends IOSSystemContextMenuItem {
   /// Creates an instance of [IOSSystemContextMenuItemLiveText].
-  const IOSSystemContextMenuItemLiveText({
-    super.attributes = IOSSystemContextMenuItemAttributes.none,
-  });
+  const IOSSystemContextMenuItemLiveText();
 
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
@@ -512,7 +497,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
   const IOSSystemContextMenuItemCustom({
     required this.title,
     required this.onPressed,
-    super.attributes = IOSSystemContextMenuItemAttributes.none,
+    this.attributes = IOSSystemContextMenuItemCustomAttributes.none,
   });
 
   @override
@@ -520,6 +505,10 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
 
   /// The callback that is called when the button is pressed.
   final VoidCallback onPressed;
+
+  /// The [IOSSystemContextMenuItemCustomAttributes] indicating
+  /// additional configurations for this button.
+  final IOSSystemContextMenuItemCustomAttributes attributes;
 
   @override
   IOSSystemContextMenuItemData getData(WidgetsLocalizations localizations) {
@@ -549,7 +538,7 @@ class IOSSystemContextMenuItemCustom extends IOSSystemContextMenuItem with Diagn
     super.debugFillProperties(properties);
     properties.add(StringProperty('title', title));
     properties.add(
-      DiagnosticsProperty<IOSSystemContextMenuItemAttributes>('attributes', attributes),
+      DiagnosticsProperty<IOSSystemContextMenuItemCustomAttributes>('attributes', attributes),
     );
     properties.add(ObjectFlagProperty<VoidCallback>.has('onPressed', onPressed));
   }

--- a/packages/flutter/lib/src/widgets/system_context_menu.dart
+++ b/packages/flutter/lib/src/widgets/system_context_menu.dart
@@ -162,7 +162,7 @@ class SystemContextMenu extends StatefulWidget {
       if (editableTextState.pasteEnabled) const IOSSystemContextMenuItemPaste(),
       if (editableTextState.selectAllEnabled)
         IOSSystemContextMenuItemCustom(
-          title: 'Select All',
+          title: WidgetsLocalizations.of(editableTextState.context).selectAllButtonLabel,
           attributes: IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented,
           onPressed: () {
             editableTextState.selectAll(SelectionChangedCause.toolbar);

--- a/packages/flutter/test/services/system_context_menu_controller_test.dart
+++ b/packages/flutter/test/services/system_context_menu_controller_test.dart
@@ -565,14 +565,14 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Action 1',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           action1Called = true;
         },
       ),
       IOSSystemContextMenuItemDataCustom(
         title: 'Action 2',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           action2Called = true;
         },
@@ -622,7 +622,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items1 = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Controller 1 Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           controller1ActionCalled = true;
         },
@@ -632,7 +632,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items2 = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Controller 2 Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           controller2ActionCalled = true;
         },
@@ -681,7 +681,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Test Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           actionCalled = true;
         },
@@ -733,7 +733,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Test Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {},
       ),
     ];
@@ -762,7 +762,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Test Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           actionCalled = true;
         },
@@ -806,7 +806,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> oldItems = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Old Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           oldActionCalled = true;
         },
@@ -823,7 +823,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> newItems = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'New Action',
-        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        attributes: IOSSystemContextMenuItemAttributes.none,
         onPressed: () {
           newActionCalled = true;
         },

--- a/packages/flutter/test/services/system_context_menu_controller_test.dart
+++ b/packages/flutter/test/services/system_context_menu_controller_test.dart
@@ -565,12 +565,14 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Action 1',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           action1Called = true;
         },
       ),
       IOSSystemContextMenuItemDataCustom(
         title: 'Action 2',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           action2Called = true;
         },
@@ -620,6 +622,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items1 = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Controller 1 Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           controller1ActionCalled = true;
         },
@@ -629,6 +632,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items2 = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Controller 2 Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           controller2ActionCalled = true;
         },
@@ -677,6 +681,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Test Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           actionCalled = true;
         },
@@ -726,7 +731,11 @@ void main() {
     });
 
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
-      IOSSystemContextMenuItemDataCustom(title: 'Test Action', onPressed: () {}),
+      IOSSystemContextMenuItemDataCustom(
+        title: 'Test Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
+        onPressed: () {},
+      ),
     ];
 
     const Rect rect = Rect.fromLTWH(0.0, 0.0, 100.0, 100.0);
@@ -753,6 +762,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> items = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Test Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           actionCalled = true;
         },
@@ -796,6 +806,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> oldItems = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'Old Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           oldActionCalled = true;
         },
@@ -812,6 +823,7 @@ void main() {
     final List<IOSSystemContextMenuItemData> newItems = <IOSSystemContextMenuItemData>[
       IOSSystemContextMenuItemDataCustom(
         title: 'New Action',
+        attributes: IOSSystemContextMenuItemCustomAttributes.none,
         onPressed: () {
           newActionCalled = true;
         },

--- a/packages/flutter/test/system_context_menu_utils.dart
+++ b/packages/flutter/test/system_context_menu_utils.dart
@@ -19,7 +19,11 @@ IOSSystemContextMenuItemData systemContextMenuItemDataFromJson(Map<String, dynam
     'share' => IOSSystemContextMenuItemDataShare(title: title!),
     'lookUp' => IOSSystemContextMenuItemDataLookUp(title: title!),
     'captureTextFromCamera' => const IOSSystemContextMenuItemDataLiveText(),
-    'custom' => IOSSystemContextMenuItemDataCustom(title: title!, onPressed: () {}),
+    'custom' => IOSSystemContextMenuItemDataCustom(
+      title: title!,
+      attributes: IOSSystemContextMenuItemCustomAttributes.none,
+      onPressed: () {},
+    ),
     _ => throw FlutterError('Invalid json for IOSSystemContextMenuItem.type $type.'),
   };
 }

--- a/packages/flutter/test/system_context_menu_utils.dart
+++ b/packages/flutter/test/system_context_menu_utils.dart
@@ -21,7 +21,7 @@ IOSSystemContextMenuItemData systemContextMenuItemDataFromJson(Map<String, dynam
     'captureTextFromCamera' => const IOSSystemContextMenuItemDataLiveText(),
     'custom' => IOSSystemContextMenuItemDataCustom(
       title: title!,
-      attributes: IOSSystemContextMenuItemCustomAttributes.none,
+      attributes: IOSSystemContextMenuItemAttributes.none,
       onPressed: () {},
     ),
     _ => throw FlutterError('Invalid json for IOSSystemContextMenuItem.type $type.'),


### PR DESCRIPTION
https://github.com/user-attachments/assets/ba9292fb-595e-485a-af06-9b5b2b964293

Fixes #168857

Issue:

When using the system context menu on iOS and pressing the `Select All` button, the context menu should remain visible and should update its options based on the new selection, and the selection handles should remain visible. Instead when pressing `Select All` the context menu disappears along with the selection handles. 

Cause of disappearing menu: By default the system will close the menu when an item is pressed.
Cause of disappearing handles: Instead of going through `EditableTextState.selectAll`, the `Select All` from the system context menu goes directly through `EditableTextState.updateEditingValue` and an accurate `SelectionChangedCause` cannot be inferred as a result causing the handles to disappear when the update is processed.

Fix:

This change exposes `attributes` on `IOSSystemContextMenuItemCustom` and `IOSSystemContextMenuItemDataCustom`. One can set multiple `IOSSystemContextMenuItemCustomAttributes` on a context menu button, for example `attributes: IOSSystemContextMenuItemCustomAttributes.destructive | IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented`, for a button that has red text and keeps the menu visible when it is pressed. These attributes are used by the underlying `UIAction` to build an action that has the given attributes set as its [`attributes`](https://developer.apple.com/documentation/uikit/uimenuelement/attributes?language=objc).

The default `Select All` item is replaced with a custom item that maps to the `EditableTextState` handling of `Select All`. This item has [`IOSSystemContextMenuItemCustomAttributes.keepsMenuPresented`](https://developer.apple.com/documentation/uikit/uimenuelement/attributes/keepsmenupresented?language=objc) as its attribute to keep the context menu visible when the `Select All` button is pressed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.