### PR TITLE
Update flutter test to use SemanticsFlags

### DIFF
--- a/packages/flutter/test/widgets/semantics_tester_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -42,6 +44,107 @@ void main() {
       semantics,
       isNot(
         hasSemantics(expectedSemantics, ignoreTransform: true, ignoreId: true, ignoreRect: true),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester support flags as an int', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        child: Semantics(
+          label: 'test1',
+          textDirection: TextDirection.ltr,
+          selected: true,
+          child: Container(),
+        ),
+      ),
+    );
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics.rootChild(
+              id: 1,
+              label: 'test1',
+              rect: TestSemantics.fullScreen,
+              flags: SemanticsFlag.hasSelectedState.index | SemanticsFlag.isSelected.index,
+            ),
+          ],
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester support flags as a list of SemanticsFlag', (
+    WidgetTester tester,
+  ) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        child: Semantics(
+          label: 'test1',
+          textDirection: TextDirection.ltr,
+          selected: true,
+          child: Container(),
+        ),
+      ),
+    );
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics.rootChild(
+              id: 1,
+              label: 'test1',
+              rect: TestSemantics.fullScreen,
+              flags: <SemanticsFlag>[SemanticsFlag.hasSelectedState, SemanticsFlag.isSelected],
+            ),
+          ],
+        ),
+      ),
+    );
+    semantics.dispose();
+  });
+
+  testWidgets('Semantics tester support flags as a SemanticsFlags', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    await tester.pumpWidget(
+      Semantics(
+        container: true,
+        child: Semantics(
+          label: 'test1',
+          textDirection: TextDirection.ltr,
+          selected: true,
+          child: Container(),
+        ),
+      ),
+    );
+
+    expect(
+      semantics,
+      hasSemantics(
+        TestSemantics.root(
+          children: <TestSemantics>[
+            TestSemantics.rootChild(
+              id: 1,
+              label: 'test1',
+              rect: TestSemantics.fullScreen,
+              flags: SemanticsFlags(isSelected: Tristate.isTrue),
+            ),
+          ],
+        ),
       ),
     );
     semantics.dispose();

--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -163,7 +163,7 @@ class MinimumTapTargetGuideline extends AccessibilityGuideline {
       }
       // skip node if it is touching the edge scrollable, since it might
       // be partially scrolled offscreen.
-      if (current.hasFlag(SemanticsFlag.hasImplicitScrolling) &&
+      if (current.flagsCollection.hasImplicitScrolling &&
           _isAtBoundary(paintBounds, current.rect)) {
         return result;
       }
@@ -207,11 +207,11 @@ class MinimumTapTargetGuideline extends AccessibilityGuideline {
     // Skip node if it has no actions, or is marked as hidden.
     if ((!data.hasAction(ui.SemanticsAction.longPress) &&
             !data.hasAction(ui.SemanticsAction.tap)) ||
-        data.hasFlag(ui.SemanticsFlag.isHidden)) {
+        data.flagsCollection.isHidden) {
       return true;
     }
     // Skip links https://www.w3.org/WAI/WCAG21/Understanding/target-size.html
-    if (data.hasFlag(ui.SemanticsFlag.isLink)) {
+    if (data.flagsCollection.isLink) {
       return true;
     }
     return false;
@@ -253,8 +253,8 @@ class LabeledTapTargetGuideline extends AccessibilityGuideline {
     });
     if (node.isMergedIntoParent ||
         node.isInvisible ||
-        node.hasFlag(ui.SemanticsFlag.isHidden) ||
-        node.hasFlag(ui.SemanticsFlag.isTextField)) {
+        node.flagsCollection.isHidden ||
+        node.flagsCollection.isTextField) {
       return result;
     }
     final SemanticsData data = node.getSemanticsData();
@@ -346,12 +346,11 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
     Evaluation result = const Evaluation.pass();
 
     // Skip disabled nodes, as they not required to pass contrast check.
-    final bool isDisabled =
-        node.hasFlag(ui.SemanticsFlag.hasEnabledState) && !node.hasFlag(ui.SemanticsFlag.isEnabled);
+    final bool isDisabled = node.flagsCollection.isEnabled == ui.Tristate.isFalse;
 
     if (node.isInvisible ||
         node.isMergedIntoParent ||
-        node.hasFlag(ui.SemanticsFlag.isHidden) ||
+        node.flagsCollection.isHidden ||
         isDisabled) {
       return result;
     }
@@ -481,8 +480,7 @@ class MinimumTextContrastGuideline extends AccessibilityGuideline {
   ///
   /// Skip routes which might have labels, and nodes without any text.
   bool shouldSkipNode(SemanticsData data) =>
-      data.hasFlag(ui.SemanticsFlag.scopesRoute) ||
-      (data.label.trim().isEmpty && data.value.trim().isEmpty);
+      data.flagsCollection.scopesRoute || (data.label.trim().isEmpty && data.value.trim().isEmpty);
 
   /// Returns if a rectangle of node is off the screen.
   ///

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -13,6 +13,7 @@
 /// @docImport 'widget_tester.dart';
 library;
 
+import 'dart:ui' as ui;
 import 'package:clock/clock.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -73,17 +74,6 @@ class SemanticsController {
       SemanticsAction.scrollLeft.index |
       SemanticsAction.scrollRight.index |
       SemanticsAction.scrollToOffset.index;
-
-  /// Based on Android's FOCUSABLE_FLAGS. See [flutter/engine/AccessibilityBridge.java](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java).
-  static final int _importantFlagsForAccessibility =
-      SemanticsFlag.hasCheckedState.index |
-      SemanticsFlag.hasToggledState.index |
-      SemanticsFlag.hasEnabledState.index |
-      SemanticsFlag.isButton.index |
-      SemanticsFlag.isTextField.index |
-      SemanticsFlag.isFocusable.index |
-      SemanticsFlag.isSlider.index |
-      SemanticsFlag.isInMutuallyExclusiveGroup.index;
 
   final WidgetController _controller;
 
@@ -353,7 +343,7 @@ class SemanticsController {
     final SemanticsData data = node.getSemanticsData();
     // If the node scopes a route, it doesn't matter what other flags/actions it
     // has, it is _not_ important for accessibility, so we short circuit.
-    if (data.hasFlag(SemanticsFlag.scopesRoute)) {
+    if (data.flagsCollection.scopesRoute) {
       return false;
     }
 
@@ -362,7 +352,17 @@ class SemanticsController {
       return true;
     }
 
-    final bool hasImportantFlag = data.flags & _importantFlagsForAccessibility != 0;
+    /// Based on Android's FOCUSABLE_FLAGS. See [flutter/engine/AccessibilityBridge.java](https://github.com/flutter/flutter/blob/main/engine/src/flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java).
+    final bool hasImportantFlag =
+        data.flagsCollection.isChecked != ui.CheckedState.none ||
+        data.flagsCollection.isToggled != ui.Tristate.none ||
+        data.flagsCollection.isEnabled != ui.Tristate.none ||
+        data.flagsCollection.isButton ||
+        data.flagsCollection.isTextField ||
+        data.flagsCollection.isFocused != ui.Tristate.none ||
+        data.flagsCollection.isSlider ||
+        data.flagsCollection.isInMutuallyExclusiveGroup;
+
     if (hasImportantFlag) {
       return true;
     }

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -2454,38 +2454,38 @@ class _MatchesSemanticsData extends Matcher {
     required String? onLongPressHint,
     required this.customActions,
     required this.children,
-  }) : flags = <SemanticsFlag, bool>{
-         SemanticsFlag.hasCheckedState: ?hasCheckedState,
-         SemanticsFlag.isChecked: ?isChecked,
-         SemanticsFlag.isCheckStateMixed: ?isCheckStateMixed,
-         SemanticsFlag.isSelected: ?isSelected,
-         SemanticsFlag.hasSelectedState: ?hasSelectedState,
-         SemanticsFlag.isButton: ?isButton,
-         SemanticsFlag.isSlider: ?isSlider,
-         SemanticsFlag.isKeyboardKey: ?isKeyboardKey,
-         SemanticsFlag.isLink: ?isLink,
-         SemanticsFlag.isTextField: ?isTextField,
-         SemanticsFlag.isReadOnly: ?isReadOnly,
-         SemanticsFlag.isFocused: ?isFocused,
-         SemanticsFlag.isFocusable: ?isFocusable,
-         SemanticsFlag.hasEnabledState: ?hasEnabledState,
-         SemanticsFlag.isEnabled: ?isEnabled,
-         SemanticsFlag.isInMutuallyExclusiveGroup: ?isInMutuallyExclusiveGroup,
-         SemanticsFlag.isHeader: ?isHeader,
-         SemanticsFlag.isObscured: ?isObscured,
-         SemanticsFlag.isMultiline: ?isMultiline,
-         SemanticsFlag.namesRoute: ?namesRoute,
-         SemanticsFlag.scopesRoute: ?scopesRoute,
-         SemanticsFlag.isHidden: ?isHidden,
-         SemanticsFlag.isImage: ?isImage,
-         SemanticsFlag.isLiveRegion: ?isLiveRegion,
-         SemanticsFlag.hasToggledState: ?hasToggledState,
-         SemanticsFlag.isToggled: ?isToggled,
-         SemanticsFlag.hasImplicitScrolling: ?hasImplicitScrolling,
-         SemanticsFlag.hasExpandedState: ?hasExpandedState,
-         SemanticsFlag.isExpanded: ?isExpanded,
-         SemanticsFlag.hasRequiredState: ?hasRequiredState,
-         SemanticsFlag.isRequired: ?isRequired,
+  }) : flags = <String, bool>{
+         'hasCheckedState': ?hasCheckedState,
+         'isChecked': ?isChecked,
+         'isCheckStateMixed': ?isCheckStateMixed,
+         'isSelected': ?isSelected,
+         'hasSelectedState': ?hasSelectedState,
+         'isButton': ?isButton,
+         'isSlider': ?isSlider,
+         'isKeyboardKey': ?isKeyboardKey,
+         'isLink': ?isLink,
+         'isTextField': ?isTextField,
+         'isReadOnly': ?isReadOnly,
+         'isFocused': ?isFocused,
+         'isFocusable': ?isFocusable,
+         'hasEnabledState': ?hasEnabledState,
+         'isEnabled': ?isEnabled,
+         'isInMutuallyExclusiveGroup': ?isInMutuallyExclusiveGroup,
+         'isHeader': ?isHeader,
+         'isObscured': ?isObscured,
+         'isMultiline': ?isMultiline,
+         'namesRoute': ?namesRoute,
+         'scopesRoute': ?scopesRoute,
+         'isHidden': ?isHidden,
+         'isImage': ?isImage,
+         'isLiveRegion': ?isLiveRegion,
+         'hasToggledState': ?hasToggledState,
+         'isToggled': ?isToggled,
+         'hasImplicitScrolling': ?hasImplicitScrolling,
+         'hasExpandedState': ?hasExpandedState,
+         'isExpanded': ?isExpanded,
+         'hasRequiredState': ?hasRequiredState,
+         'isRequired': ?isRequired,
        },
        actions = <SemanticsAction, bool>{
          SemanticsAction.tap: ?hasTapAction,
@@ -2546,7 +2546,7 @@ class _MatchesSemanticsData extends Matcher {
   ///  2. If the flag/action maps to `false`, then it must not be present in the SemanticData
   ///  3. If the flag/action is not in the map, then it will not be validated against
   final Map<SemanticsAction, bool> actions;
-  final Map<SemanticsFlag, bool> flags;
+  final Map<String, bool> flags;
 
   @override
   Description describe(Description description, [String? index]) {
@@ -2598,27 +2598,27 @@ class _MatchesSemanticsData extends Matcher {
           .toList();
 
       if (expectedActions.isNotEmpty) {
-        description.add(' with actions: ${_createEnumsSummary(expectedActions)} ');
+        description.add(' with actions: ${_createSemanticsActionSummary(expectedActions)} ');
       }
       if (notExpectedActions.isNotEmpty) {
-        description.add(' without actions: ${_createEnumsSummary(notExpectedActions)} ');
+        description.add(' without actions: ${_createSemanticsActionSummary(notExpectedActions)} ');
       }
     }
     if (flags.isNotEmpty) {
-      final List<SemanticsFlag> expectedFlags = flags.entries
-          .where((MapEntry<ui.SemanticsFlag, bool> e) => e.value)
-          .map((MapEntry<ui.SemanticsFlag, bool> e) => e.key)
+      final List<String> expectedFlags = flags.entries
+          .where((MapEntry<String, bool> e) => e.value)
+          .map((MapEntry<String, bool> e) => e.key)
           .toList();
-      final List<SemanticsFlag> notExpectedFlags = flags.entries
-          .where((MapEntry<ui.SemanticsFlag, bool> e) => !e.value)
-          .map((MapEntry<ui.SemanticsFlag, bool> e) => e.key)
+      final List<String> notExpectedFlags = flags.entries
+          .where((MapEntry<String, bool> e) => !e.value)
+          .map((MapEntry<String, bool> e) => e.key)
           .toList();
 
       if (expectedFlags.isNotEmpty) {
-        description.add(' with flags: ${_createEnumsSummary(expectedFlags)} ');
+        description.add(' with flags: ${expectedFlags.join(',')} ');
       }
       if (notExpectedFlags.isNotEmpty) {
-        description.add(' without flags: ${_createEnumsSummary(notExpectedFlags)} ');
+        description.add(' without flags: ${notExpectedFlags.join(', ')} ');
       }
     }
     if (textDirection != null) {
@@ -2803,7 +2803,7 @@ class _MatchesSemanticsData extends Matcher {
       if (unexpectedActions.isNotEmpty || missingActions.isNotEmpty) {
         return failWithDescription(
           matchState,
-          'missing actions: ${_createEnumsSummary(missingActions)} unexpected actions: ${_createEnumsSummary(unexpectedActions)}',
+          'missing actions: ${_createSemanticsActionSummary(missingActions)} unexpected actions: ${_createSemanticsActionSummary(unexpectedActions)}',
         );
       }
     }
@@ -2848,17 +2848,18 @@ class _MatchesSemanticsData extends Matcher {
       }
     }
     if (flags.isNotEmpty) {
-      final List<SemanticsFlag> unexpectedFlags = <SemanticsFlag>[];
-      final List<SemanticsFlag> missingFlags = <SemanticsFlag>[];
-      for (final MapEntry<ui.SemanticsFlag, bool> flagEntry in flags.entries) {
-        final ui.SemanticsFlag flag = flagEntry.key;
+      final Map<String, bool> foundFlags = _stringsMapFromSemanticsFlags(data.flagsCollection);
+      final List<String> unexpectedFlags = <String>[];
+      final List<String> missingFlags = <String>[];
+      for (final MapEntry<String, bool> flagEntry in flags.entries) {
+        final String flagName = flagEntry.key;
         final bool flagExpected = flagEntry.value;
-        final bool flagPresent = flag.index & data.flags == flag.index;
+        final bool flagPresent = foundFlags[flagName]!;
         if (flagPresent != flagExpected) {
           if (flagExpected) {
-            missingFlags.add(flag);
+            missingFlags.add(flagName);
           } else {
-            unexpectedFlags.add(flag);
+            unexpectedFlags.add(flagName);
           }
         }
       }
@@ -2866,7 +2867,7 @@ class _MatchesSemanticsData extends Matcher {
       if (unexpectedFlags.isNotEmpty || missingFlags.isNotEmpty) {
         return failWithDescription(
           matchState,
-          'missing flags: ${_createEnumsSummary(missingFlags)} unexpected flags: ${_createEnumsSummary(unexpectedFlags)}',
+          'missing flags: ${missingFlags.join(',')} unexpected flags: ${unexpectedFlags.join(',')}',
         );
       }
     }
@@ -2897,16 +2898,8 @@ class _MatchesSemanticsData extends Matcher {
     return mismatchDescription.add(matchState['failure'] as String);
   }
 
-  static String _createEnumsSummary<T extends Object>(List<T> enums) {
-    assert(
-      T == SemanticsAction || T == SemanticsFlag,
-      'This method is only intended for lists of SemanticsActions or SemanticsFlags.',
-    );
-    if (T == SemanticsAction) {
-      return '[${(enums as List<SemanticsAction>).map((SemanticsAction d) => d.name).join(', ')}]';
-    } else {
-      return '[${(enums as List<SemanticsFlag>).map((SemanticsFlag d) => d.name).join(', ')}]';
-    }
+  static String _createSemanticsActionSummary(List<SemanticsAction> enums) {
+    return '[${enums.map((ui.SemanticsAction d) => d.name).join(', ')}]';
   }
 }
 
@@ -2948,4 +2941,40 @@ class _DoesNotMatchAccessibilityGuideline extends AsyncMatcher {
     }
     return null;
   }
+}
+
+Map<String, bool> _stringsMapFromSemanticsFlags(SemanticsFlags flagsCollection) {
+  return <String, bool>{
+    'hasCheckedState': flagsCollection.isChecked != ui.CheckedState.none,
+    'isChecked': flagsCollection.isChecked == ui.CheckedState.isTrue,
+    'isCheckStateMixed': flagsCollection.isChecked == ui.CheckedState.mixed,
+    'isSelected': flagsCollection.isSelected == ui.Tristate.isTrue,
+    'hasSelectedState': flagsCollection.isSelected != ui.Tristate.none,
+    'isButton': flagsCollection.isButton,
+    'isSlider': flagsCollection.isSlider,
+    'isKeyboardKey': flagsCollection.isKeyboardKey,
+    'isLink': flagsCollection.isLink,
+    'isFocused': flagsCollection.isFocused == ui.Tristate.isTrue,
+    'isFocusable': flagsCollection.isFocused != ui.Tristate.none,
+    'isTextField': flagsCollection.isTextField,
+    'isReadOnly': flagsCollection.isReadOnly,
+    'hasEnabledState': flagsCollection.isEnabled != ui.Tristate.none,
+    'isEnabled': flagsCollection.isEnabled == ui.Tristate.isTrue,
+    'isInMutuallyExclusiveGroup': flagsCollection.isInMutuallyExclusiveGroup,
+    'isHeader': flagsCollection.isHeader,
+    'isObscured': flagsCollection.isObscured,
+    'isMultiline': flagsCollection.isMultiline,
+    'namesRoute': flagsCollection.namesRoute,
+    'scopesRoute': flagsCollection.scopesRoute,
+    'isHidden': flagsCollection.isHidden,
+    'isImage': flagsCollection.isImage,
+    'isLiveRegion': flagsCollection.isLiveRegion,
+    'hasToggledState': flagsCollection.isToggled != ui.Tristate.none,
+    'isToggled': flagsCollection.isToggled == ui.Tristate.isTrue,
+    'hasImplicitScrolling': flagsCollection.hasImplicitScrolling,
+    'hasExpandedState': flagsCollection.isExpanded != ui.Tristate.none,
+    'isExpanded': flagsCollection.isExpanded == ui.Tristate.isTrue,
+    'hasRequiredState': flagsCollection.isRequired != ui.Tristate.none,
+    'isRequired': flagsCollection.isRequired == ui.Tristate.isTrue,
+  };
 }


### PR DESCRIPTION

Update flutter test to use SemanticsFlags so it will support incoming flags 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
