### PR TITLE
Ignore upcoming `experimental_member_use` warnings.

### DIFF
--- a/packages/flutter_tools/lib/src/ios/xcode_debug.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_debug.dart
@@ -410,6 +410,7 @@ class XcodeDebug {
     final String schemeXml = schemeFile.readAsStringSync();
     try {
       final document = XmlDocument.parse(schemeXml);
+      // ignore: experimental_member_use
       final Iterable<XmlNode> nodes = document.xpath('/Scheme/LaunchAction');
       if (nodes.isEmpty) {
         _logger.printError('Failed to find LaunchAction for the Scheme in ${schemeFile.path}.');

--- a/packages/flutter_tools/lib/src/migrations/lldb_init_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/lldb_init_migration.dart
@@ -249,6 +249,7 @@ selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
     required XmlDocument document,
     required SchemeInfo schemeInfo,
   }) {
+    // ignore: experimental_member_use
     final Iterable<XmlNode> nodes = document.xpath('/Scheme/$action');
     if (nodes.isEmpty) {
       logger.printTrace('Failed to find $action for the Scheme in ${schemeInfo.schemeFile.path}.');


### PR DESCRIPTION
In an upcoming Dart SDK change
(https://dart-review.googlesource.com/c/sdk/+/450970), I intend to add logic to the analyzer for generating a warning if an API marked `@experimental` is used. This will allow experimental analyzer features to be developed without creating a risk of breaking changes downstream.

It looks like there are two existing uses of an experimental API in the flutter codebase: the method `XmlDocument.xpath`. This is probably safe, since Flutter pins its use of `package:xml` to an exact version. But to avoid breaking buildbots when the new analyzer logic rolls out, we need to keep Flutter warning-clean.

So this PR proactively adds `// ignore:` comments to suppress the upcoming warnings.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
