### PR TITLE
Use module names that allow for import cycles

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -855,6 +855,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
           // in the frontend_server.
           // https://github.com/flutter/flutter/issues/59902
           '--experimental-emit-debug-metadata',
+          '--debugger-module-names',
           for (final Object dartDefine in dartDefines) '-D$dartDefine',
           if (outputPath != null) ...<String>['--output-dill', outputPath],
           // If we have a platform dill, we don't need to pass the libraries spec,

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -329,7 +329,7 @@ class WebAssetServer implements AssetReader {
             ? FrontendServerDdcLibraryBundleStrategyProvider(
                 ReloadConfiguration.none,
                 server,
-                PackageUriMapper(packageConfig),
+                PackageUriMapper(packageConfig, useDebuggerModuleNames: true),
                 digestProvider,
                 BuildSettings(
                   appEntrypoint: packageConfig.toPackageUri(
@@ -345,7 +345,7 @@ class WebAssetServer implements AssetReader {
             : FrontendServerRequireStrategyProvider(
                 ReloadConfiguration.none,
                 server,
-                PackageUriMapper(packageConfig),
+                PackageUriMapper(packageConfig, useDebuggerModuleNames: true),
                 digestProvider,
                 BuildSettings(
                   appEntrypoint: packageConfig.toPackageUri(

--- a/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_asset_server.dart
@@ -676,9 +676,13 @@ _flutter.buildConfig = ${jsonEncode(buildConfig)};
     // The file might have been a package file which is signaled by a
     // `/packages/<package>/<path>` request.
     if (segments.first == 'packages') {
-      final Uri? filePath = _packages.resolve(
-        Uri(scheme: 'package', pathSegments: segments.skip(1)),
-      );
+      Iterable<String> pathSegments = segments.skip(1);
+      final String packageName = segments[1];
+      if (segments[2] == 'lib' &&
+          _packages.packages.any((package) => package.name == packageName)) {
+        pathSegments = [segments[1], ...segments.skip(3)];
+      }
+      final Uri? filePath = _packages.resolve(Uri(scheme: 'package', pathSegments: pathSegments));
       if (filePath != null) {
         final File packageFile = fileSystem.file(filePath);
         if (packageFile.existsSync()) {

--- a/packages/flutter_tools/test/integration.shard/test_data/breakpoints_import_cycle_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/breakpoints_import_cycle_project.dart
@@ -1,0 +1,113 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+
+import '../test_utils.dart';
+import 'project.dart';
+
+class BreakpointsImportCycleProject extends Project {
+  @override
+  Future<void> setUpIn(Directory dir) {
+    this.dir = dir;
+    writeFile(fileSystem.path.join(dir.path, 'lib_a', 'pubspec.yaml'), _libAPubspec);
+    writeFile(fileSystem.path.join(dir.path, 'lib_a', 'lib', 'lib_a.dart'), _libA);
+    writeFile(fileSystem.path.join(dir.path, 'lib_b', 'pubspec.yaml'), _libBPubspec);
+    writeFile(fileSystem.path.join(dir.path, 'lib_b', 'lib', 'lib_b.dart'), _libB);
+    return super.setUpIn(dir.childDirectory('main_lib'));
+  }
+
+  @override
+  final pubspec = '''
+  name: main_lib
+  environment:
+    sdk: ^3.7.0-0
+  dependencies:
+    flutter:
+      sdk: flutter
+    lib_a:
+      path: ../lib_a
+  ''';
+
+  @override
+  final main = r'''
+  import 'package:flutter/material.dart';
+  import 'package:lib_a/lib_a.dart';
+
+  void main() => runApp(MyApp());
+
+  class MyApp extends StatefulWidget {
+    @override
+    _MyAppState createState() => _MyAppState();
+  }
+
+  class _MyAppState extends State<MyApp> {
+    @override
+    void initState() {
+      print(a1());
+      print(a2());
+      super.initState();
+    }
+
+    @override
+    Widget build(BuildContext context) {
+      return MaterialApp(
+        title: 'Flutter Demo',
+        home: Container(),
+      );
+    }
+  }
+  ''';
+
+  final _libAPubspec = '''
+  name: lib_a
+  environment:
+    sdk: ^3.7.0-0
+  dependencies:
+    flutter:
+      sdk: flutter
+    lib_b:
+      path: ../lib_b
+  ''';
+
+  final _libA = r'''
+  import 'package:lib_b/lib_b.dart';
+
+  String a1() {
+    return 'a1';
+  }
+
+  String a2() {
+    return 'a2${b2()}'; // BREAKPOINT 1
+  }
+  ''';
+
+  final _libBPubspec = '''
+  name: lib_b
+  environment:
+    sdk: ^3.7.0-0
+  dependencies:
+    flutter:
+      sdk: flutter
+    lib_a:
+      path: ../lib_a
+  ''';
+
+  final _libB = r'''
+  import 'package:lib_a/lib_a.dart';
+
+  String b1() {
+    return 'b1${a1()}';
+  }
+
+  String b2() {
+    return 'b2'; // BREAKPOINT 2
+  }
+  ''';
+
+  Uri get breakpointUri1 => Uri.parse('package:lib_a/lib_a.dart');
+  int get breakpointLine1 => lineContaining(_libA, '// BREAKPOINT 1');
+  Uri get breakpointUri2 => Uri.parse('package:lib_b/lib_b.dart');
+  int get breakpointLine2 => lineContaining(_libB, '// BREAKPOINT 2');
+}

--- a/packages/flutter_tools/test/web.shard/debugger_breakpoints_circular_imports_test.dart
+++ b/packages/flutter_tools/test/web.shard/debugger_breakpoints_circular_imports_test.dart
@@ -27,8 +27,6 @@ void main() {
 
     flutter = FlutterRunTestDriver(project.dir);
 
-    print(project.dir.uri);
-
     await flutter.run(
       withDebugger: true,
       startPaused: true,
@@ -44,7 +42,9 @@ void main() {
     expect((await flutter.getSourceLocation())!.line, equals(project.breakpointLine2));
 
     await flutter.resume();
+
     // TODO(nshahan): Add some expectation that the program ran to completion.
+
     await flutter.quit();
   });
 

--- a/packages/flutter_tools/test/web.shard/debugger_breakpoints_circular_imports_test.dart
+++ b/packages/flutter_tools/test/web.shard/debugger_breakpoints_circular_imports_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@Tags(<String>['flutter-test-driver'])
+library;
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/web/web_device.dart';
+
+import '../integration.shard/test_data/breakpoints_import_cycle_project.dart';
+import '../integration.shard/test_driver.dart';
+import '../integration.shard/test_utils.dart';
+import '../src/common.dart';
+
+void main() {
+  late Directory tempDirectory;
+  late FlutterRunTestDriver flutter;
+
+  setUp(() {
+    tempDirectory = createResolvedTempDirectorySync('debugger_breakpoints_import_cycle_test.');
+  });
+
+  testWithoutContext('Web debugger can stop at breakpoints in library cycles', () async {
+    final project = BreakpointsImportCycleProject();
+    await project.setUpIn(tempDirectory);
+
+    flutter = FlutterRunTestDriver(project.dir);
+
+    print(project.dir.uri);
+
+    await flutter.run(
+      withDebugger: true,
+      startPaused: true,
+      device: GoogleChromeDevice.kChromeDeviceId,
+      additionalCommandArgs: <String>['--verbose', '--no-web-resources-cdn'],
+    );
+    await flutter.addBreakpoint(project.breakpointUri1, project.breakpointLine1);
+    await flutter.resume(waitForNextPause: true);
+    expect((await flutter.getSourceLocation())!.line, equals(project.breakpointLine1));
+
+    await flutter.addBreakpoint(project.breakpointUri2, project.breakpointLine2);
+    await flutter.resume(waitForNextPause: true);
+    expect((await flutter.getSourceLocation())!.line, equals(project.breakpointLine2));
+
+    await flutter.resume();
+    // TODO(nshahan): Add some expectation that the program ran to completion.
+    await flutter.quit();
+  });
+
+  tearDown(() async {
+    await flutter.stop();
+    tryToDelete(tempDirectory);
+  });
+}


### PR DESCRIPTION
Makes breakpoints work when set in files that are part of a library cycle and compiled into a single strongly connected component, even when the original source files are not in the same directory.

Issue: https://github.com/dart-lang/webdev/issues/1692