### PR TITLE
[win32] Runloop should use high resolution timer and avoid deadlock

### DIFF
--- a/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -105,18 +105,9 @@ TEST_F(FlutterWindowsEngineTest, TaskRunnerDoesNotDeadlock) {
   // Spam flutter tasks.
   container.PostTaskLoop();
 
-  auto WndProc = [](HWND hWnd, UINT msg, WPARAM wParam,
-                    LPARAM lParam) -> LRESULT {
-    if (msg == WM_DESTROY) {
-      PostQuitMessage(0);
-      return 0;
-    }
-    return DefWindowProc(hWnd, msg, wParam, lParam);
-  };
-
   const LPCWSTR class_name = L"FlutterTestWindowClass";
   WNDCLASS wc = {0};
-  wc.lpfnWndProc = WndProc;
+  wc.lpfnWndProc = DefWindowProc;
   wc.lpszClassName = class_name;
   RegisterClass(&wc);
 

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -25,6 +25,7 @@ TaskRunnerWindow::TaskRunnerWindow() {
   if (!timer_) {
     FML_LOG(ERROR) << "Failed to create threadpool timer, error: "
                    << GetLastError();
+    FML_CHECK(timer_);
   }
 
   if (window_handle_) {
@@ -51,6 +52,8 @@ TaskRunnerWindow::TaskRunnerWindow() {
 
 TaskRunnerWindow::~TaskRunnerWindow() {
   SetThreadpoolTimer(timer_, nullptr, 0, 0);
+  // Ensures that no callbacks will run after CloseThreadpoolTimer.
+  // https://learn.microsoft.com/en-us/windows/win32/api/threadpoolapiset/nf-threadpoolapiset-closethreadpooltimer#remarks
   WaitForThreadpoolTimerCallbacks(timer_, TRUE);
   CloseThreadpoolTimer(timer_);
 

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -5,12 +5,11 @@
 #include "flutter/shell/platform/windows/task_runner_window.h"
 
 #include <algorithm>
+#include <chrono>
 
 #include "flutter/fml/logging.h"
 
 namespace flutter {
-
-static const uintptr_t kTimerId = 0;
 
 // Timer used for PollOnce timeout.
 static const uintptr_t kPollTimeoutTimerId = 1;
@@ -20,6 +19,8 @@ TaskRunnerWindow::TaskRunnerWindow() {
   window_handle_ =
       CreateWindowEx(0, window_class.lpszClassName, L"", 0, 0, 0, 0, 0,
                      HWND_MESSAGE, nullptr, window_class.hInstance, nullptr);
+
+  timer_ = CreateThreadpoolTimer(TimerProc, this, nullptr);
 
   if (window_handle_) {
     SetWindowLongPtr(window_handle_, GWLP_USERDATA,
@@ -35,14 +36,32 @@ TaskRunnerWindow::TaskRunnerWindow() {
     OutputDebugString(message);
     LocalFree(message);
   }
+
+  thread_id_ = GetCurrentThreadId();
 }
 
 TaskRunnerWindow::~TaskRunnerWindow() {
+  SetThreadpoolTimer(timer_, nullptr, 0, 0);
+  WaitForThreadpoolTimerCallbacks(timer_, TRUE);
+  CloseThreadpoolTimer(timer_);
+
   if (window_handle_) {
     DestroyWindow(window_handle_);
     window_handle_ = nullptr;
   }
   UnregisterClass(window_class_name_.c_str(), nullptr);
+}
+
+void TaskRunnerWindow::OnTimer() {
+  if (!PostMessage(window_handle_, WM_NULL, 0, 0)) {
+    FML_LOG(ERROR) << "Failed to post message to main thread.";
+  }
+}
+
+void TaskRunnerWindow::TimerProc(PTP_CALLBACK_INSTANCE instance,
+                                 PVOID context,
+                                 PTP_TIMER timer) {
+  reinterpret_cast<TaskRunnerWindow*>(context)->OnTimer();
 }
 
 std::shared_ptr<TaskRunnerWindow> TaskRunnerWindow::GetSharedInstance() {
@@ -57,6 +76,18 @@ std::shared_ptr<TaskRunnerWindow> TaskRunnerWindow::GetSharedInstance() {
 }
 
 void TaskRunnerWindow::WakeUp() {
+  // When waking up from main thread while there are messages in the message
+  // queue use timer to post the WM_NULL message from background thread. This
+  // gives message loop chance to process input events before WM_NULL is
+  // processed - which is necessary because messages scheduled through
+  // PostMessage take precedence over input event messages. Otherwise await
+  // Future.delayed(Duration.zero) deadlocks the main thread. (See
+  // https://github.com/flutter/flutter/issues/173843)
+  if (thread_id_ == GetCurrentThreadId() && GetQueueStatus(QS_ALLEVENTS) != 0) {
+    SetTimer(std::chrono::nanoseconds::zero());
+    return;
+  }
+
   if (!PostMessage(window_handle_, WM_NULL, 0, 0)) {
     FML_LOG(ERROR) << "Failed to post message to main thread.";
   }
@@ -99,10 +130,16 @@ void TaskRunnerWindow::ProcessTasks() {
 
 void TaskRunnerWindow::SetTimer(std::chrono::nanoseconds when) {
   if (when == std::chrono::nanoseconds::max()) {
-    KillTimer(window_handle_, kTimerId);
+    SetThreadpoolTimer(timer_, nullptr, 0, 0);
   } else {
-    auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(when);
-    ::SetTimer(window_handle_, kTimerId, millis.count() + 1, nullptr);
+    auto microseconds =
+        std::chrono::duration_cast<std::chrono::microseconds>(when).count();
+    ULARGE_INTEGER ticks;
+    ticks.QuadPart = -static_cast<LONGLONG>(microseconds * 10);
+    FILETIME ft;
+    ft.dwLowDateTime = ticks.LowPart;
+    ft.dwHighDateTime = ticks.HighPart;
+    SetThreadpoolTimer(timer_, &ft, 1, 0);
   }
 }
 
@@ -129,14 +166,6 @@ TaskRunnerWindow::HandleMessage(UINT const message,
                                 WPARAM const wparam,
                                 LPARAM const lparam) noexcept {
   switch (message) {
-    case WM_TIMER:
-      if (wparam == kPollTimeoutTimerId) {
-        // Ignore PollOnce timeout timer.
-        return 0;
-      }
-      FML_DCHECK(wparam == kTimerId);
-      ProcessTasks();
-      return 0;
     case WM_NULL:
       ProcessTasks();
       return 0;

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/windows/task_runner_window.h"
 
+#include <timeapi.h>
 #include <algorithm>
 #include <chrono>
 
@@ -42,6 +43,10 @@ TaskRunnerWindow::TaskRunnerWindow() {
   }
 
   thread_id_ = GetCurrentThreadId();
+
+  // Increase timer precision for this process (the call only affects
+  // current process since Windows 10, version 2004).n
+  timeBeginPeriod(1);
 }
 
 TaskRunnerWindow::~TaskRunnerWindow() {
@@ -54,6 +59,8 @@ TaskRunnerWindow::~TaskRunnerWindow() {
     window_handle_ = nullptr;
   }
   UnregisterClass(window_class_name_.c_str(), nullptr);
+
+  timeEndPeriod(1);
 }
 
 void TaskRunnerWindow::OnTimer() {

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -21,6 +21,10 @@ TaskRunnerWindow::TaskRunnerWindow() {
                      HWND_MESSAGE, nullptr, window_class.hInstance, nullptr);
 
   timer_ = CreateThreadpoolTimer(TimerProc, this, nullptr);
+  if (!timer_) {
+    FML_LOG(ERROR) << "Failed to create threadpool timer, error: "
+                   << GetLastError();
+  }
 
   if (window_handle_) {
     SetWindowLongPtr(window_handle_, GWLP_USERDATA,

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -139,7 +139,7 @@ void TaskRunnerWindow::SetTimer(std::chrono::nanoseconds when) {
     FILETIME ft;
     ft.dwLowDateTime = ticks.LowPart;
     ft.dwHighDateTime = ticks.HighPart;
-    SetThreadpoolTimer(timer_, &ft, 1, 0);
+    SetThreadpoolTimer(timer_, &ft, 0, 0);
   }
 }
 

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.cc
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.cc
@@ -45,7 +45,7 @@ TaskRunnerWindow::TaskRunnerWindow() {
   thread_id_ = GetCurrentThreadId();
 
   // Increase timer precision for this process (the call only affects
-  // current process since Windows 10, version 2004).n
+  // current process since Windows 10, version 2004).
   timeBeginPeriod(1);
 }
 

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.h
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.h
@@ -59,9 +59,17 @@ class TaskRunnerWindow {
                                   WPARAM const wparam,
                                   LPARAM const lparam) noexcept;
 
+  void OnTimer();
+
+  static void TimerProc(PTP_CALLBACK_INSTANCE Instance,
+                        PVOID Context,
+                        PTP_TIMER Timer);
+
   HWND window_handle_;
   std::wstring window_class_name_;
   std::vector<Delegate*> delegates_;
+  PTP_TIMER timer_;
+  DWORD thread_id_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TaskRunnerWindow);
 };

--- a/engine/src/flutter/shell/platform/windows/task_runner_window.h
+++ b/engine/src/flutter/shell/platform/windows/task_runner_window.h
@@ -68,8 +68,8 @@ class TaskRunnerWindow {
   HWND window_handle_;
   std::wstring window_class_name_;
   std::vector<Delegate*> delegates_;
-  PTP_TIMER timer_;
-  DWORD thread_id_;
+  PTP_TIMER timer_ = nullptr;
+  DWORD thread_id_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TaskRunnerWindow);
 };


### PR DESCRIPTION
Replaces `SetTimer`/`WM_TIMER` with a threadpool timer, which doesn't suffer from 16ms granularity and changes the waking up mechanism to give the run loop chance to process input messages before processing flutter tasks. 

- Fixes https://github.com/flutter/flutter/issues/173843
- Fixes https://github.com/flutter/flutter/issues/175135

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
