### PR TITLE
Document Form.onChange precedence over DropdownButtonFormField.onChange

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1887,6 +1887,10 @@ class DropdownButtonFormField<T> extends FormField<T> {
        );
 
   /// {@macro flutter.material.dropdownButton.onChanged}
+  ///
+  /// This callback is invoked after the parent [Form]'s [Form.onChanged] callback.
+  /// The field's updated value is available in the [Form.onChanged] callback
+  /// via [FormFieldState.value].
   final ValueChanged<T?>? onChanged;
 
   /// The decoration to show around the dropdown button form field.


### PR DESCRIPTION
## Description

This PR adds some documentation to `DropdownButtonFormField.onChanged` to clarify the precedence order related to `Form.onChanged`.

## Related Issue

Fixes [DropdownButtonFormField changes not absorbing Form onChanged Function](https://github.com/flutter/flutter/issues/86336)  

## Tests

Documentation only

