### PR TITLE
add FragmentProgram.fromBytes to c++ and web engines. 

### DIFF
--- a/engine/src/flutter/lib/ui/dart_ui.cc
+++ b/engine/src/flutter/lib/ui/dart_ui.cc
@@ -188,6 +188,7 @@ typedef CanvasPath Path;
   V(ColorFilter, initSrgbToLinearGamma)          \
   V(EngineLayer, dispose)                        \
   V(FragmentProgram, initFromAsset)              \
+  V(FragmentProgram, initFromBytes)              \
   V(ReusableFragmentShader, Dispose)             \
   V(ReusableFragmentShader, SetImageSampler)     \
   V(ReusableFragmentShader, ValidateSamplers)    \

--- a/engine/src/flutter/lib/ui/painting.dart
+++ b/engine/src/flutter/lib/ui/painting.dart
@@ -5253,7 +5253,7 @@ base class FragmentProgram extends NativeFieldWrapperClass1 {
       return Future<FragmentProgram>.value(program);
     }
     return Future<FragmentProgram>.microtask(() {
-      final FragmentProgram program = FragmentProgram._fromBytes(nameForShaderRegistry,bytes);
+      final FragmentProgram program = FragmentProgram._fromBytes(nameForShaderRegistry, bytes);
       _shaderRegistry[nameForShaderRegistry] = program;
       return program;
     });

--- a/engine/src/flutter/lib/ui/painting/fragment_program.cc
+++ b/engine/src/flutter/lib/ui/painting/fragment_program.cc
@@ -44,7 +44,8 @@ static std::string RuntimeStageBackendToString(
   }
 }
 
-std::string FragmentProgram::Init(const std::string& asset_name, std::unique_ptr<fml::Mapping> data) {
+std::string FragmentProgram::Init(const std::string& asset_name,
+                                  std::unique_ptr<fml::Mapping> data) {
   auto runtime_stages =
       impeller::RuntimeStage::DecodeRuntimeStages(std::move(data));
 
@@ -152,7 +153,8 @@ std::string FragmentProgram::initFromAsset(const std::string& asset_name) {
   return Init(asset_name, std::move(data));
 }
 
-std::string FragmentProgram::initFromBytes(const std::string& asset_name, std::vector<uint8_t> bytes) {
+std::string FragmentProgram::initFromBytes(const std::string& asset_name,
+                                           std::vector<uint8_t> bytes) {
   FML_TRACE_EVENT("flutter", "FragmentProgram::initFromBytes", "size",
                   bytes.size());
 

--- a/engine/src/flutter/lib/ui/painting/fragment_program.h
+++ b/engine/src/flutter/lib/ui/painting/fragment_program.h
@@ -19,7 +19,8 @@
 
 namespace tonic {
 
-// DartConverter template for converting a Dart Uint8List to a C++ std::vector<uint8_t>.
+// DartConverter template for converting a Dart Uint8List to a C++
+// std::vector<uint8_t>.
 template <>
 struct DartConverter<std::vector<uint8_t>> {
   using NativeType = std::vector<uint8_t>;
@@ -52,8 +53,8 @@ struct DartConverter<std::vector<uint8_t>> {
   }
 
   static NativeType FromArguments(Dart_NativeArguments args,
-                                    int index,
-                                    Dart_Handle& exception) {
+                                  int index,
+                                  Dart_Handle& exception) {
     Dart_Handle handle = Dart_GetNativeArgument(args, index);
     if (Dart_IsError(handle)) {
       exception = handle;
@@ -71,7 +72,7 @@ struct DartConverter<std::vector<uint8_t>> {
   static bool AllowedInLeafCall() { return kAllowedInLeafCall; }
 };
 
-} // namespace tonic
+}  // namespace tonic
 
 namespace flutter {
 
@@ -87,7 +88,8 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
 
   std::string initFromAsset(const std::string& asset_name);
 
-  std::string initFromBytes(const std::string& asset_name, std::vector<uint8_t> bytes);
+  std::string initFromBytes(const std::string& asset_name,
+                            std::vector<uint8_t> bytes);
 
   fml::RefPtr<FragmentShader> shader(Dart_Handle shader,
                                      Dart_Handle uniforms_handle,
@@ -103,7 +105,8 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
 
  private:
   FragmentProgram();
-  std::string Init(const std::string& asset_name, std::unique_ptr<fml::Mapping> data);
+  std::string Init(const std::string& asset_name,
+                   std::unique_ptr<fml::Mapping> data);
   sk_sp<DlRuntimeEffect> runtime_effect_;
 };
 

--- a/engine/src/flutter/lib/ui/painting/fragment_program.h
+++ b/engine/src/flutter/lib/ui/painting/fragment_program.h
@@ -17,6 +17,62 @@
 #include <string>
 #include <vector>
 
+namespace tonic {
+
+// DartConverter template for converting a Dart Uint8List to a C++ std::vector<uint8_t>.
+template <>
+struct DartConverter<std::vector<uint8_t>> {
+  using NativeType = std::vector<uint8_t>;
+  using FfiType = Dart_Handle;
+  static constexpr const char* kDartRepresentation = "Uint8List";
+  static constexpr bool kAllowedInLeafCall = false;
+
+  static NativeType FromDart(Dart_Handle handle) {
+    if (Dart_IsError(handle) || !Dart_IsTypedData(handle)) {
+      return {};
+    }
+
+    Dart_TypedData_Type type;
+    void* data = nullptr;
+    intptr_t length = 0;
+
+    Dart_TypedDataAcquireData(handle, &type, &data, &length);
+
+    if (type != Dart_TypedData_kUint8) {
+      Dart_TypedDataReleaseData(handle);
+      return {};
+    }
+
+    const uint8_t* bytes = static_cast<const uint8_t*>(data);
+    NativeType result(bytes, bytes + length);
+
+    Dart_TypedDataReleaseData(handle);
+
+    return result;
+  }
+
+  static NativeType FromArguments(Dart_NativeArguments args,
+                                    int index,
+                                    Dart_Handle& exception) {
+    Dart_Handle handle = Dart_GetNativeArgument(args, index);
+    if (Dart_IsError(handle)) {
+      exception = handle;
+      return {};
+    }
+    if (!Dart_IsTypedData(handle)) {
+      exception = Dart_NewApiError("Expected a Uint8List argument.");
+      return {};
+    }
+    return FromDart(handle);
+  }
+
+  static NativeType FromFfi(FfiType val) { return FromDart(val); }
+  static const char* GetDartRepresentation() { return kDartRepresentation; }
+  static bool AllowedInLeafCall() { return kAllowedInLeafCall; }
+};
+
+} // namespace tonic
+
 namespace flutter {
 
 class FragmentShader;
@@ -30,6 +86,8 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
   static void Create(Dart_Handle wrapper);
 
   std::string initFromAsset(const std::string& asset_name);
+
+  std::string initFromBytes(const std::string& asset_name, std::vector<uint8_t> bytes);
 
   fml::RefPtr<FragmentShader> shader(Dart_Handle shader,
                                      Dart_Handle uniforms_handle,
@@ -45,6 +103,7 @@ class FragmentProgram : public RefCountedDartWrappable<FragmentProgram> {
 
  private:
   FragmentProgram();
+  std::string Init(const std::string& asset_name, std::unique_ptr<fml::Mapping> data);
   sk_sp<DlRuntimeEffect> runtime_effect_;
 };
 

--- a/engine/src/flutter/lib/web_ui/lib/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/painting.dart
@@ -989,6 +989,10 @@ abstract class FragmentProgram {
     return engine.renderer.createFragmentProgram(assetKey);
   }
 
+  static Future<FragmentProgram> fromBytes(String nameForShaderRegistry, Uint8List bytes) {
+    return engine.renderer.createFragmentProgramFromBytes(nameForShaderRegistry, bytes);
+  }
+
   FragmentShader fragmentShader();
 }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -514,6 +514,16 @@ class CanvasKitRenderer extends Renderer {
   }
 
   @override
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes) {
+    if (_programs.containsKey(nameForShaderRegistry)) {
+      return _programs[nameForShaderRegistry]!;
+    }
+    return _programs[nameForShaderRegistry] = Future.value(
+      CkFragmentProgram.fromBytes(nameForShaderRegistry, bytes),
+    );
+  }
+
+  @override
   ui.LineMetrics createLineMetrics({
     required bool hardBreak,
     required double ascent,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/renderer.dart
@@ -514,7 +514,10 @@ class CanvasKitRenderer extends Renderer {
   }
 
   @override
-  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes) {
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(
+    String nameForShaderRegistry,
+    Uint8List bytes,
+  ) {
     if (_programs.containsKey(nameForShaderRegistry)) {
       return _programs[nameForShaderRegistry]!;
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
@@ -202,6 +202,7 @@ abstract class Renderer {
 
   void clearFragmentProgramCache();
   Future<ui.FragmentProgram> createFragmentProgram(String assetKey);
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes);
 
   ui.Path createPath();
   ui.Path copyPath(ui.Path src);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/renderer.dart
@@ -202,7 +202,10 @@ abstract class Renderer {
 
   void clearFragmentProgramCache();
   Future<ui.FragmentProgram> createFragmentProgram(String assetKey);
-  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes);
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(
+    String nameForShaderRegistry,
+    Uint8List bytes,
+  );
 
   ui.Path createPath();
   ui.Path copyPath(ui.Path src);

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -440,7 +440,10 @@ class SkwasmRenderer extends Renderer {
   }
 
   @override
-  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes) {
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(
+    String nameForShaderRegistry,
+    Uint8List bytes,
+  ) {
     if (_programs.containsKey(nameForShaderRegistry)) {
       return _programs[nameForShaderRegistry]!;
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/renderer.dart
@@ -440,6 +440,16 @@ class SkwasmRenderer extends Renderer {
   }
 
   @override
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes) {
+    if (_programs.containsKey(nameForShaderRegistry)) {
+      return _programs[nameForShaderRegistry]!;
+    }
+    return _programs[nameForShaderRegistry] = Future.value(
+      SkwasmFragmentProgram.fromBytes(nameForShaderRegistry, bytes),
+    );
+  }
+
+  @override
   ui.LineMetrics createLineMetrics({
     required bool hardBreak,
     required double ascent,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -288,7 +288,10 @@ class SkwasmRenderer extends Renderer {
   }
 
   @override
-  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes) {
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(
+    String nameForShaderRegistry,
+    Uint8List bytes,
+  ) {
     throw UnimplementedError('Skwasm not implemented on this platform.');
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_stub/renderer.dart
@@ -288,6 +288,11 @@ class SkwasmRenderer extends Renderer {
   }
 
   @override
+  Future<ui.FragmentProgram> createFragmentProgramFromBytes(String nameForShaderRegistry, Uint8List bytes) {
+    throw UnimplementedError('Skwasm not implemented on this platform.');
+  }
+
+  @override
   ui.LineMetrics createLineMetrics({
     required bool hardBreak,
     required double ascent,


### PR DESCRIPTION
Fixes #169442
Fixes #166944
Accomodates #167404 and some of #166944 

This PR adds a FragmentProgram.fromBytes() method to allow loading of fragment shaders from outside the original asset bundle.  This greatly extends the capabilities of the current restrictions of only allowing fragment shaders to be bundled in the build time asset bundle. (allowing many new capabilities, including items like the protection of shader source code via encryption, downloads of new shaders without reinstallation of program, runtime shader editing, ad infinitum). The referenced issues only partially touch upon why this feature is desperately needed.

This PR goes hand in hand with #175470 which allows versioning of impellerc outputs and protection for the engine from attempting to load incompatible versions of any of the impellerc output flat buffers.  PR #175470 should be considered a required component of this PR to protect the engine from unexpected input.

I will incorporate unit tests for these capabilities which exercise the fromBytes() method - I wanted to initiate the conversation for now.  I personally feel that the bang for the buck from this PR is extraordinary.

Other issues that this PR resolves or at least provides capabilities for that allow work-arounds:
  resolves - #169442 - Allow for shader loading at runtime
  partial - #171284 - Add support for loading assets with non-package paths in dart:ui APIs
                     (for the FragmentProgram.fromAsset() limitations .fromBytes() can be used to load your assets from
                            any AssetBundle)
  

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [FORTHCOMING] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.
