### PR TITLE
Set minimum supported java version to 17 

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt
@@ -97,7 +97,7 @@ object DependencyVersionChecker {
     // Java error and warn should align with packages/flutter_tools/lib/src/android/gradle_utils.dart.
     @VisibleForTesting internal val warnJavaVersion: JavaVersion = JavaVersion.VERSION_17
 
-    @VisibleForTesting internal val errorJavaVersion: JavaVersion = JavaVersion.VERSION_11
+    @VisibleForTesting internal val errorJavaVersion: JavaVersion = JavaVersion.VERSION_17
 
     @VisibleForTesting internal val warnAGPVersion: AndroidPluginVersion = AndroidPluginVersion(8, 6, 0)
 

--- a/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
+++ b/packages/flutter_tools/gradle/src/test/kotlin/DependencyVersionCheckerTest.kt
@@ -171,12 +171,12 @@ class DependencyVersionCheckerTest {
             assertFailsWith<DependencyValidationException> { DependencyVersionChecker.checkDependencyVersions(mockProject) }
         assert(
             dependencyValidationException.message ==
-                    getErrorMessage(
-                        JAVA_NAME,
-                        exampleErrorJavaVersion.toString(),
-                        errorJavaVersion.toString(),
-                        POTENTIAL_JAVA_FIX
-                    )
+                getErrorMessage(
+                    JAVA_NAME,
+                    exampleErrorJavaVersion.toString(),
+                    errorJavaVersion.toString(),
+                    POTENTIAL_JAVA_FIX
+                )
         )
         verify(exactly = 1) { mockExtraPropertiesExtension.set(OUT_OF_SUPPORT_RANGE_PROPERTY, true) }
     }

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -59,7 +59,7 @@ const targetSdkVersion = '36';
 const ndkVersion = '27.0.12077973';
 final minBuildToolsVersion = Version(28, 0, 3);
 // Align with packages/flutter_tools/gradle/src/main/kotlin/DependencyVersionChecker.kt.
-final errorJavaMinVersionAndroid = Version(11, 0, 0);
+final errorJavaMinVersionAndroid = Version(17, 0, 0);
 final warnJavaMinVersionAndroid = Version(17, 0, 0);
 
 // Update these when new major versions of Java are supported by new Gradle

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -593,6 +593,7 @@ Review licenses that have not been accepted (y/N)?
     );
   });
 
+  // Warning test not available when minimum and error are aligned.
   testUsingContext('detects minimum required java version', () async {
     // Test with older version of JDK
     final Platform platform = FakePlatform()
@@ -627,49 +628,6 @@ Review licenses that have not been accepted (y/N)?
       processManager: processManager,
     ).validate();
     expect(validationResult.type, ValidationType.partial);
-    expect(validationResult.messages.last.message, errorMessage);
-    expect(
-      validationResult.messages.any(
-        (ValidationMessage message) => message.message.contains('Unable to locate Android SDK'),
-      ),
-      false,
-    );
-  });
-
-  testUsingContext('detects minimum recommended java version', () async {
-    // Test with older version of JDK
-    final Platform platform = FakePlatform()
-      ..environment = <String, String>{
-        'HOME': '/home/me',
-        Java.javaHomeEnvironmentVariable: 'home/java',
-        'PATH': '',
-      };
-    final sdkVersion = FakeAndroidSdkVersion()
-      ..sdkLevel = gradle_utils.compileSdkVersionInt
-      ..buildToolsVersion = gradle_utils.minBuildToolsVersion;
-
-    // Mock a pass through scenario to reach _checkJavaVersion()
-    sdk
-      ..licensesAvailable = true
-      ..platformToolsAvailable = true
-      ..cmdlineToolsAvailable = true
-      ..directory = fileSystem.directory('/foo/bar')
-      ..sdkManagerPath = '/foo/bar/sdkmanager'
-      ..emulatorPath = 'path/to/emulator';
-    sdk.latestVersion = sdkVersion;
-
-    const javaVersionText = 'openjdk version "16.0.1"';
-    final String errorMessage = UserMessages().androidJavaMinimumVersion(javaVersionText);
-
-    final ValidationResult validationResult = await AndroidValidator(
-      java: FakeJava(version: const Version.withText(16, 0, 1, javaVersionText)),
-      androidSdk: sdk,
-      logger: logger,
-      platform: platform,
-      userMessages: UserMessages(),
-      processManager: processManager,
-    ).validate();
-    expect(validationResult.type, ValidationType.success);
     expect(validationResult.messages.last.message, errorMessage);
     expect(
       validationResult.messages.any(


### PR DESCRIPTION
Related to #176027

Minimum agp version already requires Java 17 this aligns our tooling. This pr needs to land after the following prs 
1. https://github.com/flutter/flutter/pull/176203
2. https://github.com/flutter/flutter/pull/176204
3. https://github.com/flutter/flutter/pull/176097

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

