### PR TITLE
fix(tool): Use merge-base for content hash in detached HEAD

### DIFF
--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -44,7 +44,7 @@ if (($currentBranch -ne "main") -and
     ($currentBranch -ne "master") -and
     ($currentBranch -ne "stable") -and
     ($currentBranch -ne "beta") -and
-    ($currentBranch -ne "HEAD") -and
+    (-not (($currentBranch -eq "HEAD") -and (-not [string]::IsNullOrEmpty($env:LUCI_CI)))) -and
     (-not $currentBranch.StartsWith("gh-readonly-queue/master/pr-")) -and
     (-not ($currentBranch -like "flutter-*-candidate.*")) -and
     (-not $isShallow)) {

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -44,7 +44,7 @@ if [[ "$CURRENT_BRANCH" != "main" && \
       "$CURRENT_BRANCH" != "beta" && \
       "$CURRENT_BRANCH" != "gh-readonly-queue/master/pr-"* && \
       "$CURRENT_BRANCH" != "flutter-"*"-candidate."* && \
-      "$CURRENT_BRANCH" != "HEAD" && \
+      ! ( "$CURRENT_BRANCH" == "HEAD" && -n "$LUCI_CI" ) && \
       ! -f "$FLUTTER_ROOT/.git/shallow" ]]; then
 
   # This is a development branch. Find the merge-base.

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -230,7 +230,26 @@ void main() {
       equals('HEAD'),
     );
 
+    // Simulate being in a LUCI environment.
+    environment['LUCI_CI'] = 'true';
     expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+  });
+
+  test('generates a hash based on merge-base in local detached HEAD', () {
+    // This test validates the workflow with a detached HEAD, which is common
+    // when working with jj.
+    initGitRepoWithBlankInitialCommit(branch: 'main');
+    writeFileAndCommit(testRoot.deps, 'deps changed');
+
+    final String headSha = gitShaFor('HEAD');
+    run('git', <String>['checkout', '-f', headSha]);
+    run('git', <String>['--no-pager', 'log', '--decorate=short', '--pretty=oneline']);
+    expect(
+      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout as String).trim(),
+      equals('HEAD'),
+    );
+
+    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
   });
 
   group('stable branches calculate hash locally', () {


### PR DESCRIPTION
The `content_aware_hash.sh` script determines which version of the engine to use. For local development, it uses the merge-base with the remote tracking branch to avoid unnecessary rebuilds.

However, when using `jj`, the underlying git repository is in a detached HEAD state. The script was incorrectly interpreting this as a CI environment and was not calculating the hash based on the merge-base, leading to incorrect engine versions and failed Dart SDK downloads.

This change modifies the script to differentiate between a local detached HEAD state (like with `jj`) and a CI environment by checking for the `LUCI_CI` environment variable. This ensures the correct engine hash is generated for both local `jj` users and CI builds.

Here is an example of failing to download the Dart SDK before:

```
Downloading Darwin arm64 Dart SDK from Flutter engine f6ea244d7b75547c2c1a4613299b24dcebe3ce5c...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   258  100   258    0     0    858      0 --:--:-- --:--:-- --:--:--   857
[/Users/het/Projects/flutter/bin/cache/dart-sdk-darwin-arm64.zip]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of /Users/het/Projects/flutter/bin/cache/dart-sdk-darwin-arm64.zip or
        /Users/het/Projects/flutter/bin/cache/dart-sdk-darwin-arm64.zip.zip, and cannot find /Users/het/Projects/flutter/bin/cache/dart-sdk-darwin-arm64.zip.ZIP, period.

It appears that the downloaded file is corrupt; please try again.
If this problem persists, please report the problem at:
  https://github.com/flutter/flutter/issues/new?template=01_activation.yml
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
