### PR TITLE
[web] Fix canvas rendering artifacts in animations when 'createImageBitmap' is not supported

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/render_canvas.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/compositing/render_canvas.dart
@@ -81,6 +81,7 @@ class RenderCanvas extends DisplayCanvas {
     BitmapSize size,
   ) {
     _ensureSize(size);
+    renderContext2d.clearRect(0, 0, size.width, size.height);
     renderContext2d.drawImage(
       imageSource,
       0,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

This PR fixes canvas rendering artifacts that occur during modal bottom sheet animations on browsers that don't support the `createImageBitmap` API. While this issue was discovered through non-standard usage of `showModalBottomSheet`, it represents a fundamental rendering inconsistency that could affect other animation scenarios.

When `browserSupportsCreateImageBitmap` returns `false`, Flutter Web falls back to using `CanvasRenderingContext2D.drawImage()` instead of `transferFromImageBitmap()`. However, the fallback implementation in `renderWithNoBitmapSupport()` doesn't clear the canvas before drawing, causing visual artifacts during modal bottom sheet exit animations.

Added `clearRect()` call before `drawImage()` in `renderWithNoBitmapSupport()` to ensure the canvas is properly cleared on each frame. This change has been locally verified to resolve the rendering artifacts.

fixes https://github.com/flutter/flutter/issues/176174

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
