### PR TITLE
Add non uniform TableBorder

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -333,62 +333,22 @@ abstract class BoxBorder extends ShapeBorder {
         );
     }
     final Paint paint = Paint()..color = color;
-    final RRect inner = _deflateRRect(
-      borderRect,
-      EdgeInsets.fromLTRB(left.strokeInset, top.strokeInset, right.strokeInset, bottom.strokeInset),
-    );
-    final RRect outer = _inflateRRect(
-      borderRect,
-      EdgeInsets.fromLTRB(
-        left.strokeOutset,
-        top.strokeOutset,
-        right.strokeOutset,
-        bottom.strokeOutset,
-      ),
-    );
+
+    final RRect inner = EdgeInsets.fromLTRB(
+      left.strokeInset,
+      top.strokeInset,
+      right.strokeInset,
+      bottom.strokeInset,
+    ).deflateRRect(borderRect);
+
+    final RRect outer = EdgeInsets.fromLTRB(
+      left.strokeOutset,
+      top.strokeOutset,
+      right.strokeOutset,
+      bottom.strokeOutset,
+    ).inflateRRect(borderRect);
+
     canvas.drawDRRect(outer, inner, paint);
-  }
-
-  static RRect _inflateRRect(RRect rect, EdgeInsets insets) {
-    return RRect.fromLTRBAndCorners(
-      rect.left - insets.left,
-      rect.top - insets.top,
-      rect.right + insets.right,
-      rect.bottom + insets.bottom,
-      topLeft: (rect.tlRadius + Radius.elliptical(insets.left, insets.top)).clamp(
-        minimum: Radius.zero,
-      ),
-      topRight: (rect.trRadius + Radius.elliptical(insets.right, insets.top)).clamp(
-        minimum: Radius.zero,
-      ),
-      bottomRight: (rect.brRadius + Radius.elliptical(insets.right, insets.bottom)).clamp(
-        minimum: Radius.zero,
-      ),
-      bottomLeft: (rect.blRadius + Radius.elliptical(insets.left, insets.bottom)).clamp(
-        minimum: Radius.zero,
-      ),
-    );
-  }
-
-  static RRect _deflateRRect(RRect rect, EdgeInsets insets) {
-    return RRect.fromLTRBAndCorners(
-      rect.left + insets.left,
-      rect.top + insets.top,
-      rect.right - insets.right,
-      rect.bottom - insets.bottom,
-      topLeft: (rect.tlRadius - Radius.elliptical(insets.left, insets.top)).clamp(
-        minimum: Radius.zero,
-      ),
-      topRight: (rect.trRadius - Radius.elliptical(insets.right, insets.top)).clamp(
-        minimum: Radius.zero,
-      ),
-      bottomRight: (rect.brRadius - Radius.elliptical(insets.right, insets.bottom)).clamp(
-        minimum: Radius.zero,
-      ),
-      bottomLeft: (rect.blRadius - Radius.elliptical(insets.left, insets.bottom)).clamp(
-        minimum: Radius.zero,
-      ),
-    );
   }
 
   static void _paintUniformBorderWithCircle(Canvas canvas, Rect rect, BorderSide side) {

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -547,6 +547,66 @@ class EdgeInsets extends EdgeInsetsGeometry {
     );
   }
 
+  /// Returns a new [RRect] expanded by this [EdgeInsets], increasing each corner's
+  /// radius by the corresponding per-axis inset amounts (clamped at zero).
+  ///
+  /// The resulting rectangle's left, top, right, and bottom edges are moved outward
+  /// by the corresponding inset values. Each corner radius is also expanded by the
+  /// corresponding inset values on both axes, ensuring that the corner shape is
+  /// preserved while scaling appropriately.
+  ///
+  /// Corner radii are adjusted per-axis and clamped to be non-negative. For example,
+  /// the top-left corner radius is expanded by [left] horizontally and [top] vertically.
+  ///
+  /// See also:
+  ///
+  ///  * [deflateRRect], to deflate an [RRect] rather than inflating it.
+  ///  * [inflateRect], to inflate a [Rect] rather than an [RRect].
+  ///  * [BorderRadius], which is used to define the corner radii of an [RRect].
+  RRect inflateRRect(RRect rect) {
+    return RRect.fromLTRBAndCorners(
+      rect.left - left,
+      rect.top - top,
+      rect.right + right,
+      rect.bottom + bottom,
+      topLeft: (rect.tlRadius + Radius.elliptical(left, top)).clamp(minimum: Radius.zero),
+      topRight: (rect.trRadius + Radius.elliptical(right, top)).clamp(minimum: Radius.zero),
+      bottomRight: (rect.brRadius + Radius.elliptical(right, bottom)).clamp(minimum: Radius.zero),
+      bottomLeft: (rect.blRadius + Radius.elliptical(left, bottom)).clamp(minimum: Radius.zero),
+    );
+  }
+
+  /// Returns a new [RRect] shrunk by this [EdgeInsets], decreasing each corner's
+  /// radius by the corresponding per-axis inset amounts (clamped at zero).
+  ///
+  /// The resulting rectangle's left, top, right, and bottom edges are moved inward
+  /// by the corresponding inset values. Each corner radius is also reduced by the
+  /// corresponding inset values on both axes, maintaining the corner shape while
+  /// scaling appropriately to the new size.
+  ///
+  /// Corner radii are adjusted per-axis and clamped to be non-negative. For example,
+  /// the top-left corner radius is reduced by [left] horizontally and [top] vertically.
+  /// If either resulting dimension would be negative, the radius is clamped to zero
+  /// in that direction.
+  ///
+  /// See also:
+  ///
+  ///  * [inflateRRect], to inflate an [RRect] rather than deflating it.
+  ///  * [deflateRect], to deflate a [Rect] rather than an [RRect].
+  ///  * [BorderRadius], which is used to define the corner radii of an [RRect].
+  RRect deflateRRect(RRect rect) {
+    return RRect.fromLTRBAndCorners(
+      rect.left + left,
+      rect.top + top,
+      rect.right - right,
+      rect.bottom - bottom,
+      topLeft: (rect.tlRadius - Radius.elliptical(left, top)).clamp(minimum: Radius.zero),
+      topRight: (rect.trRadius - Radius.elliptical(right, top)).clamp(minimum: Radius.zero),
+      bottomRight: (rect.brRadius - Radius.elliptical(right, bottom)).clamp(minimum: Radius.zero),
+      bottomLeft: (rect.blRadius - Radius.elliptical(left, bottom)).clamp(minimum: Radius.zero),
+    );
+  }
+
   @override
   EdgeInsetsGeometry subtract(EdgeInsetsGeometry other) {
     if (other is EdgeInsets) {

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -516,4 +516,154 @@ void main() {
       ),
     );
   });
+
+  group('EdgeInsets RRect methods', () {
+    test('inflateRRect increases the size while preserving radius proportions', () {
+      final RRect original = RRect.fromLTRBAndCorners(
+        10.0,
+        20.0,
+        30.0,
+        60.0,
+        topLeft: const Radius.circular(5.0),
+        topRight: const Radius.circular(6.0),
+        bottomRight: const Radius.circular(7.0),
+        bottomLeft: const Radius.circular(8.0),
+      );
+
+      const EdgeInsets insets = EdgeInsets.fromLTRB(2.0, 3.0, 4.0, 5.0);
+      final RRect inflated = insets.inflateRRect(original);
+
+      expect(inflated.left, equals(original.left - insets.left));
+      expect(inflated.top, equals(original.top - insets.top));
+      expect(inflated.right, equals(original.right + insets.right));
+      expect(inflated.bottom, equals(original.bottom + insets.bottom));
+
+      expect(inflated.tlRadius.x, equals(original.tlRadius.x + insets.left));
+      expect(inflated.tlRadius.y, equals(original.tlRadius.y + insets.top));
+
+      expect(inflated.trRadius.x, equals(original.trRadius.x + insets.right));
+      expect(inflated.trRadius.y, equals(original.trRadius.y + insets.top));
+
+      expect(inflated.brRadius.x, equals(original.brRadius.x + insets.right));
+      expect(inflated.brRadius.y, equals(original.brRadius.y + insets.bottom));
+
+      expect(inflated.blRadius.x, equals(original.blRadius.x + insets.left));
+      expect(inflated.blRadius.y, equals(original.blRadius.y + insets.bottom));
+    });
+
+    test('deflateRRect decreases the size while preserving radius proportions', () {
+      final RRect original = RRect.fromLTRBAndCorners(
+        10.0,
+        20.0,
+        30.0,
+        60.0,
+        topLeft: const Radius.circular(8.0),
+        topRight: const Radius.circular(9.0),
+        bottomRight: const Radius.circular(10.0),
+        bottomLeft: const Radius.circular(11.0),
+      );
+
+      const EdgeInsets insets = EdgeInsets.fromLTRB(2.0, 3.0, 4.0, 5.0);
+      final RRect deflated = insets.deflateRRect(original);
+
+      expect(deflated.left, equals(original.left + insets.left));
+      expect(deflated.top, equals(original.top + insets.top));
+      expect(deflated.right, equals(original.right - insets.right));
+      expect(deflated.bottom, equals(original.bottom - insets.bottom));
+
+      expect(deflated.tlRadius.x, equals(original.tlRadius.x - insets.left));
+      expect(deflated.tlRadius.y, equals(original.tlRadius.y - insets.top));
+
+      expect(deflated.trRadius.x, equals(original.trRadius.x - insets.right));
+      expect(deflated.trRadius.y, equals(original.trRadius.y - insets.top));
+
+      expect(deflated.brRadius.x, equals(original.brRadius.x - insets.right));
+      expect(deflated.brRadius.y, equals(original.brRadius.y - insets.bottom));
+
+      expect(deflated.blRadius.x, equals(original.blRadius.x - insets.left));
+      expect(deflated.blRadius.y, equals(original.blRadius.y - insets.bottom));
+    });
+
+    test('inflateRRect with zero insets returns the same RRect', () {
+      final RRect original = RRect.fromLTRBAndCorners(
+        10.0,
+        20.0,
+        30.0,
+        60.0,
+        topLeft: const Radius.circular(5.0),
+      );
+
+      final RRect inflated = EdgeInsets.zero.inflateRRect(original);
+
+      expect(inflated, equals(original));
+    });
+
+    test('deflateRRect with zero insets returns the same RRect', () {
+      final RRect original = RRect.fromLTRBAndCorners(
+        10.0,
+        20.0,
+        30.0,
+        60.0,
+        topLeft: const Radius.circular(5.0),
+      );
+
+      final RRect deflated = EdgeInsets.zero.deflateRRect(original);
+
+      expect(deflated, equals(original));
+    });
+
+    test('deflateRRect clamps radius to zero when insets are larger than radius', () {
+      final RRect original = RRect.fromLTRBAndCorners(
+        10.0,
+        20.0,
+        30.0,
+        60.0,
+        topLeft: const Radius.circular(3.0),
+        topRight: const Radius.circular(3.0),
+        bottomRight: const Radius.circular(3.0),
+        bottomLeft: const Radius.circular(3.0),
+      );
+
+      const EdgeInsets largeInsets = EdgeInsets.all(5.0);
+      final RRect deflated = largeInsets.deflateRRect(original);
+
+      expect(deflated.tlRadius.x, equals(0.0));
+      expect(deflated.tlRadius.y, equals(0.0));
+      expect(deflated.trRadius.x, equals(0.0));
+      expect(deflated.trRadius.y, equals(0.0));
+      expect(deflated.brRadius.x, equals(0.0));
+      expect(deflated.brRadius.y, equals(0.0));
+      expect(deflated.blRadius.x, equals(0.0));
+      expect(deflated.blRadius.y, equals(0.0));
+    });
+
+    test('inflateRRect and deflateRRect are inverse operations', () {
+      final RRect original = RRect.fromLTRBAndCorners(
+        10.0,
+        20.0,
+        30.0,
+        60.0,
+        topLeft: const Radius.circular(5.0),
+        topRight: const Radius.circular(6.0),
+        bottomRight: const Radius.circular(7.0),
+        bottomLeft: const Radius.circular(8.0),
+      );
+
+      const EdgeInsets insets = EdgeInsets.fromLTRB(2.0, 3.0, 4.0, 5.0);
+
+      final RRect inflatedThenDeflated = insets.deflateRRect(insets.inflateRRect(original));
+
+      final RRect deflatedThenInflated = insets.inflateRRect(insets.deflateRRect(original));
+
+      expect(inflatedThenDeflated.left, closeTo(original.left, 0.001));
+      expect(inflatedThenDeflated.top, closeTo(original.top, 0.001));
+      expect(inflatedThenDeflated.right, closeTo(original.right, 0.001));
+      expect(inflatedThenDeflated.bottom, closeTo(original.bottom, 0.001));
+
+      expect(deflatedThenInflated.left, closeTo(original.left, 0.001));
+      expect(deflatedThenInflated.top, closeTo(original.top, 0.001));
+      expect(deflatedThenInflated.right, closeTo(original.right, 0.001));
+      expect(deflatedThenInflated.bottom, closeTo(original.bottom, 0.001));
+    });
+  });
 }

--- a/packages/flutter/test/rendering/table_border_test.dart
+++ b/packages/flutter/test/rendering/table_border_test.dart
@@ -148,4 +148,51 @@ void main() {
     );
     expect(tableA.borderRadius, const BorderRadius.all(Radius.circular(8.0)));
   });
+
+  test('TableBorder outer border uniformity', () {
+    const TableBorder uniformOuter = TableBorder(
+      top: BorderSide(width: 2.0),
+      right: BorderSide(width: 2.0),
+      bottom: BorderSide(width: 2.0),
+      left: BorderSide(width: 2.0),
+      horizontalInside: BorderSide(color: Color(0xFF0000FF)),
+      verticalInside: BorderSide(color: Color(0xFF0000FF)),
+    );
+
+    expect(uniformOuter.isUniform, isFalse);
+
+    final BorderSide topSide = uniformOuter.top;
+    expect(uniformOuter.right, equals(topSide));
+    expect(uniformOuter.bottom, equals(topSide));
+    expect(uniformOuter.left, equals(topSide));
+
+    const TableBorder nonUniformOuter = TableBorder(
+      top: BorderSide(width: 2.0),
+      right: BorderSide(color: Color(0xFF00FF00), width: 2.0),
+      bottom: BorderSide(width: 2.0),
+      left: BorderSide(width: 2.0),
+    );
+
+    expect(nonUniformOuter.right, isNot(equals(nonUniformOuter.top)));
+  });
+
+  test('TableBorder with non-uniform widths but uniform colors applies border radius', () {
+    const TableBorder borderWithRadius = TableBorder(
+      top: BorderSide(width: 3.0, color: Color(0xFF0000FF)),
+      right: BorderSide(color: Color(0xFF0000FF)),
+      bottom: BorderSide(width: 2.0, color: Color(0xFF0000FF)),
+      left: BorderSide(width: 1.5, color: Color(0xFF0000FF)),
+      borderRadius: BorderRadius.all(Radius.circular(8.0)),
+    );
+
+    expect(borderWithRadius.top.width, isNot(equals(borderWithRadius.bottom.width)));
+    expect(borderWithRadius.left.width, isNot(equals(borderWithRadius.right.width)));
+
+    final Color topColor = borderWithRadius.top.color;
+    expect(borderWithRadius.right.color, equals(topColor));
+    expect(borderWithRadius.bottom.color, equals(topColor));
+    expect(borderWithRadius.left.color, equals(topColor));
+
+    expect(borderWithRadius.borderRadius, const BorderRadius.all(Radius.circular(8.0)));
+  });
 }


### PR DESCRIPTION
Re-implementation of PR #172441

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Add non-uniform border radius support to TableBorder
This PR extends TableBorder to support border radius even when the outer border sides have different widths but the same color, similar to the non-uniform border support added to Border in #121921.

### Changes
- Enhanced border rendering logic: TableBorder can now apply border radius when outer border sides have uniform colors but non-uniform widths/styles
- New helper methods: Added `outerBorderIsUniform` property and `distinctVisibleOuterColors()` method to determine border uniformity
- Optimized paint method: Refactored the paint logic to handle three scenarios:
  1. Fully uniform borders (existing optimized path)
  2. Outer borders with uniform colors but non-uniform widths (new non-uniform border radius support)
  3. Completely non-uniform borders (fallback to standard border painting)

### Before/After
- Before: TableBorder with border radius required all sides (including inner borders) to be completely identical.
- After: TableBorder with border radius only requires outer border colors to be the same, allowing different widths per side.

### Example Usage
```dart
TableBorder(
  top: BorderSide(color: Colors.blue, width: 3.0),
  right: BorderSide(color: Colors.blue, width: 1.0),  // Different width
  bottom: BorderSide(color: Colors.blue, width: 2.0), // Different width  
  left: BorderSide.none,                              // No border
  horizontalInside: BorderSide(color: Colors.red, width: 1.0), // Different color OK
  verticalInside: BorderSide(color: Colors.red, width: 1.0),   // Different color OK
  borderRadius: BorderRadius.circular(8), // ✅ Now works!
)
```
Fixes: #173193


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
