### PR TITLE
fix: path was url decoded but it should not for browser

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/window.dart
@@ -632,13 +632,11 @@ final class EngineFlutterWindow extends EngineFlutterView implements ui.Singleto
           if (uriString != null) {
             final Uri uri = Uri.parse(uriString);
             // Need to remove scheme and authority.
-            path = Uri.decodeComponent(
-              Uri(
-                path: uri.path.isEmpty ? '/' : uri.path,
-                queryParameters: uri.queryParametersAll.isEmpty ? null : uri.queryParametersAll,
-                fragment: uri.fragment.isEmpty ? null : uri.fragment,
-              ).toString(),
-            );
+            path = Uri(
+              path: uri.path.isEmpty ? '/' : uri.path,
+              queryParameters: uri.queryParametersAll.isEmpty ? null : uri.queryParametersAll,
+              fragment: uri.fragment.isEmpty ? null : uri.fragment,
+            ).toString();
           } else {
             path = arguments.tryString('location')!;
           }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Web engine on `routeInformationUpdated` navigation message was handling uri parameter wrongly by decoding url encoded path leading to browser setting incorrect url.

Fix Issue:
- https://github.com/flutter/flutter/issues/171757


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

