### PR TITLE
Add onuserinteractioniferror validation

### DIFF
--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -1087,6 +1087,7 @@ void main() {
       expect(find.text('Required'), findsNothing);
 
       // Clear the input (invalid) → submit form manually → error should show.
+      await tester.enterText(find.byType(TextFormField), '');
       formState.currentState!.validate();
       await tester.pump();
       expect(find.text('Required'), findsOneWidget);

--- a/packages/flutter/test/widgets/form_test.dart
+++ b/packages/flutter/test/widgets/form_test.dart
@@ -839,6 +839,57 @@ void main() {
       expect(find.text(errorText('foo')!), findsNothing);
     },
   );
+  testWidgets(
+    'Does not auto-validate before value changes when autovalidateMode is set to onUserInteractionIfError',
+    (WidgetTester tester) async {
+      late FormFieldState<String> formFieldState;
+
+      String? errorText(String? value) => (value == null || value.isEmpty) ? 'Required' : null;
+
+      Widget builder() {
+        return MaterialApp(
+          home: MediaQuery(
+            data: const MediaQueryData(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Center(
+                child: Material(
+                  child: FormField<String>(
+                    initialValue: 'foo',
+                    autovalidateMode: AutovalidateMode.onUserInteractionIfError,
+                    builder: (FormFieldState<String> state) {
+                      formFieldState = state;
+                      return Container();
+                    },
+                    validator: errorText,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(builder());
+
+      // The form field has no error initially.
+      expect(formFieldState.hasError, isFalse);
+      expect(find.text('Required'), findsNothing);
+
+      // Clear the value manually and validate -> should show error.
+      formFieldState.didChange('');
+      formFieldState.validate();
+      await tester.pump();
+      expect(formFieldState.hasError, isTrue);
+      expect(find.text('Required'), findsOneWidget);
+
+      // Now simulate user interaction (typing something valid).
+      formFieldState.didChange('bar');
+      await tester.pump();
+      expect(formFieldState.hasError, isFalse);
+      expect(find.text('Required'), findsNothing);
+    },
+  );
 
   testWidgets('auto-validate before value changes if autovalidateMode was set to always', (
     WidgetTester tester,
@@ -995,6 +1046,60 @@ void main() {
       formState.currentState!.reset();
       await tester.pump();
       expect(find.text(errorText('bar')!), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'Form with AutovalidateMode.onUserInteractionIfError only revalidates when user interacts after an error exists',
+    (WidgetTester tester) async {
+      final GlobalKey<FormState> formState = GlobalKey<FormState>();
+      String? errorText(String? value) => (value == null || value.isEmpty) ? 'Required' : null;
+
+      Widget builder() {
+        return MaterialApp(
+          theme: ThemeData(),
+          home: MediaQuery(
+            data: const MediaQueryData(),
+            child: Directionality(
+              textDirection: TextDirection.ltr,
+              child: Center(
+                child: Form(
+                  key: formState,
+                  autovalidateMode: AutovalidateMode.onUserInteractionIfError,
+                  child: Material(
+                    child: TextFormField(initialValue: 'foo', validator: errorText),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(builder());
+
+      // No error text is visible yet.
+      expect(find.text('Required'), findsNothing);
+
+      // User types valid input → still no error.
+      await tester.enterText(find.byType(TextFormField), 'bar');
+      await tester.pump();
+      expect(find.text('Required'), findsNothing);
+
+      // Clear the input (invalid) → submit form manually → error should show.
+      formState.currentState!.validate();
+      await tester.pump();
+      expect(find.text('Required'), findsOneWidget);
+
+      // Now user interacts again → validation should re-run.
+      await tester.enterText(find.byType(TextFormField), 'baz');
+      await tester.pump();
+      expect(find.text('Required'), findsNothing); // error gone after correction
+
+      // Resetting should clear error again.
+      formState.currentState!.reset();
+      await tester.pump();
+      expect(find.text('Required'), findsNothing);
     },
   );
 


### PR DESCRIPTION
## Description

This PR adds a new `AutovalidateMode` value:  
`onUserInteractionIfError`.

This mode allows `Form` and `FormField` widgets to auto-validate **only when a field already has an error and the user interacts with it again**.  

### Why
- Current modes (`disabled`, `always`, `onUserInteraction`, `onUnfocus`) do not cover the case where developers want validation **only when correcting an error**.  
- This improves UX by reducing unnecessary validation calls while still ensuring errors disappear as soon as the user fixes them.  

### How
- Added `onUserInteractionIfError` to `AutovalidateMode`.  
- Updated Dartdoc with detailed description and example snippet.  
- Added new unit tests to validate behavior.  
- Verified no regressions in other modes (`always`, `onUnfocus`, `onUserInteraction`).  

### Example

```dart
TextFormField(
  autovalidateMode: AutovalidateMode.onUserInteractionIfError,
  validator: (value) => value!.isEmpty ? 'Required field' : null,
)
````

---

## Related Issues

Fixes #\<INSERT\_RELATED\_ISSUE\_NUMBER\_IF\_ANY>

---

## Tests

* Added widget tests to confirm that:

  * No validation occurs until a field has an error.
  * Once an error exists, validation runs automatically on user interaction.
  * Resetting the form clears errors correctly.
* Regression tests ensure that `always`, `onUserInteraction`, and `onUnfocus` modes still behave correctly.

---

## Pre-launch / Reviewer Checklist

* [x] I have read the [[Contributor Guide](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)](https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md)
* [x] I have read the \[Tree Hygiene] wiki page and followed its guidance
* [x] I have read and followed the \[Flutter Style Guide]
* [x] I signed the \[CLA]
* [x] I added a new enum value with clear Dartdoc (`onUserInteractionIfError`)
* [x] I added example code in the Dartdoc
* [x] I added new widget/unit tests for the new mode
* [x] All existing and new tests pass
* [x] I ran `flutter analyze` and fixed all issues
* [x] No breaking changes introduced (or marked accordingly)

---

## Breaking Change

* [ ] Yes
* [x] No

---

## Screenshots / Demo (if applicable)

*(N/A — logic-only change)*

---

## Reviewer Notes

* The new mode reduces unnecessary validation until the user corrects an error.
* All tests confirm correct behavior and no regressions in existing modes.

