### PR TITLE
User Invoke-Expression instead of call operator for nested Powershell scripts invocations (on Windows)

### DIFF
--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -57,7 +57,7 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 # the current branch is forked from, which would be the last version of the
 # engine artifacts built from CI.
 } else {
-  $engineVersion = Invoke-Expression "$flutterRoot/bin/internal/content_aware_hash.ps1"
+  $engineVersion = Invoke-Expression "& '$flutterRoot/bin/internal/content_aware_hash.ps1'"
 }
 
 # Write the engine version out so downstream tools know what to look for.

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -57,7 +57,7 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 # the current branch is forked from, which would be the last version of the
 # engine artifacts built from CI.
 } else {
-  $engineVersion = & "$flutterRoot/bin/internal/content_aware_hash.ps1"
+  Invoke-Expression "$flutterRoot/bin/internal/content_aware_hash.ps1"
 }
 
 # Write the engine version out so downstream tools know what to look for.

--- a/bin/internal/update_engine_version.ps1
+++ b/bin/internal/update_engine_version.ps1
@@ -57,7 +57,7 @@ if (![string]::IsNullOrEmpty($env:FLUTTER_PREBUILT_ENGINE_VERSION)) {
 # the current branch is forked from, which would be the last version of the
 # engine artifacts built from CI.
 } else {
-  Invoke-Expression "$flutterRoot/bin/internal/content_aware_hash.ps1"
+  $engineVersion = Invoke-Expression "$flutterRoot/bin/internal/content_aware_hash.ps1"
 }
 
 # Write the engine version out so downstream tools know what to look for.


### PR DESCRIPTION
With modern pwsh.exe there seems to be a problem with call operator making nested powershell script invocation. Use Invoke-Expression instead.

Fixes https://github.com/flutter/flutter/issues/173554