### PR TITLE
fix(impeller): fix params to glDiscardFrameBufferEXT

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/backend/gles/BUILD.gn
@@ -17,6 +17,7 @@ impeller_component("gles_unittests") {
     "blit_command_gles_unittests.cc",
     "buffer_bindings_gles_unittests.cc",
     "device_buffer_gles_unittests.cc",
+    "render_pass_gles_unittests.cc",
     "test/capabilities_unittests.cc",
     "test/formats_gles_unittests.cc",
     "test/gpu_tracer_gles_unittests.cc",

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -578,7 +578,9 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     // to discard the entire render target. Until we know the reason, default to
     // storing.
     bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !is_default_fbo : true;
-    const bool is_default_fbo_bound = fbo.has_value() && fbo.value() != 0;
+    GLint framebuffer_id = 0;
+    gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_id);
+    const bool is_default_fbo_bound = framebuffer_id == 0;
 
     if (pass_data.discard_color_attachment) {
       attachments[attachment_count++] =

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -578,19 +578,21 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     // to discard the entire render target. Until we know the reason, default to
     // storing.
     bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !is_default_fbo : true;
+    const bool is_default_fbo_bound = fbo.has_value() && fbo.value() != 0;
 
     if (pass_data.discard_color_attachment) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
+          (is_default_fbo_bound ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
     }
+
     if (pass_data.discard_depth_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
+          (is_default_fbo_bound ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
     }
 
     if (pass_data.discard_stencil_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
+          (is_default_fbo_bound ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
     }
     gl.DiscardFramebufferEXT(GL_FRAMEBUFFER,     // target
                              attachment_count,   // attachments to discard

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -213,10 +213,10 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
 #endif  // IMPELLER_DEBUG
 
   TextureGLES& color_gles = TextureGLES::Cast(*pass_data.color_attachment);
-  const bool is_default_fbo = color_gles.IsWrapped();
+  const bool is_wrapped_fbo = color_gles.IsWrapped();
 
   std::optional<GLuint> fbo = 0;
-  if (is_default_fbo) {
+  if (is_wrapped_fbo) {
     if (color_gles.GetFBO().has_value()) {
       // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
       gl.BindFramebuffer(GL_FRAMEBUFFER, *color_gles.GetFBO());
@@ -524,7 +524,7 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
 
   if (pass_data.resolve_attachment &&
       !gl.GetCapabilities()->SupportsImplicitResolvingMSAA() &&
-      !is_default_fbo) {
+      !is_wrapped_fbo) {
     FML_DCHECK(pass_data.resolve_attachment != pass_data.color_attachment);
     // Perform multisample resolve via blit.
     // Create and bind a resolve FBO.
@@ -570,6 +570,10 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     gl.BindFramebuffer(GL_FRAMEBUFFER, fbo.value());
   }
 
+  GLint framebuffer_id = 0;
+  gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_id);
+  const bool is_default_fbo = framebuffer_id == 0;
+
   if (gl.DiscardFramebufferEXT.IsAvailable()) {
     std::array<GLenum, 3> attachments;
     size_t attachment_count = 0;
@@ -578,23 +582,20 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     // to discard the entire render target. Until we know the reason, default to
     // storing.
     bool angle_safe = gl.GetCapabilities()->IsANGLE() ? !is_default_fbo : true;
-    GLint framebuffer_id = 0;
-    gl.GetIntegerv(GL_FRAMEBUFFER_BINDING, &framebuffer_id);
-    const bool is_default_fbo_bound = framebuffer_id == 0;
 
     if (pass_data.discard_color_attachment) {
       attachments[attachment_count++] =
-          (is_default_fbo_bound ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
+          (is_default_fbo ? GL_COLOR_EXT : GL_COLOR_ATTACHMENT0);
     }
 
     if (pass_data.discard_depth_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo_bound ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
+          (is_default_fbo ? GL_DEPTH_EXT : GL_DEPTH_ATTACHMENT);
     }
 
     if (pass_data.discard_stencil_attachment && angle_safe) {
       attachments[attachment_count++] =
-          (is_default_fbo_bound ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
+          (is_default_fbo ? GL_STENCIL_EXT : GL_STENCIL_ATTACHMENT);
     }
     gl.DiscardFramebufferEXT(GL_FRAMEBUFFER,     // target
                              attachment_count,   // attachments to discard

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -1,0 +1,125 @@
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+#include "flutter/testing/testing.h"  // IWYU pragma: keep
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "impeller/core/formats.h"
+#include "impeller/renderer/backend/gles/command_buffer_gles.h"
+#include "impeller/renderer/backend/gles/context_gles.h"
+#include "impeller/renderer/backend/gles/proc_table_gles.h"
+#include "impeller/renderer/backend/gles/reactor_gles.h"
+#include "impeller/renderer/render_pass.h"
+#include "impeller/renderer/backend/gles/test/mock_gles.h"
+#include "impeller/renderer/backend/gles/texture_gles.h"
+#include "impeller/renderer/context.h"
+#include "impeller/renderer/render_target.h"
+
+namespace impeller {
+namespace testing {
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ElementsAreArray;
+using ::testing::Args;
+using ::testing::NiceMock;
+using ::testing::SetArgPointee;
+using ::testing::TestWithParam;
+
+class TestReactorGLES : public ReactorGLES {
+ public:
+  TestReactorGLES()
+      : ReactorGLES(std::make_unique<ProcTableGLES>(kMockResolverGLES)) {}
+
+  ~TestReactorGLES() = default;
+};
+
+class MockWorker final : public ReactorGLES::Worker {
+ public:
+  MockWorker() = default;
+
+  // |ReactorGLES::Worker|
+  bool CanReactorReactOnCurrentThreadNow(
+      const ReactorGLES& reactor) const override {
+    return true;
+  }
+};
+
+struct DiscardFrameBufferParams {
+  GLuint frame_buffer_id;
+  std::array<GLenum, 3> expected_attachments;
+};
+
+class RenderPassGLESWithDiscardFrameBufferExtTest : public TestWithParam<DiscardFrameBufferParams> {};
+
+namespace {
+std::shared_ptr<ContextGLES> CreateFakeGLESContext() {
+  auto dummy_gl_procs = std::make_unique<ProcTableGLES>(kMockResolverGLES);
+  auto dummy_shader_library = std::vector<std::shared_ptr<fml::Mapping>>{};
+  auto flags = Flags{};
+  return ContextGLES::Create(flags, std::move(dummy_gl_procs), dummy_shader_library, false);
+}
+}
+
+TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, DiscardFramebufferExt) {
+  auto mock_gl_impl = std::make_unique<NiceMock<MockGLESImpl>>();
+  auto& mock_gl_impl_ref = *mock_gl_impl;
+  auto mock_gl = MockGLES::Init(std::move(mock_gl_impl), {{"GL_EXT_discard_framebuffer"}});
+
+  auto context = CreateFakeGLESContext();
+  auto dummy_worker = std::make_shared<MockWorker>();
+  context->AddReactorWorker(dummy_worker);
+  auto reactor = context->GetReactor();
+
+  const auto command_buffer = std::static_pointer_cast<Context>(context)->CreateCommandBuffer();
+  auto render_target = RenderTarget{};
+  const auto description = TextureDescriptor{
+    .format = PixelFormat::kR8G8B8A8UNormInt,
+    .size = {10, 10}
+  };
+
+  const auto& test_params = GetParam();
+  auto framebuffer_texture = TextureGLES::WrapFBO(reactor, description, test_params.frame_buffer_id);
+
+  auto color_attachment = ColorAttachment{
+    Attachment {
+      .texture = framebuffer_texture,
+      .store_action = StoreAction::kDontCare
+    }
+  };
+  render_target.SetColorAttachment(color_attachment, 0);
+  const auto render_pass = command_buffer->CreateRenderPass(render_target);
+
+  EXPECT_CALL(mock_gl_impl_ref, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
+  .WillOnce(SetArgPointee<1>(test_params.frame_buffer_id));
+  
+  EXPECT_CALL(
+    mock_gl_impl_ref,
+    DiscardFramebufferEXT(
+      GL_FRAMEBUFFER,
+      _,
+       _ )
+      ).With(Args<2,1>(ElementsAreArray(test_params.expected_attachments))).Times(1);
+  ASSERT_TRUE(render_pass->EncodeCommands());
+  ASSERT_TRUE(reactor->React());
+}
+
+INSTANTIATE_TEST_SUITE_P(FrameBufferObject, RenderPassGLESWithDiscardFrameBufferExtTest,
+  ::testing::ValuesIn(std::vector<DiscardFrameBufferParams>{
+    {
+      .frame_buffer_id = 0,
+      .expected_attachments = {GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT}
+    },
+    {
+      .frame_buffer_id = 1,
+      .expected_attachments = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT}
+    }}
+  ),
+  [](const ::testing::TestParamInfo<DiscardFrameBufferParams> &info) { return (info.param.frame_buffer_id == 0) ? "Default" : "NonDefault"; }
+);
+
+}  // namespace testing
+}  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <memory>
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gmock/gmock.h"

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -1,8 +1,3 @@
-
-// Copyright 2013 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #include <memory>
 #include "flutter/testing/testing.h"  // IWYU pragma: keep
 #include "gmock/gmock.h"
@@ -12,20 +7,20 @@
 #include "impeller/renderer/backend/gles/context_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
-#include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/backend/gles/test/mock_gles.h"
 #include "impeller/renderer/backend/gles/texture_gles.h"
 #include "impeller/renderer/context.h"
+#include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
 
 namespace impeller {
 namespace testing {
 
 using ::testing::_;
-using ::testing::Return;
-using ::testing::ElementsAreArray;
 using ::testing::Args;
+using ::testing::ElementsAreArray;
 using ::testing::NiceMock;
+using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::TestWithParam;
 
@@ -53,73 +48,67 @@ struct DiscardFrameBufferParams {
   std::array<GLenum, 3> expected_attachments;
 };
 
-class RenderPassGLESWithDiscardFrameBufferExtTest : public TestWithParam<DiscardFrameBufferParams> {};
+class RenderPassGLESWithDiscardFrameBufferExtTest
+    : public TestWithParam<DiscardFrameBufferParams> {};
 
 namespace {
 std::shared_ptr<ContextGLES> CreateFakeGLESContext() {
   auto dummy_gl_procs = std::make_unique<ProcTableGLES>(kMockResolverGLES);
   auto dummy_shader_library = std::vector<std::shared_ptr<fml::Mapping>>{};
   auto flags = Flags{};
-  return ContextGLES::Create(flags, std::move(dummy_gl_procs), dummy_shader_library, false);
+  return ContextGLES::Create(flags, std::move(dummy_gl_procs),
+                             dummy_shader_library, false);
 }
-}
+}  // namespace
 
 TEST_P(RenderPassGLESWithDiscardFrameBufferExtTest, DiscardFramebufferExt) {
   auto mock_gl_impl = std::make_unique<NiceMock<MockGLESImpl>>();
   auto& mock_gl_impl_ref = *mock_gl_impl;
-  auto mock_gl = MockGLES::Init(std::move(mock_gl_impl), {{"GL_EXT_discard_framebuffer"}});
+  auto mock_gl =
+      MockGLES::Init(std::move(mock_gl_impl), {{"GL_EXT_discard_framebuffer"}});
 
   auto context = CreateFakeGLESContext();
   auto dummy_worker = std::make_shared<MockWorker>();
   context->AddReactorWorker(dummy_worker);
   auto reactor = context->GetReactor();
 
-  const auto command_buffer = std::static_pointer_cast<Context>(context)->CreateCommandBuffer();
+  const auto command_buffer =
+      std::static_pointer_cast<Context>(context)->CreateCommandBuffer();
   auto render_target = RenderTarget{};
   const auto description = TextureDescriptor{
-    .format = PixelFormat::kR8G8B8A8UNormInt,
-    .size = {10, 10}
-  };
+      .format = PixelFormat::kR8G8B8A8UNormInt, .size = {10, 10}};
 
   const auto& test_params = GetParam();
-  auto framebuffer_texture = TextureGLES::WrapFBO(reactor, description, test_params.frame_buffer_id);
+  auto framebuffer_texture =
+      TextureGLES::WrapFBO(reactor, description, test_params.frame_buffer_id);
 
-  auto color_attachment = ColorAttachment{
-    Attachment {
-      .texture = framebuffer_texture,
-      .store_action = StoreAction::kDontCare
-    }
-  };
+  auto color_attachment = ColorAttachment{Attachment{
+      .texture = framebuffer_texture, .store_action = StoreAction::kDontCare}};
   render_target.SetColorAttachment(color_attachment, 0);
   const auto render_pass = command_buffer->CreateRenderPass(render_target);
 
   EXPECT_CALL(mock_gl_impl_ref, GetIntegerv(GL_FRAMEBUFFER_BINDING, _))
-  .WillOnce(SetArgPointee<1>(test_params.frame_buffer_id));
-  
-  EXPECT_CALL(
-    mock_gl_impl_ref,
-    DiscardFramebufferEXT(
-      GL_FRAMEBUFFER,
-      _,
-       _ )
-      ).With(Args<2,1>(ElementsAreArray(test_params.expected_attachments))).Times(1);
+      .WillOnce(SetArgPointee<1>(test_params.frame_buffer_id));
+
+  EXPECT_CALL(mock_gl_impl_ref, DiscardFramebufferEXT(GL_FRAMEBUFFER, _, _))
+      .With(Args<2, 1>(ElementsAreArray(test_params.expected_attachments)))
+      .Times(1);
   ASSERT_TRUE(render_pass->EncodeCommands());
   ASSERT_TRUE(reactor->React());
 }
 
-INSTANTIATE_TEST_SUITE_P(FrameBufferObject, RenderPassGLESWithDiscardFrameBufferExtTest,
-  ::testing::ValuesIn(std::vector<DiscardFrameBufferParams>{
-    {
-      .frame_buffer_id = 0,
-      .expected_attachments = {GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT}
-    },
-    {
-      .frame_buffer_id = 1,
-      .expected_attachments = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT, GL_STENCIL_ATTACHMENT}
-    }}
-  ),
-  [](const ::testing::TestParamInfo<DiscardFrameBufferParams> &info) { return (info.param.frame_buffer_id == 0) ? "Default" : "NonDefault"; }
-);
+INSTANTIATE_TEST_SUITE_P(
+    FrameBufferObject,
+    RenderPassGLESWithDiscardFrameBufferExtTest,
+    ::testing::ValuesIn(std::vector<DiscardFrameBufferParams>{
+        {.frame_buffer_id = 0,
+         .expected_attachments = {GL_COLOR_EXT, GL_DEPTH_EXT, GL_STENCIL_EXT}},
+        {.frame_buffer_id = 1,
+         .expected_attachments = {GL_COLOR_ATTACHMENT0, GL_DEPTH_ATTACHMENT,
+                                  GL_STENCIL_ATTACHMENT}}}),
+    [](const ::testing::TestParamInfo<DiscardFrameBufferParams>& info) {
+      return (info.param.frame_buffer_id == 0) ? "Default" : "NonDefault";
+    });
 
 }  // namespace testing
 }  // namespace impeller

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -103,7 +103,7 @@ void mockGetIntegerv(GLenum name, int* value) {
       *value = 4096;
       break;
     default:
-      *value = 0;
+      CallMockMethod(&IMockGLESImpl::GetIntegerv, name, value);
       break;
   }
 }
@@ -246,8 +246,15 @@ void mockReadPixels(GLint x,
                         type, data);
 }
 
-static_assert(CheckSameSignature<decltype(mockReadPixels),  //
-                                 decltype(glReadPixels)>::value);
+void mockDiscardFramebufferEXT(GLenum target,
+                               GLsizei numAttachments,
+                               const GLenum* attachments) {
+  return CallMockMethod(&IMockGLESImpl::DiscardFramebufferEXT, target,
+                        numAttachments, attachments);
+}
+
+static_assert(CheckSameSignature<decltype(mockDiscardFramebufferEXT),  //
+                                 decltype(glDiscardFramebufferEXT)>::value);
 
 // static
 std::shared_ptr<MockGLES> MockGLES::Init(
@@ -322,6 +329,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockGenFramebuffers);
   } else if (strcmp(name, "glBindFramebuffer") == 0) {
     return reinterpret_cast<void*>(mockBindFramebuffer);
+  } else if (strcmp(name, "glDiscardFramebufferEXT") == 0) {
+    return reinterpret_cast<void*>(mockDiscardFramebufferEXT);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 
-#include "GLES3/gl3.h"
 #include "gmock/gmock.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 
@@ -160,11 +159,7 @@ class MockGLESImpl : public IMockGLESImpl {
                GLsizei numAttachments,
                const GLenum* attachments),
               (override));
-  MOCK_METHOD(void,
-              GetIntegerv,
-              (GLenum name,
-               GLint *value),
-              (override));
+  MOCK_METHOD(void, GetIntegerv, (GLenum name, GLint* value), (override));
 };
 
 /// @brief      Provides a mocked version of the |ProcTableGLES| class.

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 
+#include "GLES3/gl3.h"
 #include "gmock/gmock.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 
@@ -66,6 +67,10 @@ class IMockGLESImpl {
   virtual void GenBuffers(GLsizei n, GLuint* buffers) {}
   virtual void DeleteBuffers(GLsizei n, const GLuint* buffers) {}
   virtual GLboolean IsTexture(GLuint texture) { return true; }
+  virtual void DiscardFramebufferEXT(GLenum target,
+                                     GLsizei numAttachments,
+                                     const GLenum* attachments) {};
+  virtual void GetIntegerv(GLenum name, GLint* attachments) {};
 };
 
 class MockGLESImpl : public IMockGLESImpl {
@@ -149,6 +154,17 @@ class MockGLESImpl : public IMockGLESImpl {
               (GLsizei n, const GLuint* buffers),
               (override));
   MOCK_METHOD(GLboolean, IsTexture, (GLuint texture), (override));
+  MOCK_METHOD(void,
+              DiscardFramebufferEXT,
+              (GLenum target,
+               GLsizei numAttachments,
+               const GLenum* attachments),
+              (override));
+  MOCK_METHOD(void,
+              GetIntegerv,
+              (GLenum name,
+               GLint *value),
+              (override));
 };
 
 /// @brief      Provides a mocked version of the |ProcTableGLES| class.


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fix parameters to [glDiscardFramebufferEXT](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_discard_framebuffer.txt) when an application-defined framebuffer is bound. The `is_default_fbo` parameter is set to `true` if `color_gles.IsWrapped()` is true, however according to the GLES spec, a non-default framebuffer is bound if `glBindFramebuffer(GL_FRAMEBUFFER, framebuffer)` is called with `framebuffer != 0`:

> _The namespace for framebuffer objects is the unsigned integers, with zero re-
served by OpenGL ES to refer to the default framebuffer. A framebuffer object
is created by binding an unused name to the target FRAMEBUFFER._ 

To reproduce this issue, run a flutter application with `--enable-impeller` on a platform where `glDiscardFramebufferEXT` is available. The following error is reported:

```
[FATAL:flutter/impeller/renderer/backend/gles/proc_table_gles.h(43)] Fatal GL Error GL_INVALID_ENUM(1280) encountered on call to glDiscardFramebufferEXT
```

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

closes #175588 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
