### PR TITLE
Migrate to `WidgetStateColor`

### DIFF
--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -44,7 +44,7 @@ class _${blockName}DefaultsM3 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get fillColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get fillColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return ${componentColor("md.comp.filled-text-field.disabled.container")};
     }
@@ -101,7 +101,7 @@ class _${blockName}DefaultsM3 extends InputDecorationThemeData {
   Color? get iconColor => ${componentColor("md.comp.filled-text-field.leading-icon")};
 
   @override
-  Color? get prefixIconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get prefixIconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return ${componentColor('md.comp.filled-text-field.disabled.leading-icon')};
     }${componentColor('md.comp.filled-text-field.error.leading-icon') == componentColor('md.comp.filled-text-field.leading-icon') ? '' : '''
@@ -124,7 +124,7 @@ class _${blockName}DefaultsM3 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get suffixIconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get suffixIconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return ${componentColor('md.comp.filled-text-field.disabled.trailing-icon')};
     }

--- a/dev/tools/gen_defaults/lib/snackbar_template.dart
+++ b/dev/tools/gen_defaults/lib/snackbar_template.dart
@@ -29,7 +29,7 @@ class _${blockName}DefaultsM3 extends SnackBarThemeData {
   Color get backgroundColor => ${componentColor("$tokenGroup.container")};
 
   @override
-  Color get actionTextColor =>  MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color get actionTextColor =>  WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return ${componentColor("$tokenGroup.action.pressed.label-text")};
     }

--- a/dev/tools/gen_defaults/lib/time_picker_template.dart
+++ b/dev/tools/gen_defaults/lib/time_picker_template.dart
@@ -53,7 +53,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dayPeriodColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return ${componentColor("$dayPeriodComponent.selected.container")};
       }
@@ -88,7 +88,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dayPeriodTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         if (states.contains(WidgetState.focused)) {
           return ${componentColor("$dayPeriodComponent.selected.focus.label-text")};
@@ -151,7 +151,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dialTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return ${componentColor('$dialComponent.selected.label-text')};
       }
@@ -189,7 +189,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get hourMinuteColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         Color overlayColor = ${componentColor('$hourMinuteComponent.selected.container')};
         if (states.contains(WidgetState.pressed)) {
@@ -249,7 +249,7 @@ class _${blockName}DefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get hourMinuteTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       return _hourMinuteTextColor.resolve(states);
     });
   }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -5821,7 +5821,7 @@ class _InputDecoratorDefaultsM2 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get fillColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get fillColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     return switch ((Theme.brightnessOf(context), states.contains(WidgetState.disabled))) {
       (Brightness.dark, true) => const Color(0x0DFFFFFF), //  5% white
       (Brightness.dark, false) => const Color(0x1AFFFFFF), // 10% white
@@ -5831,7 +5831,7 @@ class _InputDecoratorDefaultsM2 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get iconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get iconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled) && !states.contains(WidgetState.focused)) {
       return Theme.of(context).disabledColor;
     }
@@ -5845,7 +5845,7 @@ class _InputDecoratorDefaultsM2 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get prefixIconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get prefixIconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled) && !states.contains(WidgetState.focused)) {
       return Theme.of(context).disabledColor;
     }
@@ -5859,7 +5859,7 @@ class _InputDecoratorDefaultsM2 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get suffixIconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get suffixIconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled) && !states.contains(WidgetState.focused)) {
       return Theme.of(context).disabledColor;
     }
@@ -5912,7 +5912,7 @@ class _InputDecoratorDefaultsM3 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get fillColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get fillColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return _colors.onSurface.withOpacity(0.04);
     }
@@ -5969,7 +5969,7 @@ class _InputDecoratorDefaultsM3 extends InputDecorationThemeData {
   Color? get iconColor => _colors.onSurfaceVariant;
 
   @override
-  Color? get prefixIconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get prefixIconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return _colors.onSurface.withOpacity(0.38);
     }
@@ -5977,7 +5977,7 @@ class _InputDecoratorDefaultsM3 extends InputDecorationThemeData {
   });
 
   @override
-  Color? get suffixIconColor => MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color? get suffixIconColor => WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return _colors.onSurface.withOpacity(0.38);
     }

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -1151,7 +1151,7 @@ class _IndividualOverrides extends WidgetStateProperty<Color?> {
 
   @override
   Color? resolve(Set<WidgetState> states) {
-    if (explicitColor is MaterialStateColor) {
+    if (explicitColor is WidgetStateColor) {
       return WidgetStateProperty.resolveAs<Color?>(explicitColor, states);
     }
     if (states.contains(WidgetState.disabled)) {

--- a/packages/flutter/lib/src/material/material_state_mixin.dart
+++ b/packages/flutter/lib/src/material/material_state_mixin.dart
@@ -27,7 +27,7 @@ import 'package:flutter/widgets.dart';
 /// class MyWidget extends StatefulWidget {
 ///   const MyWidget({super.key, required this.color, required this.child});
 ///
-///   final MaterialStateColor color;
+///   final WidgetStateColor color;
 ///   final Widget child;
 ///
 ///   @override

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -15,7 +15,6 @@ import 'icon_button.dart';
 import 'icons.dart';
 import 'material.dart';
 import 'material_localizations.dart';
-import 'material_state.dart';
 import 'scaffold.dart';
 import 'snack_bar_theme.dart';
 import 'text_button.dart';
@@ -96,9 +95,9 @@ class SnackBarAction extends StatefulWidget {
     required this.label,
     required this.onPressed,
   }) : assert(
-         backgroundColor is! MaterialStateColor || disabledBackgroundColor == null,
+         backgroundColor is! WidgetStateColor || disabledBackgroundColor == null,
          'disabledBackgroundColor must not be provided when background color is '
-         'a MaterialStateColor',
+         'a WidgetStateColor',
        );
 
   /// The button label color. If not provided, defaults to
@@ -162,22 +161,22 @@ class _SnackBarActionState extends State<SnackBarAction> {
         : _SnackbarDefaultsM2(context);
     final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
 
-    MaterialStateColor resolveForegroundColor() {
+    WidgetStateColor resolveForegroundColor() {
       if (widget.textColor != null) {
-        if (widget.textColor is MaterialStateColor) {
-          return widget.textColor! as MaterialStateColor;
+        if (widget.textColor is WidgetStateColor) {
+          return widget.textColor! as WidgetStateColor;
         }
       } else if (snackBarTheme.actionTextColor != null) {
-        if (snackBarTheme.actionTextColor is MaterialStateColor) {
-          return snackBarTheme.actionTextColor! as MaterialStateColor;
+        if (snackBarTheme.actionTextColor is WidgetStateColor) {
+          return snackBarTheme.actionTextColor! as WidgetStateColor;
         }
       } else if (defaults.actionTextColor != null) {
-        if (defaults.actionTextColor is MaterialStateColor) {
-          return defaults.actionTextColor! as MaterialStateColor;
+        if (defaults.actionTextColor is WidgetStateColor) {
+          return defaults.actionTextColor! as WidgetStateColor;
         }
       }
 
-      return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+      return WidgetStateColor.resolveWith((Set<WidgetState> states) {
         if (states.contains(WidgetState.disabled)) {
           return widget.disabledTextColor ??
               snackBarTheme.disabledActionTextColor ??
@@ -187,14 +186,14 @@ class _SnackBarActionState extends State<SnackBarAction> {
       });
     }
 
-    MaterialStateColor? resolveBackgroundColor() {
-      if (widget.backgroundColor is MaterialStateColor) {
-        return widget.backgroundColor! as MaterialStateColor;
+    WidgetStateColor? resolveBackgroundColor() {
+      if (widget.backgroundColor is WidgetStateColor) {
+        return widget.backgroundColor! as WidgetStateColor;
       }
-      if (snackBarTheme.actionBackgroundColor is MaterialStateColor) {
-        return snackBarTheme.actionBackgroundColor! as MaterialStateColor;
+      if (snackBarTheme.actionBackgroundColor is WidgetStateColor) {
+        return snackBarTheme.actionBackgroundColor! as WidgetStateColor;
       }
-      return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+      return WidgetStateColor.resolveWith((Set<WidgetState> states) {
         if (states.contains(WidgetState.disabled)) {
           return widget.disabledBackgroundColor ??
               snackBarTheme.disabledActionBackgroundColor ??
@@ -953,7 +952,7 @@ class _SnackbarDefaultsM3 extends SnackBarThemeData {
   Color get backgroundColor => _colors.inverseSurface;
 
   @override
-  Color get actionTextColor =>  MaterialStateColor.resolveWith((Set<WidgetState> states) {
+  Color get actionTextColor =>  WidgetStateColor.resolveWith((Set<WidgetState> states) {
     if (states.contains(WidgetState.disabled)) {
       return _colors.inversePrimary;
     }

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -16,7 +16,6 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
-import 'material_state.dart';
 import 'theme.dart';
 
 /// Defines where a [SnackBar] should appear within a [Scaffold] and how its
@@ -91,9 +90,9 @@ class SnackBarThemeData with Diagnosticable {
          'Action overflow threshold must be between 0 and 1 inclusive',
        ),
        assert(
-         actionBackgroundColor is! MaterialStateColor || disabledActionBackgroundColor == null,
+         actionBackgroundColor is! WidgetStateColor || disabledActionBackgroundColor == null,
          'disabledBackgroundColor must not be provided when background color is '
-         'a MaterialStateColor',
+         'a WidgetStateColor',
        );
 
   /// Overrides the default value for [SnackBar.backgroundColor].

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -258,7 +258,7 @@ class _TabStyle extends AnimatedWidget {
   final TabBarThemeData defaults;
   final Widget child;
 
-  MaterialStateColor _resolveWithLabelColor(BuildContext context, {IconThemeData? iconTheme}) {
+  WidgetStateColor _resolveWithLabelColor(BuildContext context, {IconThemeData? iconTheme}) {
     final ThemeData themeData = Theme.of(context);
     final TabBarThemeData tabBarTheme = TabBarTheme.of(context);
     final Animation<double> animation = listenable as Animation<double>;
@@ -275,12 +275,12 @@ class _TabStyle extends AnimatedWidget {
 
     final Color unselectedColor;
 
-    if (selectedColor is MaterialStateColor) {
+    if (selectedColor is WidgetStateColor) {
       unselectedColor = selectedColor.resolve(const <WidgetState>{});
       selectedColor = selectedColor.resolve(const <WidgetState>{WidgetState.selected});
     } else {
       // unselectedLabelColor and tabBarTheme.unselectedLabelColor are ignored
-      // when labelColor is a MaterialStateColor.
+      // when labelColor is a WidgetStateColor.
       unselectedColor =
           unselectedLabelColor ??
           tabBarTheme.unselectedLabelColor ??
@@ -292,7 +292,7 @@ class _TabStyle extends AnimatedWidget {
               : selectedColor.withAlpha(0xB2)); // 70% alpha
     }
 
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return Color.lerp(selectedColor, unselectedColor, animation.value)!;
       }

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -3429,7 +3429,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
 
   @override
   Color get dayPeriodColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return _colors.primary.withOpacity(_colors.brightness == Brightness.dark ? 0.24 : 0.12);
       }
@@ -3462,7 +3462,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
 
   @override
   Color get dayPeriodTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       return states.contains(WidgetState.selected)
           ? _colors.primary
           : _colors.onSurface.withOpacity(0.60);
@@ -3506,7 +3506,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
 
   @override
   Color get dialTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return _colors.surface;
       }
@@ -3536,7 +3536,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
 
   @override
   Color get hourMinuteColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       return states.contains(WidgetState.selected)
           ? _colors.primary.withOpacity(_colors.brightness == Brightness.dark ? 0.24 : 0.12)
           : _colors.onSurface.withOpacity(0.12);
@@ -3570,7 +3570,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
 
   @override
   Color get hourMinuteTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       return states.contains(WidgetState.selected) ? _colors.primary : _colors.onSurface;
     });
   }
@@ -3581,7 +3581,7 @@ class _TimePickerDefaultsM2 extends _TimePickerDefaults {
   }
 
   Color get _hourMinuteInputColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       return states.contains(WidgetState.selected)
           ? Colors.transparent
           : _colors.onSurface.withOpacity(0.12);
@@ -3660,7 +3660,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dayPeriodColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return _colors.tertiaryContainer;
       }
@@ -3695,7 +3695,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dayPeriodTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         if (states.contains(WidgetState.focused)) {
           return _colors.onTertiaryContainer;
@@ -3758,7 +3758,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get dialTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return _colors.onPrimary;
       }
@@ -3796,7 +3796,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get hourMinuteColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         Color overlayColor = _colors.primaryContainer;
         if (states.contains(WidgetState.pressed)) {
@@ -3856,7 +3856,7 @@ class _TimePickerDefaultsM3 extends _TimePickerDefaults {
 
   @override
   Color get hourMinuteTextColor {
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       return _hourMinuteTextColor.resolve(states);
     });
   }

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -18,7 +18,6 @@ import 'package:flutter/widgets.dart';
 import 'button_style.dart';
 import 'colors.dart';
 import 'input_decorator.dart';
-import 'material_state.dart';
 import 'theme.dart';
 
 // Examples can assume:
@@ -120,10 +119,10 @@ class TimePickerThemeData with Diagnosticable {
   /// If the segment is not selected, [Colors.transparent] is used to allow the
   /// [Dialog]'s color to be used.
   Color? get dayPeriodColor {
-    if (_dayPeriodColor == null || _dayPeriodColor is MaterialStateColor) {
+    if (_dayPeriodColor == null || _dayPeriodColor is WidgetStateColor) {
       return _dayPeriodColor;
     }
-    return MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    return WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return _dayPeriodColor;
       }

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -283,10 +283,6 @@ typedef WidgetPropertyResolver<T> = T Function(Set<WidgetState> states);
 /// }
 /// ```
 /// {@end-tool}
-///
-/// See also:
-///
-///  * [MaterialStateColor], the Material specific version of `WidgetStateColor`.
 abstract class WidgetStateColor extends Color implements WidgetStateProperty<Color> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -286,7 +286,7 @@ typedef WidgetPropertyResolver<T> = T Function(Set<WidgetState> states);
 ///
 /// See also:
 ///
-///  * [MaterialStateColor], the Material specific version of `WidgetStateColor`.
+///  * [WidgetStateColor], the Material specific version of `WidgetStateColor`.
 abstract class WidgetStateColor extends Color implements WidgetStateProperty<Color> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.

--- a/packages/flutter/lib/src/widgets/widget_state.dart
+++ b/packages/flutter/lib/src/widgets/widget_state.dart
@@ -286,7 +286,7 @@ typedef WidgetPropertyResolver<T> = T Function(Set<WidgetState> states);
 ///
 /// See also:
 ///
-///  * [WidgetStateColor], the Material specific version of `WidgetStateColor`.
+///  * [MaterialStateColor], the Material specific version of `WidgetStateColor`.
 abstract class WidgetStateColor extends Color implements WidgetStateProperty<Color> {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.

--- a/packages/flutter/test/material/app_bar_sliver_test.dart
+++ b/packages/flutter/test/material/app_bar_sliver_test.dart
@@ -820,7 +820,7 @@ void main() {
     expect(titleOffset.dx, titleSpacing);
   });
 
-  group('MaterialStateColor scrolledUnder', () {
+  group('WidgetStateColor scrolledUnder', () {
     const double collapsedHeight = kToolbarHeight;
     const double expandedHeight = 200.0;
     const Color scrolledColor = Color(0xff00ff00);
@@ -838,7 +838,7 @@ void main() {
             slivers: <Widget>[
               SliverAppBar(
                 elevation: 0,
-                backgroundColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+                backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                   return states.contains(WidgetState.scrolledUnder) ? scrolledColor : defaultColor;
                 }),
                 expandedHeight: expandedHeight,

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2326,7 +2326,7 @@ void main() {
     });
   });
 
-  group('MaterialStateColor scrolledUnder', () {
+  group('WidgetStateColor scrolledUnder', () {
     const Color scrolledColor = Color(0xff00ff00);
     const Color defaultColor = Color(0xff0000ff);
 
@@ -2342,7 +2342,7 @@ void main() {
           appBar: AppBar(
             elevation: 0,
             scrolledUnderElevation: scrolledUnderElevation,
-            backgroundColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+            backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
               return states.contains(WidgetState.scrolledUnder) ? scrolledColor : defaultColor;
             }),
             title: const Text('AppBar'),
@@ -2365,7 +2365,7 @@ void main() {
           home: Scaffold(
             appBar: AppBar(
               elevation: 0,
-              backgroundColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+              backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                 return states.contains(WidgetState.scrolledUnder) ? scrolledColor : defaultColor;
               }),
               title: const Text('AppBar'),
@@ -2574,7 +2574,7 @@ void main() {
           home: Scaffold(
             appBar: AppBar(
               elevation: 0,
-              backgroundColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+              backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                 return states.contains(WidgetState.scrolledUnder) ? scrolledColor : defaultColor;
               }),
               title: const Text('AppBar'),
@@ -2656,7 +2656,7 @@ void main() {
           home: Scaffold(
             appBar: AppBar(
               elevation: 0,
-              backgroundColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+              backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                 return states.contains(WidgetState.scrolledUnder) ? scrolledColor : defaultColor;
               }),
               title: const Text('AppBar'),
@@ -2731,7 +2731,7 @@ void main() {
           home: Scaffold(
             appBar: AppBar(
               elevation: 0,
-              backgroundColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+              backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                 return states.contains(WidgetState.scrolledUnder) ? scrolledColor : defaultColor;
               }),
               title: const Text('AppBar'),

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1312,7 +1312,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           bottomSheetTheme: BottomSheetThemeData(
-            dragHandleColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+            dragHandleColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
               if (states.contains(WidgetState.hovered)) {
                 return hoveringColor;
               }

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -647,7 +647,7 @@ void main() {
       return activeEnabledFillColor;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     Widget buildFrame({required bool enabled}) {
       return wrap(
@@ -683,7 +683,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     Widget buildFrame() {
       return wrap(

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1343,7 +1343,7 @@ void main() {
       return activeEnabledFillColor;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     Widget buildFrame({required bool enabled}) {
       return Material(
@@ -1395,7 +1395,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     Widget buildFrame() {
       return Material(

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -3641,7 +3641,7 @@ void main() {
               label: const Text('Chip'),
               selected: selected,
               onSelected: enabled ? (_) {} : null,
-              labelStyle: TextStyle(color: MaterialStateColor.resolveWith(getTextColor)),
+              labelStyle: TextStyle(color: WidgetStateColor.resolveWith(getTextColor)),
             ),
           ),
         ),

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -805,7 +805,7 @@ void main() {
       return defaultColor;
     }
 
-    final TextStyle labelStyle = TextStyle(color: MaterialStateColor.resolveWith(getTextColor));
+    final TextStyle labelStyle = TextStyle(color: WidgetStateColor.resolveWith(getTextColor));
     Widget chipWidget({bool enabled = true, bool selected = false}) {
       return MaterialApp(
         theme: ThemeData(

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2176,7 +2176,7 @@ void main() {
     );
   });
 
-  testWidgets('ListTile.textColor respects MaterialStateColor', (WidgetTester tester) async {
+  testWidgets('ListTile.textColor respects WidgetStateColor', (WidgetTester tester) async {
     bool enabled = false;
     bool selected = false;
     const Color defaultColor = Colors.blue;
@@ -2192,7 +2192,7 @@ void main() {
                 return ListTile(
                   enabled: enabled,
                   selected: selected,
-                  textColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+                  textColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                     if (states.contains(WidgetState.disabled)) {
                       return disabledColor;
                     }
@@ -2231,7 +2231,7 @@ void main() {
     expect(title.text.style!.color, selectedColor);
   });
 
-  testWidgets('ListTile.iconColor respects MaterialStateColor', (WidgetTester tester) async {
+  testWidgets('ListTile.iconColor respects WidgetStateColor', (WidgetTester tester) async {
     bool enabled = false;
     bool selected = false;
     const Color defaultColor = Colors.blue;
@@ -2248,7 +2248,7 @@ void main() {
                 return ListTile(
                   enabled: enabled,
                   selected: selected,
-                  iconColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+                  iconColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                     if (states.contains(WidgetState.disabled)) {
                       return disabledColor;
                     }

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -787,7 +787,7 @@ void main() {
     expect(inkWellBorder, shapeBorder);
   });
 
-  testWidgets('ListTile respects MaterialStateColor LisTileTheme.textColor', (
+  testWidgets('ListTile respects WidgetStateColor LisTileTheme.textColor', (
     WidgetTester tester,
   ) async {
     bool enabled = false;
@@ -798,7 +798,7 @@ void main() {
 
     final ThemeData theme = ThemeData(
       listTileTheme: ListTileThemeData(
-        textColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+        textColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
           if (states.contains(WidgetState.disabled)) {
             return disabledColor;
           }
@@ -849,7 +849,7 @@ void main() {
     expect(title.text.style!.color, selectedColor);
   });
 
-  testWidgets('ListTile respects MaterialStateColor LisTileTheme.iconColor', (
+  testWidgets('ListTile respects WidgetStateColor LisTileTheme.iconColor', (
     WidgetTester tester,
   ) async {
     bool enabled = false;
@@ -861,7 +861,7 @@ void main() {
 
     final ThemeData theme = ThemeData(
       listTileTheme: ListTileThemeData(
-        iconColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+        iconColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
           if (states.contains(WidgetState.disabled)) {
             return disabledColor;
           }

--- a/packages/flutter/test/material/radio_list_tile_test.dart
+++ b/packages/flutter/test/material/radio_list_tile_test.dart
@@ -903,7 +903,7 @@ void main() {
       return inactiveEnabledFillColor;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     Widget buildApp({required bool enabled}) {
@@ -989,7 +989,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     Widget buildApp() {
@@ -2156,7 +2156,7 @@ void main() {
       return inactiveEnabledBackgroundColor;
     }
 
-    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = WidgetStateColor.resolveWith(
       getBackgroundColor,
     );
 
@@ -2243,7 +2243,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = WidgetStateColor.resolveWith(
       getBackgroundColor,
     );
 

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -1154,7 +1154,7 @@ void main() {
       return inactiveEnabledFillColor;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     const Key radioKey = Key('radio');
@@ -1271,7 +1271,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     const Key radioKey = Key('radio');
@@ -1363,7 +1363,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> fillColor = MaterialStateColor.resolveWith(getFillColor);
+    final WidgetStateProperty<Color> fillColor = WidgetStateColor.resolveWith(getFillColor);
 
     int? groupValue = 0;
     const Key radioKey = Key('radio');
@@ -2168,7 +2168,7 @@ void main() {
       return inactiveEnabledBackgroundColor;
     }
 
-    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = WidgetStateColor.resolveWith(
       getBackgroundColor,
     );
 
@@ -2282,7 +2282,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> backgroundColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> backgroundColor = WidgetStateColor.resolveWith(
       getBackgroundColor,
     );
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -1965,7 +1965,7 @@ void main() {
               builder: (BuildContext context, StateSetter setState) {
                 return Slider(
                   value: value,
-                  overlayColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+                  overlayColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                     if (states.contains(WidgetState.focused)) {
                       return Colors.purple[500]!;
                     }
@@ -2095,7 +2095,7 @@ void main() {
               builder: (BuildContext context, StateSetter setState) {
                 return Slider(
                   value: value,
-                  overlayColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+                  overlayColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                     if (states.contains(WidgetState.hovered)) {
                       return Colors.cyan[500]!;
                     }
@@ -2247,7 +2247,7 @@ void main() {
                   key: sliderKey,
                   value: value,
                   focusNode: focusNode,
-                  overlayColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+                  overlayColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                     if (states.contains(WidgetState.dragged)) {
                       return Colors.lime[500]!;
                     }

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -920,7 +920,7 @@ void main() {
   testWidgets('Slider can use theme overlay with material states', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(platform: TargetPlatform.android, primarySwatch: Colors.blue);
     final SliderThemeData sliderTheme = theme.sliderTheme.copyWith(
-      overlayColor: MaterialStateColor.resolveWith((Set<WidgetState> states) {
+      overlayColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
         if (states.contains(WidgetState.focused)) {
           return Colors.brown[500]!;
         }

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -1005,7 +1005,7 @@ void main() {
     final Widget textButton = actionTextButton.widget;
     if (textButton is TextButton) {
       final ButtonStyle buttonStyle = textButton.style!;
-      if (buttonStyle.foregroundColor is MaterialStateColor) {
+      if (buttonStyle.foregroundColor is WidgetStateColor) {
         // Same color when resolved
         expect(buttonStyle.foregroundColor!.resolve(<WidgetState>{}), usedColor);
       } else {
@@ -1016,7 +1016,7 @@ void main() {
     }
   });
 
-  testWidgets('Snackbar labels can be colored as MaterialStateColor (Material 3)', (
+  testWidgets('Snackbar labels can be colored as WidgetStateColor (Material 3)', (
     WidgetTester tester,
   ) async {
     const _TestMaterialStateColor usedColor = _TestMaterialStateColor();
@@ -1056,7 +1056,7 @@ void main() {
     final Widget textButton = actionTextButton.widget;
     if (textButton is TextButton) {
       final ButtonStyle buttonStyle = textButton.style!;
-      if (buttonStyle.foregroundColor is MaterialStateColor) {
+      if (buttonStyle.foregroundColor is WidgetStateColor) {
         // Exactly the same object
         expect(buttonStyle.foregroundColor, usedColor);
       } else {
@@ -3781,10 +3781,10 @@ void main() {
     expect(materialAfterDismissed.color, Colors.transparent);
   });
 
-  testWidgets('SnackBarAction backgroundColor works as a MaterialStateColor', (
+  testWidgets('SnackBarAction backgroundColor works as a WidgetStateColor', (
     WidgetTester tester,
   ) async {
-    final MaterialStateColor backgroundColor = MaterialStateColor.resolveWith((
+    final WidgetStateColor backgroundColor = WidgetStateColor.resolveWith((
       Set<WidgetState> states,
     ) {
       if (states.contains(WidgetState.disabled)) {
@@ -3901,9 +3901,9 @@ void main() {
   });
 
   testWidgets(
-    'SnackBarAction asserts when backgroundColor is a MaterialStateColor and disabledBackgroundColor is also provided',
+    'SnackBarAction asserts when backgroundColor is a WidgetStateColor and disabledBackgroundColor is also provided',
     (WidgetTester tester) async {
-      final Color backgroundColor = MaterialStateColor.resolveWith((Set<WidgetState> states) {
+      final Color backgroundColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
         if (states.contains(WidgetState.disabled)) {
           return Colors.blue;
         }
@@ -3948,7 +3948,7 @@ void main() {
           (AssertionError e) => e.toString(),
           'description',
           contains(
-            'disabledBackgroundColor must not be provided when background color is a MaterialStateColor',
+            'disabledBackgroundColor must not be provided when background color is a WidgetStateColor',
           ),
         ),
       );
@@ -4472,7 +4472,7 @@ Map<DismissDirection, List<Offset>> _getDragGesturesOfDismissDirections(double s
   return dragGestures;
 }
 
-class _TestMaterialStateColor extends MaterialStateColor {
+class _TestMaterialStateColor extends WidgetStateColor {
   const _TestMaterialStateColor() : super(_colorRed);
 
   static const int _colorRed = 0xFFF44336;

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -287,7 +287,7 @@ void main() {
   });
 
   testWidgets('SnackBarAction uses actionBackgroundColor', (WidgetTester tester) async {
-    final MaterialStateColor actionBackgroundColor = MaterialStateColor.resolveWith((
+    final WidgetStateColor actionBackgroundColor = WidgetStateColor.resolveWith((
       Set<WidgetState> states,
     ) {
       if (states.contains(WidgetState.disabled)) {
@@ -347,7 +347,7 @@ void main() {
   testWidgets('SnackBarAction backgroundColor overrides SnackBarThemeData actionBackgroundColor', (
     WidgetTester tester,
   ) async {
-    final MaterialStateColor snackBarActionBackgroundColor = MaterialStateColor.resolveWith((
+    final WidgetStateColor snackBarActionBackgroundColor = WidgetStateColor.resolveWith((
       Set<WidgetState> states,
     ) {
       if (states.contains(WidgetState.disabled)) {
@@ -356,7 +356,7 @@ void main() {
       return Colors.cyan;
     });
 
-    final MaterialStateColor actionBackgroundColor = MaterialStateColor.resolveWith((
+    final WidgetStateColor actionBackgroundColor = WidgetStateColor.resolveWith((
       Set<WidgetState> states,
     ) {
       if (states.contains(WidgetState.disabled)) {
@@ -418,9 +418,9 @@ void main() {
   });
 
   testWidgets(
-    'SnackBarThemeData asserts when actionBackgroundColor is a MaterialStateColor and disabledActionBackgroundColor is also provided',
+    'SnackBarThemeData asserts when actionBackgroundColor is a WidgetStateColor and disabledActionBackgroundColor is also provided',
     (WidgetTester tester) async {
-      final MaterialStateColor actionBackgroundColor = MaterialStateColor.resolveWith((
+      final WidgetStateColor actionBackgroundColor = WidgetStateColor.resolveWith((
         Set<WidgetState> states,
       ) {
         if (states.contains(WidgetState.disabled)) {
@@ -462,7 +462,7 @@ void main() {
             (AssertionError e) => e.toString(),
             'description',
             contains(
-              'disabledBackgroundColor must not be provided when background color is a MaterialStateColor',
+              'disabledBackgroundColor must not be provided when background color is a WidgetStateColor',
             ),
           ),
         ),

--- a/packages/flutter/test/material/switch_list_tile_test.dart
+++ b/packages/flutter/test/material/switch_list_tile_test.dart
@@ -748,7 +748,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile({required bool enabled, required bool selected}) {
       return MaterialApp(
@@ -843,7 +843,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile({required bool enabled, required bool selected}) {
       return MaterialApp(
@@ -921,7 +921,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile() {
       return MaterialApp(
@@ -988,7 +988,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitchListTile() {
       return MaterialApp(
@@ -1052,7 +1052,7 @@ void main() {
       return inactiveEnabledTrackColor;
     }
 
-    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = WidgetStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitchListTile({required bool enabled, required bool selected}) {
       return wrap(
@@ -1110,7 +1110,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = WidgetStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitchListTile() {
       return wrap(
@@ -1717,7 +1717,7 @@ void main() {
       return inactiveEnabledTrackOutlineColor;
     }
 
-    final WidgetStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> trackOutlineColor = WidgetStateColor.resolveWith(
       getOutlineColor,
     );
 
@@ -1787,7 +1787,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> outlineColor = MaterialStateColor.resolveWith(
+    final WidgetStateProperty<Color> outlineColor = WidgetStateColor.resolveWith(
       getTrackOutlineColor,
     );
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -2273,7 +2273,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return MaterialApp(
@@ -2388,7 +2388,7 @@ void main() {
       return inactiveEnabledThumbColor;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Theme(
@@ -2494,7 +2494,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch() {
       return MaterialApp(
@@ -2576,7 +2576,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch() {
       return MaterialApp(
@@ -2658,7 +2658,7 @@ void main() {
       return inactiveEnabledTrackColor;
     }
 
-    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = WidgetStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return MaterialApp(
@@ -2745,7 +2745,7 @@ void main() {
       return inactiveEnabledTrackColor;
     }
 
-    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = WidgetStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Theme(
@@ -2831,7 +2831,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = WidgetStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch() {
       return MaterialApp(
@@ -2903,7 +2903,7 @@ void main() {
       return Colors.transparent;
     }
 
-    final WidgetStateProperty<Color> trackColor = MaterialStateColor.resolveWith(getTrackColor);
+    final WidgetStateProperty<Color> trackColor = WidgetStateColor.resolveWith(getTrackColor);
 
     Widget buildSwitch() {
       return Theme(
@@ -2969,7 +2969,7 @@ void main() {
       return Colors.black;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
@@ -3026,7 +3026,7 @@ void main() {
       return Colors.black;
     }
 
-    final WidgetStateProperty<Color> thumbColor = MaterialStateColor.resolveWith(getThumbColor);
+    final WidgetStateProperty<Color> thumbColor = WidgetStateColor.resolveWith(getThumbColor);
 
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
@@ -3653,7 +3653,7 @@ void main() {
         return inactiveEnabledTrackOutlineColor;
       }
 
-      final WidgetStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
+      final WidgetStateProperty<Color> trackOutlineColor = WidgetStateColor.resolveWith(
         getTrackOutlineColor,
       );
 
@@ -3734,7 +3734,7 @@ void main() {
         return Colors.transparent;
       }
 
-      final WidgetStateProperty<Color> trackOutlineColor = MaterialStateColor.resolveWith(
+      final WidgetStateProperty<Color> trackOutlineColor = WidgetStateColor.resolveWith(
         getTrackOutlineColor,
       );
 

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -1537,7 +1537,7 @@ void main() {
   testWidgets('TabBarTheme.labelColor resolves material states', (WidgetTester tester) async {
     const Color selectedColor = Color(0xff00ff00);
     const Color unselectedColor = Color(0xffff0000);
-    final MaterialStateColor labelColor = MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    final WidgetStateColor labelColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return selectedColor;
       }
@@ -1571,9 +1571,7 @@ void main() {
     (WidgetTester tester) async {
       const Color selectedStateColor = Color(0xff00ff00);
       const Color unselectedStateColor = Color(0xffff0000);
-      final MaterialStateColor labelColor = MaterialStateColor.resolveWith((
-        Set<WidgetState> states,
-      ) {
+      final WidgetStateColor labelColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
         if (states.contains(WidgetState.selected)) {
           return selectedStateColor;
         }

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -5041,7 +5041,7 @@ void main() {
 
     const Color selectedColor = Color(0xff00ff00);
     const Color unselectedColor = Color(0xffff0000);
-    final MaterialStateColor labelColor = MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    final WidgetStateColor labelColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return selectedColor;
       }
@@ -5083,7 +5083,7 @@ void main() {
 
     const Color selectedStateColor = Color(0xff00ff00);
     const Color unselectedStateColor = Color(0xffff0000);
-    final MaterialStateColor labelColor = MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    final WidgetStateColor labelColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return selectedStateColor;
       }
@@ -5521,12 +5521,12 @@ void main() {
 
     Widget buildTabBar({bool stateColor = false}) {
       final Color labelColor = stateColor
-          ? MaterialStateColor.resolveWith((Set<WidgetState> states) {
+          ? WidgetStateColor.resolveWith((Set<WidgetState> states) {
               if (states.contains(WidgetState.selected)) {
                 return Colors.white;
               } else {
                 // this is a third color to also test if unselectedLabelColor
-                // is ignored when labelColor is MaterialStateColor
+                // is ignored when labelColor is WidgetStateColor
                 return Colors.transparent;
               }
             })

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -482,7 +482,7 @@ void main() {
     expect(hourDecoration.filled, true);
     expect(
       hourDecoration.fillColor,
-      MaterialStateColor.resolveWith(
+      WidgetStateColor.resolveWith(
         (Set<WidgetState> states) => defaultTheme.colorScheme.onSurface.withOpacity(0.12),
       ),
     );
@@ -942,7 +942,7 @@ void main() {
     },
   );
 
-  testWidgets('Time picker dayPeriodColor does the right thing with non-MaterialStateColor', (
+  testWidgets('Time picker dayPeriodColor does the right thing with non-WidgetStateColor', (
     WidgetTester tester,
   ) async {
     final TimePickerThemeData timePickerTheme = _timePickerTheme().copyWith(
@@ -962,10 +962,10 @@ void main() {
     expect(pmMaterial.color, Colors.transparent);
   });
 
-  testWidgets('Time picker dayPeriodColor does the right thing with MaterialStateColor', (
+  testWidgets('Time picker dayPeriodColor does the right thing with WidgetStateColor', (
     WidgetTester tester,
   ) async {
-    final MaterialStateColor testColor = MaterialStateColor.resolveWith((Set<WidgetState> states) {
+    final WidgetStateColor testColor = WidgetStateColor.resolveWith((Set<WidgetState> states) {
       if (states.contains(WidgetState.selected)) {
         return Colors.green;
       }
@@ -1075,7 +1075,7 @@ TimePickerThemeData _timePickerTheme({bool includeInputDecoration = false}) {
     return states.contains(WidgetState.selected) ? _selectedColor : _unselectedColor;
   }
 
-  final MaterialStateColor materialStateColor = MaterialStateColor.resolveWith(getColor);
+  final WidgetStateColor materialStateColor = WidgetStateColor.resolveWith(getColor);
   return TimePickerThemeData(
     backgroundColor: Colors.orange,
     cancelButtonStyle: TextButton.styleFrom(foregroundColor: Colors.red),

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -613,7 +613,7 @@ void main() {
     await tester.pumpWidget(
       boilerplate(
         child: ToggleButtons(
-          fillColor: MaterialStateColor.resolveWith(getFillColor),
+          fillColor: WidgetStateColor.resolveWith(getFillColor),
           isSelected: const <bool>[false, true],
           onPressed: (int index) {},
           children: const <Widget>[Text('First child'), Text('Second child')],
@@ -630,7 +630,7 @@ void main() {
     await tester.pumpWidget(
       boilerplate(
         child: ToggleButtons(
-          fillColor: MaterialStateColor.resolveWith(getFillColor),
+          fillColor: WidgetStateColor.resolveWith(getFillColor),
           isSelected: const <bool>[false, true],
           children: const <Widget>[Text('First child'), Text('Second child')],
         ),

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -387,7 +387,7 @@ void main() {
       Material(
         child: boilerplate(
           child: ToggleButtonsTheme(
-            data: ToggleButtonsThemeData(fillColor: MaterialStateColor.resolveWith(getColor)),
+            data: ToggleButtonsThemeData(fillColor: WidgetStateColor.resolveWith(getColor)),
             child: ToggleButtons(
               isSelected: const <bool>[true, false],
               onPressed: (int index) {},
@@ -407,7 +407,7 @@ void main() {
       Material(
         child: boilerplate(
           child: ToggleButtonsTheme(
-            data: ToggleButtonsThemeData(fillColor: MaterialStateColor.resolveWith(getColor)),
+            data: ToggleButtonsThemeData(fillColor: WidgetStateColor.resolveWith(getColor)),
             child: ToggleButtons(
               isSelected: const <bool>[true, false],
               children: const <Widget>[Text('First child'), Text('Second child')],


### PR DESCRIPTION
Follow up of https://github.com/flutter/flutter/pull/175397

Migrate the remaining files from `MaterialStateColor ` to `WidgetStateColor `. This PR only focus on `WidgetStateColor`.

- This minimizes conflicts and reduces the size of the PR for easier reviews and follow up
- I'll work on the other elements of `packages/flutter/lib/src/material/material_state.dart` into other PRs


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
