### PR TITLE
Make equality check between `IOSSystemContextMenuItemDataCustom`s more lenient

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -2828,6 +2828,11 @@ class SystemContextMenuController with SystemContextMenuClient, Diagnosticable {
               'Duplicate callback ID "${item.callbackId}" with different callbacks. '
               'Each custom menu item must have a unique ID or the same callback.',
             );
+            // TODO(Renzo-Olivares): If we do this, then the framework will have updated callbackIds
+            // (since right now it still considers onPressed), and they won't match the engines callbackIds.
+            //
+            // Ideally the callbackIds would not be based on the onPressed to make it more deterministic
+            // across rebuilds, so if an onPressed lambda hasn't changed the id should also not change.
             _customActionCallbacks[item.callbackId] = item.onPressed;
           }
         }


### PR DESCRIPTION
Issue:

https://github.com/flutter/flutter/blob/dc1f69b9a4e7468f71b88ecd6706bacf1960dd22/packages/flutter/lib/src/services/text_input.dart#L2779-L2782

The assertion above is easy to trigger if someone passes a lambda to the `IOSSystemContextMenuItemDataCustom`. The reason for this is the equality check below.

https://github.com/flutter/flutter/blob/dc1f69b9a4e7468f71b88ecd6706bacf1960dd22/packages/flutter/lib/src/services/text_input.dart#L2771-L2777

`listEquals` fails every time when involving `IOSSystemContextMenuItemDataCustom`s that have been passed a lambda for their `onPressed` method instead of a static method. Because of this when the menu is rebuilt, `showWithItems` is called even if the items passed have not changed from a user perspective causing an assertion to be triggered.

Fix:

Make the equality check between custom items more lenient by dropping `onPressed` for the comparison.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.