### PR TITLE
Remove  redundant `public` modifier  for interface members in MouseCursorPlugin.java

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/plugin/mouse/MouseCursorPlugin.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/plugin/mouse/MouseCursorPlugin.java
@@ -121,7 +121,7 @@ public class MouseCursorPlugin {
      * with the context associated with this view.
      */
     @NonNull
-    public PointerIcon getSystemPointerIcon(int type);
+    PointerIcon getSystemPointerIcon(int type);
 
     /**
      * Request the pointer to display the specified icon object.
@@ -129,6 +129,6 @@ public class MouseCursorPlugin {
      * <p>If the delegate is implemented by a {@link android.view.View}, then this method is
      * automatically implemented by View.
      */
-    public void setPointerIcon(@NonNull PointerIcon icon);
+    void setPointerIcon(@NonNull PointerIcon icon);
   }
 }


### PR DESCRIPTION
<img width="836" height="257" alt="public" src="https://github.com/user-attachments/assets/87f0dcb1-2b74-405a-bca8-9b3a9ffe5986" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
