### PR TITLE
update deps to point to the new SOT repo for package:coverage

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -534,9 +534,6 @@ deps = {
   'engine/src/flutter/third_party/pkg/archive':
   Var('chromium_git') + '/external/github.com/brendan-duncan/archive.git' + '@' + 'f1d164f8f5d8aea0be620a9b1e8d300b75a29388', # 3.6.1
 
-  'engine/src/flutter/third_party/pkg/coverage':
-  Var('flutter_git') + '/third_party/coverage.git' + '@' + 'bb0ab721ee4ceef1abfa413d8d6fd46013b583b9', # 1.7.2
-
   'engine/src/flutter/third_party/pkg/equatable':
   Var('flutter_git') + '/third_party/equatable.git' + '@' + '2117551ff3054f8edb1a58f63ffe1832a8d25623', # 2.0.5
 

--- a/engine/src/flutter/pubspec.yaml
+++ b/engine/src/flutter/pubspec.yaml
@@ -178,12 +178,14 @@ dependency_overrides:
     path: ./third_party/dart/pkg/async_helper
   boolean_selector:
     path: ./third_party/dart/third_party/pkg/tools/pkgs/boolean_selector
+  cli_config:
+    path: ./third_party/dart/third_party/pkg/tools/pkgs/cli_config
   collection:
     path: ./third_party/dart/third_party/pkg/core/pkgs/collection
   convert:
     path: ./third_party/dart/third_party/pkg/core/pkgs/convert
   coverage:
-    path: ./third_party/pkg/coverage
+    path: ./third_party/dart/third_party/pkg/tools/pkgs/coverage
   crypto:
     path: ./third_party/dart/third_party/pkg/core/pkgs/crypto
   dart_mcp:


### PR DESCRIPTION
This PR updates the deps to point to the new SOT repo for package:coverage. The engine was referencing the old location; package:test needs functionality from the latest package:coverage, and we need to update the coverage reference here in order to roll the latest `test` through dart and flutter.

Issues:
- roll failure trying to update the latest package:test into the Dart SDK; https://dart-review.googlesource.com/c/sdk/+/448423

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
