### PR TITLE
Fix TextField does not inherit local InputDecorationTheme

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1193,13 +1193,13 @@ class _TextFieldState extends State<TextField>
   InputDecoration _getEffectiveDecoration() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
-    final InputDecorationThemeData ambientDecoration = InputDecorationTheme.of(context);
+    final InputDecorationThemeData decorationTheme = InputDecorationTheme.of(context);
     final InputDecoration effectiveDecoration = (widget.decoration ?? const InputDecoration())
-        .applyDefaults(ambientDecoration)
+        .applyDefaults(decorationTheme)
         .copyWith(
           enabled: _isEnabled,
           hintMaxLines:
-              widget.decoration?.hintMaxLines ?? ambientDecoration.hintMaxLines ?? widget.maxLines,
+              widget.decoration?.hintMaxLines ?? decorationTheme.hintMaxLines ?? widget.maxLines,
         );
 
     // No need to build anything if counter or counterText were given directly.

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1193,14 +1193,13 @@ class _TextFieldState extends State<TextField>
   InputDecoration _getEffectiveDecoration() {
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final ThemeData themeData = Theme.of(context);
+    final InputDecorationThemeData ambientDecoration = InputDecorationTheme.of(context);
     final InputDecoration effectiveDecoration = (widget.decoration ?? const InputDecoration())
-        .applyDefaults(themeData.inputDecorationTheme)
+        .applyDefaults(ambientDecoration)
         .copyWith(
           enabled: _isEnabled,
           hintMaxLines:
-              widget.decoration?.hintMaxLines ??
-              themeData.inputDecorationTheme.hintMaxLines ??
-              widget.maxLines,
+              widget.decoration?.hintMaxLines ?? ambientDecoration.hintMaxLines ?? widget.maxLines,
         );
 
     // No need to build anything if counter or counterText were given directly.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -15557,26 +15557,66 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/140607.
-  testWidgets('TextFields can inherit errorStyle color from InputDecorationThemeData.', (
+  testWidgets('TextFields can inherit errorStyle color from InputDecorationThemeData', (
     WidgetTester tester,
   ) async {
-    Widget textFieldBuilder() {
-      return MaterialApp(
-        theme: ThemeData(
-          inputDecorationTheme: const InputDecorationThemeData(
-            errorStyle: TextStyle(color: Colors.green),
-          ),
-        ),
+    const InputDecorationThemeData decorationTheme = InputDecorationThemeData(
+      errorStyle: TextStyle(color: Colors.green),
+    );
+
+    EditableTextState getEditableTextState() {
+      return tester.state<EditableTextState>(find.byType(EditableText));
+    }
+
+    // Global theme.
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(inputDecorationTheme: decorationTheme),
         home: const Scaffold(
           body: TextField(decoration: InputDecoration(errorText: 'error')),
         ),
-      );
-    }
+      ),
+    );
+    expect(getEditableTextState().widget.cursorColor, Colors.green);
 
-    await tester.pumpWidget(textFieldBuilder());
-    await tester.pumpAndSettle();
-    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-    expect(state.widget.cursorColor, Colors.green);
+    // Local theme.
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InputDecorationTheme(
+            data: decorationTheme,
+            child: TextField(decoration: InputDecoration(errorText: 'error')),
+          ),
+        ),
+      ),
+    );
+    expect(getEditableTextState().widget.cursorColor, Colors.green);
+  });
+
+  testWidgets('TextField can inherit decoration from local InputDecorationThemeData', (
+    WidgetTester tester,
+  ) async {
+    const InputDecoration decoration = InputDecoration(labelText: 'Label');
+    const InputDecorationThemeData decorationTheme = InputDecorationThemeData(
+      errorStyle: TextStyle(color: Colors.green),
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: InputDecorationTheme(
+            data: decorationTheme,
+            child: TextField(decoration: decoration),
+          ),
+        ),
+      ),
+    );
+
+    final InputDecorator decorator = tester.widget(find.byType(InputDecorator));
+    final InputDecoration expectedDecoration = decoration
+        .applyDefaults(decorationTheme)
+        .copyWith(enabled: true, hintMaxLines: 1);
+    expect(decorator.decoration, expectedDecoration);
   });
 
   group('MaxLengthEnforcement', () {


### PR DESCRIPTION
## Description

This PR replaces global `ThemeData.inputDecorationTheme` usage in `TextField` with `InputDecorationTheme.of ` which returns the ambient `InputDecorationTheme`.
It is a follow up to https://github.com/flutter/flutter/pull/168981 which introduces `InputDecorationTheme.of `.

## Related Issue

Fixes [[SearchBar] Inconsistent inheritance of InputDecorationTheme](https://github.com/flutter/flutter/issues/176198)

## Tests

- Adds 1 test
- Updates 1 test