### PR TITLE
Fix SliverMainAxisGroup SliverEnsureSemantics support

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_group.dart
+++ b/packages/flutter/lib/src/rendering/sliver_group.dart
@@ -473,7 +473,7 @@ class RenderSliverMainAxisGroup extends RenderSliver
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
     RenderSliver? child = firstChild;
     while (child != null) {
-      if (child.geometry!.visible) {
+      if (child.geometry!.visible || child.geometry!.cacheExtent > 0.0 || child.ensureSemantics) {
         visitor(child);
       }
       child = childAfter(child);


### PR DESCRIPTION
To complete the work in PR #166889, this PR ensures that `SliverMainAxisGroup` correctly supports `SliverEnsureSemantics` and respects `cacheExtent` rules within its `visitChildrenForSemantics` implementation.

The fix is adapted from `RenderViewPort.visitChildrenForSemantics` code.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

