### PR TITLE
Reduce timeout for Linux web_tool_tests back to 60

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2274,7 +2274,7 @@ targets:
 
   - name: Linux web_tool_tests
     recipe: flutter/flutter_drone
-    timeout: 90 # https://github.com/flutter/flutter/issues/169634
+    timeout: 60
     properties:
       dependencies: >-
         [
@@ -2287,7 +2287,7 @@ targets:
       subshard: "1_1"
       tags: >
         ["framework", "hostonly", "shard", "linux"]
-      test_timeout_secs: "5400" # https://github.com/flutter/flutter/issues/162714
+      test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -6686,6 +6686,7 @@ targets:
       subshard: "2_2"
       tags: >
         ["framework", "hostonly", "shard"]
+      test_timeout_secs: "3600" # 60 minutes to match the global `timeout` property.
     runIf:
     - dev/**
     - packages/flutter_tools/**


### PR DESCRIPTION
Looking at recent [data](https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Linux%20web_tool_tests?limit=200), it has been consistently taking 30-35m which is comfortably below the new timeout of 60m.

Closes https://github.com/flutter/flutter/issues/169634