### PR TITLE
Roll GN to 81b24e01

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -645,7 +645,7 @@ deps = {
     'packages': [
       {
         'package': 'gn/gn/${{platform}}',
-        'version': 'git_revision:7a8aa3a08a13521336853a28c46537ec04338a2d'
+        'version': 'git_revision:81b24e01531ecf0eff12ec9359a555ec3944ec4e'
       },
     ],
     'dep_type': 'cipd',

--- a/engine/src/flutter/build/archives/BUILD.gn
+++ b/engine/src/flutter/build/archives/BUILD.gn
@@ -15,8 +15,8 @@ generated_file("artifacts_entitlement_config") {
     deps += [
       "//flutter/impeller/compiler:impellerc",
       "//flutter/impeller/tessellator:tessellator_shared",
-      "//flutter/shell/testing:testing",
-      "//flutter/tools/path_ops:path_ops",
+      "//flutter/shell/testing",
+      "//flutter/tools/path_ops",
     ]
   }
 }
@@ -50,8 +50,8 @@ if (build_engine_artifacts) {
       "//flutter/impeller/compiler:impellerc",
       "//flutter/impeller/tessellator:tessellator_shared",
       "//flutter/lib/snapshot:generate_snapshot_bin",
-      "//flutter/shell/testing:testing",
-      "//flutter/tools/path_ops:path_ops",
+      "//flutter/shell/testing",
+      "//flutter/tools/path_ops",
     ]
     if (is_mac) {
       # TODO(godofredoc): Remove after paths are standardized flutter/flutter#105351.

--- a/engine/src/flutter/common/graphics/BUILD.gn
+++ b/engine/src/flutter/common/graphics/BUILD.gn
@@ -24,7 +24,7 @@ source_set("graphics") {
     "//flutter/display_list",
     "//flutter/fml",
     "//flutter/shell/common:base64",
-    "//flutter/shell/version:version",
+    "//flutter/shell/version",
     "//flutter/skia",
     "//flutter/third_party/boringssl",
     "//flutter/third_party/rapidjson",

--- a/engine/src/flutter/display_list/testing/BUILD.gn
+++ b/engine/src/flutter/display_list/testing/BUILD.gn
@@ -21,7 +21,7 @@ source_set("display_list_testing") {
     "//flutter/txt",
   ]
 
-  public_deps = [ "//flutter/display_list:display_list" ]
+  public_deps = [ "//flutter/display_list" ]
 
   if (impeller_supports_rendering) {
     public_deps += [ "//flutter/impeller/display_list" ]

--- a/engine/src/flutter/examples/glfw/BUILD.gn
+++ b/engine/src/flutter/examples/glfw/BUILD.gn
@@ -13,7 +13,7 @@ if (build_embedder_examples) {
     ldflags = [ "-rdynamic" ]
 
     deps = [
-      "//flutter/shell/platform/embedder:embedder",
+      "//flutter/shell/platform/embedder",
       "//flutter/third_party/glfw",
     ]
   }

--- a/engine/src/flutter/examples/glfw_drm/BUILD.gn
+++ b/engine/src/flutter/examples/glfw_drm/BUILD.gn
@@ -13,7 +13,7 @@ if (build_embedder_examples) {
     ldflags = [ "-rdynamic" ]
 
     deps = [
-      "//flutter/shell/platform/embedder:embedder",
+      "//flutter/shell/platform/embedder",
       "//flutter/third_party/glfw",
     ]
 

--- a/engine/src/flutter/examples/vulkan_glfw/BUILD.gn
+++ b/engine/src/flutter/examples/vulkan_glfw/BUILD.gn
@@ -13,7 +13,7 @@ executable("vulkan_glfw") {
   ldflags = [ "-rdynamic" ]
 
   deps = [
-    "//flutter/shell/platform/embedder:embedder",
+    "//flutter/shell/platform/embedder",
     "//flutter/third_party/glfw",
     "//flutter/third_party/vulkan-deps/vulkan-headers/src:vulkan_headers",
   ]

--- a/engine/src/flutter/impeller/display_list/BUILD.gn
+++ b/engine/src/flutter/impeller/display_list/BUILD.gn
@@ -157,7 +157,7 @@ impeller_component("aiks_playground") {
     ":display_list",
     "../playground:playground_test",
     "//flutter/display_list",
-    "//flutter/impeller/display_list:display_list",
+    "//flutter/impeller/display_list",
   ]
   public_deps = [
     "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",

--- a/engine/src/flutter/impeller/golden_tests/BUILD.gn
+++ b/engine/src/flutter/impeller/golden_tests/BUILD.gn
@@ -15,7 +15,7 @@ impeller_component("golden_playground_test") {
     ":screenshot",
     "//flutter/display_list",
     "//flutter/fml",
-    "//flutter/impeller/display_list:display_list",
+    "//flutter/impeller/display_list",
     "//flutter/impeller/playground",
     "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
     "//flutter/testing:testing_lib",
@@ -70,7 +70,7 @@ if (is_mac) {
       "//flutter/fml",
       "//flutter/impeller/display_list",
       "//flutter/impeller/playground",
-      "//flutter/impeller/renderer/backend/metal:metal",
+      "//flutter/impeller/renderer/backend/metal",
       "//flutter/impeller/renderer/backend/vulkan",
     ]
   }

--- a/engine/src/flutter/impeller/renderer/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/BUILD.gn
@@ -124,7 +124,7 @@ template("renderer_unittests_component") {
       "../fixtures",
       "../playground:playground_test",
       "../tessellator:tessellator_libtess",
-      "//flutter/impeller/display_list:display_list",
+      "//flutter/impeller/display_list",
       "//flutter/testing:testing_lib",
     ]
     if (defined(invoker.public_configs)) {
@@ -159,8 +159,8 @@ impeller_component("renderer_dart_unittests") {
     "../playground:playground_test",
     "//flutter/lib/gpu",
     "//flutter/lib/snapshot",
-    "//flutter/runtime:runtime",
+    "//flutter/runtime",
+    "//flutter/testing",
     "//flutter/testing:fixture_test",
-    "//flutter/testing:testing",
   ]
 }

--- a/engine/src/flutter/impeller/tessellator/BUILD.gn
+++ b/engine/src/flutter/impeller/tessellator/BUILD.gn
@@ -53,7 +53,7 @@ impeller_component("tessellator_shared") {
     ":tessellator_libtess",
     "../core",
     "../geometry",
-    "//flutter/display_list:display_list",
+    "//flutter/display_list",
     "//flutter/fml",
     "//third_party/libtess2",
   ]

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -186,7 +186,7 @@ source_set("ui") {
     "//flutter/skia",
     "//flutter/third_party/rapidjson",
     "//flutter/third_party/tonic",
-    "//third_party/zlib:zlib",
+    "//third_party/zlib",
   ]
 
   if (impeller_supports_rendering) {

--- a/engine/src/flutter/shell/common/BUILD.gn
+++ b/engine/src/flutter/shell/common/BUILD.gn
@@ -65,7 +65,7 @@ template("dart_embedder_resources") {
 source_set("platform_message_handler") {
   sources = [ "platform_message_handler.h" ]
   public_configs = [ "//flutter:config" ]
-  deps = [ "//flutter/fml:fml" ]
+  deps = [ "//flutter/fml" ]
 }
 
 source_set("display") {
@@ -77,7 +77,7 @@ source_set("display") {
     "variable_refresh_rate_reporter.h",
   ]
   public_configs = [ "//flutter:config" ]
-  deps = [ "//flutter/fml:fml" ]
+  deps = [ "//flutter/fml" ]
 }
 
 source_set("common") {

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -29,7 +29,7 @@ source_set("image_generator") {
 
   deps = [
     "//flutter/fml",
-    "//flutter/lib/ui:ui",
+    "//flutter/lib/ui",
     "//flutter/skia",
   ]
 

--- a/engine/src/flutter/shell/platform/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/common/BUILD.gn
@@ -54,7 +54,7 @@ source_set("common_cpp_input") {
 
   public_configs = [ "//flutter:config" ]
 
-  deps = [ "//flutter/fml:fml" ]
+  deps = [ "//flutter/fml" ]
 }
 
 source_set("common_cpp_isolate_scope") {
@@ -63,7 +63,7 @@ source_set("common_cpp_isolate_scope") {
 
   deps = [
     "$dart_src/runtime:dart_api",
-    "//flutter/fml:fml",
+    "//flutter/fml",
   ]
 }
 
@@ -107,7 +107,7 @@ source_set("common_cpp_accessibility") {
       [ "//flutter/third_party/accessibility:accessibility_config" ]
 
   public_deps = [
-    "//flutter/fml:fml",
+    "//flutter/fml",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/third_party/accessibility",
   ]
@@ -134,7 +134,7 @@ source_set("common_cpp") {
 
   deps = [
     ":common_cpp_library_headers",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
 
@@ -159,8 +159,8 @@ source_set("common_cpp_core") {
   public_configs = [ "//flutter:config" ]
 
   deps = [
-    "//flutter/fml:fml",
-    "//flutter/shell/geometry:geometry",
+    "//flutter/fml",
+    "//flutter/shell/geometry",
   ]
 }
 
@@ -207,7 +207,7 @@ if (enable_unittests) {
       ":common_cpp_input",
       ":common_cpp_switches",
       "//flutter/fml:string_conversion",
-      "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+      "//flutter/shell/platform/common/client_wrapper",
       "//flutter/shell/platform/common/client_wrapper:client_wrapper_library_stubs",
       "//flutter/testing",
     ]

--- a/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/common/BUILD.gn
@@ -232,7 +232,7 @@ executable("framework_common_unittests") {
     ":framework_common_fixtures",
     "$dart_src/runtime:libdart_jit",
     "//flutter/testing",
-    "//flutter/third_party/ocmock:ocmock",
+    "//flutter/third_party/ocmock",
   ]
 
   public_configs = [ "//flutter:config" ]

--- a/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/ios/BUILD.gn
@@ -193,7 +193,7 @@ source_set("flutter_framework_source") {
 
   deps = [
     ":ios_gpu_configuration",
-    "//flutter/common:common",
+    "//flutter/common",
     "//flutter/common/graphics",
     "//flutter/fml",
     "//flutter/lib/ui",
@@ -204,7 +204,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
-    "//flutter/shell/profiling:profiling",
+    "//flutter/shell/profiling",
     "//flutter/third_party/icu",
     "//flutter/third_party/spring_animation",
   ]
@@ -289,8 +289,8 @@ if (enable_ios_unittests) {
       ":flutter_framework_source",
       ":ios_gpu_configuration",
       ":ios_test_flutter_swift",
-      "//flutter/common:common",
-      "//flutter/lib/ui:ui",
+      "//flutter/common",
+      "//flutter/lib/ui",
       "//flutter/shell/platform/darwin/common:framework_common",
       "//flutter/shell/platform/embedder:embedder_as_internal_library",
       "//flutter/shell/platform/embedder:embedder_test_utils",

--- a/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
+++ b/engine/src/flutter/shell/platform/darwin/macos/BUILD.gn
@@ -142,7 +142,7 @@ source_set("flutter_framework_source") {
 
   deps = [
     ":macos_gpu_configuration",
-    "//flutter/flow:flow",
+    "//flutter/flow",
     "//flutter/fml",
     "//flutter/shell/platform/common:common_cpp_accessibility",
     "//flutter/shell/platform/common:common_cpp_core",
@@ -152,7 +152,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_switches",
     "//flutter/shell/platform/darwin/common:availability_version_check",
     "//flutter/shell/platform/darwin/common:framework_common",
-    "//flutter/shell/platform/darwin/graphics:graphics",
+    "//flutter/shell/platform/darwin/graphics",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/skia",
   ]
@@ -263,7 +263,7 @@ executable("flutter_desktop_darwin_unittests") {
     "//flutter/testing:dart",
     "//flutter/testing:skia",
     "//flutter/testing:testing_lib",
-    "//flutter/third_party/ocmock:ocmock",
+    "//flutter/third_party/ocmock",
   ]
 }
 

--- a/engine/src/flutter/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -33,7 +33,7 @@ template("runner_sources") {
     if (!invoker.product) {
       dart_public_deps += [
         "$dart_src/runtime/bin:dart_io_api",
-        "//flutter/shell/platform/fuchsia/runtime/dart/utils:utils",
+        "//flutter/shell/platform/fuchsia/runtime/dart/utils",
       ]
     } else {
       dart_public_deps += [

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/BUILD.gn
@@ -124,7 +124,7 @@ template("runner_sources") {
       "//flutter/lib/ui",
       "//flutter/runtime",
       "//flutter/shell/common",
-      "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+      "//flutter/shell/platform/common/client_wrapper",
     ]
 
     flutter_deps = [
@@ -498,7 +498,7 @@ if (enable_unittests) {
     flutter_deps = [
       "$dart_src/runtime:libdart_jit",
       "$dart_src/runtime/platform:libdart_platform_jit",
-      "//flutter/assets:assets",
+      "//flutter/assets",
       "//flutter/common/graphics",
       "//flutter/flow",
       "//flutter/lib/ui",

--- a/engine/src/flutter/shell/platform/glfw/BUILD.gn
+++ b/engine/src/flutter/shell/platform/glfw/BUILD.gn
@@ -56,7 +56,7 @@ source_set("flutter_glfw") {
     ":flutter_glfw_headers",
     "//flutter/shell/platform/common:common_cpp",
     "//flutter/shell/platform/common:common_cpp_input",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw",
     "//flutter/third_party/glfw",

--- a/engine/src/flutter/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/engine/src/flutter/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -32,7 +32,7 @@ source_set("client_wrapper_glfw") {
 
   deps = [
     "//flutter/shell/platform/common:common_cpp_library_headers",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/glfw:flutter_glfw_headers",
   ]
 

--- a/engine/src/flutter/shell/platform/windows/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/BUILD.gn
@@ -163,14 +163,14 @@ source_set("flutter_windows_source") {
 
   deps = [
     ":flutter_windows_headers",
-    "//flutter/fml:fml",
+    "//flutter/fml",
     "//flutter/impeller/renderer/backend/gles",
-    "//flutter/shell/geometry:geometry",
+    "//flutter/shell/geometry",
     "//flutter/shell/platform/common:common_cpp",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_isolate_scope",
     "//flutter/shell/platform/common:common_cpp_switches",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows",
 
@@ -276,7 +276,7 @@ executable("flutter_windows_unittests") {
     ":flutter_windows_source",
     "//flutter/impeller/renderer/backend/gles",
     "//flutter/shell/platform/common:common_cpp",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/embedder:embedder_test_utils",
     "//flutter/testing",

--- a/engine/src/flutter/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/engine/src/flutter/shell/platform/windows/client_wrapper/BUILD.gn
@@ -36,7 +36,7 @@ source_set("client_wrapper_windows") {
 
   deps = [
     "//flutter/shell/platform/common:common_cpp_library_headers",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
     "//flutter/shell/platform/windows:flutter_windows_headers",
   ]
 
@@ -117,7 +117,7 @@ zip_bundle("client_wrapper_archive") {
   deps = [
     ":client_wrapper_windows",
     ":publish_wrapper_windows",
-    "//flutter/shell/platform/common/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/common/client_wrapper",
   ]
   tmp_files = []
   foreach(source_file, client_wrapper_file_archive_list) {

--- a/engine/src/flutter/skia/modules/canvaskit/BUILD.gn
+++ b/engine/src/flutter/skia/modules/canvaskit/BUILD.gn
@@ -43,12 +43,12 @@ canvaskit_wasm_lib("canvaskit") {
   deps = [ "../..:skia" ]
   if (skia_canvaskit_enable_paragraph) {
     deps += [
-      "../../modules/skparagraph:skparagraph",
-      "../../modules/skunicode:skunicode",
+      "../../modules/skparagraph",
+      "../../modules/skunicode",
     ]
   }
   if (skia_canvaskit_enable_bidi) {
-    deps += [ "../../modules/skunicode:skunicode" ]
+    deps += [ "../../modules/skunicode" ]
   }
 
   sources = [

--- a/engine/src/flutter/testing/BUILD.gn
+++ b/engine/src/flutter/testing/BUILD.gn
@@ -40,7 +40,7 @@ source_set("testing_lib") {
   public_deps = [
     "//flutter/display_list",
     "//flutter/fml",
-    "//flutter/impeller/typographer:typographer",
+    "//flutter/impeller/typographer",
     "//flutter/third_party/googletest:gmock",
     "//flutter/third_party/googletest:gtest",
   ]

--- a/engine/src/flutter/txt/BUILD.gn
+++ b/engine/src/flutter/txt/BUILD.gn
@@ -141,7 +141,7 @@ if (enable_unittests) {
       ":txt",
       ":txt_fixtures",
       "//flutter/fml",
-      "//flutter/skia/modules/skparagraph:skparagraph",
+      "//flutter/skia/modules/skparagraph",
       "//flutter/skia/modules/skparagraph:utils",
       "//flutter/testing:testing_lib",
       "//flutter/third_party/benchmark",
@@ -171,7 +171,7 @@ if (enable_unittests) {
       ":txt_fixtures",
       "//flutter/fml",
       "//flutter/runtime:test_font",
-      "//flutter/skia/modules/skparagraph:skparagraph",
+      "//flutter/skia/modules/skparagraph",
       "//flutter/testing:skia",
       "//flutter/testing:testing_lib",
     ]

--- a/engine/src/flutter/web_sdk/BUILD.gn
+++ b/engine/src/flutter/web_sdk/BUILD.gn
@@ -289,7 +289,6 @@ group("flutter_platform_dills") {
     ":flutter_dart2js_kernel_sdk_full",
     ":flutter_dart2wasm_kernel_sdk_full",
     ":flutter_dartdevc_kernel_sdk_outline",
-    ":flutter_dartdevc_kernel_sdk_outline",
   ]
 }
 


### PR DESCRIPTION
This version contains a change that adds support for the hpp11 file suffix (see https://gn.googlesource.com/gn/+/487f8353f15456474437df32bb186187b0940b45)

The change is needed when using current versions of the vulkan-deps SPIR-V headers.