### PR TITLE
Document how to hide counter in TextField.maxLength

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -548,7 +548,8 @@ class TextField extends StatefulWidget {
   /// field showing how many characters have been entered. If set to a number
   /// greater than 0, it will also display the maximum number allowed. If set
   /// to [TextField.noMaxLength] then only the current character count is displayed.
-  /// To remove the counter, set [InputDecoration.counterText] to an empty string.
+  /// To remove the counter, set [InputDecoration.counterText] to an empty string or
+  /// return null from [TextField.buildCounter] callback.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforcement] is set to

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -545,10 +545,10 @@ class TextField extends StatefulWidget {
   /// the text field.
   ///
   /// If set, a character counter will be displayed below the
-  /// field showing how many characters have been entered. To remove the automatically
-  /// added counter, set [InputDecoration.counterText] to an empty string.
-  /// If set to a number greater than 0, it will also display the maximum number allowed.
-  /// If set to [TextField.noMaxLength] then only the current character count is displayed.
+  /// field showing how many characters have been entered. If set to a number
+  /// greater than 0, it will also display the maximum number allowed. If set
+  /// to [TextField.noMaxLength] then only the current character count is displayed.
+  /// To remove the counter, set [InputDecoration.counterText] to an empty string.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforcement] is set to

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -545,9 +545,10 @@ class TextField extends StatefulWidget {
   /// the text field.
   ///
   /// If set, a character counter will be displayed below the
-  /// field showing how many characters have been entered. If set to a number
-  /// greater than 0, it will also display the maximum number allowed. If set
-  /// to [TextField.noMaxLength] then only the current character count is displayed.
+  /// field showing how many characters have been entered. To remove the automatically
+  /// added counter, set [InputDecoration.counterText] to an empty string.
+  /// If set to a number greater than 0, it will also display the maximum number allowed.
+  /// If set to [TextField.noMaxLength] then only the current character count is displayed.
   ///
   /// After [maxLength] characters have been input, additional input
   /// is ignored, unless [maxLengthEnforcement] is set to


### PR DESCRIPTION
## Description

This PR adds some documentation to TextField.maxLength mentionning how to remove the counter.
See https://github.com/flutter/flutter/issues/99914#issuecomment-2871088451 for context.

## Related Issue

Fixes [TextField hint and input text go outside of given constraints](https://github.com/flutter/flutter/issues/99914)  

## Tests

Documentation only.