### PR TITLE
chore: update content workflow to use itnernal script

### DIFF
--- a/.github/workflows/content-aware-hash.yml
+++ b/.github/workflows/content-aware-hash.yml
@@ -15,9 +15,8 @@ jobs:
 
       - name: Generate Hash
         run: |
-          # IMPORTANT: Keep the list of files in sync with bin/internal/content_aware_hash.sh
-          # We call this directly here as we're expected to be in the merge queue (not master)
-          engine_content_hash=$(git ls-tree --format "%(objectname) %(path)" HEAD -- DEPS engine bin/internal/release-candidate-branch.version | git hash-object --stdin)
+          # Script updated to handle gh-readonly-queue/ branches
+          engine_content_hash=$(bin/internal/content_aware_hash.sh)
           # test notice annotation for retrival from api
           echo "::notice ::{\"engine_content_hash\": \"${engine_content_hash}\"}"
           # test summary writing


### PR DESCRIPTION
Now that our internal scripts check for private github branches, this makes the itnernal scripts the source of truth.

towards #175265