### PR TITLE
Search PATH for code_assets dependencies if needed

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
@@ -11,37 +11,52 @@ import '../../../globals.dart' as globals;
 
 /// Flutter expects `clang++` to be on the path on Linux hosts.
 ///
-/// Search for the accompanying `clang`, `ar`, and `ld`.
+/// Search for the accompanying `clang`, `ar`, and `ld`, if they can be found.
+/// Otherwise, default to looking on the `PATH`,
+/// as some systems do not ship these executables together.
 Future<CCompilerConfig> cCompilerConfigLinux() async {
   const kClangPlusPlusBinary = 'clang++';
   const kClangBinary = 'clang';
   const kArBinary = 'llvm-ar';
   const kLdBinary = 'ld.lld';
 
+  final File clangPpFile = await _findExecutable(kClangPlusPlusBinary);
+  final Directory clangDir = clangPpFile.parent;
+
+  return CCompilerConfig(
+    linker: (await _findExecutable(kLdBinary, preferredPath: clangDir)).uri,
+    archiver: (await _findExecutable(kArBinary, preferredPath: clangDir)).uri,
+    compiler: (await _findExecutable(kClangBinary, preferredPath: clangDir)).uri,
+  );
+}
+
+/// Finds [executableName] if it exists in the [preferredPath] (if provided).
+/// Otherwise, defaults to looking in the `PATH`.
+///
+/// If [executableName] cannot be found in either of these locations,
+/// an error is thrown.
+Future<File> _findExecutable(String executableName, {Directory? preferredPath}) async {
+  // If we can find the executable at the preferred path, use it
+  if (preferredPath != null) {
+    final File binaryFile = preferredPath.childFile(executableName);
+    if (await binaryFile.exists()) {
+      return binaryFile;
+    }
+  }
+
+  // Otherwise, default to checking the PATH
   final ProcessResult whichResult = await globals.processManager.run(<String>[
     'which',
-    kClangPlusPlusBinary,
+    executableName,
   ]);
   if (whichResult.exitCode != 0) {
-    throwToolExit('Failed to find $kClangPlusPlusBinary on PATH.');
+    throwToolExit(
+      preferredPath != null
+          ? 'Failed to find $executableName in $preferredPath and on PATH'
+          : 'Failed to find $executableName on PATH.',
+    );
   }
-  File clangPpFile = globals.fs.file((whichResult.stdout as String).trim());
-  clangPpFile = globals.fs.file(await clangPpFile.resolveSymbolicLinks());
 
-  final Directory clangDir = clangPpFile.parent;
-  final binaryPaths = <String, Uri>{};
-  for (final binary in <String>[kClangBinary, kArBinary, kLdBinary]) {
-    final File binaryFile = clangDir.childFile(binary);
-    if (!await binaryFile.exists()) {
-      throwToolExit("Failed to find $binary relative to $clangPpFile: $binaryFile doesn't exist.");
-    }
-    binaryPaths[binary] = binaryFile.uri;
-  }
-  final Uri? archiver = binaryPaths[kArBinary];
-  final Uri? compiler = binaryPaths[kClangBinary];
-  final Uri? linker = binaryPaths[kLdBinary];
-  if (archiver == null || compiler == null || linker == null) {
-    throwToolExit('Clang could not be found.');
-  }
-  return CCompilerConfig(archiver: archiver, compiler: compiler, linker: linker);
+  final File executableFile = globals.fs.file((whichResult.stdout as String).trim());
+  return globals.fs.file(await executableFile.resolveSymbolicLinks());
 }


### PR DESCRIPTION
If the executable dependencies of `code_assets` are not found in the usual location (next to `clang++` on Linux), search for them on the `PATH`.
This is necessary on some systems, such as NixOS.

Fixes #175311

CC @dcharkes , looks like you're the relevant SME here based on `git blame` (sorry I keep tagging you in everything...)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing. (_Also verified this patch fixes my CI, which is using nix flakes to setup the build environment._)

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
