### PR TITLE
[a11y-app] Add label to TextFormField in AutoCompleteUseCase.

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/auto_complete.dart
+++ b/dev/a11y_assessments/lib/use_cases/auto_complete.dart
@@ -36,6 +36,7 @@ class _MainWidgetState extends State<_MainWidget> {
     VoidCallback onFieldSubmitted,
   ) {
     return TextFormField(
+      decoration: const InputDecoration(labelText: 'Fruit'),
       focusNode: focusNode,
       controller: textEditingController,
       onFieldSubmitted: (String value) {

--- a/dev/a11y_assessments/test/auto_complete_test.dart
+++ b/dev/a11y_assessments/test/auto_complete_test.dart
@@ -9,6 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'test_utils.dart';
 
 void main() {
+  testWidgets('text field label is visible', (WidgetTester tester) async {
+    await pumpsUseCase(tester, AutoCompleteUseCase());
+    expect(find.text('Fruit'), findsOneWidget);
+  });
+
   testWidgets('auto complete can run', (WidgetTester tester) async {
     await pumpsUseCase(tester, AutoCompleteUseCase());
     await tester.enterText(find.byType(TextFormField), 'a');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/173050

### Description

- Adds `labelText` to `TextFormField` in `AutoCompleteUseCase`

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
