### PR TITLE
Add an assertion for the relationship between `Visibility.maintainState` and `Visibility.maintainFocusability`

### DIFF
--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -95,18 +95,14 @@ class Visibility extends StatelessWidget {
   /// "maintain" fields set to true. This constructor should be used in place of
   /// an [Opacity] widget that only takes on values of `0.0` or `1.0`, as it
   /// avoids extra compositing when fully opaque.
-  const Visibility.maintain({
-    super.key,
-    required this.child,
-    this.visible = true,
-  }) : maintainState = true,
-       maintainAnimation = true,
-       maintainSize = true,
-       maintainSemantics = true,
-       maintainInteractivity = true,
-       maintainFocusability = true,
-       replacement =
-           const SizedBox.shrink(); // Unused since maintainState is always true.
+  const Visibility.maintain({super.key, required this.child, this.visible = true})
+    : maintainState = true,
+      maintainAnimation = true,
+      maintainSize = true,
+      maintainSemantics = true,
+      maintainInteractivity = true,
+      maintainFocusability = true,
+      replacement = const SizedBox.shrink(); // Unused since maintainState is always true.
 
   /// The widget to show or hide, as controlled by [visible].
   ///
@@ -255,33 +251,25 @@ class Visibility extends StatelessWidget {
     InheritedElement? ancestor = ancestorContext
         .getElementForInheritedWidgetOfExactType<_VisibilityScope>();
     while (isVisible && ancestor != null) {
-      final _VisibilityScope scope =
-          context.dependOnInheritedElement(ancestor) as _VisibilityScope;
+      final _VisibilityScope scope = context.dependOnInheritedElement(ancestor) as _VisibilityScope;
       isVisible = scope.isVisible;
       ancestor.visitAncestorElements((Element parent) {
         ancestorContext = parent;
         return false;
       });
-      ancestor = ancestorContext
-          .getElementForInheritedWidgetOfExactType<_VisibilityScope>();
+      ancestor = ancestorContext.getElementForInheritedWidgetOfExactType<_VisibilityScope>();
     }
     return isVisible;
   }
 
   @override
   Widget build(BuildContext context) {
-    Widget result = ExcludeFocus(
-      excluding: !visible && !maintainFocusability,
-      child: child,
-    );
+    Widget result = ExcludeFocus(excluding: !visible && !maintainFocusability, child: child);
     if (maintainSize) {
       result = _Visibility(
         visible: visible,
         maintainSemantics: maintainSemantics,
-        child: IgnorePointer(
-          ignoring: !visible && !maintainInteractivity,
-          child: result,
-        ),
+        child: IgnorePointer(ignoring: !visible && !maintainInteractivity, child: result),
       );
     } else {
       assert(!maintainInteractivity);
@@ -304,41 +292,14 @@ class Visibility extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(FlagProperty('visible', value: visible, ifFalse: 'hidden', ifTrue: 'visible'));
+    properties.add(FlagProperty('maintainState', value: maintainState, ifFalse: 'maintainState'));
     properties.add(
-      FlagProperty(
-        'visible',
-        value: visible,
-        ifFalse: 'hidden',
-        ifTrue: 'visible',
-      ),
+      FlagProperty('maintainAnimation', value: maintainAnimation, ifFalse: 'maintainAnimation'),
     );
+    properties.add(FlagProperty('maintainSize', value: maintainSize, ifFalse: 'maintainSize'));
     properties.add(
-      FlagProperty(
-        'maintainState',
-        value: maintainState,
-        ifFalse: 'maintainState',
-      ),
-    );
-    properties.add(
-      FlagProperty(
-        'maintainAnimation',
-        value: maintainAnimation,
-        ifFalse: 'maintainAnimation',
-      ),
-    );
-    properties.add(
-      FlagProperty(
-        'maintainSize',
-        value: maintainSize,
-        ifFalse: 'maintainSize',
-      ),
-    );
-    properties.add(
-      FlagProperty(
-        'maintainSemantics',
-        value: maintainSemantics,
-        ifFalse: 'maintainSemantics',
-      ),
+      FlagProperty('maintainSemantics', value: maintainSemantics, ifFalse: 'maintainSemantics'),
     );
     properties.add(
       FlagProperty(
@@ -558,10 +519,7 @@ class SliverVisibility extends StatelessWidget {
   Widget build(BuildContext context) {
     if (maintainSize) {
       Widget result = sliver;
-      result = SliverIgnorePointer(
-        ignoring: !visible && !maintainInteractivity,
-        sliver: result,
-      );
+      result = SliverIgnorePointer(ignoring: !visible && !maintainInteractivity, sliver: result);
       return _SliverVisibility(
         visible: visible,
         maintainSemantics: maintainSemantics,
@@ -586,41 +544,14 @@ class SliverVisibility extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
+    properties.add(FlagProperty('visible', value: visible, ifFalse: 'hidden', ifTrue: 'visible'));
+    properties.add(FlagProperty('maintainState', value: maintainState, ifFalse: 'maintainState'));
     properties.add(
-      FlagProperty(
-        'visible',
-        value: visible,
-        ifFalse: 'hidden',
-        ifTrue: 'visible',
-      ),
+      FlagProperty('maintainAnimation', value: maintainAnimation, ifFalse: 'maintainAnimation'),
     );
+    properties.add(FlagProperty('maintainSize', value: maintainSize, ifFalse: 'maintainSize'));
     properties.add(
-      FlagProperty(
-        'maintainState',
-        value: maintainState,
-        ifFalse: 'maintainState',
-      ),
-    );
-    properties.add(
-      FlagProperty(
-        'maintainAnimation',
-        value: maintainAnimation,
-        ifFalse: 'maintainAnimation',
-      ),
-    );
-    properties.add(
-      FlagProperty(
-        'maintainSize',
-        value: maintainSize,
-        ifFalse: 'maintainSize',
-      ),
-    );
-    properties.add(
-      FlagProperty(
-        'maintainSemantics',
-        value: maintainSemantics,
-        ifFalse: 'maintainSemantics',
-      ),
+      FlagProperty('maintainSemantics', value: maintainSemantics, ifFalse: 'maintainSemantics'),
     );
     properties.add(
       FlagProperty(
@@ -639,11 +570,7 @@ class SliverVisibility extends StatelessWidget {
 // different layers. This can be significantly more expensive, so the issue is avoided by a
 // specialized render object that does not ever force compositing.
 class _Visibility extends SingleChildRenderObjectWidget {
-  const _Visibility({
-    required this.visible,
-    required this.maintainSemantics,
-    super.child,
-  });
+  const _Visibility({required this.visible, required this.maintainSemantics, super.child});
 
   final bool visible;
   final bool maintainSemantics;
@@ -654,10 +581,7 @@ class _Visibility extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(
-    BuildContext context,
-    _RenderVisibility renderObject,
-  ) {
+  void updateRenderObject(BuildContext context, _RenderVisibility renderObject) {
     renderObject
       ..visible = visible
       ..maintainSemantics = maintainSemantics;
@@ -710,11 +634,8 @@ class _RenderVisibility extends RenderProxyBox {
 // different layers. This can be significantly more expensive, so the issue is avoided by a
 // specialized render object that does not ever force compositing.
 class _SliverVisibility extends SingleChildRenderObjectWidget {
-  const _SliverVisibility({
-    required this.visible,
-    required this.maintainSemantics,
-    Widget? sliver,
-  }) : super(child: sliver);
+  const _SliverVisibility({required this.visible, required this.maintainSemantics, Widget? sliver})
+    : super(child: sliver);
 
   final bool visible;
   final bool maintainSemantics;
@@ -725,10 +646,7 @@ class _SliverVisibility extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(
-    BuildContext context,
-    _RenderSliverVisibility renderObject,
-  ) {
+  void updateRenderObject(BuildContext context, _RenderSliverVisibility renderObject) {
     renderObject
       ..visible = visible
       ..maintainSemantics = maintainSemantics;

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -83,6 +83,10 @@ class Visibility extends StatelessWidget {
        assert(
          maintainSize || !maintainInteractivity,
          'Cannot maintain interactivity if size is not maintained.',
+       ),
+       assert(
+         maintainState || !maintainFocusability,
+         'Cannot maintain focusability if the state is not also maintained.',
        );
 
   /// Control whether the given [child] is [visible].
@@ -91,14 +95,18 @@ class Visibility extends StatelessWidget {
   /// "maintain" fields set to true. This constructor should be used in place of
   /// an [Opacity] widget that only takes on values of `0.0` or `1.0`, as it
   /// avoids extra compositing when fully opaque.
-  const Visibility.maintain({super.key, required this.child, this.visible = true})
-    : maintainState = true,
-      maintainAnimation = true,
-      maintainSize = true,
-      maintainSemantics = true,
-      maintainInteractivity = true,
-      maintainFocusability = true,
-      replacement = const SizedBox.shrink(); // Unused since maintainState is always true.
+  const Visibility.maintain({
+    super.key,
+    required this.child,
+    this.visible = true,
+  }) : maintainState = true,
+       maintainAnimation = true,
+       maintainSize = true,
+       maintainSemantics = true,
+       maintainInteractivity = true,
+       maintainFocusability = true,
+       replacement =
+           const SizedBox.shrink(); // Unused since maintainState is always true.
 
   /// The widget to show or hide, as controlled by [visible].
   ///
@@ -142,6 +150,8 @@ class Visibility extends StatelessWidget {
   /// instead of replacing it with [replacement].
   ///
   /// If this property is false, then [maintainAnimation] must also be false.
+  ///
+  /// If this property is false, then [maintainFocusability] must also be false.
   ///
   /// Dynamically changing this value may cause the current state of the
   /// subtree to be lost (and a new instance of the subtree, with new [State]
@@ -220,7 +230,12 @@ class Visibility extends StatelessWidget {
 
   /// Whether to allow the widget to receive focus when hidden. Only in effect if [visible] is false.
   ///
-  /// Defaults to false.
+  /// To set this to true, [maintainState] must also be set to true.
+  ///
+  /// By default, with [maintainFocusability] set to false, focus events cannot
+  /// reach the [child] because an [ExcludeFocus] widget is used to exclude
+  /// the child subtree from the focus tree. If this flag is set to true,
+  /// then focus events will reach the child subtree.
   final bool maintainFocusability;
 
   /// Tells the visibility state of an element in the tree based off its
@@ -240,25 +255,33 @@ class Visibility extends StatelessWidget {
     InheritedElement? ancestor = ancestorContext
         .getElementForInheritedWidgetOfExactType<_VisibilityScope>();
     while (isVisible && ancestor != null) {
-      final _VisibilityScope scope = context.dependOnInheritedElement(ancestor) as _VisibilityScope;
+      final _VisibilityScope scope =
+          context.dependOnInheritedElement(ancestor) as _VisibilityScope;
       isVisible = scope.isVisible;
       ancestor.visitAncestorElements((Element parent) {
         ancestorContext = parent;
         return false;
       });
-      ancestor = ancestorContext.getElementForInheritedWidgetOfExactType<_VisibilityScope>();
+      ancestor = ancestorContext
+          .getElementForInheritedWidgetOfExactType<_VisibilityScope>();
     }
     return isVisible;
   }
 
   @override
   Widget build(BuildContext context) {
-    Widget result = ExcludeFocus(excluding: !visible && !maintainFocusability, child: child);
+    Widget result = ExcludeFocus(
+      excluding: !visible && !maintainFocusability,
+      child: child,
+    );
     if (maintainSize) {
       result = _Visibility(
         visible: visible,
         maintainSemantics: maintainSemantics,
-        child: IgnorePointer(ignoring: !visible && !maintainInteractivity, child: result),
+        child: IgnorePointer(
+          ignoring: !visible && !maintainInteractivity,
+          child: result,
+        ),
       );
     } else {
       assert(!maintainInteractivity);
@@ -281,14 +304,41 @@ class Visibility extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(FlagProperty('visible', value: visible, ifFalse: 'hidden', ifTrue: 'visible'));
-    properties.add(FlagProperty('maintainState', value: maintainState, ifFalse: 'maintainState'));
     properties.add(
-      FlagProperty('maintainAnimation', value: maintainAnimation, ifFalse: 'maintainAnimation'),
+      FlagProperty(
+        'visible',
+        value: visible,
+        ifFalse: 'hidden',
+        ifTrue: 'visible',
+      ),
     );
-    properties.add(FlagProperty('maintainSize', value: maintainSize, ifFalse: 'maintainSize'));
     properties.add(
-      FlagProperty('maintainSemantics', value: maintainSemantics, ifFalse: 'maintainSemantics'),
+      FlagProperty(
+        'maintainState',
+        value: maintainState,
+        ifFalse: 'maintainState',
+      ),
+    );
+    properties.add(
+      FlagProperty(
+        'maintainAnimation',
+        value: maintainAnimation,
+        ifFalse: 'maintainAnimation',
+      ),
+    );
+    properties.add(
+      FlagProperty(
+        'maintainSize',
+        value: maintainSize,
+        ifFalse: 'maintainSize',
+      ),
+    );
+    properties.add(
+      FlagProperty(
+        'maintainSemantics',
+        value: maintainSemantics,
+        ifFalse: 'maintainSemantics',
+      ),
     );
     properties.add(
       FlagProperty(
@@ -508,7 +558,10 @@ class SliverVisibility extends StatelessWidget {
   Widget build(BuildContext context) {
     if (maintainSize) {
       Widget result = sliver;
-      result = SliverIgnorePointer(ignoring: !visible && !maintainInteractivity, sliver: result);
+      result = SliverIgnorePointer(
+        ignoring: !visible && !maintainInteractivity,
+        sliver: result,
+      );
       return _SliverVisibility(
         visible: visible,
         maintainSemantics: maintainSemantics,
@@ -533,14 +586,41 @@ class SliverVisibility extends StatelessWidget {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(FlagProperty('visible', value: visible, ifFalse: 'hidden', ifTrue: 'visible'));
-    properties.add(FlagProperty('maintainState', value: maintainState, ifFalse: 'maintainState'));
     properties.add(
-      FlagProperty('maintainAnimation', value: maintainAnimation, ifFalse: 'maintainAnimation'),
+      FlagProperty(
+        'visible',
+        value: visible,
+        ifFalse: 'hidden',
+        ifTrue: 'visible',
+      ),
     );
-    properties.add(FlagProperty('maintainSize', value: maintainSize, ifFalse: 'maintainSize'));
     properties.add(
-      FlagProperty('maintainSemantics', value: maintainSemantics, ifFalse: 'maintainSemantics'),
+      FlagProperty(
+        'maintainState',
+        value: maintainState,
+        ifFalse: 'maintainState',
+      ),
+    );
+    properties.add(
+      FlagProperty(
+        'maintainAnimation',
+        value: maintainAnimation,
+        ifFalse: 'maintainAnimation',
+      ),
+    );
+    properties.add(
+      FlagProperty(
+        'maintainSize',
+        value: maintainSize,
+        ifFalse: 'maintainSize',
+      ),
+    );
+    properties.add(
+      FlagProperty(
+        'maintainSemantics',
+        value: maintainSemantics,
+        ifFalse: 'maintainSemantics',
+      ),
     );
     properties.add(
       FlagProperty(
@@ -559,7 +639,11 @@ class SliverVisibility extends StatelessWidget {
 // different layers. This can be significantly more expensive, so the issue is avoided by a
 // specialized render object that does not ever force compositing.
 class _Visibility extends SingleChildRenderObjectWidget {
-  const _Visibility({required this.visible, required this.maintainSemantics, super.child});
+  const _Visibility({
+    required this.visible,
+    required this.maintainSemantics,
+    super.child,
+  });
 
   final bool visible;
   final bool maintainSemantics;
@@ -570,7 +654,10 @@ class _Visibility extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderVisibility renderObject) {
+  void updateRenderObject(
+    BuildContext context,
+    _RenderVisibility renderObject,
+  ) {
     renderObject
       ..visible = visible
       ..maintainSemantics = maintainSemantics;
@@ -623,8 +710,11 @@ class _RenderVisibility extends RenderProxyBox {
 // different layers. This can be significantly more expensive, so the issue is avoided by a
 // specialized render object that does not ever force compositing.
 class _SliverVisibility extends SingleChildRenderObjectWidget {
-  const _SliverVisibility({required this.visible, required this.maintainSemantics, Widget? sliver})
-    : super(child: sliver);
+  const _SliverVisibility({
+    required this.visible,
+    required this.maintainSemantics,
+    Widget? sliver,
+  }) : super(child: sliver);
 
   final bool visible;
   final bool maintainSemantics;
@@ -635,7 +725,10 @@ class _SliverVisibility extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderSliverVisibility renderObject) {
+  void updateRenderObject(
+    BuildContext context,
+    _RenderSliverVisibility renderObject,
+  ) {
     renderObject
       ..visible = visible
       ..maintainSemantics = maintainSemantics;

--- a/packages/flutter/lib/src/widgets/visibility.dart
+++ b/packages/flutter/lib/src/widgets/visibility.dart
@@ -229,9 +229,9 @@ class Visibility extends StatelessWidget {
   /// To set this to true, [maintainState] must also be set to true.
   ///
   /// By default, with [maintainFocusability] set to false, focus events cannot
-  /// reach the [child] because an [ExcludeFocus] widget is used to exclude
-  /// the child subtree from the focus tree. If this flag is set to true,
-  /// then focus events will reach the child subtree.
+  /// reach the [child] when this widget is not [visible] because an [ExcludeFocus]
+  /// widget is used to exclude the child subtree from the focus tree. If this flag
+  /// is set to true, then focus events will reach the child subtree.
   final bool maintainFocusability;
 
   /// Tells the visibility state of an element in the tree based off its

--- a/packages/flutter/test/widgets/visibility_test.dart
+++ b/packages/flutter/test/widgets/visibility_test.dart
@@ -492,6 +492,18 @@ void main() {
     },
   );
 
+  testWidgets(
+    'Visibility throws assertion error if maintainFocusability is true without maintainState',
+    (WidgetTester tester) async {
+      expect(() {
+        Visibility(
+          maintainFocusability: true,
+          child: const Text('hello', textDirection: TextDirection.ltr),
+        );
+      }, throwsAssertionError);
+    },
+  );
+
   testWidgets('Visibility does not force compositing when visible and maintain*', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
This change adds an assertion for the relationship between `Visibility.maintainState` and `Visibility.maintainFocusability`. Setting `maintainFocusability` to `true` is a no-op if `maintainState` is set to `false`, so we should add a helpful assertion here.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.