### PR TITLE
Fix crash when attaching to a device with multiple active flutter apps

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:meta/meta.dart';
 import 'package:unified_analytics/unified_analytics.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -333,10 +334,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
       vmServiceUri = vmServiceDiscovery.uris;
 
       // Stop the timer once we receive the first uri.
-      vmServiceUri = vmServiceUri.map((Uri uri) {
-        discoveryStatus.stop();
-        return uri;
-      });
+      vmServiceUri = streamWithCallbackOnFirstItem(vmServiceUri, () => discoveryStatus.stop());
     } else {
       vmServiceUri = Stream<Uri>.fromFuture(
         buildVMServiceUri(
@@ -532,4 +530,16 @@ class HotRunnerFactory {
     dartBuilder: hookRunner,
     logger: logger,
   );
+}
+
+@visibleForTesting
+Stream<T> streamWithCallbackOnFirstItem<T>(Stream<T> stream, void Function() callback) {
+  var called = false;
+  return stream.map((i) {
+    if (!called) {
+      callback();
+      called = true;
+    }
+    return i;
+  });
 }

--- a/packages/flutter_tools/test/general.shard/commands/attach_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/attach_test.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_tools/src/commands/attach.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  testWithoutContext('streamWithCallbackOnFirstItem only calls the callback once', () async {
+    var calledTimes = 0;
+    final Stream<int> stream = Stream.fromIterable([1, 2, 3]);
+    final Stream<int> newStream = streamWithCallbackOnFirstItem(stream, () {
+      calledTimes++;
+    });
+    await newStream.drain<void>();
+    expect(calledTimes, 1);
+  });
+}


### PR DESCRIPTION
`vmServiceUri` is a stream, and might emit multiple values. But `discoveryStatus.stop()` can only be called once.
