### PR TITLE
[Impeller] Optimize scale translate rectangle transforms

### DIFF
--- a/engine/src/flutter/impeller/geometry/matrix.h
+++ b/engine/src/flutter/impeller/geometry/matrix.h
@@ -273,12 +273,12 @@ struct Matrix {
     } else {
       return Type::kGeneral;
     }
-  };
+  }
 
   /// Classify the |Type| of matrix for a 2D operation on coordinates of the
   /// form {x,y,0,1}. Matrix entries that only affect incoming or outgoing
   /// z values are ignored.
-  constexpr inline Type Classify2D() const {
+  constexpr Type Classify2D() const {
     if (m[3] == 0.0f && m[7] == 0.0f && m[15] == 1.0f) {
       if (m[1] == 0.0f && m[4] == 0.0f) {
         return Type::kScaleTranslate;
@@ -287,7 +287,7 @@ struct Matrix {
     } else {
       return Type::kGeneral;
     }
-  };
+  }
 
   /// The Matrix without its `w` components (without translation).
   constexpr Matrix Basis() const {

--- a/engine/src/flutter/impeller/geometry/matrix.h
+++ b/engine/src/flutter/impeller/geometry/matrix.h
@@ -35,6 +35,31 @@ namespace impeller {
 ///                 * This is NOT the same as OpenGL! Be careful.
 ///               * NDC origin is at (0.0f, 0.0f, 0.5f).
 struct Matrix {
+  /// The transform complexity type for the matrix, targeting the primary
+  /// optimizable operations that rectangle transforms can take advantage
+  /// of.
+  ///
+  /// The caller can query the type of the matrix for either 3D or 2D
+  /// operations with the 2D query only considering the entries that
+  /// are involved in transforming 2D coordinates.
+  ///
+  /// @see Classify
+  /// @see Classify2D
+  enum class Type {
+    /// The matrix contains only values that can scale and transform
+    /// coordinates. An Identity matrix also qualifies as kScaleTranslate.
+    kScaleTranslate,
+
+    /// The matrix contains only values that can perform affine operations
+    /// on the coordinates (no perspective).
+    kAffine,
+
+    /// The matrix contains perspective values that require the most general
+    /// type of transform computations. Any NaN values in the matrix will
+    /// also result in this classification.
+    kGeneral,
+  };
+
   union {
     Scalar m[16];
     Scalar e[4][4];
@@ -234,6 +259,35 @@ struct Matrix {
     );
     // clang-format on
   }
+
+  /// Classify the |Type| of matrix for a 3D operation on coordinates of the
+  /// form {x,y,z,1}.
+  constexpr Type Classify() const {
+    if (m[3] == 0.0f && m[7] == 0.0f && m[11] == 0.0f && m[15] == 1.0f) {
+      if (m[1] == 0.0f && m[2] == 0.0f &&  //
+          m[4] == 0.0f && m[6] == 0.0f &&  //
+          m[8] == 0.0f && m[9] == 0.0f) {
+        return Type::kScaleTranslate;
+      }
+      return Type::kAffine;
+    } else {
+      return Type::kGeneral;
+    }
+  };
+
+  /// Classify the |Type| of matrix for a 2D operation on coordinates of the
+  /// form {x,y,0,1}. Matrix entries that only affect incoming or outgoing
+  /// z values are ignored.
+  constexpr inline Type Classify2D() const {
+    if (m[3] == 0.0f && m[7] == 0.0f && m[15] == 1.0f) {
+      if (m[1] == 0.0f && m[4] == 0.0f) {
+        return Type::kScaleTranslate;
+      }
+      return Type::kAffine;
+    } else {
+      return Type::kGeneral;
+    }
+  };
 
   /// The Matrix without its `w` components (without translation).
   constexpr Matrix Basis() const {

--- a/engine/src/flutter/impeller/geometry/rect.h
+++ b/engine/src/flutter/impeller/geometry/rect.h
@@ -504,20 +504,20 @@ struct TRect {
       return {};
     }
 
-    Scalar tx = transform.m[12];
-    Scalar ty = transform.m[13];
-    Scalar sx = transform.m[0];
-    Scalar sy = transform.m[5];
+    Scalar translate_x = transform.m[12];
+    Scalar translate_y = transform.m[13];
+    Scalar scale_x = transform.m[0];
+    Scalar scale_y = transform.m[5];
 
-    Scalar l = GetLeft() * sx + tx;
-    Scalar r = GetRight() * sx + tx;
-    Scalar t = GetTop() * sy + ty;
-    Scalar b = GetBottom() * sy + ty;
+    Scalar x1 = translate_x + scale_x * GetLeft();
+    Scalar x2 = translate_x + scale_x * GetRight();
+    Scalar y1 = translate_y + scale_y * GetTop();
+    Scalar y2 = translate_y + scale_y * GetBottom();
 
-    return TRect<float>::MakeLTRB(std::min(l, r),  //
-                                  std::min(t, b),  //
-                                  std::max(l, r),  //
-                                  std::max(t, b)   //
+    return TRect::MakeLTRB(std::min(x1, x2),  //
+                           std::min(y1, y2),  //
+                           std::max(x1, x2),  //
+                           std::max(y1, y2)   //
     );
   }
 

--- a/engine/src/flutter/impeller/geometry/rect_unittests.cc
+++ b/engine/src/flutter/impeller/geometry/rect_unittests.cc
@@ -3243,5 +3243,25 @@ TEST(RectTest, TransformAndClipBounds) {
   }
 }
 
+TEST(RectTest, TransformBoundsTranslateScale) {
+  std::vector<Matrix> matrices = {
+      Matrix::MakeTranslateScale({2, 2, 1}, {10, 10, 0}),
+      Matrix::MakeTranslateScale({-2, 2, 1}, {10, 10, 0}),
+      Matrix::MakeTranslateScale({2, -2, 1}, {10, 10, 0}),
+      Matrix::MakeTranslateScale({-2, -2, 1}, {10, 10, 0}),
+  };
+  std::vector<Rect> rects = {
+      Rect::MakeLTRB(0, 0, 10, 10), Rect::MakeLTRB(100, 100, 110, 110),
+      Rect::MakeLTRB(0, 0, 0, 0), Rect::MakeLTRB(-10, -10, 10, 10)};
+
+  for (auto i = 0u; i < matrices.size(); i++) {
+    for (auto j = 0u; j < rects.size(); j++) {
+      EXPECT_EQ(rects[j].TransformBounds(matrices[i]),
+                rects[j].TransformBoundsTranslateScale2D(matrices[i]))
+          << rects[j] << " * " << matrices[i];
+    }
+  }
+}
+
 }  // namespace testing
 }  // namespace impeller


### PR DESCRIPTION
Taken partially from https://github.com/flutter/flutter/pull/170446 with only the changes to add a ScaleTranslate rectangle transform method brought over. Unlike the original PR, this PR will apply that optimized method for any caller who transforms a rectangle rather than just the matrix/clip tracker for the engine layer tree code.

A benchmark for the new methods is also provided to verify their improved performance.