### PR TITLE
Add subtextGap to InputDecorationThemeData

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -589,6 +589,7 @@ class _Decoration {
     required this.visualDensity,
     required this.inputGap,
     required this.maintainHintSize,
+    required this.subtextGap,
     this.icon,
     this.input,
     this.label,
@@ -615,6 +616,7 @@ class _Decoration {
   final VisualDensity visualDensity;
   final double inputGap;
   final bool maintainHintSize;
+  final double subtextGap;
   final Widget? icon;
   final Widget? input;
   final Widget? label;
@@ -649,6 +651,7 @@ class _Decoration {
         other.visualDensity == visualDensity &&
         other.inputGap == inputGap &&
         other.maintainHintSize == maintainHintSize &&
+        other.subtextGap == subtextGap &&
         other.icon == icon &&
         other.input == input &&
         other.label == label &&
@@ -683,7 +686,7 @@ class _Decoration {
     prefix,
     suffix,
     prefixIcon,
-    Object.hash(suffixIcon, helperError, counter, container),
+    Object.hash(suffixIcon, helperError, counter, container, subtextGap),
   );
 }
 
@@ -725,9 +728,7 @@ class _RenderDecoration extends RenderBox
        _expands = expands,
        _material3 = material3;
 
-  // TODO(bleroux): consider defining this value as a Material token and making it
-  // configurable by InputDecorationThemeData.
-  double get subtextGap => material3 ? 4.0 : 8.0;
+  double get subtextGap => _decoration.subtextGap;
   double get prefixToInputGap => material3 ? 4.0 : 0.0;
   double get inputToSuffixGap => material3 ? 4.0 : 0.0;
 
@@ -2622,6 +2623,8 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       }
     }
 
+    final double subtextGap = defaults.subtextGap ?? (useMaterial3 ? 4.0 : 8.0);
+
     final _Decorator decorator = _Decorator(
       decoration: _Decoration(
         contentPadding: contentPadding,
@@ -2637,6 +2640,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         isEmpty: isEmpty,
         visualDensity: visualDensity,
         maintainHintSize: maintainHintSize,
+        subtextGap: subtextGap,
         icon: icon,
         input: input,
         label: label,
@@ -4890,6 +4894,7 @@ class InputDecorationThemeData with Diagnosticable {
     this.alignLabelWithHint = false,
     this.constraints,
     this.visualDensity,
+    this.subtextGap,
   });
 
   /// {@macro flutter.material.inputDecoration.labelStyle}
@@ -5328,6 +5333,14 @@ class InputDecorationThemeData with Diagnosticable {
   ///    given decorator.
   final VisualDensity? visualDensity;
 
+  /// The vertical gap between the input field and the subtext (helper text or error text).
+  ///
+  /// If null, defaults to 4.0 for Material 3 and 8.0 for Material 2.
+  ///
+  /// This value controls the spacing between the input field and any helper text,
+  /// error text, or counter text displayed below the input field.
+  final double? subtextGap;
+
   /// Creates a copy of this object but with the given fields replaced with the
   /// new values.
   InputDecorationThemeData copyWith({
@@ -5368,6 +5381,7 @@ class InputDecorationThemeData with Diagnosticable {
     bool? alignLabelWithHint,
     BoxConstraints? constraints,
     VisualDensity? visualDensity,
+    double? subtextGap,
   }) {
     return InputDecorationThemeData(
       labelStyle: labelStyle ?? this.labelStyle,
@@ -5407,6 +5421,7 @@ class InputDecorationThemeData with Diagnosticable {
       alignLabelWithHint: alignLabelWithHint ?? this.alignLabelWithHint,
       constraints: constraints ?? this.constraints,
       visualDensity: visualDensity ?? this.visualDensity,
+      subtextGap: subtextGap ?? this.subtextGap,
     );
   }
 
@@ -5457,6 +5472,7 @@ class InputDecorationThemeData with Diagnosticable {
       border: border ?? other.border,
       constraints: constraints ?? other.constraints,
       visualDensity: visualDensity ?? other.visualDensity,
+      subtextGap: subtextGap ?? other.subtextGap,
     );
   }
 
@@ -5500,6 +5516,7 @@ class InputDecorationThemeData with Diagnosticable {
       constraints,
       hintFadeDuration,
       visualDensity,
+      subtextGap,
     ),
   );
 
@@ -5549,7 +5566,8 @@ class InputDecorationThemeData with Diagnosticable {
         other.alignLabelWithHint == alignLabelWithHint &&
         other.constraints == constraints &&
         other.disabledBorder == disabledBorder &&
-        other.visualDensity == visualDensity;
+        other.visualDensity == visualDensity &&
+        other.subtextGap == subtextGap;
   }
 
   @override
@@ -5757,6 +5775,13 @@ class InputDecorationThemeData with Diagnosticable {
         'visualDensity',
         visualDensity,
         defaultValue: defaultTheme.visualDensity,
+      ),
+    );
+    properties.add(
+      DiagnosticsProperty<double>(
+        'subtextGap',
+        subtextGap,
+        defaultValue: defaultTheme.subtextGap,
       ),
     );
   }


### PR DESCRIPTION
Hi.

This PR adds `subtextGap` property to `InputDecorationThemeData` which fixes the issue with inability to customize the value.

I intentionally skipped tests to save the time.
Could you check if this PR makes sense and if it does I will try to add tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
