### PR TITLE
[engine][fuchsia] Update to Fuchsia API level 28 and roll latest GN SDK

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -206,7 +206,7 @@ vars = {
 
   # The version / instance id of the cipd:chromium/fuchsia/gn-sdk which will be
   # used altogether with fuchsia-sdk to generate gn based build rules.
-  'fuchsia_gn_sdk_version': '_tkqOQZ2qB5CxDe57Ip_iSLO3uEEcFAo_h8GAav6u80C',
+  'fuchsia_gn_sdk_version': 'NAEC5tfgSl8g94nwpKsGtNMEdbiAlgwrNa9XQ7cIcbcC',
 }
 
 gclient_gn_args_file = 'engine/src/flutter/third_party/dart/build/config/gclient_args.gni'

--- a/engine/src/flutter/fml/BUILD.gn
+++ b/engine/src/flutter/fml/BUILD.gn
@@ -214,7 +214,7 @@ source_set("fml") {
     ]
 
     public_deps += [
-      "${fuchsia_sdk}/fidl/fuchsia.diagnostics:fuchsia.diagnostics_cpp",
+      "${fuchsia_sdk}/fidl/fuchsia.diagnostics.types:fuchsia.diagnostics.types_cpp",
       "${fuchsia_sdk}/fidl/fuchsia.logger:fuchsia.logger_cpp",
       "${fuchsia_sdk}/pkg/async-cpp",
       "${fuchsia_sdk}/pkg/async-loop-cpp",

--- a/engine/src/flutter/fml/platform/fuchsia/log_interest_listener.cc
+++ b/engine/src/flutter/fml/platform/fuchsia/log_interest_listener.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/platform/fuchsia/log_interest_listener.h"
 
-#include <fidl/fuchsia.diagnostics/cpp/fidl.h>
+#include <fidl/fuchsia.diagnostics.types/cpp/fidl.h>
 #include <fidl/fuchsia.logger/cpp/fidl.h>
 #include <zircon/assert.h>
 
@@ -31,16 +31,16 @@ void LogInterestListener::AsyncWaitForInterestChanged() {
 }
 
 void LogInterestListener::HandleInterestChange(
-    const fuchsia_diagnostics::Interest& interest) {
-  auto severity =
-      interest.min_severity().value_or(fuchsia_diagnostics::Severity::kInfo);
-  if (severity <= fuchsia_diagnostics::Severity::kDebug) {
+    const fuchsia_diagnostics_types::Interest& interest) {
+  using fuchsia_diagnostics_types::Severity;
+  auto severity = interest.min_severity().value_or(Severity::kInfo);
+  if (severity <= Severity::kDebug) {
     fml::SetLogSettings({.min_log_level = -1});  // Verbose
-  } else if (severity <= fuchsia_diagnostics::Severity::kInfo) {
+  } else if (severity <= Severity::kInfo) {
     fml::SetLogSettings({.min_log_level = kLogInfo});
-  } else if (severity <= fuchsia_diagnostics::Severity::kWarn) {
+  } else if (severity <= Severity::kWarn) {
     fml::SetLogSettings({.min_log_level = kLogWarning});
-  } else if (severity <= fuchsia_diagnostics::Severity::kError) {
+  } else if (severity <= Severity::kError) {
     fml::SetLogSettings({.min_log_level = kLogError});
   } else {
     fml::SetLogSettings({.min_log_level = kLogFatal});

--- a/engine/src/flutter/fml/platform/fuchsia/log_interest_listener.h
+++ b/engine/src/flutter/fml/platform/fuchsia/log_interest_listener.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_FML_PLATFORM_FUCHSIA_LOG_INTEREST_LISTENER_H_
 #define FLUTTER_FML_PLATFORM_FUCHSIA_LOG_INTEREST_LISTENER_H_
 
-#include <fidl/fuchsia.diagnostics/cpp/fidl.h>
+#include <fidl/fuchsia.diagnostics.types/cpp/fidl.h>
 #include <fidl/fuchsia.logger/cpp/fidl.h>
 #include <lib/fidl/cpp/client.h>
 
@@ -26,7 +26,7 @@ class LogInterestListener {
 
   // Updates the global log settings in response to a log interest change.
   static void HandleInterestChange(
-      const fuchsia_diagnostics::Interest& interest);
+      const fuchsia_diagnostics_types::Interest& interest);
 
  private:
   fidl::Client<::fuchsia_logger::LogSink> log_sink_;

--- a/engine/src/flutter/fml/platform/fuchsia/log_interest_listener_unittests.cc
+++ b/engine/src/flutter/fml/platform/fuchsia/log_interest_listener_unittests.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <fidl/fuchsia.diagnostics/cpp/fidl.h>
+#include <fidl/fuchsia.diagnostics.types/cpp/fidl.h>
 #include <fidl/fuchsia.logger/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async-loop/default.h>
@@ -27,26 +27,29 @@ namespace testing {
 
 constexpr static char kLogSink[] = "log_sink";
 
+using fuchsia_diagnostics_types::Interest;
+using fuchsia_diagnostics_types::Severity;
+
 class LogInterestListenerFuchsia : public ::loop_fixture::RealLoop,
                                    public ::testing::Test {};
 
 TEST_F(LogInterestListenerFuchsia, SeverityChanges) {
   ScopedSetLogSettings backup({.min_log_level = kLogInfo});
   {
-    ::fuchsia_diagnostics::Interest interest;
-    interest.min_severity(::fuchsia_diagnostics::Severity::kTrace);
+    Interest interest;
+    interest.min_severity(Severity::kTrace);
     LogInterestListener::HandleInterestChange(interest);
     EXPECT_EQ(GetMinLogLevel(), -1);  // VERBOSE
   }
   {
-    ::fuchsia_diagnostics::Interest interest;
-    interest.min_severity(::fuchsia_diagnostics::Severity::kInfo);
+    Interest interest;
+    interest.min_severity(Severity::kInfo);
     LogInterestListener::HandleInterestChange(interest);
     EXPECT_EQ(GetMinLogLevel(), kLogInfo);
   }
   {
-    ::fuchsia_diagnostics::Interest interest;
-    interest.min_severity(::fuchsia_diagnostics::Severity::kError);
+    Interest interest;
+    interest.min_severity(Severity::kError);
     LogInterestListener::HandleInterestChange(interest);
     EXPECT_EQ(GetMinLogLevel(), kLogError);
   }
@@ -64,7 +67,7 @@ class MockLogSink : public component_testing::LocalComponentImpl,
     if (first_call_) {
       // If it has not been called before, then return a result right away.
       fuchsia_logger::LogSinkWaitForInterestChangeResponse response = {
-          {.data = {{.min_severity = fuchsia_diagnostics::Severity::kWarn}}}};
+          {.data = {{.min_severity = Severity::kWarn}}}};
       completer.Reply(fit::ok(response));
       first_call_ = false;
     } else {

--- a/engine/src/flutter/fml/platform/fuchsia/log_interest_listener_unittests.cc
+++ b/engine/src/flutter/fml/platform/fuchsia/log_interest_listener_unittests.cc
@@ -35,23 +35,25 @@ class LogInterestListenerFuchsia : public ::loop_fixture::RealLoop,
 
 TEST_F(LogInterestListenerFuchsia, SeverityChanges) {
   ScopedSetLogSettings backup({.min_log_level = kLogInfo});
-  {
+
+  const struct {
+    Severity severity;
+    int expected_log_level;
+    const char* name;
+  } kTestCases[] = {
+      {Severity::kTrace, -1, "VERBOSE"},
+      {Severity::kInfo, kLogInfo, "INFO"},
+      {Severity::kWarn, kLogWarning, "WARNING"},
+      {Severity::kError, kLogError, "ERROR"},
+      {Severity::kFatal, kLogFatal, "FATAL"},
+  };
+
+  for (const auto& test_case : kTestCases) {
+    SCOPED_TRACE(test_case.name);
     Interest interest;
-    interest.min_severity(Severity::kTrace);
+    interest.min_severity(test_case.severity);
     LogInterestListener::HandleInterestChange(interest);
-    EXPECT_EQ(GetMinLogLevel(), -1);  // VERBOSE
-  }
-  {
-    Interest interest;
-    interest.min_severity(Severity::kInfo);
-    LogInterestListener::HandleInterestChange(interest);
-    EXPECT_EQ(GetMinLogLevel(), kLogInfo);
-  }
-  {
-    Interest interest;
-    interest.min_severity(Severity::kError);
-    LogInterestListener::HandleInterestChange(interest);
-    EXPECT_EQ(GetMinLogLevel(), kLogError);
+    EXPECT_EQ(GetMinLogLevel(), test_case.expected_log_level);
   }
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -227,7 +227,7 @@ bool DartComponentController::CreateAndBindNamespace() {
       fidl::ClientEnd<fuchsia_io::Directory>(dart_public_dir.TakeChannel()));
 
   // Request an event from the directory to ensure it is servicing requests.
-  dart_outgoing_dir_ptr_->Open3(
+  dart_outgoing_dir_ptr_->Open(
       ".",
       fuchsia::io::Flags::PROTOCOL_NODE |
           fuchsia::io::Flags::FLAG_SEND_REPRESENTATION,

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/component_v2.cc
@@ -272,10 +272,10 @@ ComponentV2::ComponentV2(
       fidl::ClientEnd<fuchsia_io::Directory>(flutter_public_dir.TakeChannel()));
 
   // Request an event from the directory to ensure it is servicing requests.
-  directory_ptr_->Open3(".",
-                        fuchsia::io::Flags::PROTOCOL_NODE |
-                            fuchsia::io::Flags::FLAG_SEND_REPRESENTATION,
-                        {}, cloned_directory_ptr_.NewRequest().TakeChannel());
+  directory_ptr_->Open(".",
+                       fuchsia::io::Flags::PROTOCOL_NODE |
+                           fuchsia::io::Flags::FLAG_SEND_REPRESENTATION,
+                       {}, cloned_directory_ptr_.NewRequest().TakeChannel());
 
   // Collect our standard set of directories along with directories that are
   // included in the cml file to expose.


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

There were some changes made in API level 28 to the fuchsia diagnostics types, which are preventing [the Fuchsia GN SDK roll](https://github.com/flutter/flutter/pulls?q=is%3Apr+%22roll+fuchsia+gn+sdk%22+). This CL prepares the Fuchsia logging subsystem to transition to these new types.  As part of this change I've also rolled the latest SDK, which is required for the changes made here.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA]. (I am a Googler)
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

test-exempt: No functional change.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
