### PR TITLE
[benchmarks] Allow passing --local-web-sdk and --build-mode flags to benchmarks

### DIFF
--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -32,6 +32,8 @@ Future<void> main(List<String> rawArgs) async {
   /// Suppresses standard output, prints only standard error output.
   final bool silent = (args['silent'] as bool?) ?? false;
 
+  final String buildMode = args['build-mode'] as String;
+
   /// The build of the local engine to use.
   ///
   /// Required for A/B test mode.
@@ -120,6 +122,7 @@ Future<void> main(List<String> rawArgs) async {
       resultsFile: resultsFile,
       taskName: taskNames.single,
       onlyLocalEngine: (args['ab-local-engine-only'] as bool?) ?? false,
+      buildMode: buildMode,
     );
   } else {
     await runTasks(
@@ -128,6 +131,7 @@ Future<void> main(List<String> rawArgs) async {
       localEngine: localEngine,
       localEngineHost: localEngineHost,
       localEngineSrcPath: localEngineSrcPath,
+      localWebSdk: localWebSdk,
       deviceId: deviceId,
       exitOnFirstTestFailure: exitOnFirstTestFailure,
       terminateStrayDartProcesses: terminateStrayDartProcesses,
@@ -135,6 +139,7 @@ Future<void> main(List<String> rawArgs) async {
       luciBuilder: luciBuilder,
       resultsPath: resultsPath,
       useEmulator: useEmulator,
+      buildMode: buildMode,
     );
   }
 }
@@ -145,6 +150,7 @@ Future<void> _runABTest({
   required String? localEngine,
   required String? localEngineHost,
   required String? localWebSdk,
+  required String buildMode,
   required String? localEngineSrcPath,
   required String? deviceId,
   required String resultsFile,
@@ -171,6 +177,7 @@ Future<void> _runABTest({
         taskName,
         silent: silent,
         deviceId: deviceId,
+        buildMode: buildMode,
       );
 
       print('Default engine result:');
@@ -192,6 +199,7 @@ Future<void> _runABTest({
       localEngineHost: localEngineHost,
       localWebSdk: localWebSdk,
       localEngineSrcPath: localEngineSrcPath,
+      buildMode: buildMode,
       deviceId: deviceId,
     );
 
@@ -254,6 +262,12 @@ ArgParser createArgParser(List<String> taskNames) {
       callback: (List<String> tasks) {
         taskNames.addAll(tasks);
       },
+    )
+    ..addOption(
+      'build-mode',
+      defaultsTo: 'profile',
+      allowed: <String>['debug', 'profile'],
+      help: 'The build mode to use for the benchmark.',
     )
     ..addOption(
       'device-id',

--- a/dev/devicelab/bin/tasks/build_mode_test.dart
+++ b/dev/devicelab/bin/tasks/build_mode_test.dart
@@ -3,17 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/tasks/web_benchmarks.dart';
+import 'package:flutter_devicelab/framework/task_result.dart';
 
-/// Runs all Web benchmarks using DDC.
+const String buildMode = String.fromEnvironment('buildMode');
+
 Future<void> main() async {
   await task(() async {
-    return runWebBenchmark((
-      useWasm: false,
-      forceSingleThreadedSkwasm: false,
-      useDdc: true,
-      withHotReload: true,
-      buildMode: 'debug',
-    ));
+    print('buildMode: $buildMode');
+    return TaskResult.success(null);
   });
 }

--- a/dev/devicelab/bin/tasks/web_benchmarks_canvaskit.dart
+++ b/dev/devicelab/bin/tasks/web_benchmarks_canvaskit.dart
@@ -5,6 +5,8 @@
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_benchmarks.dart';
 
+const String buildMode = String.fromEnvironment('buildMode', defaultValue: 'profile');
+
 /// Runs all Web benchmarks using the CanvasKit rendering backend.
 Future<void> main() async {
   await task(() async {
@@ -13,6 +15,7 @@ Future<void> main() async {
       forceSingleThreadedSkwasm: false,
       useDdc: false,
       withHotReload: false,
+      buildMode: buildMode,
     ));
   });
 }

--- a/dev/devicelab/bin/tasks/web_benchmarks_ddc.dart
+++ b/dev/devicelab/bin/tasks/web_benchmarks_ddc.dart
@@ -13,6 +13,7 @@ Future<void> main() async {
       forceSingleThreadedSkwasm: false,
       useDdc: true,
       withHotReload: false,
+      buildMode: 'debug',
     ));
   });
 }

--- a/dev/devicelab/bin/tasks/web_benchmarks_skwasm.dart
+++ b/dev/devicelab/bin/tasks/web_benchmarks_skwasm.dart
@@ -5,6 +5,8 @@
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_benchmarks.dart';
 
+const String buildMode = String.fromEnvironment('buildMode', defaultValue: 'profile');
+
 /// Runs all Web benchmarks using the Skwasm rendering backend.
 Future<void> main() async {
   await task(() async {
@@ -13,6 +15,7 @@ Future<void> main() async {
       forceSingleThreadedSkwasm: false,
       useDdc: false,
       withHotReload: false,
+      buildMode: buildMode,
     ));
   });
 }

--- a/dev/devicelab/bin/tasks/web_benchmarks_skwasm_st.dart
+++ b/dev/devicelab/bin/tasks/web_benchmarks_skwasm_st.dart
@@ -5,6 +5,8 @@
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/web_benchmarks.dart';
 
+const String buildMode = String.fromEnvironment('buildMode', defaultValue: 'profile');
+
 /// Runs all Web benchmarks using the Skwasm rendering backend.
 Future<void> main() async {
   await task(() async {
@@ -13,6 +15,7 @@ Future<void> main() async {
       forceSingleThreadedSkwasm: true,
       useDdc: false,
       withHotReload: false,
+      buildMode: buildMode,
     ));
   });
 }

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -38,10 +38,12 @@ Future<void> runTasks(
   String? localEngine,
   String? localEngineHost,
   String? localEngineSrcPath,
+  String? localWebSdk,
   String? luciBuilder,
   String? resultsPath,
   List<String>? taskArgs,
   bool useEmulator = false,
+  String buildMode = 'profile',
   @visibleForTesting Map<String, String>? isolateParams,
   @visibleForTesting void Function(String) print = print,
   @visibleForTesting List<String>? logs,
@@ -56,6 +58,7 @@ Future<void> runTasks(
         localEngine: localEngine,
         localEngineHost: localEngineHost,
         localEngineSrcPath: localEngineSrcPath,
+        localWebSdk: localWebSdk,
         terminateStrayDartProcesses: terminateStrayDartProcesses,
         silent: silent,
         taskArgs: taskArgs,
@@ -64,6 +67,7 @@ Future<void> runTasks(
         luciBuilder: luciBuilder,
         isolateParams: isolateParams,
         useEmulator: useEmulator,
+        buildMode: buildMode,
       );
 
       if (!result.succeeded) {
@@ -109,6 +113,7 @@ Future<TaskResult> rerunTask(
   String? localEngine,
   String? localEngineHost,
   String? localEngineSrcPath,
+  String? localWebSdk,
   bool terminateStrayDartProcesses = false,
   bool silent = false,
   List<String>? taskArgs,
@@ -116,6 +121,7 @@ Future<TaskResult> rerunTask(
   String? gitBranch,
   String? luciBuilder,
   bool useEmulator = false,
+  String buildMode = 'profile',
   @visibleForTesting Map<String, String>? isolateParams,
 }) async {
   section('Running task "$taskName"');
@@ -125,11 +131,13 @@ Future<TaskResult> rerunTask(
     localEngine: localEngine,
     localEngineHost: localEngineHost,
     localEngineSrcPath: localEngineSrcPath,
+    localWebSdk: localWebSdk,
     terminateStrayDartProcesses: terminateStrayDartProcesses,
     silent: silent,
     taskArgs: taskArgs,
     isolateParams: isolateParams,
     useEmulator: useEmulator,
+    buildMode: buildMode,
   );
 
   print('Task result:');
@@ -169,6 +177,7 @@ Future<TaskResult> runTask(
   String? deviceId,
   List<String>? taskArgs,
   bool useEmulator = false,
+  String buildMode = 'profile',
   @visibleForTesting Map<String, String>? isolateParams,
 }) async {
   final String taskExecutable = 'bin/tasks/$taskName.dart';
@@ -192,6 +201,7 @@ Future<TaskResult> runTask(
     <String>[
       '--enable-vm-service=0', // zero causes the system to choose a free port
       '--no-pause-isolates-on-exit',
+      '-DbuildMode=$buildMode',
       if (localEngine != null) '-DlocalEngine=$localEngine',
       if (localEngineHost != null) '-DlocalEngineHost=$localEngineHost',
       if (localWebSdk != null) '-DlocalWebSdk=$localWebSdk',

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -31,6 +31,7 @@ typedef WebBenchmarkOptions = ({
   bool forceSingleThreadedSkwasm,
   bool useDdc,
   bool withHotReload,
+  String buildMode,
 });
 
 Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
@@ -107,7 +108,7 @@ Future<TaskResult> runWebBenchmark(WebBenchmarkOptions benchmarkOptions) async {
           '--no-tree-shake-icons', // local engine builds are frequently out of sync with the Dart Kernel version
           if (benchmarkOptions.useWasm) ...<String>['--wasm', '--no-strip-wasm'],
           '--dart-define=FLUTTER_WEB_ENABLE_PROFILING=true',
-          '--profile',
+          '--${benchmarkOptions.buildMode}',
           '--no-web-resources-cdn',
           '-t',
           'lib/web_benchmarks.dart',

--- a/dev/devicelab/test/run_test.dart
+++ b/dev/devicelab/test/run_test.dart
@@ -192,5 +192,14 @@ void main() {
       );
       expect(result.exitCode, 1);
     });
+
+    test('passes build mode to the test', () async {
+      final ProcessResult result = await runScript(
+        <String>['build_mode_test'],
+        <String>['--build-mode=debug'],
+      );
+      expect(result.exitCode, 0);
+      expect(result.stdout, contains('buildMode: debug'));
+    });
   });
 }


### PR DESCRIPTION
This allows setting the `--local-web-sdk` and `--build-mode` flags to benchmarks. This makes it easier to debug benchmarks that only fail with local engine changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
