### PR TITLE
[web] Fix image and color filters equality in SkWASM.

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/filters.dart
@@ -99,10 +99,24 @@ class SkwasmBlurFilter extends SkwasmImageFilter {
   }
 
   @override
-  String toString() => 'ImageFilter.blur($sigmaX, $sigmaY, ${tileModeString(tileMode)})';
+  Matrix4? get transform => null;
 
   @override
-  Matrix4? get transform => null;
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmBlurFilter &&
+        other.sigmaX == sigmaX &&
+        other.sigmaY == sigmaY &&
+        other.tileMode == tileMode;
+  }
+
+  @override
+  int get hashCode => Object.hash(sigmaX, sigmaY, tileMode);
+
+  @override
+  String toString() => 'ImageFilter.blur($sigmaX, $sigmaY, ${tileModeString(tileMode)})';
 }
 
 class SkwasmDilateFilter extends SkwasmImageFilter {
@@ -123,10 +137,21 @@ class SkwasmDilateFilter extends SkwasmImageFilter {
   }
 
   @override
-  String toString() => 'ImageFilter.dilate($radiusX, $radiusY)';
+  Matrix4? get transform => null;
 
   @override
-  Matrix4? get transform => null;
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmDilateFilter && other.radiusX == radiusX && other.radiusY == radiusY;
+  }
+
+  @override
+  int get hashCode => Object.hash(radiusX, radiusY);
+
+  @override
+  String toString() => 'ImageFilter.dilate($radiusX, $radiusY)';
 }
 
 class SkwasmErodeFilter extends SkwasmImageFilter {
@@ -147,10 +172,21 @@ class SkwasmErodeFilter extends SkwasmImageFilter {
   }
 
   @override
-  String toString() => 'ImageFilter.erode($radiusX, $radiusY)';
+  Matrix4? get transform => null;
 
   @override
-  Matrix4? get transform => null;
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmErodeFilter && other.radiusX == radiusX && other.radiusY == radiusY;
+  }
+
+  @override
+  int get hashCode => Object.hash(radiusX, radiusY);
+
+  @override
+  String toString() => 'ImageFilter.erode($radiusX, $radiusY)';
 }
 
 class SkwasmMatrixFilter extends SkwasmImageFilter {
@@ -174,10 +210,23 @@ class SkwasmMatrixFilter extends SkwasmImageFilter {
   });
 
   @override
-  String toString() => 'ImageFilter.matrix($matrix4, $filterQuality)';
+  Matrix4? get transform => Matrix4.fromFloat32List(toMatrix32(matrix4));
 
   @override
-  Matrix4? get transform => Matrix4.fromFloat32List(toMatrix32(matrix4));
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is SkwasmMatrixFilter &&
+        other.filterQuality == filterQuality &&
+        listEquals<double>(other.matrix4, matrix4);
+  }
+
+  @override
+  int get hashCode => Object.hash(filterQuality, Object.hashAll(matrix4));
+
+  @override
+  String toString() => 'ImageFilter.matrix($matrix4, $filterQuality)';
 }
 
 class SkwasmColorImageFilter extends SkwasmImageFilter {
@@ -197,10 +246,21 @@ class SkwasmColorImageFilter extends SkwasmImageFilter {
   });
 
   @override
-  String toString() => filter.toString();
+  Matrix4? get transform => null;
 
   @override
-  Matrix4? get transform => null;
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmColorImageFilter && other.filter == filter;
+  }
+
+  @override
+  int get hashCode => filter.hashCode;
+
+  @override
+  String toString() => filter.toString();
 }
 
 class SkwasmComposedImageFilter extends SkwasmImageFilter {
@@ -224,9 +284,6 @@ class SkwasmComposedImageFilter extends SkwasmImageFilter {
   );
 
   @override
-  String toString() => 'ImageFilter.compose($outer, $inner)';
-
-  @override
   Matrix4? get transform {
     final outerTransform = outer.transform;
     final innerTransform = inner.transform;
@@ -235,6 +292,20 @@ class SkwasmComposedImageFilter extends SkwasmImageFilter {
     }
     return outerTransform ?? innerTransform;
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmComposedImageFilter && other.outer == outer && other.inner == inner;
+  }
+
+  @override
+  int get hashCode => Object.hash(outer, inner);
+
+  @override
+  String toString() => 'ImageFilter.compose($outer, $inner)';
 }
 
 typedef ColorFilterHandleBorrow<T> = T Function(ColorFilterHandle handle);
@@ -273,6 +344,17 @@ class SkwasmModeColorFilter extends SkwasmColorFilter {
   }
 
   @override
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmModeColorFilter && other.color == color && other.blendMode == blendMode;
+  }
+
+  @override
+  int get hashCode => Object.hash(color, blendMode);
+
+  @override
   String toString() => 'ColorFilter.mode($color, $blendMode)';
 }
 
@@ -287,6 +369,12 @@ class SkwasmLinearToSrgbGammaColorFilter extends SkwasmColorFilter {
   T withRawColorFilter<T>(ColorFilterHandleBorrow<T> borrow) => borrow(_rawColorFilter);
 
   @override
+  bool operator ==(Object other) => runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
   String toString() => 'ColorFilter.linearToSrgbGamma()';
 }
 
@@ -299,6 +387,12 @@ class SkwasmSrgbToLinearGammaColorFilter extends SkwasmColorFilter {
 
   @override
   T withRawColorFilter<T>(ColorFilterHandleBorrow<T> borrow) => borrow(_rawColorFilter);
+
+  @override
+  bool operator ==(Object other) => runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
 
   @override
   String toString() => 'ColorFilter.srgbToLinearGamma()';
@@ -327,6 +421,17 @@ class SkwasmMatrixColorFilter extends SkwasmColorFilter {
     colorFilterDispose(rawColorFilter);
     return result;
   });
+
+  @override
+  bool operator ==(Object other) {
+    if (runtimeType != other.runtimeType) {
+      return false;
+    }
+    return other is SkwasmMatrixColorFilter && listEquals<double>(matrix, other.matrix);
+  }
+
+  @override
+  int get hashCode => Object.hashAll(matrix);
 
   @override
   String toString() => 'ColorFilter.matrix($matrix)';

--- a/engine/src/flutter/lib/web_ui/test/ui/filters_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/filters_test.dart
@@ -516,9 +516,7 @@ Future<void> testMain() async {
         );
       }
     }
-    // == for ImageFilter is not implemented in Skwasm.
-    // See: https://github.com/flutter/flutter/issues/173968
-  }, skip: isSkwasm);
+  });
 
   group('MaskFilter', () {
     test('with 0 sigma can be set on a Paint', () {
@@ -531,37 +529,23 @@ Future<void> testMain() async {
 }
 
 List<ui.ColorFilter> createColorFilters() {
+  // Creates new color filter instances on each invocation.
   return <ui.ColorFilter>[
-    const EngineColorFilter.mode(ui.Color(0x12345678), ui.BlendMode.srcOver),
-    const EngineColorFilter.mode(ui.Color(0x12345678), ui.BlendMode.dstOver),
-    const EngineColorFilter.mode(ui.Color(0x87654321), ui.BlendMode.dstOver),
-    const EngineColorFilter.matrix(<double>[
-      1,
-      0,
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-      0,
-      0,
-      0,
-      0,
-      1,
-      0,
-    ]),
+    // ignore: prefer_const_constructors
+    EngineColorFilter.mode(ui.Color(0x12345678), ui.BlendMode.srcOver),
+    // ignore: prefer_const_constructors
+    EngineColorFilter.mode(ui.Color(0x12345678), ui.BlendMode.dstOver),
+    // ignore: prefer_const_constructors
+    EngineColorFilter.mode(ui.Color(0x87654321), ui.BlendMode.dstOver),
+    // ignore: prefer_const_constructors
+    EngineColorFilter.matrix(<double>[1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0]),
     EngineColorFilter.matrix(
       Float32List.fromList(<double>[2, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 2, 0]),
     ),
-    const EngineColorFilter.linearToSrgbGamma(),
-    const EngineColorFilter.srgbToLinearGamma(),
+    // ignore: prefer_const_constructors
+    EngineColorFilter.linearToSrgbGamma(),
+    // ignore: prefer_const_constructors
+    EngineColorFilter.srgbToLinearGamma(),
   ];
 }
 


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/173968

- Adds equality support to `ImageFilter`s in SkWASM
- Adds equality support to `ColorFilter`s in SkWASM
- Fixes test to not use const objects in the equality checks

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
