### PR TITLE
Fix SliverMainAxisGroup.cacheOrigin

### DIFF
--- a/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
+++ b/packages/flutter/test/widgets/sliver_main_axis_group_test.dart
@@ -856,6 +856,38 @@ void main() {
     expect(renderGroup.geometry!.cacheExtent, 850.0);
   });
 
+  testWidgets('SliverMainAxisGroup has consistent cacheOrigin', (WidgetTester tester) async {
+    const Widget item = SizedBox.square(dimension: 50);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverMainAxisGroup(
+              slivers: <Widget>[
+                const PinnedHeaderSliver(child: SizedBox(height: 500)),
+                SliverList.builder(
+                  itemCount: 100,
+                  itemBuilder: (BuildContext context, int index) => item,
+                ),
+                const SliverToBoxAdapter(child: item),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.scrollUntilVisible(find.byType(SliverToBoxAdapter), 500);
+    await tester.pumpAndSettle();
+
+    final RenderSliver sliverList =
+        find.byType(SliverList).evaluate().single.findRenderObject()! as RenderSliver;
+
+    expect(sliverList.constraints.cacheOrigin, -250.0);
+    expect(sliverList.constraints.remainingCacheExtent, 1100);
+  });
+
   testWidgets('SliverMainAxisGroup correctly handles ensureVisible', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(


### PR DESCRIPTION
Fix #175759 

The fix involves using the same logic for cache calculation on RenderViewport.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

