### PR TITLE
Fix default overlay color in `TabBar`

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1937,8 +1937,7 @@ class _TabBarState extends State<TabBar> {
       final WidgetStateProperty<Color?> defaultOverlay = WidgetStateProperty.resolveWith<Color?>((
         Set<WidgetState> states,
       ) {
-        // TODO(ValentinVignal): Don't selectedState.
-        final Set<WidgetState> effectiveStates = selectedState..addAll(states);
+        final Set<WidgetState> effectiveStates = selectedState.toSet()..addAll(states);
         return _defaults.overlayColor?.resolve(effectiveStates);
       });
       wrappedTabs[index] = InkWell(

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -594,6 +594,10 @@ void main() {
     await tester.pumpAndSettle();
     expect(overlayColor(), paints..rect(color: theme.colorScheme.onSurface.withOpacity(0.08)));
 
+    await gesture.moveTo(tester.getCenter(find.text(selectedValue)));
+    await tester.pumpAndSettle();
+    expect(overlayColor(), paints..rect(color: theme.colorScheme.primary.withOpacity(0.08)));
+
     await gesture.down(tester.getCenter(find.text(selectedValue)));
     await tester.pumpAndSettle();
     expect(


### PR DESCRIPTION
Fix the TODO introduced in https://github.com/flutter/flutter/pull/174746#discussion_r2320322217

The hidden bug was that the incorrect color was used for the overlay color of `TabBar` when using the default theme:

Consider the scenario for a selected tab:
1. The user over it
2. The user presses it
3. The user stops the press and hovers it again


https://github.com/flutter/flutter/blob/2efda9cc146fa6eef5f758511cf04a55635366cb/packages/flutter/lib/src/material/tabs.dart#L2698-L2723

Since the hovered and pressed colors are very similar, it is hard to catch. I've made a video to illustrate it when the hovered color is blue 🟦  and the pressed color is red 🟥:

<table>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td>Overlay color</td>
<td>
1. <code>primary.withOpacity(0.08)</code><br/>
2. <code>primary.withOpacity(0.1)</code><br/>
3. <code>primary.withOpacity(0.1)</code> ❌  Wrong color
</td>

<td>
1. <code>primary.withOpacity(0.08)</code><br/>
2. <code>primary.withOpacity(0.1)</code><br/>
3. <code>primary.withOpacity(0.08)</code> ✅  Correct color
</td>
</tr>

<tr>
<td></td>
<td>


https://github.com/user-attachments/assets/667ea9b9-dce1-446b-93ae-68114464d518



</td>
<td>

https://github.com/user-attachments/assets/e0910b73-11cc-4fc2-982a-e32a7f47dd1b


</td>
</tr>

</table>


| | Before | After |
| :---: |  :---: | :---: |
| overlay color| 1. `primary.withOpacity(0.08)`
5. `` | 1. `primary.withOpacity(0.08)`  |



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
