### PR TITLE
[a11y-app] Fix Autocomplete semantics label

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -55,22 +55,25 @@ class _MainWidgetState extends State<_MainWidget> {
         title: Semantics(headingLevel: 1, child: Text('$pageTitle Demo')),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Text('Type below to autocomplete the following possible results: $_kOptions.'),
-            Autocomplete<String>(
-              optionsBuilder: (TextEditingValue textEditingValue) {
-                if (textEditingValue.text == '') {
-                  return const Iterable<String>.empty();
-                }
-                return _kOptions.where((String option) {
-                  return option.contains(textEditingValue.text.toLowerCase());
-                });
-              },
-              fieldViewBuilder: _fieldViewBuilder,
-            ),
-          ],
+        child: Semantics(
+          container: true,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text('Type below to autocomplete the following possible results: $_kOptions.'),
+              Autocomplete<String>(
+                optionsBuilder: (TextEditingValue textEditingValue) {
+                  if (textEditingValue.text == '') {
+                    return const Iterable<String>.empty();
+                  }
+                  return _kOptions.where((String option) {
+                    return option.contains(textEditingValue.text.toLowerCase());
+                  });
+                },
+                fieldViewBuilder: _fieldViewBuilder,
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/dev/a11y_assessments/test/auto_complete_test.dart
+++ b/dev/a11y_assessments/test/auto_complete_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:a11y_assessments/use_cases/auto_complete.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'test_utils.dart';
@@ -27,5 +28,20 @@ void main() {
     final Finder findHeadingLevelOnes = find.bySemanticsLabel(RegExp('AutoComplete Demo'));
     await tester.pumpAndSettle();
     expect(findHeadingLevelOnes, findsOne);
+  });
+
+  testWidgets('The text is used as semantics label for the text field', (
+    WidgetTester tester,
+  ) async {
+    await pumpsUseCase(tester, AutoCompleteUseCase());
+    await tester.pumpAndSettle();
+
+    const List<String> kOptions = <String>['apple', 'banana', 'lemon'];
+    const String label = 'Fruit';
+    final String message =
+        'Type below to autocomplete the following possible results: $kOptions.\n$label';
+
+    final SemanticsNode node = tester.semantics.find(find.bySemanticsLabel(message));
+    expect(node.flagsCollection.isTextField, isTrue);
   });
 }


### PR DESCRIPTION
## Description

This PR updates the autocomplete page of the A11y assessments app. It creates a single semantics node for the text above the autocomplete and the autocomplete.

## Related Issue

Fixes [[VPAT][A11y][a11y-app] fix a11y_assessment autocomplete to have proper labels](https://github.com/flutter/flutter/issues/173002)  

## Tests

Adds 1 test.