### PR TITLE
[web] Remove mention of non-existent `canvaskit_lock.yaml`

### DIFF
--- a/engine/src/flutter/lib/web_ui/README.md
+++ b/engine/src/flutter/lib/web_ui/README.md
@@ -247,9 +247,6 @@ Resources:
 web. Versions are not automatically updated whenever a new release is available.
 Instead, we update this file manually once in a while.
 
-`canvaskit_lock.yaml` locks the version of CanvasKit for tests and production
-use.
-
 ### Debugging the Web Engine
 
 Build the Flutter Web engine locally:


### PR DESCRIPTION
`canvaskit_lock.yaml` has been removed in [2023](https://github.com/flutter/engine/pull/40293).