### PR TITLE
Fix(tools): Rely on FLUTTER_ROOT in Xcode build scripts

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -16,26 +16,19 @@ set -euo pipefail
 # Needed because if it is set, cd may print the path it changed to.
 unset CDPATH
 
-function follow_links() (
-  cd -P "$(dirname -- "$1")"
-  file="$PWD/$(basename -- "$1")"
-  while [[ -h "$file" ]]; do
-    cd -P "$(dirname -- "$file")"
-    file="$(readlink -- "$file")"
-    cd -P "$(dirname -- "$file")"
-    file="$PWD/$(basename -- "$file")"
-  done
-  echo "$file"
-)
+# Run `dart xcode_backend.dart` with the dart from the Flutter SDK.
+# The FLUTTER_ROOT environment variable is required.
+if [[ -z "$FLUTTER_ROOT" ]]; then
+  echo "error: FLUTTER_ROOT must be set."
+  exit 1
+fi
 
-PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
-BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
-FLUTTER_ROOT="$BIN_DIR/../../.."
 DART="$FLUTTER_ROOT/bin/dart"
+XCODE_BACKEND_DART="$(dirname "${BASH_SOURCE[0]}")/xcode_backend.dart"
 
 # Main entry point.
 if [[ $# == 0 ]]; then
-  "$DART" "$BIN_DIR/xcode_backend.dart" "build" "macos"
+  exec "$DART" "$XCODE_BACKEND_DART" "build" "macos"
 else
-  "$DART" "$BIN_DIR/xcode_backend.dart" "$@" "macos"
+  exec "$DART" "$XCODE_BACKEND_DART" "$@" "macos"
 fi

--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -16,11 +16,25 @@ set -euo pipefail
 # Needed because if it is set, cd may print the path it changed to.
 unset CDPATH
 
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
 # Run `dart xcode_backend.dart` with the dart from the Flutter SDK.
-# The FLUTTER_ROOT environment variable is required.
+# Prefer the FLUTTER_ROOT environment variable if set, otherwise fallback
+# to path resolution via symlink canonicalization.
 if [[ -z "$FLUTTER_ROOT" ]]; then
-  echo "error: FLUTTER_ROOT must be set."
-  exit 1
+  PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
+  BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+  FLUTTER_ROOT="$BIN_DIR/../../.."
 fi
 
 DART="$FLUTTER_ROOT/bin/dart"
@@ -28,7 +42,6 @@ XCODE_BACKEND_DART="$(dirname "${BASH_SOURCE[0]}")/xcode_backend.dart"
 
 # Main entry point.
 if [[ $# == 0 ]]; then
-  exec "$DART" "$XCODE_BACKEND_DART" "build" "macos"
-else
-  exec "$DART" "$XCODE_BACKEND_DART" "$@" "macos"
+  set -- "build"
 fi
+exec "$DART" "$XCODE_BACKEND_DART" "$@" "macos"

--- a/packages/flutter_tools/bin/xcode_backend.sh
+++ b/packages/flutter_tools/bin/xcode_backend.sh
@@ -16,21 +16,14 @@ set -euo pipefail
 # Needed because if it is set, cd may print the path it changed to.
 unset CDPATH
 
-function follow_links() (
-  cd -P "$(dirname -- "$1")"
-  file="$PWD/$(basename -- "$1")"
-  while [[ -h "$file" ]]; do
-    cd -P "$(dirname -- "$file")"
-    file="$(readlink -- "$file")"
-    cd -P "$(dirname -- "$file")"
-    file="$PWD/$(basename -- "$file")"
-  done
-  echo "$file"
-)
+# Run `dart xcode_backend.dart` with the dart from the Flutter SDK.
+# The FLUTTER_ROOT environment variable is required.
+if [[ -z "$FLUTTER_ROOT" ]]; then
+  echo "error: FLUTTER_ROOT must be set."
+  exit 1
+fi
 
-PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
-BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
-FLUTTER_ROOT="$BIN_DIR/../../.."
 DART="$FLUTTER_ROOT/bin/dart"
+XCODE_BACKEND_DART="$(dirname "${BASH_SOURCE[0]}")/xcode_backend.dart"
 
-"$DART" "$BIN_DIR/xcode_backend.dart" "$@" "ios"
+exec "$DART" "$XCODE_BACKEND_DART" "$@" "ios"


### PR DESCRIPTION
This PR fixes an issue that prevents building Flutter applications for iOS and macOS in environments where the Flutter SDK is installed via a package manager that uses symlinks, such as Nix.

The `xcode_backend.sh` and `macos_assemble.sh` scripts, which are invoked by Xcode during the build process, attempt to determine the Flutter SDK root by resolving the script's own path using path canonicalization logic. In a Nix environment, this logic fails and resolves to an incorrect, "unwrapped" directory.

This PR removes the problematic path canonicalization and modifies the scripts to rely on the `FLUTTER_ROOT` environment variable, which is guaranteed to be set in the Xcode build environment.

This change makes the build scripts more robust and fixes the build failures on Nix and similar environments. The solution was originally proposed in #155139.

Fixes #175842

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
