### PR TITLE
Update `build.gradle` to remove deprecation warning in `flutter\engine\src\flutter\shell\platform\android`

### DIFF
--- a/engine/src/flutter/shell/platform/android/build.gradle
+++ b/engine/src/flutter/shell/platform/android/build.gradle
@@ -22,7 +22,7 @@ repositories {
 apply plugin: "com.android.library"
 
 android {
-    namespace "io.flutter.embedding"
+    namespace = "io.flutter.embedding"
     compileSdk = 36
 
     defaultConfig {


### PR DESCRIPTION
part of #173321

when excuting `./gradlew help --scan --warning-mode all` in `flutter\engine\src\flutter\shell\platform\android`
i see a warning :
```gradle
> Configure project :
Build file 'C:\flutter\engine\src\flutter\shell\platform\android\build.gradle': line 25
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('namespace = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.0-milestone-1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_6pliwxbny923etvz9fwvbblij$_run_closure2.doCall$original(C:\flutter\engine\src\flutter\shell\platform\android\build.gradle:25)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_6pliwxbny923etvz9fwvbblij.run(C:\flutter\engine\src\flutter\shell\platform\android\build.gradle:24)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
which is the line
```gradle
namespace "io.flutter.embedding"
```
after changing it to :
```gradle
namespace = "io.flutter.embedding"
```
the error is gone :
```gradle
C:\flutter\engine\src\flutter\shell\platform\android git:[master]
./gradlew help --scan --warning-mode all

> Task :help

Welcome to Gradle 9.0-milestone-1.

```
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
