### PR TITLE
feat: apply radioGroup role to segmented control widgets

### DIFF
--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -190,12 +190,87 @@ class CupertinoSegmentedControl<T extends Object> extends StatefulWidget {
   State<CupertinoSegmentedControl<T>> createState() => _SegmentedControlState<T>();
 }
 
+/// A wrapper widget that implements RadioClient for each segment button.
+class _SegmentButton<T> extends StatefulWidget {
+  const _SegmentButton({
+    super.key,
+    required this.value,
+    required this.child,
+    required this.enabled,
+  });
+
+  final T value;
+  final Widget child;
+  final bool enabled;
+
+  @override
+  State<_SegmentButton<T>> createState() => _SegmentButtonState<T>();
+}
+
+class _SegmentButtonState<T> extends State<_SegmentButton<T>> with RadioClient<T> {
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(debugLabel: 'CupertinoSegmentedControl<$T>[${widget.value}]');
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    registry = widget.enabled ? RadioGroup.maybeOf<T>(context) : null;
+  }
+
+  @override
+  void didUpdateWidget(_SegmentButton<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.enabled != widget.enabled) {
+      registry = widget.enabled ? RadioGroup.maybeOf<T>(context) : null;
+    }
+  }
+
+  @override
+  void dispose() {
+    registry = null;
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  T get radioValue => widget.value;
+
+  @override
+  FocusNode get focusNode => _focusNode;
+
+  @override
+  bool get tristate => false;
+
+  void requestFocus() {
+    if (widget.enabled) {
+      _focusNode.requestFocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      canRequestFocus: widget.enabled,
+      onKeyEvent: (FocusNode node, KeyEvent event) => KeyEventResult.ignored,
+      child: widget.child,
+    );
+  }
+}
+
 class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedControl<T>>
     with TickerProviderStateMixin<CupertinoSegmentedControl<T>> {
   T? _pressedKey;
 
   final List<AnimationController> _selectionControllers = <AnimationController>[];
   final List<ColorTween> _childTweens = <ColorTween>[];
+  final Map<T, GlobalKey<_SegmentButtonState<T>>> _segmentKeys =
+      <T, GlobalKey<_SegmentButtonState<T>>>{};
 
   late ColorTween _forwardBackgroundColorTween;
   late ColorTween _reverseBackgroundColorTween;
@@ -341,11 +416,15 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
       return;
     }
     if (!widget.disabledChildren.contains(currentKey)) {
+      _segmentKeys[currentKey]?.currentState?.requestFocus();
+
       if (currentKey != widget.groupValue) {
         widget.onValueChanged(currentKey);
       }
     }
-    _pressedKey = null;
+    setState(() {
+      _pressedKey = null;
+    });
   }
 
   Color? getTextColor(int index, T currentKey) {
@@ -395,28 +474,43 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
 
       Widget child = Center(child: widget.children[currentKey]);
 
-      child = MouseRegion(
-        cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          onTapDown: widget.disabledChildren.contains(currentKey)
-              ? null
-              : (TapDownDetails event) {
-                  _onTapDown(currentKey);
-                },
-          onTapCancel: widget.disabledChildren.contains(currentKey) ? null : _onTapCancel,
-          onTap: () {
-            _onTap(currentKey);
-          },
-          child: IconTheme(
-            data: iconTheme,
-            child: DefaultTextStyle(
-              style: textStyle,
-              child: Semantics(
-                button: true,
-                inMutuallyExclusiveGroup: true,
-                selected: widget.groupValue == currentKey,
-                child: child,
+      final bool isEnabled = !widget.disabledChildren.contains(currentKey);
+
+      final GlobalKey<_SegmentButtonState<T>> segmentKey = _segmentKeys.putIfAbsent(
+        currentKey,
+        () => GlobalKey<_SegmentButtonState<T>>(),
+      );
+
+      child = _SegmentButton<T>(
+        key: segmentKey,
+        value: currentKey,
+        enabled: isEnabled,
+        child: MouseRegion(
+          cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTapDown: isEnabled
+                ? (TapDownDetails event) {
+                    _onTapDown(currentKey);
+                  }
+                : null,
+            onTapCancel: isEnabled ? _onTapCancel : null,
+            onTap: () {
+              if (isEnabled) {
+                _segmentKeys[currentKey]?.currentState?.requestFocus();
+              }
+              _onTap(currentKey);
+            },
+            child: IconTheme(
+              data: iconTheme,
+              child: DefaultTextStyle(
+                style: textStyle,
+                child: Semantics(
+                  button: true,
+                  inMutuallyExclusiveGroup: true,
+                  selected: widget.groupValue == currentKey,
+                  child: child,
+                ),
               ),
             ),
           ),
@@ -436,12 +530,19 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
       children: gestureChildren,
     );
 
-    return Semantics(
-      container: true,
-      role: SemanticsRole.radioGroup,
-      child: Padding(
-        padding: widget.padding ?? _kHorizontalItemPadding,
-        child: UnconstrainedBox(constrainedAxis: Axis.horizontal, child: box),
+    return Actions(
+      actions: <Type, Action<Intent>>{VoidCallbackIntent: VoidCallbackAction()},
+      child: RadioGroup<T>(
+        groupValue: widget.groupValue,
+        onChanged: (T? value) {
+          if (value != null && !widget.disabledChildren.contains(value)) {
+            widget.onValueChanged(value);
+          }
+        },
+        child: Padding(
+          padding: widget.padding ?? _kHorizontalItemPadding,
+          child: UnconstrainedBox(constrainedAxis: Axis.horizontal, child: box),
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -436,9 +436,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
       children: gestureChildren,
     );
 
-    return Padding(
-      padding: widget.padding ?? _kHorizontalItemPadding,
-      child: UnconstrainedBox(constrainedAxis: Axis.horizontal, child: box),
+    return Semantics(
+      container: true,
+      role: SemanticsRole.radioGroup,
+      child: Padding(
+        padding: widget.padding ?? _kHorizontalItemPadding,
+        child: UnconstrainedBox(constrainedAxis: Axis.horizontal, child: box),
+      ),
     );
   }
 }

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -838,30 +838,34 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         }
     }
 
-    return UnconstrainedBox(
-      constrainedAxis: Axis.horizontal,
-      child: Container(
-        // Clip the thumb shadow if it is outside of the segmented control. This
-        // behavior is eyeballed by the iOS 17.5 simulator.
-        clipBehavior: Clip.antiAlias,
-        padding: widget.padding.resolve(Directionality.of(context)),
-        decoration: ShapeDecoration(
-          shape: const RoundedSuperellipseBorder(borderRadius: BorderRadius.all(_kCornerRadius)),
-          color: CupertinoDynamicColor.resolve(widget.backgroundColor, context),
-        ),
-        child: AnimatedBuilder(
-          animation: thumbScaleAnimation,
-          builder: (BuildContext context, Widget? child) {
-            return _SegmentedControlRenderWidget<T>(
-              key: segmentedControlRenderWidgetKey,
-              highlightedIndex: widget.isMomentary ? null : highlightedIndex,
-              thumbColor: CupertinoDynamicColor.resolve(widget.thumbColor, context),
-              thumbScale: thumbScaleAnimation.value,
-              proportionalWidth: widget.proportionalWidth,
-              state: this,
-              children: children,
-            );
-          },
+    return Semantics(
+      container: true,
+      role: SemanticsRole.radioGroup,
+      child: UnconstrainedBox(
+        constrainedAxis: Axis.horizontal,
+        child: Container(
+          // Clip the thumb shadow if it is outside of the segmented control. This
+          // behavior is eyeballed by the iOS 17.5 simulator.
+          clipBehavior: Clip.antiAlias,
+          padding: widget.padding.resolve(Directionality.of(context)),
+          decoration: ShapeDecoration(
+            shape: const RoundedSuperellipseBorder(borderRadius: BorderRadius.all(_kCornerRadius)),
+            color: CupertinoDynamicColor.resolve(widget.backgroundColor, context),
+          ),
+          child: AnimatedBuilder(
+            animation: thumbScaleAnimation,
+            builder: (BuildContext context, Widget? child) {
+              return _SegmentedControlRenderWidget<T>(
+                key: segmentedControlRenderWidgetKey,
+                highlightedIndex: widget.isMomentary ? null : highlightedIndex,
+                thumbColor: CupertinoDynamicColor.resolve(widget.thumbColor, context),
+                thumbScale: thumbScaleAnimation.value,
+                proportionalWidth: widget.proportionalWidth,
+                state: this,
+                children: children,
+              );
+            },
+          ),
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -513,6 +513,79 @@ class CupertinoSlidingSegmentedControl<T extends Object> extends StatefulWidget 
   State<CupertinoSlidingSegmentedControl<T>> createState() => _SegmentedControlState<T>();
 }
 
+/// A wrapper widget that implements RadioClient for each segment button in sliding segmented control.
+class _SlidingSegmentButton<T> extends StatefulWidget {
+  const _SlidingSegmentButton({
+    super.key,
+    required this.value,
+    required this.child,
+    required this.enabled,
+  });
+
+  final T value;
+  final Widget child;
+  final bool enabled;
+
+  @override
+  State<_SlidingSegmentButton<T>> createState() => _SlidingSegmentButtonState<T>();
+}
+
+class _SlidingSegmentButtonState<T> extends State<_SlidingSegmentButton<T>> with RadioClient<T> {
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(debugLabel: 'CupertinoSlidingSegmentedControl<$T>[${widget.value}]');
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    registry = widget.enabled ? RadioGroup.maybeOf<T>(context) : null;
+  }
+
+  @override
+  void didUpdateWidget(_SlidingSegmentButton<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.enabled != widget.enabled) {
+      registry = widget.enabled ? RadioGroup.maybeOf<T>(context) : null;
+    }
+  }
+
+  @override
+  void dispose() {
+    registry = null;
+    _focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  T get radioValue => widget.value;
+
+  @override
+  FocusNode get focusNode => _focusNode;
+
+  @override
+  bool get tristate => false;
+
+  void requestFocus() {
+    if (widget.enabled) {
+      _focusNode.requestFocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Focus(
+      focusNode: _focusNode,
+      canRequestFocus: widget.enabled,
+      onKeyEvent: (FocusNode node, KeyEvent event) => KeyEventResult.ignored,
+      child: widget.child,
+    );
+  }
+}
+
 class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSegmentedControl<T>>
     with TickerProviderStateMixin<CupertinoSlidingSegmentedControl<T>> {
   late final AnimationController thumbController = AnimationController(
@@ -535,6 +608,8 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
   final HorizontalDragGestureRecognizer drag = HorizontalDragGestureRecognizer();
   final LongPressGestureRecognizer longPress = LongPressGestureRecognizer();
   final GlobalKey segmentedControlRenderWidgetKey = GlobalKey();
+  final Map<T, GlobalKey<_SlidingSegmentButtonState<T>>> _segmentKeys =
+      <T, GlobalKey<_SlidingSegmentButtonState<T>>>{};
 
   @override
   void initState() {
@@ -682,8 +757,13 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
 
     final T segment = segmentForXPosition(details.localPosition.dx);
     onPressedChangedByGesture(null);
-    if (segment != widget.groupValue && !widget.disabledChildren.contains(segment)) {
-      widget.onValueChanged(segment);
+
+    if (!widget.disabledChildren.contains(segment)) {
+      _segmentKeys[segment]?.currentState?.requestFocus();
+
+      if (segment != widget.groupValue) {
+        widget.onValueChanged(segment);
+      }
     }
   }
 
@@ -729,12 +809,14 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
     if (isThumbDragging) {
       _playThumbScaleAnimation(isExpanding: true);
       if (highlighted != widget.groupValue) {
+        _segmentKeys[highlighted]?.currentState?.requestFocus();
         widget.onValueChanged(highlighted);
       }
     } else if (pressed != null) {
       onHighlightChangedByGesture(pressed);
       assert(pressed == highlighted);
       if (highlighted != widget.groupValue) {
+        _segmentKeys[highlighted]?.currentState?.requestFocus();
         widget.onValueChanged(highlighted);
       }
     }
@@ -795,28 +877,39 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         TextDirection.rtl when index == 0 => _SegmentLocation.rightmost,
         TextDirection.ltr || TextDirection.rtl => _SegmentLocation.inbetween,
       };
+      final GlobalKey<_SlidingSegmentButtonState<T>> segmentKey = _segmentKeys.putIfAbsent(
+        entry.key,
+        () => GlobalKey<_SlidingSegmentButtonState<T>>(),
+      );
+
       children.add(
-        Semantics(
-          button: true,
-          onTap: () {
-            if (widget.disabledChildren.contains(entry.key)) {
-              return;
-            }
-            widget.onValueChanged(entry.key);
-          },
-          inMutuallyExclusiveGroup: true,
-          selected: widget.groupValue == entry.key,
-          child: MouseRegion(
-            cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
-            child: _Segment<T>(
-              key: ValueKey<T>(entry.key),
-              highlighted: isHighlighted,
-              pressed: pressed == entry.key,
-              isDragging: isThumbDragging,
-              enabled: !widget.disabledChildren.contains(entry.key),
-              segmentLocation: segmentLocation,
-              isMomentary: widget.isMomentary,
-              child: entry.value,
+        _SlidingSegmentButton<T>(
+          key: segmentKey,
+          value: entry.key,
+          enabled: !widget.disabledChildren.contains(entry.key),
+          child: Semantics(
+            button: true,
+            onTap: () {
+              if (widget.disabledChildren.contains(entry.key)) {
+                return;
+              }
+              _segmentKeys[entry.key]?.currentState?.requestFocus();
+              widget.onValueChanged(entry.key);
+            },
+            inMutuallyExclusiveGroup: true,
+            selected: widget.groupValue == entry.key,
+            child: MouseRegion(
+              cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+              child: _Segment<T>(
+                key: ValueKey<T>(entry.key),
+                highlighted: isHighlighted,
+                pressed: pressed == entry.key,
+                isDragging: isThumbDragging,
+                enabled: !widget.disabledChildren.contains(entry.key),
+                segmentLocation: segmentLocation,
+                isMomentary: widget.isMomentary,
+                child: entry.value,
+              ),
             ),
           ),
         ),
@@ -838,33 +931,42 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSlidingSeg
         }
     }
 
-    return Semantics(
-      container: true,
-      role: SemanticsRole.radioGroup,
-      child: UnconstrainedBox(
-        constrainedAxis: Axis.horizontal,
-        child: Container(
-          // Clip the thumb shadow if it is outside of the segmented control. This
-          // behavior is eyeballed by the iOS 17.5 simulator.
-          clipBehavior: Clip.antiAlias,
-          padding: widget.padding.resolve(Directionality.of(context)),
-          decoration: ShapeDecoration(
-            shape: const RoundedSuperellipseBorder(borderRadius: BorderRadius.all(_kCornerRadius)),
-            color: CupertinoDynamicColor.resolve(widget.backgroundColor, context),
-          ),
-          child: AnimatedBuilder(
-            animation: thumbScaleAnimation,
-            builder: (BuildContext context, Widget? child) {
-              return _SegmentedControlRenderWidget<T>(
-                key: segmentedControlRenderWidgetKey,
-                highlightedIndex: widget.isMomentary ? null : highlightedIndex,
-                thumbColor: CupertinoDynamicColor.resolve(widget.thumbColor, context),
-                thumbScale: thumbScaleAnimation.value,
-                proportionalWidth: widget.proportionalWidth,
-                state: this,
-                children: children,
-              );
-            },
+    return Actions(
+      actions: <Type, Action<Intent>>{VoidCallbackIntent: VoidCallbackAction()},
+      child: RadioGroup<T>(
+        groupValue: widget.groupValue,
+        onChanged: (T? value) {
+          if (value != null && !widget.disabledChildren.contains(value)) {
+            widget.onValueChanged(value);
+          }
+        },
+        child: UnconstrainedBox(
+          constrainedAxis: Axis.horizontal,
+          child: Container(
+            // Clip the thumb shadow if it is outside of the segmented control. This
+            // behavior is eyeballed by the iOS 17.5 simulator.
+            clipBehavior: Clip.antiAlias,
+            padding: widget.padding.resolve(Directionality.of(context)),
+            decoration: ShapeDecoration(
+              shape: const RoundedSuperellipseBorder(
+                borderRadius: BorderRadius.all(_kCornerRadius),
+              ),
+              color: CupertinoDynamicColor.resolve(widget.backgroundColor, context),
+            ),
+            child: AnimatedBuilder(
+              animation: thumbScaleAnimation,
+              builder: (BuildContext context, Widget? child) {
+                return _SegmentedControlRenderWidget<T>(
+                  key: segmentedControlRenderWidgetKey,
+                  highlightedIndex: widget.isMomentary ? null : highlightedIndex,
+                  thumbColor: CupertinoDynamicColor.resolve(widget.thumbColor, context),
+                  thumbScale: thumbScaleAnimation.value,
+                  proportionalWidth: widget.proportionalWidth,
+                  state: this,
+                  children: children,
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -844,24 +844,29 @@ void main() {
         TestSemantics.root(
           children: <TestSemantics>[
             TestSemantics.rootChild(
-              label: 'Child 1',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                SemanticsFlag.hasSelectedState,
-                SemanticsFlag.isSelected,
+              role: SemanticsRole.radioGroup,
+              children: <TestSemantics>[
+                TestSemantics(
+                  label: 'Child 1',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    SemanticsFlag.hasSelectedState,
+                    SemanticsFlag.isSelected,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
+                TestSemantics(
+                  label: 'Child 2',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    // Declares that it is selectable, but not currently selected.
+                    SemanticsFlag.hasSelectedState,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
               ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
-            ),
-            TestSemantics.rootChild(
-              label: 'Child 2',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                // Declares that it is selectable, but not currently selected.
-                SemanticsFlag.hasSelectedState,
-              ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
             ),
           ],
         ),
@@ -880,24 +885,29 @@ void main() {
         TestSemantics.root(
           children: <TestSemantics>[
             TestSemantics.rootChild(
-              label: 'Child 1',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                // Declares that it is selectable, but not currently selected.
-                SemanticsFlag.hasSelectedState,
+              role: SemanticsRole.radioGroup,
+              children: <TestSemantics>[
+                TestSemantics(
+                  label: 'Child 1',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    // Declares that it is selectable, but not currently selected.
+                    SemanticsFlag.hasSelectedState,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
+                TestSemantics(
+                  label: 'Child 2',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    SemanticsFlag.hasSelectedState,
+                    SemanticsFlag.isSelected,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
               ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
-            ),
-            TestSemantics.rootChild(
-              label: 'Child 2',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                SemanticsFlag.hasSelectedState,
-                SemanticsFlag.isSelected,
-              ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
             ),
           ],
         ),

--- a/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/sliding_segmented_control_test.dart
@@ -971,24 +971,29 @@ void main() {
         TestSemantics.root(
           children: <TestSemantics>[
             TestSemantics.rootChild(
-              label: 'Child 1',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                SemanticsFlag.hasSelectedState,
-                SemanticsFlag.isSelected,
+              role: SemanticsRole.radioGroup,
+              children: <TestSemantics>[
+                TestSemantics(
+                  label: 'Child 1',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    SemanticsFlag.hasSelectedState,
+                    SemanticsFlag.isSelected,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
+                TestSemantics(
+                  label: 'Child 2',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    // Declares that it is selectable, but not currently selected.
+                    SemanticsFlag.hasSelectedState,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
               ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
-            ),
-            TestSemantics.rootChild(
-              label: 'Child 2',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                // Declares that it is selectable, but not currently selected.
-                SemanticsFlag.hasSelectedState,
-              ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
             ),
           ],
         ),
@@ -1007,24 +1012,29 @@ void main() {
         TestSemantics.root(
           children: <TestSemantics>[
             TestSemantics.rootChild(
-              label: 'Child 1',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                // Declares that it is selectable, but not currently selected.
-                SemanticsFlag.hasSelectedState,
+              role: SemanticsRole.radioGroup,
+              children: <TestSemantics>[
+                TestSemantics(
+                  label: 'Child 1',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    // Declares that it is selectable, but not currently selected.
+                    SemanticsFlag.hasSelectedState,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
+                TestSemantics(
+                  label: 'Child 2',
+                  flags: <SemanticsFlag>[
+                    SemanticsFlag.isButton,
+                    SemanticsFlag.isInMutuallyExclusiveGroup,
+                    SemanticsFlag.hasSelectedState,
+                    SemanticsFlag.isSelected,
+                  ],
+                  actions: <SemanticsAction>[SemanticsAction.tap],
+                ),
               ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
-            ),
-            TestSemantics.rootChild(
-              label: 'Child 2',
-              flags: <SemanticsFlag>[
-                SemanticsFlag.isButton,
-                SemanticsFlag.isInMutuallyExclusiveGroup,
-                SemanticsFlag.hasSelectedState,
-                SemanticsFlag.isSelected,
-              ],
-              actions: <SemanticsAction>[SemanticsAction.tap],
             ),
           ],
         ),


### PR DESCRIPTION
feat: apply radioGroup role to segmented control widgets
fixes: #164589

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.