### PR TITLE
Add CupertinoPageRouteWithDynamicTitle for dynamic title support #175129

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2195,8 +2195,8 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   }
 
   @override
-  void changedInternalState() {
-    super.changedInternalState();
+  void changedInternalState({bool notifyNeighbors = false}) {
+    super.changedInternalState(notifyNeighbors: notifyNeighbors);
     // No need to mark dirty if this method is called during build phase.
     if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.persistentCallbacks) {
       setState(() {

--- a/packages/flutter/test/cupertino/dynamic_title_route_test.dart
+++ b/packages/flutter/test/cupertino/dynamic_title_route_test.dart
@@ -1,0 +1,405 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CupertinoPageRouteWithDynamicTitle', () {
+    testWidgets('creates route with dynamic title', (WidgetTester tester) async {
+      final ValueNotifier<String?> titleNotifier = ValueNotifier<String?>('Initial Title');
+      addTearDown(titleNotifier.dispose);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) => CupertinoButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  CupertinoPageRouteWithDynamicTitle<void>(
+                    builder: (BuildContext context) => const CupertinoPageScaffold(
+                      navigationBar: CupertinoNavigationBar(middle: Text('Test Page')),
+                      child: Center(child: Text('Page Content')),
+                    ),
+                    titleListenable: titleNotifier,
+                  ),
+                );
+              },
+              child: const Text('Push Route'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Route'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Page Content'), findsOneWidget);
+      // Check that the navigation bar shows the title
+      expect(find.byType(CupertinoNavigationBar), findsOneWidget);
+    });
+
+    testWidgets('updates title dynamically', (WidgetTester tester) async {
+      final ValueNotifier<String?> titleNotifier = ValueNotifier<String?>('Initial Title');
+      addTearDown(titleNotifier.dispose);
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) => CupertinoButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  CupertinoPageRouteWithDynamicTitle<void>(
+                    builder: (BuildContext context) => const CupertinoPageScaffold(
+                      navigationBar: CupertinoNavigationBar(middle: Text('Test Page')),
+                      child: Center(child: Text('Page Content')),
+                    ),
+                    titleListenable: titleNotifier,
+                  ),
+                );
+              },
+              child: const Text('Push Route'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Route'));
+      await tester.pumpAndSettle();
+
+      // Check that the navigation bar is present
+      expect(find.byType(CupertinoNavigationBar), findsOneWidget);
+
+      // Update the title
+      titleNotifier.value = 'Updated Title';
+      await tester.pump();
+
+      // Check that the navigation bar is still present after title update
+      expect(find.byType(CupertinoNavigationBar), findsOneWidget);
+    });
+
+    testWidgets('notifies neighboring routes when title changes', (WidgetTester tester) async {
+      final ValueNotifier<String?> firstTitleNotifier = ValueNotifier<String?>('First Page');
+      final ValueNotifier<String?> secondTitleNotifier = ValueNotifier<String?>('Second Page');
+      addTearDown(() {
+        firstTitleNotifier.dispose();
+        secondTitleNotifier.dispose();
+      });
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) => CupertinoButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  CupertinoPageRouteWithDynamicTitle<void>(
+                    builder: (BuildContext context) => CupertinoPageScaffold(
+                      navigationBar: const CupertinoNavigationBar(middle: Text('First Page')),
+                      child: Center(
+                        child: CupertinoButton(
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              CupertinoPageRouteWithDynamicTitle<void>(
+                                builder: (BuildContext context) => const CupertinoPageScaffold(
+                                  navigationBar: CupertinoNavigationBar(
+                                    middle: Text('Second Page'),
+                                  ),
+                                  child: Center(child: Text('Second Page Content')),
+                                ),
+                                titleListenable: secondTitleNotifier,
+                              ),
+                            );
+                          },
+                          child: const Text('Push Second Route'),
+                        ),
+                      ),
+                    ),
+                    titleListenable: firstTitleNotifier,
+                  ),
+                );
+              },
+              child: const Text('Push First Route'),
+            ),
+          ),
+        ),
+      );
+
+      // Push first route
+      await tester.tap(find.text('Push First Route'));
+      await tester.pumpAndSettle();
+
+      // Push second route
+      await tester.tap(find.text('Push Second Route'));
+      await tester.pumpAndSettle();
+
+      // Verify initial state
+      final Finder backButton = find.byType(CupertinoNavigationBarBackButton);
+      expect(backButton, findsOneWidget);
+      expect(find.descendant(of: backButton, matching: find.text('First Page')), findsOneWidget);
+      expect(find.text('Second Page'), findsOneWidget);
+
+      // Update first route title (keep it short to avoid "Back" label)
+      firstTitleNotifier.value = 'Updated';
+      await tester.pumpAndSettle();
+
+      // The second route should now show the updated first page title in its back button.
+      expect(find.descendant(of: backButton, matching: find.text('Updated')), findsOneWidget);
+      expect(find.descendant(of: backButton, matching: find.text('First Page')), findsNothing);
+    });
+
+    testWidgets('disposes listener when route is disposed', (WidgetTester tester) async {
+      final ValueNotifier<String?> titleNotifier = ValueNotifier<String?>('Initial Title');
+      addTearDown(titleNotifier.dispose);
+      int listenerCallCount = 0;
+
+      titleNotifier.addListener(() {
+        listenerCallCount++;
+      });
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) => CupertinoButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  CupertinoPageRouteWithDynamicTitle<void>(
+                    builder: (BuildContext context) => const CupertinoPageScaffold(
+                      navigationBar: CupertinoNavigationBar(middle: Text('Test Page')),
+                      child: Center(child: Text('Page Content')),
+                    ),
+                    titleListenable: titleNotifier,
+                  ),
+                );
+              },
+              child: const Text('Push Route'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Route'));
+      await tester.pumpAndSettle();
+
+      // Pop the route
+      await tester.tap(find.byType(CupertinoNavigationBarBackButton));
+      await tester.pumpAndSettle();
+
+      // Update the title - should not trigger the route's listener since it's disposed
+      titleNotifier.value = 'Updated Title';
+      await tester.pump();
+
+      // The listener should only be called once (from the direct addListener above)
+      expect(listenerCallCount, equals(1));
+    });
+  });
+
+  group('Route.changedInternalState with notifyNeighbors', () {
+    testWidgets('notifies neighboring routes when called with notifyNeighbors=true', (
+      WidgetTester tester,
+    ) async {
+      final ValueNotifier<String?> titleNotifier = ValueNotifier<String?>('Initial Title');
+      addTearDown(titleNotifier.dispose);
+      bool didChangePreviousCalled = false;
+      bool didChangeNextCalled = false;
+
+      // Create a custom route that tracks when didChangePrevious/didChangeNext are called
+      final _TestRoute customRoute = _TestRoute(
+        titleListenable: titleNotifier,
+        onDidChangePrevious: () => didChangePreviousCalled = true,
+        onDidChangeNext: () => didChangeNextCalled = true,
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) => CupertinoButton(
+              onPressed: () {
+                Navigator.push(context, customRoute);
+              },
+              child: const Text('Push Route'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Route'));
+      await tester.pumpAndSettle();
+
+      // Reset flags
+      didChangePreviousCalled = false;
+      didChangeNextCalled = false;
+
+      // Call changedInternalState with notifyNeighbors=true
+      customRoute.changedInternalState(notifyNeighbors: true);
+      await tester.pump();
+
+      // Since this is the only route, no neighbors should be notified
+      expect(didChangePreviousCalled, isFalse);
+      expect(didChangeNextCalled, isFalse);
+    });
+
+    testWidgets('notifies neighboring routes with actual neighbors', (WidgetTester tester) async {
+      final ValueNotifier<String?> firstTitleNotifier = ValueNotifier<String?>('First Page');
+      final ValueNotifier<String?> secondTitleNotifier = ValueNotifier<String?>('Second Page');
+      final ValueNotifier<String?> thirdTitleNotifier = ValueNotifier<String?>('Third Page');
+      addTearDown(() {
+        firstTitleNotifier.dispose();
+        secondTitleNotifier.dispose();
+        thirdTitleNotifier.dispose();
+      });
+
+      bool firstDidChangePreviousCalled = false;
+      bool firstDidChangeNextCalled = false;
+      bool secondDidChangePreviousCalled = false;
+      bool secondDidChangeNextCalled = false;
+      bool thirdDidChangePreviousCalled = false;
+      bool thirdDidChangeNextCalled = false;
+
+      // Create test routes that track when didChangePrevious/didChangeNext are called
+      final _TestRoute firstRoute = _TestRoute(
+        titleListenable: firstTitleNotifier,
+        onDidChangePrevious: () => firstDidChangePreviousCalled = true,
+        onDidChangeNext: () => firstDidChangeNextCalled = true,
+      );
+
+      final _TestRoute secondRoute = _TestRoute(
+        titleListenable: secondTitleNotifier,
+        onDidChangePrevious: () => secondDidChangePreviousCalled = true,
+        onDidChangeNext: () => secondDidChangeNextCalled = true,
+      );
+
+      final _TestRoute thirdRoute = _TestRoute(
+        titleListenable: thirdTitleNotifier,
+        onDidChangePrevious: () => thirdDidChangePreviousCalled = true,
+        onDidChangeNext: () => thirdDidChangeNextCalled = true,
+      );
+
+      late NavigatorState navigator;
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              navigator = Navigator.of(context);
+              return const CupertinoPageScaffold(
+                navigationBar: CupertinoNavigationBar(middle: Text('Home')),
+                child: Center(child: Text('Home Page')),
+              );
+            },
+          ),
+        ),
+      );
+
+      // Push all three routes to create a stack: home -> first -> second -> third
+      navigator.push(firstRoute);
+      await tester.pumpAndSettle();
+      navigator.push(secondRoute);
+      await tester.pumpAndSettle();
+      navigator.push(thirdRoute);
+      await tester.pumpAndSettle();
+
+      // Reset all flags
+      firstDidChangePreviousCalled = false;
+      firstDidChangeNextCalled = false;
+      secondDidChangePreviousCalled = false;
+      secondDidChangeNextCalled = false;
+      thirdDidChangePreviousCalled = false;
+      thirdDidChangeNextCalled = false;
+
+      // Call changedInternalState on the middle route (secondRoute) with notifyNeighbors=true
+      secondRoute.changedInternalState(notifyNeighbors: true);
+      await tester.pump();
+
+      // The first route (previous neighbor) should be notified via didChangeNext
+      expect(firstDidChangeNextCalled, isTrue);
+      expect(firstDidChangePreviousCalled, isFalse);
+
+      // The third route (next neighbor) should be notified via didChangePrevious
+      expect(thirdDidChangePreviousCalled, isTrue);
+      expect(thirdDidChangeNextCalled, isFalse);
+
+      // The middle route (secondRoute) should not have its own callbacks called
+      expect(secondDidChangePreviousCalled, isFalse);
+      expect(secondDidChangeNextCalled, isFalse);
+    });
+
+    testWidgets('does not notify neighboring routes when called with notifyNeighbors=false', (
+      WidgetTester tester,
+    ) async {
+      final ValueNotifier<String?> titleNotifier = ValueNotifier<String?>('Initial Title');
+      addTearDown(titleNotifier.dispose);
+      bool didChangePreviousCalled = false;
+      bool didChangeNextCalled = false;
+
+      final _TestRoute customRoute = _TestRoute(
+        titleListenable: titleNotifier,
+        onDidChangePrevious: () => didChangePreviousCalled = true,
+        onDidChangeNext: () => didChangeNextCalled = true,
+      );
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Builder(
+            builder: (BuildContext context) => CupertinoButton(
+              onPressed: () {
+                Navigator.push(context, customRoute);
+              },
+              child: const Text('Push Route'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Push Route'));
+      await tester.pumpAndSettle();
+
+      // Reset flags
+      didChangePreviousCalled = false;
+      didChangeNextCalled = false;
+
+      // Call changedInternalState with notifyNeighbors=false (default)
+      customRoute.changedInternalState();
+      await tester.pump();
+
+      // No neighbors should be notified
+      expect(didChangePreviousCalled, isFalse);
+      expect(didChangeNextCalled, isFalse);
+    });
+  });
+}
+
+/// A test route that implements CupertinoRouteTransitionMixin for testing purposes.
+class _TestRoute extends PageRoute<void> with CupertinoRouteTransitionMixin<void> {
+  _TestRoute({required this.titleListenable, this.onDidChangePrevious, this.onDidChangeNext});
+
+  final ValueListenable<String?> titleListenable;
+  final VoidCallback? onDidChangePrevious;
+  final VoidCallback? onDidChangeNext;
+
+  @override
+  String? get title => titleListenable.value;
+
+  @override
+  bool get maintainState => true;
+
+  @override
+  Widget buildContent(BuildContext context) => const Text('Test Route');
+
+  @override
+  void didChangePrevious(Route<dynamic>? previousRoute) {
+    super.didChangePrevious(previousRoute);
+    onDidChangePrevious?.call();
+  }
+
+  @override
+  void didChangeNext(Route<dynamic>? nextRoute) {
+    super.didChangeNext(nextRoute);
+    onDidChangeNext?.call();
+  }
+}


### PR DESCRIPTION
Introduces a new route class, CupertinoPageRouteWithDynamicTitle, which extends CupertinoPageRoute to allow dynamic updates of the route title using a ValueListenable<String?>. This change enables neighboring routes to be notified of title changes, enhancing navigation bar functionality in iOS-designed apps.

Additionally, updates to the Route class's changedInternalState method allow for notifying adjacent routes about state changes. Comprehensive tests have been added to ensure the correct behavior of dynamic title updates and neighbor notifications.

Fix: #175129


<details>
<summary>Demo Code</summary> 

```
import 'package:flutter/cupertino.dart';
import 'package:flutter/foundation.dart';
import 'dart:async';

import 'package:flutter/material.dart';

void main() {
  runApp(CupertinoTitleBugApp());
}

class CupertinoTitleBugApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoApp(
      title: 'Cupertino Title Bug Reproduction',
      theme: CupertinoThemeData(
        primaryColor: CupertinoColors.systemBlue,
      ),
      home: HomePage(),
      debugShowCheckedModeBanner: false,
    );
  }
}

final valueNotifier = ValueNotifier<String>("Loading...");

class HomePage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(
        middle: Text('Home'),
        trailing: CupertinoButton(
          padding: EdgeInsets.zero,
          child: Text('Next'),
          onPressed: () {
            Navigator.of(context).push(
              CupertinoPageRouteWithDynamicTitle(
                titleListenable: valueNotifier,
                builder: (context) => DynamicTitlePage(),
              ),
            );
          },
        ),
      ),
      child: SafeArea(
        child: Center(
          child: Column(
            mainAxisAlignment: MainAxisAlignment.center,
            children: [
              Icon(
                CupertinoIcons.home,
                size: 64,
                color: CupertinoColors.systemGrey,
              ),
              SizedBox(height: 16),
              Text(
                'ValueNotifier Demo',
                style: CupertinoTheme.of(context).textTheme.navTitleTextStyle,
                textAlign: TextAlign.center,
              ),
              SizedBox(height: 8),
              Text(
                'Tap "Next" to see the demo',
                style: CupertinoTheme.of(context).textTheme.textStyle,
                textAlign: TextAlign.center,
              ),
            ],
          ),
        ),
      ),
    );
  }
}

class DynamicTitlePage extends StatefulWidget {
  @override
  _DynamicTitlePageState createState() => _DynamicTitlePageState();
}

class _DynamicTitlePageState extends State<DynamicTitlePage> {
  @override
  void initState() {
    super.initState();
  }

  @override
  void dispose() {
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(
        middle: ValueListenableBuilder(valueListenable: valueNotifier, builder: (context,value,child)=> Text(value)),
        trailing: CupertinoButton(
          padding: EdgeInsets.zero,
          child: Text('Next'),
          onPressed: () {
            Navigator.of(context).push(
              CupertinoPageRoute(
                  title: "Another Page", builder: (context) => AnotherPage()),
            );
          },
        ),
      ),
      child: SafeArea(
        child: Padding(
          padding: EdgeInsets.all(16),
          child: Column(
            crossAxisAlignment: CrossAxisAlignment.start,
            children: [
              // Simple demo section
              Container(
                padding: EdgeInsets.all(16),
                decoration: BoxDecoration(
                  color: CupertinoColors.systemBlue.withOpacity(0.1),
                  borderRadius: BorderRadius.circular(8),
                ),
                child: Column(
                  children: [
                    Text(
                      '📱 Demo: Dynamic Title',
                      style: TextStyle(
                        fontWeight: FontWeight.bold,
                        fontSize: 18,
                      ),
                    ),
                    SizedBox(height: 8),
                    ValueListenableBuilder(
                      valueListenable: valueNotifier,
                      builder: (context,value,child)=> Text(
                        'Current title: "${valueNotifier.value}"',
                        style: TextStyle(fontSize: 16),
                      ),
                    ),
                    SizedBox(height: 8),
                    Text(
                      'Tap "Next" to see the issue!',
                      style: TextStyle(color: CupertinoColors.systemGrey),
                    ),
                  ],
                ),
              ),

              SizedBox(height: 24),

              ElevatedButton(
                  onPressed: () {
                    valueNotifier.value = "Hello World";
                  },
                  child: Text("Update Page Title"))
            ],
          ),
        ),
      ),
    );
  }
}

class AnotherPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return CupertinoPageScaffold(
      navigationBar: CupertinoNavigationBar(
        middle: Text("Another Page"),
      ),
      child: SafeArea(
        child: Padding(
          padding: EdgeInsets.all(16),
          child: Center(
            child: Column(
              mainAxisAlignment: MainAxisAlignment.center,
              children: [
                Icon(
                  CupertinoIcons.info_circle,
                  size: 64,
                  color: CupertinoColors.systemBlue,
                ),
                SizedBox(height: 24),
                Text(
                  'Check the Navigation Bar!',
                  style: TextStyle(
                    fontSize: 24,
                    fontWeight: FontWeight.bold,
                  ),
                ),
                SizedBox(height: 16),
                Text(
                  'The back button should show "Hello World" but it shows "Loading..." instead.',
                  style: TextStyle(fontSize: 16),
                  textAlign: TextAlign.center,
                ),
                SizedBox(height: 24),
                CupertinoButton.filled(
                  onPressed: () {
                    Navigator.of(context).pop();
                  },
                  child: Text('Go Back'),
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}

```
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.  
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.  
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].  
- [x] I signed the [CLA].  
- [x] I listed at least one issue that this PR fixes in the description above.  
- [x] I updated/added relevant documentation (doc comments with `///`).  
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].  
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.  
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
