### PR TITLE
[Android] Use headingLevel for heading accessibility property

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1033,7 +1033,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     // Heading support
     if (Build.VERSION.SDK_INT >= API_LEVELS.API_28) {
-      result.setHeading(semanticsNode.hasFlag(Flag.IS_HEADER));
+      result.setHeading(semanticsNode.headingLevel > 0);
     }
 
     // Accessibility Focus
@@ -2225,7 +2225,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     HAS_ENABLED_STATE(1 << 6),
     IS_ENABLED(1 << 7),
     IS_IN_MUTUALLY_EXCLUSIVE_GROUP(1 << 8),
-    IS_HEADER(1 << 9),
     IS_OBSCURED(1 << 10),
     SCOPES_ROUTE(1 << 11),
     NAMES_ROUTE(1 << 12),
@@ -2391,6 +2390,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     // The locale of the content of this node.
     @Nullable private String locale;
 
+    // The heading level for this node (0 means not a heading).
+    private int headingLevel;
+
     // The id of the sibling node that is before this node in traversal
     // order.
     //
@@ -2516,6 +2518,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 + flags
                 + "\n"
                 + indent
+                + "  +-- headingLevel="
+                + headingLevel
+                + "\n"
+                + indent
                 + "  +-- textDirection="
                 + textDirection
                 + "\n"
@@ -2591,6 +2597,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       linkUrl = getStringFromBuffer(buffer, strings);
       locale = getStringFromBuffer(buffer, strings);
 
+      headingLevel = buffer.getInt();
       textDirection = TextDirection.fromInt(buffer.getInt());
 
       left = buffer.getFloat();

--- a/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2225,6 +2225,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     HAS_ENABLED_STATE(1 << 6),
     IS_ENABLED(1 << 7),
     IS_IN_MUTUALLY_EXCLUSIVE_GROUP(1 << 8),
+    IS_HEADER(1 << 9),
     IS_OBSCURED(1 << 10),
     SCOPES_ROUTE(1 << 11),
     NAMES_ROUTE(1 << 12),

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -239,6 +239,7 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
       putStringIntoBuffer(node.linkUrl, buffer_int32, &position, strings);
       putStringIntoBuffer(node.locale, buffer_int32, &position, strings);
 
+      buffer_int32[position++] = node.headingLevel;
       buffer_int32[position++] = node.textDirection;
       buffer_float32[position++] = node.rect.left();
       buffer_float32[position++] = node.rect.top();

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
@@ -17,7 +17,7 @@ namespace flutter {
 class PlatformViewAndroidDelegate {
  public:
   static constexpr size_t kBytesPerNode =
-      51 * sizeof(int32_t);  // The # fields in SemanticsNode
+      52 * sizeof(int32_t);  // The # fields in SemanticsNode
   static constexpr size_t kBytesPerChild = sizeof(int32_t);
   static constexpr size_t kBytesPerCustomAction = sizeof(int32_t);
   static constexpr size_t kBytesPerAction = 4 * sizeof(int32_t);

--- a/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -61,6 +61,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   expected_strings.push_back(node0.tooltip);
   buffer_int32[position++] = -1;  // node0.linkUrl
   buffer_int32[position++] = -1;  // node0.locale
+  buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
   buffer_float32[position++] = node0.rect.top();
@@ -128,6 +129,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesUpdateLinkUrl) {
   buffer_int32[position++] = expected_strings.size();  // node0.linkUrl
   expected_strings.push_back(node0.linkUrl);
   buffer_int32[position++] = -1;  // node0.locale
+  buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
   buffer_float32[position++] = node0.rect.top();
@@ -195,6 +197,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesUpdateLocale) {
   buffer_int32[position++] = -1;  // node0.linkUrl
   buffer_int32[position++] = expected_strings.size();
   expected_strings.push_back(node0.locale);  // node0.locale
+  buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
   buffer_float32[position++] = node0.rect.top();
@@ -289,6 +292,7 @@ TEST(PlatformViewShell,
   buffer_int32[position++] = -1;  // node0.tooltip
   buffer_int32[position++] = -1;  // node0.linkUrl
   buffer_int32[position++] = -1;  // node0.locale
+  buffer_int32[position++] = node0.headingLevel;
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
   buffer_float32[position++] = node0.rect.top();

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -2269,6 +2269,36 @@ public class AccessibilityBridgeTest {
     verify(mockChannel).dispatchSemanticsAction(0, AccessibilityBridge.Action.COLLAPSE);
   }
 
+  @Config(sdk = API_LEVELS.API_28)
+  @TargetApi(API_LEVELS.API_28)
+  @Test
+  public void itSetsHeadingWhenHeadingLevelIsPositive() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+
+    TestSemanticsNode headingNode = new TestSemanticsNode();
+    headingNode.headingLevel = 2;
+    headingNode.label = "Level 2 heading";
+    TestSemanticsUpdate headingUpdate = headingNode.toUpdate();
+    headingUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo headingInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertTrue(headingInfo.isHeading());
+  }
+
+  @Config(sdk = API_LEVELS.API_28)
+  @TargetApi(API_LEVELS.API_28)
+  @Test
+  public void itDoesNotSetHeadingWhenHeadingLevelIsZero() {
+    AccessibilityBridge accessibilityBridge = setUpBridge();
+
+    TestSemanticsNode nonHeadingNode = new TestSemanticsNode();
+    nonHeadingNode.headingLevel = 0;
+    nonHeadingNode.label = "Not a heading";
+    TestSemanticsUpdate nonHeadingUpdate = nonHeadingNode.toUpdate();
+    nonHeadingUpdate.sendUpdateToBridge(accessibilityBridge);
+    AccessibilityNodeInfo nonHeadingInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
+    assertFalse(nonHeadingInfo.isHeading());
+  }
+
   AccessibilityBridge setUpBridge() {
     return setUpBridge(null, null, null, null, null, null);
   }
@@ -2402,6 +2432,7 @@ public class AccessibilityBridgeTest {
     String tooltip = null;
     String linkUrl = null;
     String locale = null;
+    int headingLevel = 0;
     int textDirection = 0;
     float left = 0.0f;
     float top = 0.0f;
@@ -2477,6 +2508,7 @@ public class AccessibilityBridgeTest {
         strings.add(locale);
         bytes.putInt(strings.size() - 1);
       }
+      bytes.putInt(headingLevel);
       bytes.putInt(textDirection);
       bytes.putFloat(left);
       bytes.putFloat(top);

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.cc
@@ -584,6 +584,7 @@ AccessibilityBridge::FromFlutterSemanticsNode(
 
   result.flags = flutter_node.flags2;
   result.actions = flutter_node.actions;
+  result.heading_level = flutter_node.heading_level;
   result.text_selection_base = flutter_node.text_selection_base;
   result.text_selection_extent = flutter_node.text_selection_extent;
   result.scroll_child_count = flutter_node.scroll_child_count;

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.h
@@ -177,11 +177,11 @@ class AccessibilityBridge
     std::string decreased_value;
     std::string tooltip;
     FlutterTextDirection text_direction;
-    int32_t heading_level;
     FlutterRect rect;
     FlutterTransformation transform;
     std::vector<int32_t> children_in_traversal_order;
     std::vector<int32_t> custom_accessibility_actions;
+    int32_t heading_level;
   } SemanticsNode;
 
   // See FlutterSemanticsCustomAction in embedder.h

--- a/engine/src/flutter/shell/platform/common/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/common/accessibility_bridge.h
@@ -177,6 +177,7 @@ class AccessibilityBridge
     std::string decreased_value;
     std::string tooltip;
     FlutterTextDirection text_direction;
+    int32_t heading_level;
     FlutterRect rect;
     FlutterTransformation transform;
     std::vector<int32_t> children_in_traversal_order;

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -219,7 +219,6 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
   FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
-  root.id = 0;
   root.label = "root";
   root.hint = "";
   root.value = "";
@@ -237,7 +236,6 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
   FlutterSemanticsNode2 child1{sizeof(FlutterSemanticsNode2), 1};
-  child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";
   child1.value = "";

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -226,8 +226,8 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   root.increased_value = "";
   root.decreased_value = "";
   root.tooltip = "";
-  root.child_count = 1;
   root.heading_level = 0;
+  root.child_count = 1;
   root.flags2 = &flags;
   int32_t children[] = {1};
   root.children_in_traversal_order = children;

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -227,6 +227,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   root.decreased_value = "";
   root.tooltip = "";
   root.child_count = 1;
+  root.heading_level = 0;
   root.flags2 = &flags;
   int32_t children[] = {1};
   root.children_in_traversal_order = children;
@@ -243,6 +244,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   child1.increased_value = "";
   child1.decreased_value = "";
   child1.tooltip = "";
+  child1.heading_level = 0;
   child1.child_count = 0;
   child1.flags2 = &flags;
   child1.custom_accessibility_actions_count = 0;

--- a/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
+++ b/engine/src/flutter/shell/platform/common/flutter_platform_node_delegate_unittests.cc
@@ -218,7 +218,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   std::shared_ptr<TestAccessibilityBridge> bridge =
       std::make_shared<TestAccessibilityBridge>();
   FlutterSemanticsFlags flags = FlutterSemanticsFlags{0};
-  FlutterSemanticsNode2 root;
+  FlutterSemanticsNode2 root{sizeof(FlutterSemanticsNode2), 0};
   root.id = 0;
   root.label = "root";
   root.hint = "";
@@ -236,7 +236,7 @@ TEST(FlutterPlatformNodeDelegateTest, canUseOwnerBridge) {
   root.transform = {1, 0, 0, 0, 1, 0, 0, 0, 1};
   bridge->AddFlutterSemanticsNodeUpdate(root);
 
-  FlutterSemanticsNode2 child1;
+  FlutterSemanticsNode2 child1{sizeof(FlutterSemanticsNode2), 1};
   child1.id = 1;
   child1.label = "child 1";
   child1.hint = "";

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -1569,10 +1569,6 @@ typedef struct {
   /// The reading direction for `label`, `value`, `hint`, `increasedValue`,
   /// `decreasedValue`, and `tooltip`.
   FlutterTextDirection text_direction;
-  /// The heading level for this node. A value of 0 means the node is not a
-  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
-  /// numbers being higher-level headings.
-  int32_t heading_level;
   /// The bounding box for this node in its coordinate system.
   FlutterRect rect;
   /// The transform from this node's coordinate system to its parent's
@@ -1594,6 +1590,10 @@ typedef struct {
   FlutterPlatformViewIdentifier platform_view_id;
   /// A textual tooltip attached to the node.
   const char* tooltip;
+  /// The heading level for this node. A value of 0 means the node is not a
+  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
+  /// numbers being higher-level headings.
+  int32_t heading_level;
 } FlutterSemanticsNode;
 
 /// A node in the Flutter semantics tree.
@@ -1652,10 +1652,6 @@ typedef struct {
   /// The reading direction for `label`, `value`, `hint`, `increasedValue`,
   /// `decreasedValue`, and `tooltip`.
   FlutterTextDirection text_direction;
-  /// The heading level for this node. A value of 0 means the node is not a
-  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
-  /// numbers being higher-level headings.
-  int32_t heading_level;
   /// The bounding box for this node in its coordinate system.
   FlutterRect rect;
   /// The transform from this node's coordinate system to its parent's
@@ -1705,6 +1701,10 @@ typedef struct {
   // The set of semantics flags associated with this node. Prefer to use this
   // over `flags__deprecated__`.
   FlutterSemanticsFlags* flags2;
+  /// The heading level for this node. A value of 0 means the node is not a
+  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
+  /// numbers being higher-level headings.
+  int32_t heading_level;
 } FlutterSemanticsNode2;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a

--- a/engine/src/flutter/shell/platform/embedder/embedder.h
+++ b/engine/src/flutter/shell/platform/embedder/embedder.h
@@ -1569,6 +1569,10 @@ typedef struct {
   /// The reading direction for `label`, `value`, `hint`, `increasedValue`,
   /// `decreasedValue`, and `tooltip`.
   FlutterTextDirection text_direction;
+  /// The heading level for this node. A value of 0 means the node is not a
+  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
+  /// numbers being higher-level headings.
+  int32_t heading_level;
   /// The bounding box for this node in its coordinate system.
   FlutterRect rect;
   /// The transform from this node's coordinate system to its parent's
@@ -1648,6 +1652,10 @@ typedef struct {
   /// The reading direction for `label`, `value`, `hint`, `increasedValue`,
   /// `decreasedValue`, and `tooltip`.
   FlutterTextDirection text_direction;
+  /// The heading level for this node. A value of 0 means the node is not a
+  /// heading; higher values (1, 2, …) indicate the heading rank, with lower
+  /// numbers being higher-level headings.
+  int32_t heading_level;
   /// The bounding box for this node in its coordinate system.
   FlutterRect rect;
   /// The transform from this node's coordinate system to its parent's

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -163,6 +163,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV3Callbacks) {
           ASSERT_EQ(9.0, node->transform.pers2);
           ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1),
                     0);
+          ASSERT_EQ(node->heading_level, 0);
 
           if (node->id == 128) {
             ASSERT_EQ(0x3f3, node->platform_view_id);
@@ -458,6 +459,7 @@ TEST_F(EmbedderA11yTest, A11yTreeIsConsistentUsingV2Callbacks) {
       ASSERT_EQ(8.0, node->transform.pers1);
       ASSERT_EQ(9.0, node->transform.pers2);
       ASSERT_EQ(std::strncmp(kTooltip, node->tooltip, sizeof(kTooltip) - 1), 0);
+      ASSERT_EQ(node->heading_level, 0);
 
       if (node->id == 128) {
         ASSERT_EQ(0x3f3, node->platform_view_id);

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_frozen.h
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_frozen.h
@@ -95,6 +95,7 @@ typedef struct {
   const int32_t* custom_accessibility_actions;
   FlutterPlatformViewIdentifier platform_view_id;
   const char* tooltip;
+  int32_t heading_level;
 } FrozenFlutterSemanticsNode;
 
 // New members must not be added to `FlutterSemanticsCustomAction`

--- a/engine/src/flutter/shell/platform/embedder/tests/embedder_frozen_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/tests/embedder_frozen_unittests.cc
@@ -106,6 +106,8 @@ TEST(EmbedderFrozen, FlutterSemanticsNodeIsFrozen) {
   ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
                    platform_view_id);
   ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode, tooltip);
+  ASSERT_EQ_OFFSET(FlutterSemanticsNode, FrozenFlutterSemanticsNode,
+                   heading_level);
 }
 
 // New members must not be added to `FlutterSemanticsCustomAction`


### PR DESCRIPTION
[![talabat.com](https://img.shields.io/badge/talabat.com-contributions-FF5A00?style=flat&logo=flutter&logoColor=white)](https://www.talabat.com) [![Talabat Flutter PRs](https://img.shields.io/badge/Talabat_Flutter_PRs-10%20merged-97ca00?style=flat&logo=flutter&logoColor=white)](https://github.com/search?q=org%3Aflutter+talabat&type=pullrequests)

Fixes #174150

This PR updates the Android `AccessibilityBridge` to use the `headingLevel` property from `SemanticsNode` to determine if a node should be marked as a heading for accessibility purposes.

Previously, the `IS_HEADER` flag was used. Now, a node is considered a heading if `headingLevel > 0`. This aligns with the common accessibility pattern where heading levels (like H1, H2, etc.) define the structure.

The following changes were made:
- Modified `AccessibilityBridge.java` to set the heading status based on `semanticsNode.headingLevel > 0` for Android API level 28 and above.
- Added `headingLevel` to the `SemanticsNode` data structure in Java and its serialization/deserialization logic.
- Updated the C++ `PlatformViewAndroidDelegate` to include `headingLevel` when serializing `SemanticsNode` data.
- Increased `kBytesPerNode` in `platform_view_android_delegate.h` to account for the new `headingLevel` field.
- Added tests in `AccessibilityBridgeTest.java` to verify the new heading logic:
    - Nodes with `headingLevel = 0` are not headings.
    - Nodes with `headingLevel > 0` are headings.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md