### PR TITLE
Remove comment about trailing commas from templates

### DIFF
--- a/dev/integration_tests/ios_app_with_extensions/lib/main.dart
+++ b/dev/integration_tests/ios_app_with_extensions/lib/main.dart
@@ -106,7 +106,7 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      ),
     );
   }
 }

--- a/engine/src/flutter/examples/glfw/main.dart
+++ b/engine/src/flutter/examples/glfw/main.dart
@@ -122,7 +122,7 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      ),
     );
   }
 }

--- a/packages/flutter_tools/templates/app/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/app/lib/main.dart.tmpl
@@ -150,7 +150,7 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      ),
     );
   }
 }

--- a/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
+++ b/packages/flutter_tools/templates/module/common/lib/main.dart.tmpl
@@ -111,7 +111,7 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
+      ),
     );
   }
 }


### PR DESCRIPTION
With the new changes to `dart format` that insert trailing commas automatically, these comments don't serve a purpose.

Fixes https://github.com/flutter/flutter/issues/175655