### PR TITLE
Fix expansion tile is missing state announcement on non-Apple platforms

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -596,19 +596,13 @@ class _ExpansionTileState extends State<ExpansionTile> {
     final String onTapHint = _tileController.isExpanded
         ? localizations.expansionTileExpandedTapHint
         : localizations.expansionTileCollapsedTapHint;
-    String? semanticsHint;
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        semanticsHint = _tileController.isExpanded
+    final String semanticsHint = switch (defaultTargetPlatform) {
+      TargetPlatform.iOS || TargetPlatform.macOS =>
+        _tileController.isExpanded
             ? '${localizations.collapsedHint}\n ${localizations.expansionTileExpandedHint}'
-            : '${localizations.expandedHint}\n ${localizations.expansionTileCollapsedHint}';
-      case TargetPlatform.android:
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-        break;
-    }
+            : '${localizations.expandedHint}\n ${localizations.expansionTileCollapsedHint}',
+      _ => _tileController.isExpanded ? localizations.collapsedHint : localizations.expandedHint,
+    };
 
     return Semantics(
       hint: semanticsHint,

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -1904,4 +1904,98 @@ void main() {
       TargetPlatform.macOS,
     }),
   );
+
+  // Regression test for https://github.com/flutter/flutter/issues/173060
+  group('Semantics tests for non-iOS/macOS platforms', () {
+    testWidgets(
+      'Semantics hint should show current state',
+      (WidgetTester tester) async {
+        final SemanticsHandle handle = tester.ensureSemantics();
+        const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Material(
+              child: Column(
+                children: <Widget>[
+                  ExpansionTile(title: Text('First Expansion Tile')),
+                  ExpansionTile(initiallyExpanded: true, title: Text('Second Expansion Tile')),
+                ],
+              ),
+            ),
+          ),
+        );
+
+        // Test collapsed tile - should show "Collapsed" hint.
+        SemanticsNode semantics = tester.getSemantics(
+          find.ancestor(of: find.byType(ListTile).first, matching: find.byType(Semantics)).first,
+        );
+        expect(semantics, isNotNull);
+        expect(semantics.hint, localizations.expandedHint);
+
+        // Test expanded tile - should show "Expanded" hint.
+        semantics = tester.getSemantics(
+          find.ancestor(of: find.byType(ListTile).last, matching: find.byType(Semantics)).first,
+        );
+        expect(semantics, isNotNull);
+        expect(semantics.hint, localizations.collapsedHint);
+
+        handle.dispose();
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{
+        TargetPlatform.android,
+        TargetPlatform.fuchsia,
+        TargetPlatform.linux,
+        TargetPlatform.windows,
+      }),
+    );
+
+    testWidgets(
+      'Semantics hint updates when expansion state changes',
+      (WidgetTester tester) async {
+        final SemanticsHandle handle = tester.ensureSemantics();
+        const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Material(
+              child: ExpansionTile(title: Text('Test Tile'), children: <Widget>[Text('Child')]),
+            ),
+          ),
+        );
+
+        // Initially collapsed - should show "Collapsed".
+        SemanticsNode semantics = tester.getSemantics(
+          find.ancestor(of: find.byType(ListTile), matching: find.byType(Semantics)).first,
+        );
+        expect(semantics.hint, localizations.expandedHint);
+
+        // Tap to expand.
+        await tester.tap(find.text('Test Tile'));
+        await tester.pumpAndSettle();
+
+        // Now expanded - should show "Expanded".
+        semantics = tester.getSemantics(
+          find.ancestor(of: find.byType(ListTile), matching: find.byType(Semantics)).first,
+        );
+        expect(semantics.hint, localizations.collapsedHint);
+
+        // Tap to collapse.
+        await tester.tap(find.text('Test Tile'));
+        await tester.pumpAndSettle();
+
+        // Back to collapsed - should show "Collapsed" again.
+        semantics = tester.getSemantics(
+          find.ancestor(of: find.byType(ListTile), matching: find.byType(Semantics)).first,
+        );
+        expect(semantics.hint, localizations.expandedHint);
+
+        handle.dispose();
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{
+        TargetPlatform.android,
+        TargetPlatform.fuchsia,
+        TargetPlatform.linux,
+        TargetPlatform.windows,
+      }),
+    );
+  });
 }


### PR DESCRIPTION
- Fix https://github.com/flutter/flutter/issues/173060
- The reason of the issue is that `semanticsHint` is null in `Semantics.hint` for non iOS/macOS platforms, see:

https://github.com/flutter/flutter/blob/7ec7baf3a24ecb055b6cb8874ae38e9c8dac3f86/packages/flutter/lib/src/material/expansion_tile.dart#L592-L607

#### Demo of the fix

<details open>
<summary>Demo video</summary>


https://github.com/user-attachments/assets/7604d65c-1f31-4e12-adcd-bf85290efd28


</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
