### PR TITLE
[ Widget Preview ] Forward Widget Inspector navigation events via DTD

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -448,6 +448,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
             widgetPreviewScaffoldProject.packageConfig.readAsBytesSync(),
             widgetPreviewScaffoldProject.packageConfig.uri,
           ),
+          trackWidgetCreation: true,
           // Don't try and download canvaskit from the CDN.
           useLocalCanvasKit: true,
           webEnableHotReload: true,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1468,11 +1468,11 @@ abstract class ResidentRunner extends ResidentHandlers {
         /// of the default URI encoding.
         String urlToDisplayString(Uri uri) {
           final base = StringBuffer(uri.withoutQueryParameters().toString());
-          base.write(
-            uri.queryParameters.keys
-                .map((String key) => '$key=${uri.queryParameters[key]}')
-                .join('&'),
-          );
+          if (uri.hasQuery) {
+            base.write(
+              '?${uri.queryParameters.keys.map((String key) => '$key=${uri.queryParameters[key]}').join('&')}',
+            );
+          }
           return base.toString();
         }
 

--- a/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
@@ -101,9 +101,9 @@ class _PreviewVisitor extends RecursiveAstVisitor<void> {
       return;
     }
     final LineInfo lineInfo = _currentUnit.lineInfo;
-    final location = lineInfo.getLocation(node.offset);
-    final line = location.lineNumber;
-    final column = location.columnNumber;
+    final CharacterLocation location = lineInfo.getLocation(node.offset);
+    final int line = location.lineNumber;
+    final int column = location.columnNumber;
     if (_currentFunction != null &&
         !hasRequiredParams(_currentFunction!.functionExpression.parameters)) {
       final TypeAnnotation? returnTypeAnnotation = _currentFunction!.returnType;

--- a/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_code_generator.dart
@@ -32,7 +32,9 @@ class PreviewCodeGenerator {
   static const _kBuildMultiWidgetPreview = 'buildMultiWidgetPreview';
   static const _kBuildWidgetPreview = 'buildWidgetPreview';
   static const _kBuildWidgetPreviewError = 'buildWidgetPreviewError';
+  static const _kColumn = 'column';
   static const _kDependencyHasErrors = 'dependencyHasErrors';
+  static const _kLine = 'line';
   static const _kListType = 'List';
   static const _kPackageName = 'packageName';
   static const _kPackageUri = 'packageUri';
@@ -164,6 +166,8 @@ class PreviewCodeGenerator {
     final args = <String, cb.Expression>{
       _kPackageName: cb.literalString(preview.packageName!),
       _kScriptUri: cb.literalString(preview.scriptUri.toString()),
+      _kLine: cb.literalNum(preview.line),
+      _kColumn: cb.literalNum(preview.column),
     };
     // TODO(bkonyi): improve the error related code.
     if (libraryDetails.hasErrors || libraryDetails.dependencyHasErrors) {

--- a/packages/flutter_tools/lib/src/widget_preview/preview_details.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_details.dart
@@ -22,10 +22,10 @@ final class PreviewDetails {
   /// The file:// URI pointing to the script in which the preview is defined.
   final Uri scriptUri;
 
-  /// The line at which the Preview annotation was applied.
+  /// The 1-based line at which the Preview annotation was applied.
   final int line;
 
-  /// The column at which the Preview annotation was applied.
+  /// The 1-based column at which the Preview annotation was applied.
   final int column;
 
   /// The name of the package in which the preview was defined.

--- a/packages/flutter_tools/lib/src/widget_preview/preview_details.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_details.dart
@@ -10,6 +10,8 @@ typedef PreviewProperty = ({String key, DartObject object, bool isCallback});
 final class PreviewDetails {
   PreviewDetails({
     required this.scriptUri,
+    required this.line,
+    required this.column,
     required this.packageName,
     required this.functionName,
     required this.isBuilder,
@@ -19,6 +21,12 @@ final class PreviewDetails {
 
   /// The file:// URI pointing to the script in which the preview is defined.
   final Uri scriptUri;
+
+  /// The line at which the Preview annotation was applied.
+  final int line;
+
+  /// The column at which the Preview annotation was applied.
+  final int column;
 
   /// The name of the package in which the preview was defined.
   ///

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/utils.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/utils.dart.tmpl
@@ -9,6 +9,8 @@ import 'package:widget_preview_scaffold/src/widget_preview.dart';
 Iterable<WidgetPreview> buildMultiWidgetPreview({
   required String packageName,
   required String scriptUri,
+  required int line,
+  required int column,
   required MultiPreview preview,
   required Object? Function() previewFunction,
 }) {
@@ -16,6 +18,8 @@ Iterable<WidgetPreview> buildMultiWidgetPreview({
     (p) => buildWidgetPreview(
       packageName: packageName,
       scriptUri: scriptUri,
+      line: line,
+      column: column,
       transformedPreview: p,
       previewFunction: previewFunction,
     ),
@@ -25,6 +29,8 @@ Iterable<WidgetPreview> buildMultiWidgetPreview({
 WidgetPreview buildWidgetPreview({
   required String packageName,
   required String scriptUri,
+  required int line,
+  required int column,
   required Preview transformedPreview,
   required Object? Function() previewFunction,
 }) {
@@ -39,6 +45,8 @@ WidgetPreview buildWidgetPreview({
   return WidgetPreview(
     builder: previewBuilder,
     scriptUri: scriptUri,
+    line: line,
+    column: column,
     previewData: transformedPreview,
     packageName: packageName,
   );
@@ -47,6 +55,8 @@ WidgetPreview buildWidgetPreview({
 WidgetPreview buildWidgetPreviewError({
   required String packageName,
   required String scriptUri,
+  required int line,
+  required int column,
   required String packageUri,
   required String functionName,
   required bool dependencyHasErrors,
@@ -58,6 +68,8 @@ WidgetPreview buildWidgetPreviewError({
   return WidgetPreview(
     builder: () => Text('$functionName: $errorMessage'),
     scriptUri: scriptUri,
+    line: line,
+    column: column,
     previewData: const Preview(group: 'Invalid Previews'),
     packageName: packageName,
   );

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview.dart.tmpl
@@ -31,14 +31,32 @@ class WidgetPreview {
   const WidgetPreview({
     required this.builder,
     required this.scriptUri,
+    required this.line,
+    required this.column,
     required this.previewData,
     required this.packageName,
+  });
+
+  @visibleForTesting
+  const WidgetPreview.test({
+    required this.builder,
+    required this.previewData,
+    this.scriptUri = '',
+    this.line = -1,
+    this.column = -1,
+    this.packageName = '',
   });
 
   /// The absolute file:// URI pointing to the script containing this preview.
   ///
   /// This matches the URI format sent by IDEs for active location change events.
   final String scriptUri;
+
+  /// The line at which the Preview annotation was applied.
+  final int line;
+
+  /// The column at which the Preview annotation was applied.
+  final int column;
 
   /// The name of the package in which a preview was defined.
   ///
@@ -104,6 +122,7 @@ class WidgetPreview {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties
       ..add(DiagnosticsProperty<String>('name', name, ifNull: 'not set'))
+      ..add(DiagnosticsProperty<String>('group', previewData.group))
       ..add(DiagnosticsProperty<Size>('size', size))
       ..add(DiagnosticsProperty<double>('textScaleFactor', textScaleFactor))
       ..add(DiagnosticsProperty<PreviewThemeData>('theme', theme))

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_rendering.dart.tmpl
@@ -178,11 +178,15 @@ class NoPreviewsDetectedWidget extends StatelessWidget {
   }
 }
 
+/// A wrapper that serves as the root entry for a single preview in the widget inspector.
 class PreviewWidget extends StatelessWidget {
   const PreviewWidget({super.key, required this.preview, required this.child});
 
   final WidgetPreview preview;
   final Widget child;
+
+  @override
+  StatelessElement createElement() => PreviewWidgetElement(this);
 
   @override
   Widget build(BuildContext context) {
@@ -191,7 +195,9 @@ class PreviewWidget extends StatelessWidget {
 
   @override
   String toStringShort() {
-    final StringBuffer buffer = StringBuffer('@Preview');
+    final StringBuffer buffer = StringBuffer(
+      '@${preview.previewData.runtimeType}',
+    );
     if (preview.name != null) {
       buffer.write('(name: "${preview.name}")');
     }
@@ -203,6 +209,12 @@ class PreviewWidget extends StatelessWidget {
     super.debugFillProperties(properties);
     preview.debugFillProperties(properties);
   }
+}
+
+/// A custom [StatelessElement] with the sole purpose of simplifying identifying
+/// selections of @Preview annotations in the widget inspector.
+class PreviewWidgetElement extends StatelessElement {
+  PreviewWidgetElement(super.widget);
 }
 
 class WidgetPreviewGroupWidget extends StatelessWidget {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -228,7 +228,9 @@ class _WidgetPreviewScaffoldInspectorService with WidgetInspectorService {
           kColumn: location.column,
         });
       }
-      dtdServices.navigateToCode(location!);
+      if (location != null) {
+        dtdServices.navigateToCode(location);
+      }
     }
     super.postEvent(eventKind, eventData, stream: stream);
   }

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -222,10 +222,10 @@ class _WidgetPreviewScaffoldInspectorService with WidgetInspectorService {
         // event data, just in case an IDE is attached and listening for
         // navigation events through the VM service.
         // TODO(bkonyi): determine if this is necessary
-        eventData.addAll({
+        eventData.addAll(<String, Object>{
           kFile: location.uri,
-          kLine: location.line,
-          kColumn: location.column,
+          kLine: location.line!,
+          kColumn: location.column!,
         });
       }
       if (location != null) {

--- a/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
+++ b/packages/flutter_tools/templates/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart.tmpl
@@ -3,7 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as path;
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
 import 'dtd/dtd_services.dart';
 import 'widget_preview.dart';
 
@@ -21,7 +24,11 @@ class WidgetPreviewScaffoldController {
     required PreviewsCallback previews,
     @visibleForTesting WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
   }) : _previews = previews,
-       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
+       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices() {
+    // Overrides the default WidgetInspectorService instance to handle selection
+    // events.
+    _WidgetPreviewScaffoldInspectorService(dtdServices: dtdServices);
+  }
 
   /// Initializes the controller by establishing a connection to DTD and
   /// listening for events.
@@ -152,5 +159,77 @@ class WidgetPreviewScaffoldController {
           .where((group) => group.hasPreviews)
           .toList();
     }
+  }
+}
+
+/// A custom [WidgetInspectorService] responsible for routing navigation events
+/// to the IDE.
+class _WidgetPreviewScaffoldInspectorService with WidgetInspectorService {
+  _WidgetPreviewScaffoldInspectorService({required this.dtdServices}) {
+    WidgetInspectorService.instance = this;
+  }
+
+  final WidgetPreviewScaffoldDtdServices dtdServices;
+
+  // Keys used to specify the creation location of a widget when serializing a
+  // DiagnosticsNode to JSON. This location is used by the widget inspector
+  // to jump to the creation location of a selected widget.
+  static const kFile = 'fileUri';
+  static const kLine = 'line';
+  static const kColumn = 'column';
+
+  CodeLocation? _nextNavigationLocation;
+
+  @protected
+  @override
+  bool setSelection(Object? object, [String? groupName]) {
+    // The next navigation event sent to `postEvent` will be for this selection.
+    // Save the location of preview annotation applications so we can override
+    // the navigation target in `postEvent`.
+    if (object is PreviewWidgetElement) {
+      final previewData = (object.widget as PreviewWidget).preview;
+      _nextNavigationLocation = CodeLocation(
+        uri: previewData.scriptUri,
+        line: previewData.line,
+        column: previewData.column,
+      );
+    }
+    final result = super.setSelection(object, groupName);
+    _nextNavigationLocation = null;
+    return result;
+  }
+
+  @override
+  void postEvent(
+    String eventKind,
+    Map<Object, Object?> eventData, {
+    String stream = 'Extension',
+  }) {
+    // It's unlikely that the widget previewer will be connected to directly by
+    // an IDE via the VM service, so we forward navigation events via the
+    // Editor DTD service.
+    if (eventKind == 'navigate') {
+      CodeLocation? location = _nextNavigationLocation;
+      if (eventData case {
+        kFile: final String file,
+        kLine: final int line,
+        kColumn: final int column,
+      } when location == null) {
+        location = CodeLocation(uri: file, line: line, column: column);
+      } else if (location != null) {
+        // If a [PreviewWidgetElement] was selected, we're not navigating to the
+        // creation location of the widget. Override the location details in the
+        // event data, just in case an IDE is attached and listening for
+        // navigation events through the VM service.
+        // TODO(bkonyi): determine if this is necessary
+        eventData.addAll({
+          kFile: location.uri,
+          kLine: location.line,
+          kColumn: location.column,
+        });
+      }
+      dtdServices.navigateToCode(location!);
+    }
+    super.postEvent(eventKind, eventData, stream: stream);
   }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -297,18 +297,24 @@ List<_i1.WidgetPreview> previews() => [
       _i2.buildWidgetPreview(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 4,
+        column: 1,
         previewFunction: () => _i3.preview(),
         transformedPreview: const _i4.Preview().transform(),
       ),
       _i2.buildWidgetPreview(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 10,
+        column: 1,
         previewFunction: () => _i5.barPreview1(),
         transformedPreview: const _i4.Preview(group: 'group').transform(),
       ),
       _i2.buildWidgetPreview(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 13,
+        column: 1,
         previewFunction: () => _i5.barPreview2(),
         transformedPreview:
             const _i4.Preview(brightness: _i6.brightnessConstant).transform(),
@@ -316,6 +322,8 @@ List<_i1.WidgetPreview> previews() => [
       _i2.buildWidgetPreview(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 16,
+        column: 1,
         previewFunction: () => _i5.barPreview3(),
         transformedPreview: const _i4.Preview(
           group: 'group',
@@ -334,12 +342,16 @@ List<_i1.WidgetPreview> previews() => [
       ..._i2.buildMultiWidgetPreview(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 51,
+        column: 1,
         previewFunction: () => _i11.preview(),
         preview: const _i11.BrightnessPreview(name: 'Foo'),
       ),
       _i2.buildWidgetPreview(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 52,
+        column: 1,
         previewFunction: () => _i11.preview(),
         transformedPreview:
             const _i11.FixedSizePreview(name: 'Bar').transform(),
@@ -347,6 +359,8 @@ List<_i1.WidgetPreview> previews() => [
       _i2.buildWidgetPreviewError(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 6,
+        column: 1,
         packageUri: 'package:foo_project/src/error.dart',
         functionName: 'preview',
         dependencyHasErrors: false,
@@ -354,6 +368,8 @@ List<_i1.WidgetPreview> previews() => [
       _i2.buildWidgetPreviewError(
         packageName: 'foo_project',
         scriptUri: 'STRIPPED',
+        line: 6,
+        column: 1,
         packageUri: 'package:foo_project/src/transitive_error.dart',
         functionName: 'preview',
         dependencyHasErrors: true,

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -335,6 +335,8 @@ List<_i1.WidgetPreview> previews() => [
       _i2.buildWidgetPreview(
         packageName: 'flutter_project',
         scriptUri: 'STRIPPED',
+        line: 4,
+        column: 1,
         previewFunction: () => _i3.preview(),
         transformedPreview: const _i4.Preview(name: 'preview').transform(),
       )

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/utils.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/utils.dart
@@ -9,6 +9,8 @@ import 'package:widget_preview_scaffold/src/widget_preview.dart';
 Iterable<WidgetPreview> buildMultiWidgetPreview({
   required String packageName,
   required String scriptUri,
+  required int line,
+  required int column,
   required MultiPreview preview,
   required Object? Function() previewFunction,
 }) {
@@ -16,6 +18,8 @@ Iterable<WidgetPreview> buildMultiWidgetPreview({
     (p) => buildWidgetPreview(
       packageName: packageName,
       scriptUri: scriptUri,
+      line: line,
+      column: column,
       transformedPreview: p,
       previewFunction: previewFunction,
     ),
@@ -25,6 +29,8 @@ Iterable<WidgetPreview> buildMultiWidgetPreview({
 WidgetPreview buildWidgetPreview({
   required String packageName,
   required String scriptUri,
+  required int line,
+  required int column,
   required Preview transformedPreview,
   required Object? Function() previewFunction,
 }) {
@@ -39,6 +45,8 @@ WidgetPreview buildWidgetPreview({
   return WidgetPreview(
     builder: previewBuilder,
     scriptUri: scriptUri,
+    line: line,
+    column: column,
     previewData: transformedPreview,
     packageName: packageName,
   );
@@ -47,6 +55,8 @@ WidgetPreview buildWidgetPreview({
 WidgetPreview buildWidgetPreviewError({
   required String packageName,
   required String scriptUri,
+  required int line,
+  required int column,
   required String packageUri,
   required String functionName,
   required bool dependencyHasErrors,
@@ -58,6 +68,8 @@ WidgetPreview buildWidgetPreviewError({
   return WidgetPreview(
     builder: () => Text('$functionName: $errorMessage'),
     scriptUri: scriptUri,
+    line: line,
+    column: column,
     previewData: const Preview(group: 'Invalid Previews'),
     packageName: packageName,
   );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview.dart
@@ -31,14 +31,32 @@ class WidgetPreview {
   const WidgetPreview({
     required this.builder,
     required this.scriptUri,
+    required this.line,
+    required this.column,
     required this.previewData,
     required this.packageName,
+  });
+
+  @visibleForTesting
+  const WidgetPreview.test({
+    required this.builder,
+    required this.previewData,
+    this.scriptUri = '',
+    this.line = -1,
+    this.column = -1,
+    this.packageName = '',
   });
 
   /// The absolute file:// URI pointing to the script containing this preview.
   ///
   /// This matches the URI format sent by IDEs for active location change events.
   final String scriptUri;
+
+  /// The line at which the Preview annotation was applied.
+  final int line;
+
+  /// The column at which the Preview annotation was applied.
+  final int column;
 
   /// The name of the package in which a preview was defined.
   ///
@@ -104,6 +122,7 @@ class WidgetPreview {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     properties
       ..add(DiagnosticsProperty<String>('name', name, ifNull: 'not set'))
+      ..add(DiagnosticsProperty<String>('group', previewData.group))
       ..add(DiagnosticsProperty<Size>('size', size))
       ..add(DiagnosticsProperty<double>('textScaleFactor', textScaleFactor))
       ..add(DiagnosticsProperty<PreviewThemeData>('theme', theme))

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_rendering.dart
@@ -178,11 +178,15 @@ class NoPreviewsDetectedWidget extends StatelessWidget {
   }
 }
 
+/// A wrapper that serves as the root entry for a single preview in the widget inspector.
 class PreviewWidget extends StatelessWidget {
   const PreviewWidget({super.key, required this.preview, required this.child});
 
   final WidgetPreview preview;
   final Widget child;
+
+  @override
+  StatelessElement createElement() => PreviewWidgetElement(this);
 
   @override
   Widget build(BuildContext context) {
@@ -191,7 +195,9 @@ class PreviewWidget extends StatelessWidget {
 
   @override
   String toStringShort() {
-    final StringBuffer buffer = StringBuffer('@Preview');
+    final StringBuffer buffer = StringBuffer(
+      '@${preview.previewData.runtimeType}',
+    );
     if (preview.name != null) {
       buffer.write('(name: "${preview.name}")');
     }
@@ -203,6 +209,12 @@ class PreviewWidget extends StatelessWidget {
     super.debugFillProperties(properties);
     preview.debugFillProperties(properties);
   }
+}
+
+/// A custom [StatelessElement] with the sole purpose of simplifying identifying
+/// selections of @Preview annotations in the widget inspector.
+class PreviewWidgetElement extends StatelessElement {
+  PreviewWidgetElement(super.widget);
 }
 
 class WidgetPreviewGroupWidget extends StatelessWidget {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
@@ -228,7 +228,9 @@ class _WidgetPreviewScaffoldInspectorService with WidgetInspectorService {
           kColumn: location.column,
         });
       }
-      dtdServices.navigateToCode(location!);
+      if (location != null) {
+        dtdServices.navigateToCode(location);
+      }
     }
     super.postEvent(eventKind, eventData, stream: stream);
   }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
@@ -222,10 +222,10 @@ class _WidgetPreviewScaffoldInspectorService with WidgetInspectorService {
         // event data, just in case an IDE is attached and listening for
         // navigation events through the VM service.
         // TODO(bkonyi): determine if this is necessary
-        eventData.addAll({
+        eventData.addAll(<String, Object>{
           kFile: location.uri,
-          kLine: location.line,
-          kColumn: location.column,
+          kLine: location.line!,
+          kColumn: location.column!,
         });
       }
       if (location != null) {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/widget_preview_scaffold_controller.dart
@@ -3,7 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as path;
+import 'package:widget_preview_scaffold/src/dtd/editor_service.dart';
+import 'package:widget_preview_scaffold/src/widget_preview_rendering.dart';
 import 'dtd/dtd_services.dart';
 import 'widget_preview.dart';
 
@@ -21,7 +24,11 @@ class WidgetPreviewScaffoldController {
     required PreviewsCallback previews,
     @visibleForTesting WidgetPreviewScaffoldDtdServices? dtdServicesOverride,
   }) : _previews = previews,
-       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices();
+       dtdServices = dtdServicesOverride ?? WidgetPreviewScaffoldDtdServices() {
+    // Overrides the default WidgetInspectorService instance to handle selection
+    // events.
+    _WidgetPreviewScaffoldInspectorService(dtdServices: dtdServices);
+  }
 
   /// Initializes the controller by establishing a connection to DTD and
   /// listening for events.
@@ -152,5 +159,77 @@ class WidgetPreviewScaffoldController {
           .where((group) => group.hasPreviews)
           .toList();
     }
+  }
+}
+
+/// A custom [WidgetInspectorService] responsible for routing navigation events
+/// to the IDE.
+class _WidgetPreviewScaffoldInspectorService with WidgetInspectorService {
+  _WidgetPreviewScaffoldInspectorService({required this.dtdServices}) {
+    WidgetInspectorService.instance = this;
+  }
+
+  final WidgetPreviewScaffoldDtdServices dtdServices;
+
+  // Keys used to specify the creation location of a widget when serializing a
+  // DiagnosticsNode to JSON. This location is used by the widget inspector
+  // to jump to the creation location of a selected widget.
+  static const kFile = 'fileUri';
+  static const kLine = 'line';
+  static const kColumn = 'column';
+
+  CodeLocation? _nextNavigationLocation;
+
+  @protected
+  @override
+  bool setSelection(Object? object, [String? groupName]) {
+    // The next navigation event sent to `postEvent` will be for this selection.
+    // Save the location of preview annotation applications so we can override
+    // the navigation target in `postEvent`.
+    if (object is PreviewWidgetElement) {
+      final previewData = (object.widget as PreviewWidget).preview;
+      _nextNavigationLocation = CodeLocation(
+        uri: previewData.scriptUri,
+        line: previewData.line,
+        column: previewData.column,
+      );
+    }
+    final result = super.setSelection(object, groupName);
+    _nextNavigationLocation = null;
+    return result;
+  }
+
+  @override
+  void postEvent(
+    String eventKind,
+    Map<Object, Object?> eventData, {
+    String stream = 'Extension',
+  }) {
+    // It's unlikely that the widget previewer will be connected to directly by
+    // an IDE via the VM service, so we forward navigation events via the
+    // Editor DTD service.
+    if (eventKind == 'navigate') {
+      CodeLocation? location = _nextNavigationLocation;
+      if (eventData case {
+        kFile: final String file,
+        kLine: final int line,
+        kColumn: final int column,
+      } when location == null) {
+        location = CodeLocation(uri: file, line: line, column: column);
+      } else if (location != null) {
+        // If a [PreviewWidgetElement] was selected, we're not navigating to the
+        // creation location of the widget. Override the location details in the
+        // event data, just in case an IDE is attached and listening for
+        // navigation events through the VM service.
+        // TODO(bkonyi): determine if this is necessary
+        eventData.addAll({
+          kFile: location.uri,
+          kLine: location.line,
+          kColumn: location.column,
+        });
+      }
+      dtdServices.navigateToCode(location!);
+    }
+    super.postEvent(eventKind, eventData, stream: stream);
   }
 }

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/custom_previews_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/custom_previews_test.dart
@@ -71,6 +71,8 @@ WidgetPreviewerWidgetScaffolding previewsForCustomMultiPreview() {
     scriptUri: '',
     preview: BrightnessPreview(name: 'MyPreview'),
     previewFunction: () => Text('Foo'),
+    line: -1,
+    column: -1,
   );
   final controller = FakeWidgetPreviewScaffoldController();
   return WidgetPreviewerWidgetScaffolding(

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/error_widget_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/error_widget_test.dart
@@ -42,11 +42,9 @@ void main() {
     final controller = WidgetPreviewScaffoldController(
       dtdServicesOverride: fakeDtdServices,
       previews: () => [
-        WidgetPreview(
+        WidgetPreview.test(
           builder: () => throw Exception('Error!'),
-          scriptUri: '',
           previewData: Preview(),
-          packageName: '',
         ),
       ],
     );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
@@ -187,21 +187,13 @@ void main() {
   ) async {
     final dtdServices = FakeWidgetPreviewScaffoldDtdServices();
     final previews = <WidgetPreview>[
-      WidgetPreview(
+      WidgetPreview.test(
         builder: () => Text('widget1'),
-        scriptUri: '',
-        line: -1,
-        column: -1,
         previewData: Preview(group: 'group'),
-        packageName: '',
       ),
-      WidgetPreview(
+      WidgetPreview.test(
         builder: () => Text('widget2'),
-        scriptUri: '',
-        line: -1,
-        column: -1,
         previewData: Preview(group: 'group'),
-        packageName: '',
       ),
     ];
     final controller = FakeWidgetPreviewScaffoldController(

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/filter_by_selected_file_test.dart
@@ -29,17 +29,15 @@ Future<void> testImpl({
     isWindows: isWindows,
   );
   final previews = <WidgetPreview>[
-    WidgetPreview(
+    WidgetPreview.test(
       builder: () => Text('widget1'),
       scriptUri: script1Uri.toString(),
       previewData: Preview(group: 'group'),
-      packageName: '',
     ),
-    WidgetPreview(
+    WidgetPreview.test(
       builder: () => Text('widget2'),
       scriptUri: script2Uri.toString(),
       previewData: Preview(group: 'group'),
-      packageName: '',
     ),
   ];
   final controller = FakeWidgetPreviewScaffoldController(
@@ -192,12 +190,16 @@ void main() {
       WidgetPreview(
         builder: () => Text('widget1'),
         scriptUri: '',
+        line: -1,
+        column: -1,
         previewData: Preview(group: 'group'),
         packageName: '',
       ),
       WidgetPreview(
         builder: () => Text('widget2'),
         scriptUri: '',
+        line: -1,
+        column: -1,
         previewData: Preview(group: 'group'),
         packageName: '',
       ),

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/localizations_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/localizations_test.dart
@@ -37,11 +37,9 @@ WidgetPreviewerWidgetScaffolding previewForLocalizations({
   return WidgetPreviewerWidgetScaffolding(
     child: WidgetPreviewWidget(
       controller: controller,
-      preview: WidgetPreview(
-        scriptUri: '',
+      preview: WidgetPreview.test(
         builder: () => Text('Foo', key: key),
         previewData: Preview(localizations: previewLocalizationsData),
-        packageName: '',
       ),
     ),
   );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/no_previews_detected_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/no_previews_detected_test.dart
@@ -50,6 +50,8 @@ void main() {
       currentPreviews.add(
         WidgetPreview(
           scriptUri: '',
+          line: -1,
+          column: -1,
           builder: () => const Text('Foo'),
           previewData: Preview(),
           packageName: '',

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/soft_restart_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/soft_restart_test.dart
@@ -23,11 +23,9 @@ void main() {
       final widgetPreview = WidgetPreviewerWidgetScaffolding(
         child: WidgetPreviewWidget(
           controller: controller,
-          preview: WidgetPreview(
-            scriptUri: '',
+          preview: WidgetPreview.test(
             builder: () => const Text(kTestText),
             previewData: Preview(),
-            packageName: '',
           ),
         ),
       );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/theming_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/theming_test.dart
@@ -55,11 +55,9 @@ WidgetPreviewerWidgetScaffolding previewForBrightness({
     platformBrightness: platformBrightness ?? Brightness.light,
     child: WidgetPreviewWidget(
       controller: controller,
-      preview: WidgetPreview(
-        scriptUri: '',
+      preview: WidgetPreview.test(
         builder: () => Text('Foo', key: key),
         previewData: Preview(theme: previewTheme, brightness: brightness),
-        packageName: '',
       ),
     ),
   );


### PR DESCRIPTION
With the assumption that IDEs will not create a debug session for the widget previewer, the widget inspector's source navigation functionality won't function as there's no IDE to listen to `navigate` events sent via `postEvent`.

This change overrides some widget inspector behavior to allow for navigating to source locations via the DTD Editor service instead of relying on the VM service's `postEvent`.

This change also makes some minor changes to the diagnostic properties and descriptions displayed within the inspector to display group and custom preview annotation details.

Towards https://github.com/flutter/flutter/issues/166423
