### PR TITLE
[CP-stable]Made the view controller weak for the accessibility bridge.

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -88,7 +88,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
                                         NSMutableArray<NSNumber*>* doomed_uids);
 
-  FlutterViewController* view_controller_;
+  __weak FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   __weak FlutterPlatformViewsController* platform_views_controller_;
   // If the this id is kSemanticObjectIdInvalid, it means either nothing has

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -2401,4 +2401,39 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(const std::string& name) {
   latch.Wait();
 }
 
+- (void)testWeakViewController {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/mock_delegate.settings_.enable_impeller
+          ? flutter::IOSRenderingAPI::kMetal
+          : flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/nil,
+      /*task_runners=*/runners,
+      /*worker_task_runner=*/nil,
+      /*is_gpu_disabled_sync_switch=*/std::make_shared<fml::SyncSwitch>());
+
+  std::unique_ptr<flutter::AccessibilityBridge> bridge;
+  @autoreleasepool {
+    id mockFlutterView = OCMClassMock([FlutterView class]);
+    id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+    OCMStub([mockFlutterViewController viewIfLoaded]).andReturn(mockFlutterView);
+    OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
+
+    bridge = std::make_unique<flutter::AccessibilityBridge>(
+        /*view_controller=*/mockFlutterViewController,
+        /*platform_view=*/platform_view.get(),
+        /*platform_views_controller=*/nil);
+    XCTAssertTrue(bridge.get());
+    XCTAssertNotNil(bridge->view());
+  }
+  XCTAssertNil(bridge->view());
+}
+
 @end


### PR DESCRIPTION
This pull request is a manual cherry pick of https://github.com/flutter/flutter/pull/172871 after I had trouble updating the automatic cherry pick pull request (https://github.com/flutter/flutter/pull/175595).

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/172105

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

Fixes issue in iOS add-to-app where Flutter view may hang after multiple transitions.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

App may hang after transitioning between multiple pages on iOS.

### Workaround:
Is there a workaround for this issue?

No

### Risk:
What is the risk level of this cherry-pick?

  - [x] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [x] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

Using https://github.com/flutter/samples/tree/main/add_to_app/fullscreen
* Launch a Flutter screen
* Dismiss or pop the Flutter screen to return to native
* Repeat the process several times (open Flutter, close, then open again)
* Flutter screen should not freeze
