### PR TITLE
Fix name of driver file

### DIFF
--- a/dev/integration_tests/windowing_test/README.md
+++ b/dev/integration_tests/windowing_test/README.md
@@ -6,5 +6,5 @@ Integration tests for windowing.
 From this directory, run:
 
 ```sh
-flutter drive -t .\lib\main.dart --driver .\test_driver\windowing_test.dart
+flutter drive -t .\lib\main.dart --driver .\test_driver\main_test.dart
 ```


### PR DESCRIPTION
It referred to a file that did not exist.