### PR TITLE
fix: cupertino sheet broken example with programatic pop

### DIFF
--- a/examples/api/lib/cupertino/sheet/cupertino_sheet.1.dart
+++ b/examples/api/lib/cupertino/sheet/cupertino_sheet.1.dart
@@ -73,7 +73,7 @@ class _SheetBody extends StatelessWidget {
           Text(title),
           CupertinoButton.filled(
             onPressed: () {
-              Navigator.of(context).pop();
+              Navigator.of(context).maybePop();
             },
             child: const Text('Go Back'),
           ),

--- a/examples/api/test/cupertino/sheet/cupertino_sheet.1_test.dart
+++ b/examples/api/test/cupertino/sheet/cupertino_sheet.1_test.dart
@@ -41,4 +41,18 @@ void main() {
     expect(dialogTitle, findsNothing);
     expect(nextPageTitle, findsNothing);
   });
+
+  testWidgets('Go Back button uses maybePop and handles edge cases', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.CupertinoSheetApp());
+
+    await tester.tap(find.byType(CupertinoButton));
+    await tester.pumpAndSettle();
+    expect(find.text('CupertinoSheetRoute'), findsOneWidget);
+
+    await tester.tap(find.text('Go Back'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('CupertinoSheetRoute'), findsNothing);
+    expect(find.text('Open Bottom Sheet'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Add maybePop instead of direct pop to fix navigation in example

fixes: #175390 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.