### PR TITLE
Add DropdownMenu.decorationBuilder

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1176,7 +1176,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
         final InputDecoration effectiveDecoration = decoration.applyDefaults(
           effectiveInputDecorationTheme,
         );
-        final InputDecoration keyedDecoration = effectiveDecoration.prefixIcon == null
+        final InputDecoration textFieldDecoration = effectiveDecoration.prefixIcon == null
             ? effectiveDecoration
             : effectiveDecoration.copyWith(
                 prefixIcon: SizedBox(
@@ -1243,7 +1243,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
                 });
               },
               inputFormatters: widget.inputFormatters,
-              decoration: keyedDecoration,
+              decoration: textFieldDecoration,
               restorationId: widget.restorationId,
             ),
           ),

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -46,6 +46,16 @@ typedef FilterCallback<T> =
 /// Used by [DropdownMenu.searchCallback].
 typedef SearchCallback<T> = int? Function(List<DropdownMenuEntry<T>> entries, String query);
 
+/// The type of builder function used by [DropdownMenu.decorationBuilder] to
+/// build the [InputDecoration] passed to the inner text field.
+///
+/// The `context` is the context that the decoration is being built in.
+///
+/// The `controller` is the [MenuController] that can be used to open and close
+/// the menu with and query the current state.
+typedef DropdownMenuDecorationBuilder =
+    InputDecoration Function(BuildContext context, MenuController controller);
+
 const double _kMinimumWidth = 112.0;
 
 const double _kDefaultHorizontalPadding = 12.0;
@@ -182,6 +192,7 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
     this.textAlign = TextAlign.start,
     // TODO(bleroux): Clean this up once `InputDecorationTheme` is fully normalized.
     Object? inputDecorationTheme,
+    this.decorationBuilder,
     this.menuStyle,
     this.controller,
     this.initialSelection,
@@ -207,6 +218,10 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
                  inputDecorationTheme is InputDecorationThemeData),
        ),
        assert(trailingIconFocusNode == null || showTrailingIcon),
+       assert(
+         decorationBuilder == null ||
+             (label == null && hintText == null && helperText == null && errorText == null),
+       ),
        _inputDecorationTheme = inputDecorationTheme;
 
   /// Determine if the [DropdownMenu] is enabled.
@@ -368,6 +383,23 @@ class DropdownMenu<T extends Object> extends StatefulWidget {
   }
 
   final Object? _inputDecorationTheme;
+
+  /// The builder function used to create the [InputDecoration] passed to the text field.
+  ///
+  /// If a value is provided for this property and the resulting [InputDecoration.suffixIcon]
+  /// is null, a default [IconButton] is assigned as the suffix icon. This button's icon will
+  /// use [trailingIcon] and [selectedTrailingIcon] if those are explicitly defined; otherwise,
+  /// it defaults to [Icons.arrow_drop_down] for the collapsed state and [Icons.arrow_drop_up]
+  /// for the expanded state.
+  ///
+  /// If null, the default builder creates a decoration where:
+  /// - [InputDecoration.label] is set to [label].
+  /// - [InputDecoration.hintText] is set to [hintText].
+  /// - [InputDecoration.helperText] is set to [helperText].
+  /// - [InputDecoration.errorText] is set to [errorText].
+  /// - [InputDecoration.prefixIcon] is set to [leadingIcon].
+  /// - [InputDecoration.suffixIcon] is set to an [IconButton] which uses [trailingIcon] and [selectedTrailingIcon] if defined, or [Icons.arrow_drop_down] and [Icons.arrow_drop_up] otherwise.
+  final DropdownMenuDecorationBuilder? decorationBuilder;
 
   /// The [MenuStyle] that defines the visual attributes of the menu.
   ///
@@ -1132,38 +1164,26 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
       crossAxisUnconstrained: false,
       builder: (BuildContext context, MenuController controller, Widget? child) {
         assert(_initialMenu != null);
-        final bool isCollapsed = widget.inputDecorationTheme?.isCollapsed ?? false;
-        final Widget trailingButton = widget.showTrailingIcon
-            ? Padding(
-                padding: isCollapsed ? EdgeInsets.zero : const EdgeInsets.all(4.0),
-                child: ExcludeSemantics(
-                  // When the text field is treated as a button (i.e., it can
-                  // not be focused), the trailing button should become part of
-                  // the text field button by excluding semantics. Otherwise,
-                  // it will inappropriately announce whether this icon button
-                  // is selected or not.
-                  excluding: !canRequestFocus(),
-                  child: IconButton(
-                    focusNode: _trailingIconButtonFocusNode,
-                    isSelected: controller.isOpen,
-                    constraints: widget.inputDecorationTheme?.suffixIconConstraints,
-                    padding: isCollapsed ? EdgeInsets.zero : null,
-                    icon: widget.trailingIcon ?? const Icon(Icons.arrow_drop_down),
-                    selectedIcon: widget.selectedTrailingIcon ?? const Icon(Icons.arrow_drop_up),
-                    onPressed: !widget.enabled
-                        ? null
-                        : () {
-                            handlePressed(controller);
-                          },
-                  ),
-                ),
-              )
-            : const SizedBox.shrink();
-
-        final Widget leadingButton = Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: widget.leadingIcon ?? const SizedBox.shrink(),
+        final DropdownMenuDecorationBuilder decorationBuilder =
+            widget.decorationBuilder ?? _buildDefaultDecoration;
+        InputDecoration decoration = decorationBuilder(context, controller);
+        // If no suffixIcon is provided, the default IconButton is used for convenience.
+        if (decoration.suffixIcon == null) {
+          decoration = decoration.copyWith(
+            suffixIcon: _buildDefaultSuffixIcon(context, controller),
+          );
+        }
+        final InputDecoration effectiveDecoration = decoration.applyDefaults(
+          effectiveInputDecorationTheme,
         );
+        final InputDecoration keyedDecoration = effectiveDecoration.prefixIcon == null
+            ? effectiveDecoration
+            : effectiveDecoration.copyWith(
+                prefixIcon: SizedBox(
+                  key: _leadingKey, // Used to query the width in refreshLeadingPadding.
+                  child: effectiveDecoration.prefixIcon,
+                ),
+              );
 
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
         final bool isButton = !canRequestFocus();
@@ -1223,16 +1243,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
                 });
               },
               inputFormatters: widget.inputFormatters,
-              decoration: InputDecoration(
-                label: widget.label,
-                hintText: widget.hintText,
-                helperText: widget.helperText,
-                errorText: widget.errorText,
-                prefixIcon: widget.leadingIcon != null
-                    ? SizedBox(key: _leadingKey, child: widget.leadingIcon)
-                    : null,
-                suffixIcon: widget.showTrailingIcon ? trailingButton : null,
-              ).applyDefaults(effectiveInputDecorationTheme),
+              decoration: keyedDecoration,
               restorationId: widget.restorationId,
             ),
           ),
@@ -1250,6 +1261,11 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
                 // and leadingButton.
                 //
                 // See _RenderDropdownMenuBody layout logic.
+                //
+                // TODO(bleroux): find a more accurate way to measure the text field minimum width.
+                // The text field width computation is not accurate as it is based only on label,
+                // prefixIcon and suffixIcon. Other InputDecoration parameters can have an
+                // impact on the total width.
                 children: <Widget>[
                   textField,
                   ..._initialMenu!.map(
@@ -1263,8 +1279,14 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
                         child: DefaultTextStyle(style: effectiveTextStyle!, child: widget.label!),
                       ),
                     ),
-                  trailingButton,
-                  leadingButton,
+                  effectiveDecoration.suffixIcon ?? const SizedBox.shrink(),
+                  Padding(
+                    // TODO(bleroux): find a more accurate way to get the correct width.
+                    // This padding is used to mimic default input decorator padding.
+                    // It won't be correct if non default values are used.
+                    padding: const EdgeInsets.all(8.0),
+                    child: effectiveDecoration.prefixIcon ?? const SizedBox.shrink(),
+                  ),
                 ],
               );
 
@@ -1336,6 +1358,47 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
         ],
       ),
     );
+  }
+
+  InputDecoration _buildDefaultDecoration(BuildContext context, MenuController controller) {
+    return InputDecoration(
+      label: widget.label,
+      hintText: widget.hintText,
+      helperText: widget.helperText,
+      errorText: widget.errorText,
+      prefixIcon: widget.leadingIcon,
+      suffixIcon: _buildDefaultSuffixIcon(context, controller),
+    );
+  }
+
+  Widget? _buildDefaultSuffixIcon(BuildContext context, MenuController controller) {
+    final bool isCollapsed = widget.inputDecorationTheme?.isCollapsed ?? false;
+    return widget.showTrailingIcon
+        ? Padding(
+            padding: isCollapsed ? EdgeInsets.zero : const EdgeInsets.all(4.0),
+            child: ExcludeSemantics(
+              // When the text field is treated as a button (i.e., it can
+              // not be focused), the trailing button should become part of
+              // the text field button by excluding semantics. Otherwise,
+              // it will inappropriately announce whether this icon button
+              // is selected or not.
+              excluding: !canRequestFocus(),
+              child: IconButton(
+                focusNode: _trailingIconButtonFocusNode,
+                isSelected: controller.isOpen,
+                constraints: widget.inputDecorationTheme?.suffixIconConstraints,
+                padding: isCollapsed ? EdgeInsets.zero : null,
+                icon: widget.trailingIcon ?? const Icon(Icons.arrow_drop_down),
+                selectedIcon: widget.selectedTrailingIcon ?? const Icon(Icons.arrow_drop_up),
+                onPressed: !widget.enabled
+                    ? null
+                    : () {
+                        handlePressed(controller);
+                      },
+              ),
+            ),
+          )
+        : null;
   }
 }
 

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4791,6 +4791,162 @@ void main() {
     await tester.pumpAndSettle();
     expect(findMenuItemButton('Item 0').hitTestable(), findsNothing);
   });
+
+  group('DropdownMenu.decorationBuilder', () {
+    const String labelText = 'labelText';
+    InputDecoration buildDecorationWithSuffixIcon(BuildContext context, MenuController controller) {
+      return InputDecoration(
+        labelText: labelText,
+        suffixIcon: controller.isOpen
+            ? const Icon(Icons.arrow_drop_up)
+            : const Icon(Icons.arrow_drop_down),
+      );
+    }
+
+    InputDecoration buildDecoration(BuildContext context, MenuController controller) {
+      return const InputDecoration(labelText: labelText);
+    }
+
+    testWidgets('Custom decorationBuilder can replace default suffixIcon', (
+      WidgetTester tester,
+    ) async {
+      final MenuController menuController = MenuController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenu<TestMenu>(
+              menuController: menuController,
+              dropdownMenuEntries: menuChildren,
+              decorationBuilder: buildDecorationWithSuffixIcon,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.arrow_drop_down), findsNWidgets(2));
+      expect(find.byType(IconButton), findsNothing);
+    });
+
+    testWidgets('Custom decorationBuilder is called when the menu opens and closes', (
+      WidgetTester tester,
+    ) async {
+      final MenuController menuController = MenuController();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenu<TestMenu>(
+              menuController: menuController,
+              dropdownMenuEntries: menuChildren,
+              decorationBuilder: buildDecorationWithSuffixIcon,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.arrow_drop_down), findsNWidgets(2));
+      expect(find.byIcon(Icons.arrow_drop_up), findsNothing);
+
+      // Open the menu.
+      await tester.tap(find.byType(DropdownMenu<TestMenu>));
+      await tester.pump();
+
+      // Check that the custom decorationBuilder updated the icon.
+      expect(find.byIcon(Icons.arrow_drop_down), findsNothing);
+      expect(find.byIcon(Icons.arrow_drop_up), findsNWidgets(2));
+    });
+
+    testWidgets(
+      'Default IconButton is used when decorationBuilder does not set InputDecoration.suffixIcon',
+      (WidgetTester tester) async {
+        final MenuController menuController = MenuController();
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                menuController: menuController,
+                dropdownMenuEntries: menuChildren,
+                decorationBuilder: buildDecoration,
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(IconButton), findsNWidgets(2));
+      },
+    );
+
+    testWidgets('Passing label and decorationBuilder throws', (WidgetTester tester) async {
+      final MenuController menuController = MenuController();
+      await expectLater(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                menuController: menuController,
+                dropdownMenuEntries: menuChildren,
+                label: const Text('Label'),
+                decorationBuilder: buildDecoration,
+              ),
+            ),
+          ),
+        );
+      }, throwsAssertionError);
+    });
+
+    testWidgets('Passing hintText and decorationBuilder throws', (WidgetTester tester) async {
+      final MenuController menuController = MenuController();
+      await expectLater(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                menuController: menuController,
+                dropdownMenuEntries: menuChildren,
+                hintText: 'hintText',
+                decorationBuilder: buildDecoration,
+              ),
+            ),
+          ),
+        );
+      }, throwsAssertionError);
+    });
+
+    testWidgets('Passing helperText and decorationBuilder throws', (WidgetTester tester) async {
+      final MenuController menuController = MenuController();
+      await expectLater(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                menuController: menuController,
+                dropdownMenuEntries: menuChildren,
+                hintText: 'hintText',
+                decorationBuilder: buildDecoration,
+              ),
+            ),
+          ),
+        );
+      }, throwsAssertionError);
+    });
+
+    testWidgets('Passing errorText and decorationBuilder throws', (WidgetTester tester) async {
+      final MenuController menuController = MenuController();
+      await expectLater(() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: DropdownMenu<TestMenu>(
+                menuController: menuController,
+                dropdownMenuEntries: menuChildren,
+                errorText: 'errorText',
+                decorationBuilder: buildDecoration,
+              ),
+            ),
+          ),
+        );
+      }, throwsAssertionError);
+    });
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4807,6 +4807,40 @@ void main() {
       return const InputDecoration(labelText: labelText);
     }
 
+    testWidgets('Decoration properties set by decorationBuilder are applied', (
+      WidgetTester tester,
+    ) async {
+      final MenuController menuController = MenuController();
+      const InputDecoration decoration = InputDecoration(
+        labelText: labelText,
+        helperText: 'helperText',
+        hintText: 'hintText',
+        filled: true,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenu<TestMenu>(
+              menuController: menuController,
+              dropdownMenuEntries: menuChildren,
+              decorationBuilder: (BuildContext context, MenuController controller) {
+                return decoration;
+              },
+            ),
+          ),
+        ),
+      );
+
+      final TextField textField = tester.firstWidget(find.byType(TextField));
+      final InputDecoration effectiveDecoration = textField.decoration!;
+
+      expect(effectiveDecoration.labelText, decoration.labelText);
+      expect(effectiveDecoration.helperText, decoration.helperText);
+      expect(effectiveDecoration.hintText, decoration.hintText);
+      expect(effectiveDecoration.filled, decoration.filled);
+    });
+
     testWidgets('Custom decorationBuilder can replace default suffixIcon', (
       WidgetTester tester,
     ) async {


### PR DESCRIPTION
## Description

This PR adds `DropdownMenu.decorationBuilder`.
The goal is to make `DropdownMenu` more flexible.

Before this PR, several fields are used by `DropdownMenu` to create an inner `InputDecoration`. This approach has several limitations:
- `InputDecoration` has more fields that the ones that are exposed
- `DropdownMenu` makes some choices that can't be change. Especially, it creates an IconButton (with hardcoded padding)  which is passed to `InputDecoration.suffixIcon`. This inner `IconButton` introduces some difficulty related to focus management and UI customization.

The new `DropdownMenu.decorationBuilder` property offers users a way to take control on the inner `InputDecoration` in a non-breaking way.

In a future PR, this property will help replacing the default `IconButton`.
Currently users can replace the `IconButton` using this code sample:

<details><summary>DropdownMenu without IconButton</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  MyApp({super.key});

  final List<DropdownMenuEntry<String>> menuEntries = [
    "Red",
    "Green",
    "Blue",
  ].map((t) => DropdownMenuEntry<String>(label: t, value: t)).toList();

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: Center(
          child: SizedBox(
            width: 220,
            child: DropdownMenu<String>(
              expandedInsets: EdgeInsets.zero,
              requestFocusOnTap: true,
              dropdownMenuEntries: menuEntries,
              decorationBuilder: (context, controller) {
                return InputDecoration(
                  labelText: 'Label text',
                  helperText: 'Select a color or enter one',
                  suffixIcon: controller.isOpen
                      ? const Icon(Icons.arrow_drop_up)
                      : const Icon(Icons.arrow_drop_down),
                );
              },
            ),
          ),
        ),
      ),
    );
  }
}
``` 

</details> 

## Related Issue

Fixes [DropDownMenu secondary trailing widget](https://github.com/flutter/flutter/issues/175847)
Will help for [Make DropdownMenu's trailing icon not focusable by default](https://github.com/flutter/flutter/issues/174096)

## Related discussions

https://github.com/flutter/flutter/issues/175847#issuecomment-3330098375
https://github.com/flutter/flutter/pull/175558#discussion_r2380227394

## Tests

- Adds 7 tests.