### PR TITLE
Fix RadioGroup single selection check.

### DIFF
--- a/packages/flutter/lib/src/widgets/radio_group.dart
+++ b/packages/flutter/lib/src/widgets/radio_group.dart
@@ -98,6 +98,9 @@ class _RadioGroupState<T> extends State<RadioGroup<T>> implements RadioGroupRegi
   final Set<RadioClient<T>> _radios = <RadioClient<T>>{};
 
   bool _debugHasScheduledSingleSelectionCheck = false;
+
+  /// Schedules a check for the next frame to verify that there is only one
+  /// radio with the group value.
   bool _debugScheduleSingleSelectionCheck() {
     if (_debugHasScheduledSingleSelectionCheck) {
       return true;

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -253,6 +253,7 @@ void main() {
     FlutterError.onError = (FlutterErrorDetails details) {
       error = details;
     };
+    addTearDown(() => FlutterError.onError = handler);
 
     final UniqueKey key1 = UniqueKey();
     await tester.pumpWidget(
@@ -286,8 +287,6 @@ void main() {
         "RadioGroupPolicy can't be used for a radio group that allows multiple selection.",
       ),
     );
-
-    FlutterError.onError = handler;
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/175258.
@@ -299,6 +298,7 @@ void main() {
     FlutterError.onError = (FlutterErrorDetails details) {
       error = details;
     };
+    addTearDown(() => FlutterError.onError = handler);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -342,8 +342,6 @@ void main() {
     );
 
     expect(error, isNull);
-
-    FlutterError.onError = handler;
   });
 }
 

--- a/packages/flutter/test/widgets/radio_group_test.dart
+++ b/packages/flutter/test/widgets/radio_group_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
@@ -248,13 +247,6 @@ void main() {
 
   // Regression test for https://github.com/flutter/flutter/issues/175258.
   testWidgets('Radio group throws on multiple selection', (WidgetTester tester) async {
-    final FlutterExceptionHandler? handler = FlutterError.onError;
-    FlutterErrorDetails? error;
-    FlutterError.onError = (FlutterErrorDetails details) {
-      error = details;
-    };
-    addTearDown(() => FlutterError.onError = handler);
-
     final UniqueKey key1 = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
@@ -273,14 +265,13 @@ void main() {
       ),
     );
 
-    expect(error, isNull);
+    expect(tester.takeException(), isNull);
 
     await tester.tap(find.byKey(key1));
     await tester.pump();
 
-    expect(error, isNotNull);
     expect(
-      error!.exception,
+      tester.takeException(),
       isA<FlutterError>().having(
         (FlutterError e) => e.message,
         'message',
@@ -293,13 +284,6 @@ void main() {
   testWidgets('Radio group does not throw when number of children decreases', (
     WidgetTester tester,
   ) async {
-    final FlutterExceptionHandler? handler = FlutterError.onError;
-    FlutterErrorDetails? error;
-    FlutterError.onError = (FlutterErrorDetails details) {
-      error = details;
-    };
-    addTearDown(() => FlutterError.onError = handler);
-
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -320,7 +304,7 @@ void main() {
       ),
     );
 
-    expect(error, isNull);
+    expect(tester.takeException(), isNull);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -341,7 +325,7 @@ void main() {
       ),
     );
 
-    expect(error, isNull);
+    expect(tester.takeException(), isNull);
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/175258

### Description

This PR fixes the single selection check in `RadioGroup` by delaying it to the next frame, which ensures that all `registerClient` and `unregisterClient` calls are processed.

The same pattern can be found in `_TabBarState._debugScheduleCheckHasValidTabsCount` and `RawScrollbarState._debugScheduleCheckHasValidScrollPosition`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
