### PR TITLE
Make sure that a FloatingActionButton doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -1467,6 +1467,19 @@ void main() {
       },
     );
   });
+
+  testWidgets('FloatingActionButton does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          floatingActionButton: Center(
+            child: SizedBox.shrink(child: FloatingActionButton(onPressed: () {})),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(FloatingActionButton)), Size.zero);
+  });
 }
 
 Offset _rightEdgeOfFab(WidgetTester tester) {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the FloatingActionButton widget.