### PR TITLE
Update `CODEOWNERS` (for dev-tooling)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,19 +12,8 @@
 /packages/flutter_tools/lib/src/ios/ @vashworth
 
 # Internal dev infra that is closely tied to team-infra.
-/bin/internal/update_engine_version.ps1 @matanlurey
-/bin/internal/update_engine_version.sh @matanlurey
-/dev/bots/** @matanlurey
-/dev/conductor/** @matanlurey
-/dev/devicelab/** @matanlurey
-/dev/tools/test/update_engine_version_test.dart @matanlurey
-
-# flutter_drver, integration_test. Intentionally omit root files (i.e. pubspec.yaml upgrades).
-/dev/tools/android_driver_extensions @matanlurey
-/packages/flutter_driver/lib/** @matanlurey
-/packages/flutter_driver/test/** @matanlurey
-/packages/integration_test/lib/** @matanlurey
-/packages/integration_test/test/** @matanlurey
+/bin/internal/** @jtmcdole
+/dev/tools/test/** @jtmcdole
 
 # The following files define an Application Binary Interface (ABI) that must maintain
 # both forward and backward compatibility. Changes should be heavily


### PR DESCRIPTION
I'll be OOO for a bit, so there is no reason to confuse contributors by having PRs auto-assigned to me.

I transferred over ownership of the `internal/*.sh` scripts (and tests) to @jtmcdole for the time being, and just removed the remaining (which do not have full-time owners anyway).