### PR TITLE
[native assets] Enable build hooks and code assets on stable

### DIFF
--- a/packages/flutter_tools/lib/src/features.dart
+++ b/packages/flutter_tools/lib/src/features.dart
@@ -188,6 +188,7 @@ const nativeAssets = Feature(
   environmentOverride: 'FLUTTER_NATIVE_ASSETS',
   master: FeatureChannelSetting(available: true, enabledByDefault: true),
   beta: FeatureChannelSetting(available: true, enabledByDefault: true),
+  stable: FeatureChannelSetting(available: true, enabledByDefault: true),
 );
 
 /// Enable Dart data assets building and bundling.

--- a/packages/flutter_tools/test/general.shard/features_test.dart
+++ b/packages/flutter_tools/test/general.shard/features_test.dart
@@ -334,7 +334,7 @@ void main() {
         nativeAssets,
         allOf(<Matcher>[
           _onChannelIs('master', available: true, enabledByDefault: true),
-          _onChannelIs('stable', available: false, enabledByDefault: false),
+          _onChannelIs('stable', available: true, enabledByDefault: true),
           _onChannelIs('beta', available: true, enabledByDefault: true),
         ]),
       );


### PR DESCRIPTION
Dart CL enabling for next stable:

* https://dart-review.googlesource.com/c/sdk/+/449803

Tests:

* All existing tests for the feature on the other channels.