### PR TITLE
Do not present textures in FlutterMetalLayer if the drawable size changed and the texture's size does not match the new drawable size

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -248,20 +248,26 @@ extern CFTimeInterval display_link_target;
 }
 
 - (void)setDrawableSize:(CGSize)drawableSize {
-  [_availableTextures removeAllObjects];
-  _front = nil;
-  _totalTextures = 0;
-  _drawableSize = drawableSize;
+  @synchronized(self) {
+    [_availableTextures removeAllObjects];
+    _front = nil;
+    _totalTextures = 0;
+    _drawableSize = drawableSize;
+  }
 }
 
 - (void)didEnterBackground:(id)notification {
-  [_availableTextures removeAllObjects];
-  _totalTextures = _front != nil ? 1 : 0;
+  @synchronized(self) {
+    [_availableTextures removeAllObjects];
+    _totalTextures = _front != nil ? 1 : 0;
+  }
   _displayLink.paused = YES;
 }
 
 - (CGSize)drawableSize {
-  return _drawableSize;
+  @synchronized(self) {
+    return _drawableSize;
+  }
 }
 
 - (IOSurface*)createIOSurface {
@@ -418,6 +424,10 @@ extern CFTimeInterval display_link_target;
 
 - (void)presentTexture:(FlutterTexture*)texture {
   @synchronized(self) {
+    if (texture.texture.width != _drawableSize.width ||
+        texture.texture.height != _drawableSize.height) {
+      return;
+    }
     if (_front != nil) {
       [_availableTextures addObject:_front];
     }

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -446,7 +446,10 @@ extern CFTimeInterval display_link_target;
 
 - (void)returnTexture:(FlutterTexture*)texture {
   @synchronized(self) {
-    [_availableTextures addObject:texture];
+    if (texture.texture.width == _drawableSize.width &&
+        texture.texture.height == _drawableSize.height) {
+      [_availableTextures addObject:texture];
+    }
   }
 }
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterMetalLayer.mm
@@ -30,9 +30,9 @@ extern CFTimeInterval display_link_target;
 
   NSUInteger _nextDrawableId;
 
+  // Access to these variables must be synchronized.
   NSMutableSet<FlutterTexture*>* _availableTextures;
   NSUInteger _totalTextures;
-
   FlutterTexture* _front;
 
   // There must be a CADisplayLink scheduled *on main thread* otherwise
@@ -445,6 +445,9 @@ extern CFTimeInterval display_link_target;
 }
 
 - (void)returnTexture:(FlutterTexture*)texture {
+  if (texture == nil) {
+    return;
+  }
   @synchronized(self) {
     if (texture.texture.width == _drawableSize.width &&
         texture.texture.height == _drawableSize.height) {


### PR DESCRIPTION
Also add locks around some methods that access texture and drawable state.

Fixes https://github.com/flutter/flutter/issues/175253