### PR TITLE
Set the font weight variation axis based on the text style's FontWeight

### DIFF
--- a/engine/src/flutter/impeller/toolkit/interop/formats.h
+++ b/engine/src/flutter/impeller/toolkit/interop/formats.h
@@ -456,28 +456,28 @@ constexpr txt::TextDecorationStyle ToTxtType(
   return txt::TextDecorationStyle::kSolid;
 }
 
-constexpr txt::FontWeight ToTxtType(ImpellerFontWeight weight) {
+constexpr int ToTxtType(ImpellerFontWeight weight) {
   switch (weight) {
     case kImpellerFontWeight100:
-      return txt::FontWeight::w100;
+      return 100;
     case kImpellerFontWeight200:
-      return txt::FontWeight::w200;
+      return 200;
     case kImpellerFontWeight300:
-      return txt::FontWeight::w300;
+      return 300;
     case kImpellerFontWeight400:
-      return txt::FontWeight::w400;
+      return 400;
     case kImpellerFontWeight500:
-      return txt::FontWeight::w500;
+      return 500;
     case kImpellerFontWeight600:
-      return txt::FontWeight::w600;
+      return 600;
     case kImpellerFontWeight700:
-      return txt::FontWeight::w700;
+      return 700;
     case kImpellerFontWeight800:
-      return txt::FontWeight::w800;
+      return 800;
     case kImpellerFontWeight900:
-      return txt::FontWeight::w900;
+      return 900;
   }
-  return txt::FontWeight::w400;
+  return txt::FontWeight::normal;
 }
 
 constexpr txt::FontStyle ToTxtType(ImpellerFontStyle style) {

--- a/engine/src/flutter/impeller/toolkit/interop/paragraph_style.cc
+++ b/engine/src/flutter/impeller/toolkit/interop/paragraph_style.cc
@@ -12,7 +12,7 @@ ParagraphStyle::ParagraphStyle() = default;
 
 ParagraphStyle::~ParagraphStyle() = default;
 
-void ParagraphStyle::SetFontWeight(txt::FontWeight weight) {
+void ParagraphStyle::SetFontWeight(int weight) {
   style_.font_weight = weight;
 }
 

--- a/engine/src/flutter/impeller/toolkit/interop/paragraph_style.h
+++ b/engine/src/flutter/impeller/toolkit/interop/paragraph_style.h
@@ -28,7 +28,7 @@ class ParagraphStyle final
 
   void SetBackground(ScopedObject<Paint> paint);
 
-  void SetFontWeight(txt::FontWeight weight);
+  void SetFontWeight(int weight);
 
   void SetFontStyle(txt::FontStyle style);
 

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -56,15 +56,18 @@ enum FontStyle {
 ///
 /// Some modern fonts allow the weight to be adjusted in arbitrary increments.
 /// When using these fonts, applications can specify [FontWeight] instances
-/// constructed using values other than the predefined values.
+/// constructed using values other than the predefined values. For these fonts,
+/// [FontWeight] will set the value of the `wght` axis (producing the same
+/// results as explicitly setting that attribute using [FontVariation.weight]).
 class FontWeight {
-  /// Create a [FontWeight] object, which can be added to a [TextStyle] to
+  /// Creates a [FontWeight] object, which can be added to a [TextStyle] to
   /// select the thickness of a font's glyphs.
   const FontWeight(this.value)
     : assert(value >= 1, 'Font weight must be between 1 and 1000'),
       assert(value <= 1000, 'Font weight must be between 1 and 1000');
 
   /// The encoded integer value of this font weight.
+  @Deprecated('Use value, which is more precise.')
   int get index => (value ~/ 100 - 1).clamp(0, 8);
 
   /// The thickness value of this font weight.

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -58,6 +58,8 @@ enum FontStyle {
 /// When using these fonts, applications can specify [FontWeight] instances
 /// constructed using values other than the predefined values.
 class FontWeight {
+  /// Create a [FontWeight] object, which can be added to a [TextStyle] to
+  /// select the thickness of a font's glyphs.
   const FontWeight(this.value)
     : assert(value >= 1, 'Font weight must be between 1 and 1000'),
       assert(value <= 1000, 'Font weight must be between 1 and 1000');
@@ -121,6 +123,9 @@ class FontWeight {
     }
     return other is FontWeight && other.value == value;
   }
+
+  @override
+  int get hashCode => value;
 
   /// Linearly interpolates between two font weights.
   ///

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -2232,6 +2232,7 @@ ByteData _encodeStrut(
   data.setInt32(0, bitmask, _kFakeHostEndian);
 
   assert(byteCount <= 24);
+  assert(bitmask >> 32 == 0, 'strut bitmask overflow: $bitmask');
   return ByteData.view(data.buffer, 0, byteCount);
 }
 
@@ -3560,9 +3561,9 @@ base class _NativeParagraphBuilder extends NativeFieldWrapperClass1 implements P
       final TextLeadingDistribution leadingDistribution =
           strutStyle._leadingDistribution ?? style._leadingDistribution;
       encodedStrutStyle = strutStyle._encoded;
-      int bitmask = encodedStrutStyle.getInt8(0);
+      int bitmask = encodedStrutStyle.getInt32(0, _kFakeHostEndian);
       bitmask |= (leadingDistribution.index) << 3;
-      encodedStrutStyle.setInt8(0, bitmask);
+      encodedStrutStyle.setInt32(0, bitmask, _kFakeHostEndian);
     } else {
       encodedStrutStyle = null;
     }

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -53,42 +53,43 @@ enum FontStyle {
 /// with the name "Roboto" and the weight [FontWeight.w500].
 ///
 /// Some modern fonts allow the weight to be adjusted in arbitrary increments.
-/// See [FontVariation.weight] for details.
+/// When using these fonts, applications can specify [FontWeight] instances
+/// constructed using values other than the predefined values.
 class FontWeight {
-  const FontWeight._(this.index, this.value);
+  const FontWeight(this.value);
 
   /// The encoded integer value of this font weight.
-  final int index;
+  int get index => (value ~/ 100 - 1).clamp(0, 8);
 
   /// The thickness value of this font weight.
   final int value;
 
   /// Thin, the least thick.
-  static const FontWeight w100 = FontWeight._(0, 100);
+  static const FontWeight w100 = FontWeight(100);
 
   /// Extra-light.
-  static const FontWeight w200 = FontWeight._(1, 200);
+  static const FontWeight w200 = FontWeight(200);
 
   /// Light.
-  static const FontWeight w300 = FontWeight._(2, 300);
+  static const FontWeight w300 = FontWeight(300);
 
   /// Normal / regular / plain.
-  static const FontWeight w400 = FontWeight._(3, 400);
+  static const FontWeight w400 = FontWeight(400);
 
   /// Medium.
-  static const FontWeight w500 = FontWeight._(4, 500);
+  static const FontWeight w500 = FontWeight(500);
 
   /// Semi-bold.
-  static const FontWeight w600 = FontWeight._(5, 600);
+  static const FontWeight w600 = FontWeight(600);
 
   /// Bold.
-  static const FontWeight w700 = FontWeight._(6, 700);
+  static const FontWeight w700 = FontWeight(700);
 
   /// Extra-bold.
-  static const FontWeight w800 = FontWeight._(7, 800);
+  static const FontWeight w800 = FontWeight(800);
 
   /// Black, the most thick.
-  static const FontWeight w900 = FontWeight._(8, 900);
+  static const FontWeight w900 = FontWeight(900);
 
   /// The default font weight.
   static const FontWeight normal = w400;
@@ -109,13 +110,15 @@ class FontWeight {
     w900,
   ];
 
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is FontWeight && other.value == value;
+  }
+
   /// Linearly interpolates between two font weights.
-  ///
-  /// Rather than using fractional weights, the interpolation rounds to the
-  /// nearest weight.
-  ///
-  /// For a smoother animation of font weight, consider using
-  /// [FontVariation.weight] if the font in question supports it.
   ///
   /// If both `a` and `b` are null, then this method will return null. Otherwise,
   /// any null values for `a` or `b` are interpreted as equivalent to [normal]
@@ -137,11 +140,16 @@ class FontWeight {
     if (a == null && b == null) {
       return null;
     }
-    return values[_lerpInt((a ?? normal).index, (b ?? normal).index, t).round().clamp(0, 8)];
+    return FontWeight(
+      _lerpInt((a ?? normal).value, (b ?? normal).value, t).round().clamp(100, 900),
+    );
   }
 
   @override
   String toString() {
+    if (value % 100 != 0) {
+      return 'FontWeight($value)';
+    }
     return const <int, String>{
       0: 'FontWeight.w100',
       1: 'FontWeight.w200',
@@ -992,7 +1000,7 @@ class FontFeature {
 /// For example:
 ///
 /// ```dart
-/// const TextStyle(fontVariations: <ui.FontVariation>[ui.FontVariation('wght', 800.0)])
+/// const TextStyle(fontVariations: <ui.FontVariation>[ui.FontVariation('slnt', -5.0)])
 /// ```
 ///
 /// Font variations are distinct from font features, as exposed by the
@@ -1110,8 +1118,12 @@ class FontVariation {
 
   /// Variable font weight. (`wght`)
   ///
-  /// Varies the stroke thickness of the font, similar to [FontWeight] but on a
-  /// continuous axis.
+  /// Applications should avoid using this and should instead declare font
+  /// weight by specifying a [FontWeight], which will implicitly set this
+  /// attribute. However, if a value is provided for this attribute, then it
+  /// will override the [FontWeight].
+  ///
+  /// Varies the stroke thickness of the font.
   ///
   /// Values must be in the range 1..1000, and are to be interpreted in a manner
   /// consistent with the values of [FontWeight]. For instance, `400` is the
@@ -1630,7 +1642,7 @@ Int32List _encodeTextStyle(
   }
   if (fontWeight != null) {
     result[0] |= 1 << 5;
-    result[5] = fontWeight.index;
+    result[5] = fontWeight.value;
   }
   if (fontStyle != null) {
     result[0] |= 1 << 6;
@@ -1869,7 +1881,7 @@ class TextStyle {
         'decorationStyle: ${_encoded[0] & 0x00010 == 0x00010 ? TextDecorationStyle.values[_encoded[4]] : "unspecified"}, '
         // The decorationThickness is not in encoded order in order to keep it near the other decoration properties.
         'decorationThickness: ${_encoded[0] & 0x00100 == 0x00100 ? _decorationThickness : "unspecified"}, '
-        'fontWeight: ${_encoded[0] & 0x00020 == 0x00020 ? FontWeight.values[_encoded[5]] : "unspecified"}, '
+        'fontWeight: ${_encoded[0] & 0x00020 == 0x00020 ? FontWeight(_encoded[5]) : "unspecified"}, '
         'fontStyle: ${_encoded[0] & 0x00040 == 0x00040 ? FontStyle.values[_encoded[6]] : "unspecified"}, '
         'textBaseline: ${_encoded[0] & 0x00080 == 0x00080 ? TextBaseline.values[_encoded[7]] : "unspecified"}, '
         'fontFamily: ${_encoded[0] & 0x00200 == 0x00200 && _fontFamily != '' ? _fontFamily : "unspecified"}, '
@@ -1935,7 +1947,7 @@ Int32List _encodeParagraphStyle(
   }
   if (fontWeight != null) {
     result[0] |= 1 << 3;
-    result[3] = fontWeight.index;
+    result[3] = fontWeight.value;
   }
   if (fontStyle != null) {
     result[0] |= 1 << 4;
@@ -2121,7 +2133,7 @@ class ParagraphStyle {
     return 'ParagraphStyle('
         'textAlign: ${_encoded[0] & 0x002 == 0x002 ? TextAlign.values[_encoded[1]] : "unspecified"}, '
         'textDirection: ${_encoded[0] & 0x004 == 0x004 ? TextDirection.values[_encoded[2]] : "unspecified"}, '
-        'fontWeight: ${_encoded[0] & 0x008 == 0x008 ? FontWeight.values[_encoded[3]] : "unspecified"}, '
+        'fontWeight: ${_encoded[0] & 0x008 == 0x008 ? FontWeight(_encoded[3]) : "unspecified"}, '
         'fontStyle: ${_encoded[0] & 0x010 == 0x010 ? FontStyle.values[_encoded[4]] : "unspecified"}, '
         'maxLines: ${_encoded[0] & 0x020 == 0x020 ? _encoded[5] : "unspecified"}, '
         'textHeightBehavior: ${_encoded[0] & 0x040 == 0x040 ? TextHeightBehavior._fromEncoded(_encoded[6], _leadingDistribution).toString() : "unspecified"}, '
@@ -2169,18 +2181,18 @@ ByteData _encodeStrut(
     return ByteData(0);
   }
 
-  final ByteData data = ByteData(16); // Max size is 16 bytes
-  int bitmask = 0; // 8 bit mask
-  int byteCount = 1;
+  final ByteData data = ByteData(24); // Max size is 24 bytes
+  int bitmask = 0;
+  int byteCount = 4;
   if (fontWeight != null) {
     bitmask |= 1 << 0;
-    data.setInt8(byteCount, fontWeight.index);
-    byteCount += 1;
+    data.setInt32(byteCount, fontWeight.value, _kFakeHostEndian);
+    byteCount += 4;
   }
   if (fontStyle != null) {
     bitmask |= 1 << 1;
-    data.setInt8(byteCount, fontStyle.index);
-    byteCount += 1;
+    data.setInt32(byteCount, fontStyle.index, _kFakeHostEndian);
+    byteCount += 4;
   }
   if (fontFamily != null || (fontFamilyFallback != null && fontFamilyFallback.isNotEmpty)) {
     bitmask |= 1 << 2;
@@ -2208,10 +2220,9 @@ ByteData _encodeStrut(
     bitmask |= 1 << 7;
   }
 
-  data.setInt8(0, bitmask);
+  data.setInt32(0, bitmask, _kFakeHostEndian);
 
-  assert(byteCount <= 16);
-  assert(bitmask >> 8 == 0, 'strut bitmask overflow: $bitmask');
+  assert(byteCount <= 24);
   return ByteData.view(data.buffer, 0, byteCount);
 }
 

--- a/engine/src/flutter/lib/ui/text.dart
+++ b/engine/src/flutter/lib/ui/text.dart
@@ -27,6 +27,8 @@ enum FontStyle {
 
 /// The thickness of the glyphs used to draw the text.
 ///
+/// Values must be in the range 1..1000.
+///
 /// Fonts are typically weighted on a 9-point scale, which, for historical
 /// reasons, uses the names 100 to 900. In Flutter, these are named `w100` to
 /// `w900` and have the following conventional meanings:
@@ -56,7 +58,9 @@ enum FontStyle {
 /// When using these fonts, applications can specify [FontWeight] instances
 /// constructed using values other than the predefined values.
 class FontWeight {
-  const FontWeight(this.value);
+  const FontWeight(this.value)
+    : assert(value >= 1, 'Font weight must be between 1 and 1000'),
+      assert(value <= 1000, 'Font weight must be between 1 and 1000');
 
   /// The encoded integer value of this font weight.
   int get index => (value ~/ 100 - 1).clamp(0, 8);

--- a/engine/src/flutter/lib/ui/text/paragraph_builder.cc
+++ b/engine/src/flutter/lib/ui/text/paragraph_builder.cc
@@ -176,29 +176,23 @@ void decodeStrut(Dart_Handle strut_data,
   }
   paragraph_style.strut_enabled = true;
 
-  const uint8_t* uint8_data = static_cast<const uint8_t*>(byte_data.data());
-  uint8_t mask = uint8_data[0];
+  const int32_t* int32_data = static_cast<const int32_t*>(byte_data.data());
+  int32_t mask = int32_data[0];
 
-  // Data is stored in order of increasing size, eg, 8 bit ints will be before
-  // any 32 bit ints. In addition, the order of decoding is the same order
-  // as it is encoded, and the order is used to maintain consistency.
-  size_t byte_count = 1;
+  size_t int32_count = 1;
   if (mask & kSFontWeightMask) {
-    paragraph_style.strut_font_weight =
-        static_cast<txt::FontWeight>(uint8_data[byte_count++]);
+    paragraph_style.strut_font_weight = int32_data[int32_count++];
   }
   if (mask & kSFontStyleMask) {
     paragraph_style.strut_font_style =
-        static_cast<txt::FontStyle>(uint8_data[byte_count++]);
+        static_cast<txt::FontStyle>(int32_data[int32_count++]);
   }
 
   paragraph_style.strut_half_leading = mask & kSLeadingDistributionMask;
 
   std::vector<float> float_data;
-  float_data.resize((byte_data.length_in_bytes() - byte_count) / 4);
-  memcpy(float_data.data(),
-         static_cast<const char*>(byte_data.data()) + byte_count,
-         byte_data.length_in_bytes() - byte_count);
+  float_data.resize((byte_data.length_in_bytes() / 4) - int32_count);
+  memcpy(float_data.data(), int32_data + int32_count, float_data.size() * 4);
   size_t float_count = 0;
   if (mask & kSFontSizeMask) {
     paragraph_style.strut_font_size = float_data[float_count++];
@@ -251,8 +245,7 @@ ParagraphBuilder::ParagraphBuilder(
     }
 
     if (mask & kPSFontWeightMask) {
-      style.font_weight =
-          static_cast<txt::FontWeight>(encoded[kPSFontWeightIndex]);
+      style.font_weight = encoded[kPSFontWeightIndex];
     }
 
     if (mask & kPSFontStyleMask) {
@@ -423,8 +416,7 @@ void ParagraphBuilder::pushStyle(const tonic::Int32List& encoded,
   if (mask & (kTSFontWeightMask | kTSFontStyleMask | kTSFontSizeMask |
               kTSLetterSpacingMask | kTSWordSpacingMask)) {
     if (mask & kTSFontWeightMask) {
-      style.font_weight =
-          static_cast<txt::FontWeight>(encoded[kTSFontWeightIndex]);
+      style.font_weight = encoded[kTSFontWeightIndex];
     }
 
     if (mask & kTSFontStyleMask) {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -11,6 +11,8 @@ import 'package:ui/src/engine/skwasm/skwasm_impl.dart';
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
+const String _kWeightAxisTag = 'wght';
+
 final List<String> _testFonts = <String>['FlutterTest', 'Ahem'];
 List<String> _computeEffectiveFontFamilies(List<String> fontFamilies) {
   if (!ui_web.TestEnvironment.instance.forceTestFonts) {
@@ -18,6 +20,11 @@ List<String> _computeEffectiveFontFamilies(List<String> fontFamilies) {
   }
   final Iterable<String> filteredFonts = fontFamilies.where(_testFonts.contains);
   return filteredFonts.isEmpty ? _testFonts : filteredFonts.toList();
+}
+
+int getFourByteTag(String s) {
+  assert(s.length == 4);
+  return s.codeUnitAt(0) << 24 | s.codeUnitAt(1) << 16 | s.codeUnitAt(2) << 8 | s.codeUnitAt(3);
 }
 
 class SkwasmLineMetrics implements ui.LineMetrics {
@@ -433,26 +440,30 @@ class SkwasmTextStyle implements ui.TextStyle {
       }
     }
 
-    if (fontVariations != null && fontVariations!.isNotEmpty) {
-      final int variationCount = fontVariations!.length;
-      withStackScope((StackScope scope) {
-        final Pointer<Uint32> axisBuffer = scope.allocUint32Array(variationCount);
-        final Pointer<Float> valueBuffer = scope.allocFloatArray(variationCount);
-        for (int i = 0; i < variationCount; i++) {
-          final ui.FontVariation variation = fontVariations![i];
-          final String axis = variation.axis;
-          assert(axis.length == 4); // 4 byte code
-          final int axisNumber =
-              axis.codeUnitAt(0) << 24 |
-              axis.codeUnitAt(1) << 16 |
-              axis.codeUnitAt(2) << 8 |
-              axis.codeUnitAt(3);
-          axisBuffer[i] = axisNumber;
-          valueBuffer[i] = variation.value;
-        }
-        textStyleSetFontVariations(handle, axisBuffer, valueBuffer, variationCount);
-      });
+    final int weightValue = fontWeight?.value ?? ui.FontWeight.normal.value;
+    final List<ui.FontVariation> weightVariation = <ui.FontVariation>[
+      ui.FontVariation(_kWeightAxisTag, weightValue.toDouble()),
+    ];
+    Iterable<ui.FontVariation> allFontVariations;
+    if (fontVariations == null) {
+      allFontVariations = weightVariation;
+    } else if (fontVariations!.any((ui.FontVariation v) => v.axis == _kWeightAxisTag)) {
+      allFontVariations = fontVariations!;
+    } else {
+      allFontVariations = fontVariations!.followedBy(weightVariation);
     }
+    final int variationCount = allFontVariations.length;
+    withStackScope((StackScope scope) {
+      final Pointer<Uint32> axisBuffer = scope.allocUint32Array(variationCount);
+      final Pointer<Float> valueBuffer = scope.allocFloatArray(variationCount);
+      int i = 0;
+      for (final ui.FontVariation variation in allFontVariations) {
+        axisBuffer[i] = getFourByteTag(variation.axis);
+        valueBuffer[i] = variation.value;
+        i++;
+      }
+      textStyleSetFontVariations(handle, axisBuffer, valueBuffer, variationCount);
+    });
   }
 
   List<String> get fontFamilies => <String>[?fontFamily, ...?fontFamilyFallback];
@@ -792,6 +803,14 @@ class SkwasmParagraphStyle implements ui.ParagraphStyle {
         (_fontStyle ?? ui.FontStyle.normal).index,
       );
     }
+    withStackScope((StackScope scope) {
+      final Pointer<Uint32> axisBuffer = scope.allocUint32Array(1);
+      final Pointer<Float> valueBuffer = scope.allocFloatArray(1);
+      axisBuffer[0] = getFourByteTag(_kWeightAxisTag);
+      final int weightValue = _fontWeight?.value ?? ui.FontWeight.normal.value;
+      valueBuffer[0] = weightValue.toDouble();
+      textStyleSetFontVariations(textStyleHandle, axisBuffer, valueBuffer, 1);
+    });
     if (_textHeightBehavior != null) {
       textStyleSetHalfLeading(
         textStyleHandle,

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/paragraph.dart
@@ -440,17 +440,20 @@ class SkwasmTextStyle implements ui.TextStyle {
       }
     }
 
-    final int weightValue = fontWeight?.value ?? ui.FontWeight.normal.value;
-    final List<ui.FontVariation> weightVariation = <ui.FontVariation>[
-      ui.FontVariation(_kWeightAxisTag, weightValue.toDouble()),
-    ];
     Iterable<ui.FontVariation> allFontVariations;
-    if (fontVariations == null) {
-      allFontVariations = weightVariation;
-    } else if (fontVariations!.any((ui.FontVariation v) => v.axis == _kWeightAxisTag)) {
+    if (fontVariations != null &&
+        fontVariations!.any((ui.FontVariation v) => v.axis == _kWeightAxisTag)) {
       allFontVariations = fontVariations!;
     } else {
-      allFontVariations = fontVariations!.followedBy(weightVariation);
+      final int weightValue = fontWeight?.value ?? ui.FontWeight.normal.value;
+      final List<ui.FontVariation> weightVariation = <ui.FontVariation>[
+        ui.FontVariation(_kWeightAxisTag, weightValue.toDouble()),
+      ];
+      if (fontVariations == null) {
+        allFontVariations = weightVariation;
+      } else {
+        allFontVariations = fontVariations!.followedBy(weightVariation);
+      }
     }
     final int variationCount = allFontVariations.length;
     withStackScope((StackScope scope) {

--- a/engine/src/flutter/lib/web_ui/lib/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/text.dart
@@ -52,6 +52,9 @@ class FontWeight {
     return other is FontWeight && other.value == value;
   }
 
+  @override
+  int get hashCode => value;
+
   static FontWeight? lerp(FontWeight? a, FontWeight? b, double t) {
     if (a == null && b == null) {
       return null;

--- a/engine/src/flutter/lib/web_ui/lib/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/text.dart
@@ -14,7 +14,9 @@ enum FontStyle { normal, italic }
 enum PlaceholderAlignment { baseline, aboveBaseline, belowBaseline, top, bottom, middle }
 
 class FontWeight {
-  const FontWeight(this.value);
+  const FontWeight(this.value)
+    : assert(value >= 1, 'Font weight must be between 1 and 1000'),
+      assert(value <= 1000, 'Font weight must be between 1 and 1000');
 
   final int value;
   int get index => (value ~/ 100 - 1).clamp(0, 8);

--- a/engine/src/flutter/lib/web_ui/lib/text.dart
+++ b/engine/src/flutter/lib/web_ui/lib/text.dart
@@ -14,18 +14,20 @@ enum FontStyle { normal, italic }
 enum PlaceholderAlignment { baseline, aboveBaseline, belowBaseline, top, bottom, middle }
 
 class FontWeight {
-  const FontWeight._(this.index, this.value);
-  final int index;
+  const FontWeight(this.value);
+
   final int value;
-  static const FontWeight w100 = FontWeight._(0, 100);
-  static const FontWeight w200 = FontWeight._(1, 200);
-  static const FontWeight w300 = FontWeight._(2, 300);
-  static const FontWeight w400 = FontWeight._(3, 400);
-  static const FontWeight w500 = FontWeight._(4, 500);
-  static const FontWeight w600 = FontWeight._(5, 600);
-  static const FontWeight w700 = FontWeight._(6, 700);
-  static const FontWeight w800 = FontWeight._(7, 800);
-  static const FontWeight w900 = FontWeight._(8, 900);
+  int get index => (value ~/ 100 - 1).clamp(0, 8);
+
+  static const FontWeight w100 = FontWeight(100);
+  static const FontWeight w200 = FontWeight(200);
+  static const FontWeight w300 = FontWeight(300);
+  static const FontWeight w400 = FontWeight(400);
+  static const FontWeight w500 = FontWeight(500);
+  static const FontWeight w600 = FontWeight(600);
+  static const FontWeight w700 = FontWeight(700);
+  static const FontWeight w800 = FontWeight(800);
+  static const FontWeight w900 = FontWeight(900);
   static const FontWeight normal = w400;
   static const FontWeight bold = w700;
   static const List<FontWeight> values = <FontWeight>[
@@ -39,19 +41,29 @@ class FontWeight {
     w800,
     w900,
   ];
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is FontWeight && other.value == value;
+  }
+
   static FontWeight? lerp(FontWeight? a, FontWeight? b, double t) {
     if (a == null && b == null) {
       return null;
     }
-    return values[engine.clampInt(
-      lerpDouble(a?.index ?? normal.index, b?.index ?? normal.index, t)!.round(),
-      0,
-      8,
-    )];
+    return FontWeight(
+      lerpDouble(a?.value ?? normal.value, b?.value ?? normal.value, t)!.round().clamp(100, 900),
+    );
   }
 
   @override
   String toString() {
+    if (value % 100 != 0) {
+      return 'FontWeight($value)';
+    }
     return const <int, String>{
       0: 'FontWeight.w100',
       1: 'FontWeight.w200',

--- a/engine/src/flutter/lib/web_ui/test/ui/text_golden_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/ui/text_golden_test.dart
@@ -573,6 +573,40 @@ Future<void> testMain() async {
     );
   });
 
+  test('font weight is applied to variable fonts', () async {
+    const double testWidth = 400;
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final ui.Canvas canvas = ui.Canvas(recorder);
+    final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
+      ui.ParagraphStyle(
+        fontFamily: 'RobotoVariable',
+        fontSize: 40.0,
+        fontWeight: ui.FontWeight.w100,
+        textDirection: ui.TextDirection.ltr,
+      ),
+    );
+
+    builder.addText('Web Thin - 100\n');
+    builder.pushStyle(ui.TextStyle(fontWeight: ui.FontWeight.w300));
+    builder.addText('Web Light - 300\n');
+    builder.pushStyle(ui.TextStyle(fontWeight: ui.FontWeight.normal));
+    builder.addText('Web Normal - 400\n');
+    builder.pushStyle(ui.TextStyle(fontWeight: ui.FontWeight.w700));
+    builder.addText('Web Bold - 700\n');
+    builder.pushStyle(ui.TextStyle(fontWeight: ui.FontWeight.w900));
+    builder.addText('Web Black - 900\n');
+
+    final ui.Paragraph paragraph = builder.build();
+    paragraph.layout(const ui.ParagraphConstraints(width: testWidth - 20));
+    canvas.drawParagraph(paragraph, const ui.Offset(10, 10));
+    final ui.Picture picture = recorder.endRecording();
+    await drawPictureUsingCurrentRenderer(picture);
+    await matchGoldenFile(
+      'ui_text_font_weight_variable.png',
+      region: ui.Rect.fromLTRB(0, 0, testWidth, paragraph.height + 20),
+    );
+  });
+
   test('text style - woff2 font', () async {
     await testTextStyle('emoji woff2', outerText: '🙂 🇺🇸 🙋‍♂️', innerText: '', fontSize: 24);
   });

--- a/engine/src/flutter/testing/dart/text_test.dart
+++ b/engine/src/flutter/testing/dart/text_test.dart
@@ -434,7 +434,7 @@ void testFontVariation() {
     pb.pushStyle(TextStyle(fontWeight: FontWeight.w900));
     pb.addText('Black - 900\n');
 
-    final ParagraphConstraints paragraphConstraints = ParagraphConstraints(width: 300);
+    const ParagraphConstraints paragraphConstraints = ParagraphConstraints(width: 300);
     final Paragraph paragraph = pb.build()..layout(paragraphConstraints);
 
     final PictureRecorder recorder = PictureRecorder();
@@ -443,7 +443,7 @@ void testFontVariation() {
       recorder,
       Rect.fromLTWH(0.0, 0.0, imageSize.toDouble(), imageSize.toDouble()),
     );
-    canvas.drawParagraph(paragraph, Offset(10, 10));
+    canvas.drawParagraph(paragraph, const Offset(10, 10));
     final Image image = await recorder.endRecording().toImage(imageSize, imageSize);
 
     final ImageComparer comparer = await ImageComparer.create();

--- a/engine/src/flutter/testing/dart/text_test.dart
+++ b/engine/src/flutter/testing/dart/text_test.dart
@@ -13,6 +13,7 @@ import 'dart:ui';
 
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
+import 'goldens.dart';
 
 Future<Uint8List> readFile(String fileName) async {
   final File file = File(path.join('flutter', 'testing', 'resources', fileName));
@@ -414,6 +415,39 @@ void testFontVariation() {
       FontVariation.lerp(const FontVariation.width(90.0), const FontVariation.italic(0.2), 0.9),
       const FontVariation.italic(0.2),
     );
+  });
+
+  test('FontWeight is applied to variable fonts', () async {
+    final Uint8List fontData = await readFile('RobotoSlab-VariableFont_wght.ttf');
+    await loadFontFromList(fontData, fontFamily: 'RobotoSerif');
+
+    final ParagraphBuilder pb = ParagraphBuilder(
+      ParagraphStyle(fontFamily: 'RobotoSerif', fontSize: 40.0, fontWeight: FontWeight.w100),
+    );
+    pb.addText('Thin - 100\n');
+    pb.pushStyle(TextStyle(fontWeight: FontWeight.w300));
+    pb.addText('Light - 300\n');
+    pb.pushStyle(TextStyle(fontWeight: FontWeight.normal));
+    pb.addText('Normal - 400\n');
+    pb.pushStyle(TextStyle(fontWeight: FontWeight.w700));
+    pb.addText('Bold - 700\n');
+    pb.pushStyle(TextStyle(fontWeight: FontWeight.w900));
+    pb.addText('Black - 900\n');
+
+    final ParagraphConstraints paragraphConstraints = ParagraphConstraints(width: 300);
+    final Paragraph paragraph = pb.build()..layout(paragraphConstraints);
+
+    final PictureRecorder recorder = PictureRecorder();
+    const int imageSize = 300;
+    final Canvas canvas = Canvas(
+      recorder,
+      Rect.fromLTWH(0.0, 0.0, imageSize.toDouble(), imageSize.toDouble()),
+    );
+    canvas.drawParagraph(paragraph, Offset(10, 10));
+    final Image image = await recorder.endRecording().toImage(imageSize, imageSize);
+
+    final ImageComparer comparer = await ImageComparer.create();
+    await comparer.addGoldenImage(image, 'text_test_fontWeightVariable.png');
   });
 }
 

--- a/engine/src/flutter/testing/dart/text_test.dart
+++ b/engine/src/flutter/testing/dart/text_test.dart
@@ -424,6 +424,7 @@ void testFontVariation() {
     final ParagraphBuilder pb = ParagraphBuilder(
       ParagraphStyle(fontFamily: 'RobotoSerif', fontSize: 40.0, fontWeight: FontWeight.w100),
     );
+    pb.pushStyle(TextStyle(color: const Color(0xFF000000)));
     pb.addText('Thin - 100\n');
     pb.pushStyle(TextStyle(fontWeight: FontWeight.w300));
     pb.addText('Light - 300\n');

--- a/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
+++ b/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
@@ -16,19 +16,17 @@ namespace txt {
 
 namespace {
 
-// Convert txt::FontWeight values (ranging from 0-8) to SkFontStyle::Weight
-// values (ranging from 100-900).
-SkFontStyle::Weight GetSkFontStyleWeight(txt::FontWeight font_weight) {
-  return static_cast<SkFontStyle::Weight>(static_cast<int>(font_weight) * 100 +
-                                          100);
+constexpr std::string kWeightAxisTag("wght");
+
+SkFourByteTag GetFourByteTag(const std::string& tag) {
+  return SkSetFourByteTag(tag[0], tag[1], tag[2], tag[3]);
 }
 
-SkFontStyle MakeSkFontStyle(txt::FontWeight font_weight,
-                            txt::FontStyle font_style) {
-  return SkFontStyle(
-      GetSkFontStyleWeight(font_weight), SkFontStyle::Width::kNormal_Width,
-      font_style == txt::FontStyle::normal ? SkFontStyle::Slant::kUpright_Slant
-                                           : SkFontStyle::Slant::kItalic_Slant);
+SkFontStyle MakeSkFontStyle(int font_weight, txt::FontStyle font_style) {
+  return SkFontStyle(font_weight, SkFontStyle::Width::kNormal_Width,
+                     font_style == txt::FontStyle::normal
+                         ? SkFontStyle::Slant::kUpright_Slant
+                         : SkFontStyle::Slant::kItalic_Slant);
 }
 
 }  // anonymous namespace
@@ -106,6 +104,10 @@ skt::ParagraphStyle ParagraphBuilderSkia::TxtToSkia(const ParagraphStyle& txt) {
   text_style.setHeightOverride(txt.has_height_override);
   text_style.setFontFamilies({SkString(txt.font_family.c_str())});
   text_style.setLocale(SkString(txt.locale.c_str()));
+  SkFontArguments::VariationPosition::Coordinate weight_coord{
+      GetFourByteTag(kWeightAxisTag), static_cast<float>(txt.font_weight)};
+  text_style.setFontArguments(
+      SkFontArguments().setVariationDesignPosition({&weight_coord, 1}));
   skia.setTextStyle(text_style);
 
   skt::StrutStyle strut_style;
@@ -183,23 +185,29 @@ skt::TextStyle ParagraphBuilderSkia::TxtToSkia(const TextStyle& txt) {
     skia.addFontFeature(SkString(ff.first.c_str()), ff.second);
   }
 
+  std::vector<SkFontArguments::VariationPosition::Coordinate> coordinates;
+  bool weight_axis_set = false;
   if (!txt.font_variations.GetAxisValues().empty()) {
-    std::vector<SkFontArguments::VariationPosition::Coordinate> coordinates;
     for (const auto& it : txt.font_variations.GetAxisValues()) {
       const std::string& axis = it.first;
       if (axis.length() != 4) {
         continue;
       }
-      coordinates.push_back({
-          SkSetFourByteTag(axis[0], axis[1], axis[2], axis[3]),
-          it.second,
-      });
+      if (axis == kWeightAxisTag) {
+        weight_axis_set = true;
+      }
+      coordinates.push_back({GetFourByteTag(axis), it.second});
     }
-    SkFontArguments::VariationPosition position = {
-        coordinates.data(), static_cast<int>(coordinates.size())};
-    skia.setFontArguments(
-        SkFontArguments().setVariationDesignPosition(position));
   }
+  if (!weight_axis_set) {
+    coordinates.push_back({
+        GetFourByteTag(kWeightAxisTag),
+        static_cast<float>(txt.font_weight),
+    });
+  }
+  SkFontArguments::VariationPosition position = {
+      coordinates.data(), static_cast<int>(coordinates.size())};
+  skia.setFontArguments(SkFontArguments().setVariationDesignPosition(position));
 
   skia.resetShadows();
   for (const txt::TextShadow& txt_shadow : txt.text_shadows) {

--- a/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
+++ b/engine/src/flutter/txt/src/skia/paragraph_builder_skia.cc
@@ -16,9 +16,10 @@ namespace txt {
 
 namespace {
 
-constexpr std::string kWeightAxisTag("wght");
+constexpr std::string_view kWeightAxisTag = "wght";
 
-SkFourByteTag GetFourByteTag(const std::string& tag) {
+template <typename T>
+SkFourByteTag GetFourByteTag(const T& tag) {
   return SkSetFourByteTag(tag[0], tag[1], tag[2], tag[3]);
 }
 

--- a/engine/src/flutter/txt/src/skia/paragraph_skia.cc
+++ b/engine/src/flutter/txt/src/skia/paragraph_skia.cc
@@ -24,15 +24,6 @@ using namespace flutter;
 
 namespace {
 
-// Convert SkFontStyle::Weight values (ranging from 100-900) to txt::FontWeight
-// values (ranging from 0-8).
-txt::FontWeight GetTxtFontWeight(int font_weight) {
-  int txt_weight = (font_weight - 100) / 100;
-  txt_weight = std::clamp(txt_weight, static_cast<int>(txt::FontWeight::w100),
-                          static_cast<int>(txt::FontWeight::w900));
-  return static_cast<txt::FontWeight>(txt_weight);
-}
-
 txt::FontStyle GetTxtFontStyle(SkFontStyle::Slant font_slant) {
   return font_slant == SkFontStyle::Slant::kUpright_Slant
              ? txt::FontStyle::normal
@@ -387,7 +378,7 @@ TextStyle ParagraphSkia::SkiaToTxt(const skt::TextStyle& skia) {
       static_cast<TextDecorationStyle>(skia.getDecorationStyle());
   txt.decoration_thickness_multiplier =
       SkScalarToDouble(skia.getDecorationThicknessMultiplier());
-  txt.font_weight = GetTxtFontWeight(skia.getFontStyle().weight());
+  txt.font_weight = skia.getFontStyle().weight();
   txt.font_style = GetTxtFontStyle(skia.getFontStyle().slant());
 
   txt.text_baseline = static_cast<TextBaseline>(skia.getTextBaseline());

--- a/engine/src/flutter/txt/src/txt/font_weight.h
+++ b/engine/src/flutter/txt/src/txt/font_weight.h
@@ -7,17 +7,9 @@
 
 namespace txt {
 
-enum class FontWeight {
+enum FontWeight : int {
   // NOLINTBEGIN(readability-identifier-naming)
-  w100,  // Thin
-  w200,  // Extra-Light
-  w300,  // Light
-  w400,  // Normal/Regular
-  w500,  // Medium
-  w600,  // Semi-bold
-  w700,  // Bold
-  w800,  // Extra-Bold
-  w900,  // Black
+  normal = 400,  // Normal/Regular
   // NOLINTEND(readability-identifier-naming)
 };
 

--- a/engine/src/flutter/txt/src/txt/paragraph_style.h
+++ b/engine/src/flutter/txt/src/txt/paragraph_style.h
@@ -57,7 +57,7 @@ class ParagraphStyle {
  public:
   // Default TextStyle. Used in GetTextStyle() to obtain the base TextStyle to
   // inherit off of.
-  FontWeight font_weight = FontWeight::w400;
+  int font_weight = FontWeight::normal;
   FontStyle font_style = FontStyle::normal;
   std::string font_family = "";
   double font_size = 14;
@@ -69,7 +69,7 @@ class ParagraphStyle {
   // properties to take effect.
   // TODO(garyq): Break the strut properties into a separate class.
   bool strut_enabled = false;
-  FontWeight strut_font_weight = FontWeight::w400;
+  int strut_font_weight = FontWeight::normal;
   FontStyle strut_font_style = FontStyle::normal;
   std::vector<std::string> strut_font_families;
   double strut_font_size = 14;

--- a/engine/src/flutter/txt/src/txt/text_style.h
+++ b/engine/src/flutter/txt/src/txt/text_style.h
@@ -31,7 +31,7 @@ class TextStyle {
   TextDecorationStyle decoration_style = TextDecorationStyle::kSolid;
   // Thickness is applied as a multiplier to the default thickness of the font.
   double decoration_thickness_multiplier = 1.0;
-  FontWeight font_weight = FontWeight::w400;
+  int font_weight = FontWeight::normal;
   FontStyle font_style = FontStyle::normal;
   TextBaseline text_baseline = TextBaseline::kAlphabetic;
   bool half_leading = false;

--- a/engine/src/flutter/txt/tests/paragraph_unittests.cc
+++ b/engine/src/flutter/txt/tests/paragraph_unittests.cc
@@ -97,9 +97,9 @@ class PainterTestBase : public CanvasTestBase<T> {
  protected:
   txt::TextStyle makeDecoratedStyle(txt::TextDecorationStyle style) {
     auto t_style = txt::TextStyle();
-    t_style.color = SK_ColorBLACK;                // default
-    t_style.font_weight = txt::FontWeight::w400;  // normal
-    t_style.font_size = 14;                       // default
+    t_style.color = SK_ColorBLACK;  // default
+    t_style.font_weight = txt::FontWeight::normal;
+    t_style.font_size = 14;  // default
     t_style.decoration = txt::TextDecoration::kUnderline;
     t_style.decoration_style = style;
     t_style.decoration_color = SK_ColorBLACK;
@@ -109,18 +109,18 @@ class PainterTestBase : public CanvasTestBase<T> {
 
   txt::TextStyle makeEmoji() {
     auto t_style = txt::TextStyle();
-    t_style.color = SK_ColorBLACK;                // default
-    t_style.font_weight = txt::FontWeight::w400;  // normal
-    t_style.font_size = 14;                       // default
+    t_style.color = SK_ColorBLACK;  // default
+    t_style.font_weight = txt::FontWeight::normal;
+    t_style.font_size = 14;  // default
     t_style.font_families.push_back(kEmojiFontName);
     return t_style;
   }
 
   txt::TextStyle makeStyle() {
     auto t_style = txt::TextStyle();
-    t_style.color = SK_ColorBLACK;                // default
-    t_style.font_weight = txt::FontWeight::w400;  // normal
-    t_style.font_size = 14;                       // default
+    t_style.color = SK_ColorBLACK;  // default
+    t_style.font_weight = txt::FontWeight::normal;
+    t_style.font_size = 14;  // default
     t_style.font_families.push_back("ahem");
     return t_style;
   }

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -209,7 +209,7 @@ void main() {
       flying(tester, find.text('Page 1')).first,
     );
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight(595));
+    expect(bottomMiddle.text.style!.fontWeight, const FontWeight(595));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
@@ -221,7 +221,7 @@ void main() {
       flying(tester, find.text('Page 1')).last,
     );
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight(595));
+    expect(topBackLabel.text.style!.fontWeight, const FontWeight(595));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -230,14 +230,14 @@ void main() {
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight(445));
+    expect(bottomMiddle.text.style!.fontWeight, const FontWeight(445));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.0);
 
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight(445));
+    expect(topBackLabel.text.style!.fontWeight, const FontWeight(445));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -259,7 +259,7 @@ void main() {
       flying(tester, find.text('Page 1')).first,
     );
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xfff8fbff)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight(595));
+    expect(bottomMiddle.text.style!.fontWeight, const FontWeight(595));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
@@ -271,7 +271,7 @@ void main() {
       flying(tester, find.text('Page 1')).last,
     );
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xfff8fbff)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight(595));
+    expect(topBackLabel.text.style!.fontWeight, const FontWeight(595));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -280,14 +280,14 @@ void main() {
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xff409fff)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight(445));
+    expect(bottomMiddle.text.style!.fontWeight, const FontWeight(445));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.0);
 
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff409fff)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight(445));
+    expect(topBackLabel.text.style!.fontWeight, const FontWeight(445));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -1408,7 +1408,7 @@ void main() {
       flying(tester, find.text('Page 1')).first,
     );
     expect(bottomLargeTitle.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(bottomLargeTitle.text.style!.fontWeight, FontWeight(692));
+    expect(bottomLargeTitle.text.style!.fontWeight, const FontWeight(692));
     expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemDisplay');
     expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(0.35967791542410854));
 
@@ -1417,19 +1417,19 @@ void main() {
       flying(tester, find.text('Page 1')).last,
     );
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight(692));
+    expect(topBackLabel.text.style!.fontWeight, const FontWeight(692));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemDisplay');
     expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(0.35967791542410854));
 
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomLargeTitle.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(bottomLargeTitle.text.style!.fontWeight, FontWeight(467));
+    expect(bottomLargeTitle.text.style!.fontWeight, const FontWeight(467));
     expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(-0.23270857974886894));
 
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight(467));
+    expect(topBackLabel.text.style!.fontWeight, const FontWeight(467));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(-0.23270857974886894));
   });

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -209,7 +209,7 @@ void main() {
       flying(tester, find.text('Page 1')).first,
     );
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight.w600);
+    expect(bottomMiddle.text.style!.fontWeight, FontWeight(595));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
@@ -221,7 +221,7 @@ void main() {
       flying(tester, find.text('Page 1')).last,
     );
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight.w600);
+    expect(topBackLabel.text.style!.fontWeight, FontWeight(595));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -230,14 +230,14 @@ void main() {
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight.w400);
+    expect(bottomMiddle.text.style!.fontWeight, FontWeight(445));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.0);
 
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight.w400);
+    expect(topBackLabel.text.style!.fontWeight, FontWeight(445));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -259,7 +259,7 @@ void main() {
       flying(tester, find.text('Page 1')).first,
     );
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xfff8fbff)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight.w600);
+    expect(bottomMiddle.text.style!.fontWeight, FontWeight(595));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
@@ -271,7 +271,7 @@ void main() {
       flying(tester, find.text('Page 1')).last,
     );
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xfff8fbff)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight.w600);
+    expect(topBackLabel.text.style!.fontWeight, FontWeight(595));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -280,14 +280,14 @@ void main() {
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomMiddle.text.style!.color, isSameColorAs(const Color(0xff409fff)));
-    expect(bottomMiddle.text.style!.fontWeight, FontWeight.w400);
+    expect(bottomMiddle.text.style!.fontWeight, FontWeight(445));
     expect(bottomMiddle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomMiddle.text.style!.letterSpacing, -0.41);
 
     checkOpacity(tester, flying(tester, find.text('Page 1')).first, 0.0);
 
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff409fff)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight.w400);
+    expect(topBackLabel.text.style!.fontWeight, FontWeight(445));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, -0.41);
 
@@ -1408,7 +1408,7 @@ void main() {
       flying(tester, find.text('Page 1')).first,
     );
     expect(bottomLargeTitle.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(bottomLargeTitle.text.style!.fontWeight, FontWeight.w700);
+    expect(bottomLargeTitle.text.style!.fontWeight, FontWeight(692));
     expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemDisplay');
     expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(0.35967791542410854));
 
@@ -1417,19 +1417,19 @@ void main() {
       flying(tester, find.text('Page 1')).last,
     );
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff000306)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight.w700);
+    expect(topBackLabel.text.style!.fontWeight, FontWeight(692));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemDisplay');
     expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(0.35967791542410854));
 
     // Move animation further a bit.
     await tester.pump(const Duration(milliseconds: 200));
     expect(bottomLargeTitle.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(bottomLargeTitle.text.style!.fontWeight, FontWeight.w500);
+    expect(bottomLargeTitle.text.style!.fontWeight, FontWeight(467));
     expect(bottomLargeTitle.text.style!.fontFamily, 'CupertinoSystemText');
     expect(bottomLargeTitle.text.style!.letterSpacing, moreOrLessEquals(-0.23270857974886894));
 
     expect(topBackLabel.text.style!.color, isSameColorAs(const Color(0xff005ec5)));
-    expect(topBackLabel.text.style!.fontWeight, FontWeight.w500);
+    expect(topBackLabel.text.style!.fontWeight, FontWeight(467));
     expect(topBackLabel.text.style!.fontFamily, 'CupertinoSystemText');
     expect(topBackLabel.text.style!.letterSpacing, moreOrLessEquals(-0.23270857974886894));
   });


### PR DESCRIPTION
This makes it possible for applications to set a FontWeight and get the expected result for both variable fonts and fonts that provide separate assets for each weight.

See https://github.com/flutter/flutter/issues/148026