### PR TITLE
fix: support older git (ubuntu 22.04) in content hash

### DIFF
--- a/bin/internal/content_aware_hash.ps1
+++ b/bin/internal/content_aware_hash.ps1
@@ -79,6 +79,6 @@ if (($currentBranch -ne "main") -and
 # 3. Out-File -NoNewline -Encoding ascii outputs 8bit ascii
 # 4. git hash-object with stdin from a pipeline consumes UTF-16, so consume
 #.   the contents of hash.txt
-(git -C "$flutterRoot" ls-tree --format "%(objectname) %(path)" "$baseRef" -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
+(git -C "$flutterRoot" ls-tree "$baseRef" -- $trackedFiles | Out-String) -replace "`r`n", "`n"  | Out-File -NoNewline -Encoding ascii hash.txt
 git hash-object hash.txt
 Remove-Item hash.txt

--- a/bin/internal/content_aware_hash.sh
+++ b/bin/internal/content_aware_hash.sh
@@ -68,4 +68,4 @@ if [[ "$CURRENT_BRANCH" != "main" && \
   fi
 fi
 
-git -C "$FLUTTER_ROOT" ls-tree --format "%(objectname) %(path)" "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin
+git -C "$FLUTTER_ROOT" ls-tree "$BASEREF" -- "${TRACKEDFILES[@]}" | git hash-object --stdin

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -30,8 +30,7 @@ void main() {
   // linux: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux
   //
   // Then, set this variable to true:
-  final bool usePowershellOnPosix =
-      io.Platform.environment['FORCE_POWERSHELL'] == 'true';
+  final bool usePowershellOnPosix = io.Platform.environment['FORCE_POWERSHELL'] == 'true';
 
   print('env: ${io.Platform.environment}');
 
@@ -50,14 +49,8 @@ void main() {
     }
   }
 
-  io.ProcessResult run(
-    String executable,
-    List<String> args, {
-    String? workingPath,
-  }) {
-    print(
-      'Running "$executable ${args.join(" ")}"${workingPath != null ? ' $workingPath' : ''}',
-    );
+  io.ProcessResult run(String executable, List<String> args, {String? workingPath}) {
+    print('Running "$executable ${args.join(" ")}"${workingPath != null ? ' $workingPath' : ''}');
     final io.ProcessResult result = io.Process.runSync(
       executable,
       args,
@@ -79,30 +72,20 @@ void main() {
 
   setUpAll(() async {
     if (usePowershellOnPosix) {
-      final io.ProcessResult result = io.Process.runSync('pwsh', <String>[
-        '--version',
-      ]);
-      print(
-        'Using Powershell (${result.stdout}) on POSIX for local debugging and testing',
-      );
+      final io.ProcessResult result = io.Process.runSync('pwsh', <String>['--version']);
+      print('Using Powershell (${result.stdout}) on POSIX for local debugging and testing');
     }
   });
 
   setUp(() async {
     tmpDir = localFs.systemTempDirectory.createTempSync('content_aware_hash.');
-    testRoot = _FlutterRootUnderTest.fromPath(
-      tmpDir.childDirectory('flutter').path,
-    );
+    testRoot = _FlutterRootUnderTest.fromPath(tmpDir.childDirectory('flutter').path);
 
     environment = <String, String>{};
 
     if (const LocalPlatform().isWindows || usePowershellOnPosix) {
       // Copy a minimal set of environment variables needed to run the update_engine_version script in PowerShell.
-      const List<String> powerShellVariables = <String>[
-        'SystemRoot',
-        'PATH',
-        'PATHEXT',
-      ];
+      const List<String> powerShellVariables = <String>['SystemRoot', 'PATH', 'PATHEXT'];
       for (final String key in powerShellVariables) {
         final String? value = io.Platform.environment[key];
         if (value != null) {
@@ -144,12 +127,7 @@ void main() {
       executable = 'powershell';
       // "ExecutionPolicy Bypass" is required to execute scripts from temp
       // folders on Windows 11 machines.
-      args = <String>[
-        '-ExecutionPolicy',
-        'Bypass',
-        '-File',
-        testRoot.contentAwareHashPs1.path,
-      ];
+      args = <String>['-ExecutionPolicy', 'Bypass', '-File', testRoot.contentAwareHashPs1.path];
     } else if (usePowershellOnPosix) {
       executable = 'pwsh';
       args = <String>[testRoot.contentAwareHashPs1.path];
@@ -179,29 +157,16 @@ void main() {
     String branch = 'master',
     String remote = 'upstream',
   }) {
-    run('git', <String>[
-      'init',
-      '--initial-branch',
-      branch,
-    ], workingPath: workingPath);
+    run('git', <String>['init', '--initial-branch', branch], workingPath: workingPath);
     // autocrlf is very important for tests to work on windows.
-    run(
-      'git',
-      'config --local core.autocrlf true'.split(' '),
-      workingPath: workingPath,
-    );
+    run('git', 'config --local core.autocrlf true'.split(' '), workingPath: workingPath);
     run('git', <String>[
       'config',
       '--local',
       'user.email',
       'test@example.com',
     ], workingPath: workingPath);
-    run('git', <String>[
-      'config',
-      '--local',
-      'user.name',
-      'Test User',
-    ], workingPath: workingPath);
+    run('git', <String>['config', '--local', 'user.name', 'Test User'], workingPath: workingPath);
     run('git', <String>['add', '.'], workingPath: workingPath);
     run('git', <String>[
       'commit',
@@ -214,23 +179,14 @@ void main() {
   }
 
   String gitShaFor(String ref, {String? workingPath}) {
-    return (run('git', <String>[
-              'rev-parse',
-              ref,
-            ], workingPath: workingPath).stdout
-            as String)
+    return (run('git', <String>['rev-parse', ref], workingPath: workingPath).stdout as String)
         .trim();
   }
 
   void writeFileAndCommit(File file, String contents) {
     file.writeAsStringSync(contents);
     run('git', <String>['add', '--all']);
-    run('git', <String>[
-      'commit',
-      '--all',
-      '-m',
-      'changed ${file.basename} to $contents',
-    ]);
+    run('git', <String>['commit', '--all', '-m', 'changed ${file.basename} to $contents']);
   }
 
   void gitSwitchBranch(String branch, {bool create = true}) {
@@ -242,34 +198,22 @@ void main() {
 
   test('generates a hash or upstream/master', () async {
     initGitRepoWithBlankInitialCommit();
-    expect(
-      runContentAwareHash(),
-      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-    );
+    expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
   test('generates a hash for origin/master', () {
     initGitRepoWithBlankInitialCommit(remote: 'origin');
-    expect(
-      runContentAwareHash(),
-      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-    );
+    expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
   test('generates a hash for origin/main', () {
     initGitRepoWithBlankInitialCommit(remote: 'origin', branch: 'main');
-    expect(
-      runContentAwareHash(),
-      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-    );
+    expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
   test('generates a hash for upstream/main', () {
     initGitRepoWithBlankInitialCommit(branch: 'main');
-    expect(
-      runContentAwareHash(),
-      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-    );
+    expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
   test('generates a hash for CI/CD from HEAD', () {
@@ -280,25 +224,15 @@ void main() {
 
     final String headSha = gitShaFor('HEAD');
     run('git', <String>['checkout', '-f', headSha]);
-    run('git', <String>[
-      '--no-pager',
-      'log',
-      '--decorate=short',
-      '--pretty=oneline',
-    ]);
+    run('git', <String>['--no-pager', 'log', '--decorate=short', '--pretty=oneline']);
     expect(
-      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout
-              as String)
-          .trim(),
+      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout as String).trim(),
       equals('HEAD'),
     );
 
     // Simulate being in a LUCI environment.
     environment['LUCI_CI'] = 'true';
-    expect(
-      runContentAwareHash(),
-      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-    );
+    expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
   });
 
   test('generates a hash based on merge-base in local detached HEAD', () {
@@ -309,33 +243,20 @@ void main() {
 
     final String headSha = gitShaFor('HEAD');
     run('git', <String>['checkout', '-f', headSha]);
-    run('git', <String>[
-      '--no-pager',
-      'log',
-      '--decorate=short',
-      '--pretty=oneline',
-    ]);
+    run('git', <String>['--no-pager', 'log', '--decorate=short', '--pretty=oneline']);
     expect(
-      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout
-              as String)
-          .trim(),
+      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout as String).trim(),
       equals('HEAD'),
     );
 
-    expect(
-      runContentAwareHash(),
-      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-    );
+    expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
   group('stable branches calculate hash locally', () {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
       gitSwitchBranch('stable');
-      expect(
-        runContentAwareHash(),
-        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-      );
+      expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
     });
 
     test('with engine changes', () {
@@ -343,10 +264,7 @@ void main() {
       gitSwitchBranch('stable');
       writeFileAndCommit(testRoot.deps, 'deps changed');
 
-      expect(
-        runContentAwareHash(),
-        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-      );
+      expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
     });
   });
 
@@ -354,10 +272,7 @@ void main() {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
       gitSwitchBranch('beta');
-      expect(
-        runContentAwareHash(),
-        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-      );
+      expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
     });
 
     test('with engine changes', () {
@@ -365,10 +280,7 @@ void main() {
       gitSwitchBranch('beta');
       writeFileAndCommit(testRoot.deps, 'deps changed');
 
-      expect(
-        runContentAwareHash(),
-        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-      );
+      expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
     });
   });
 
@@ -376,10 +288,7 @@ void main() {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
       gitSwitchBranch('flutter-4.35-candidate.2');
-      expect(
-        runContentAwareHash(),
-        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-      );
+      expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
     });
 
     test('with engine changes', () {
@@ -387,10 +296,7 @@ void main() {
       gitSwitchBranch('flutter-4.35-candidate.2');
       writeFileAndCommit(testRoot.deps, 'deps changed');
 
-      expect(
-        runContentAwareHash(),
-        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-      );
+      expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
     });
   });
 
@@ -401,10 +307,7 @@ void main() {
     );
     writeFileAndCommit(testRoot.deps, 'deps changed');
 
-    expect(
-      runContentAwareHash(),
-      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-    );
+    expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
   });
 
   test('generates a hash for shallow clones', () {
@@ -414,10 +317,7 @@ void main() {
         .childFile(localFs.path.joinAll('.git/shallow'.split('/')))
         .writeAsStringSync(headSha);
     writeFileAndCommit(testRoot.deps, 'deps changed');
-    expect(
-      runContentAwareHash(),
-      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-    );
+    expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
   });
 
   group('ignores local engine for', () {
@@ -465,23 +365,17 @@ void main() {
 
     test('DEPS is changed', () async {
       writeFileAndCommit(testRoot.deps, 'deps changed');
-      expect(
-        runContentAwareHash(),
-        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
-      );
+      expect(runContentAwareHash(), processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'));
     });
 
     test('an engine file changes', () async {
       writeFileAndCommit(testRoot.engineReadMe, 'engine file changed');
-      expect(
-        runContentAwareHash(),
-        processStdout('bc993ee46320d3831092bc2c3dd86881d5c15d5f'),
-      );
+      expect(runContentAwareHash(), processStdout('bc993ee46320d3831092bc2c3dd86881d5c15d5f'));
     });
 
     test('a new engine file is added', () async {
-      final List<String> gibberish =
-          ('_abcdefghijklmnopqrstuvqxyz0123456789' * 20).split('')..shuffle();
+      final List<String> gibberish = ('_abcdefghijklmnopqrstuvqxyz0123456789' * 20).split('')
+        ..shuffle();
       final String newFileName = gibberish.take(20).join();
 
       writeFileAndCommit(
@@ -497,40 +391,24 @@ void main() {
 
     test('bin/internal/release-candidate-branch.version is present', () {
       writeFileAndCommit(
-        testRoot.contentAwareHashPs1.parent.childFile(
-          'release-candidate-branch.version',
-        ),
+        testRoot.contentAwareHashPs1.parent.childFile('release-candidate-branch.version'),
         'sup',
       );
-      expect(
-        runContentAwareHash(),
-        processStdout('ec994692b9e9610655484436cecd691cecee4c78'),
-      );
+      expect(runContentAwareHash(), processStdout('ec994692b9e9610655484436cecd691cecee4c78'));
     });
   });
 
   test('does not hash non-engine files', () async {
     initGitRepoWithBlankInitialCommit();
     testRoot.flutterReadMe.writeAsStringSync('codefu was here');
-    expect(
-      runContentAwareHash(),
-      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
-    );
+    expect(runContentAwareHash(), processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'));
   });
 
   test('missing merge-base defaults to HEAD', () {
     initGitRepoWithBlankInitialCommit();
 
-    run('git', <String>[
-      'branch',
-      '-m',
-      'no-merge-base',
-    ], workingPath: testRoot.root.path);
-    run('git', <String>[
-      'remote',
-      'remove',
-      'upstream',
-    ], workingPath: testRoot.root.path);
+    run('git', <String>['branch', '-m', 'no-merge-base'], workingPath: testRoot.root.path);
+    run('git', <String>['remote', 'remove', 'upstream'], workingPath: testRoot.root.path);
 
     writeFileAndCommit(testRoot.deps, 'deps changed');
     expect(
@@ -557,18 +435,12 @@ final class _FlutterRootUnderTest {
     return _FlutterRootUnderTest._(
       root,
       contentAwareHashPs1: root.childFile(
-        fileSystem.path.joinAll(
-          'bin/internal/content_aware_hash.ps1'.split('/'),
-        ),
+        fileSystem.path.joinAll('bin/internal/content_aware_hash.ps1'.split('/')),
       ),
       contentAwareHashSh: root.childFile(
-        fileSystem.path.joinAll(
-          'bin/internal/content_aware_hash.sh'.split('/'),
-        ),
+        fileSystem.path.joinAll('bin/internal/content_aware_hash.sh'.split('/')),
       ),
-      engineReadMe: root.childFile(
-        fileSystem.path.joinAll('engine/README.md'.split('/')),
-      ),
+      engineReadMe: root.childFile(fileSystem.path.joinAll('engine/README.md'.split('/'))),
       deps: root.childFile(fileSystem.path.join('DEPS')),
       flutterReadMe: root.childFile(
         fileSystem.path.joinAll('packages/flutter/README.md'.split('/')),
@@ -584,11 +456,7 @@ final class _FlutterRootUnderTest {
     Directory current = fileSystem.directory(path);
     while (!current.childFile('DEPS').existsSync()) {
       if (current.path == current.parent.path) {
-        throw ArgumentError.value(
-          path,
-          'path',
-          'Could not resolve flutter root',
-        );
+        throw ArgumentError.value(path, 'path', 'Could not resolve flutter root');
       }
       current = current.parent;
     }
@@ -621,9 +489,7 @@ final class _FlutterRootUnderTest {
 
 extension on File {
   void copySyncRecursive(String newPath) {
-    fileSystem
-        .directory(fileSystem.path.dirname(newPath))
-        .createSync(recursive: true);
+    fileSystem.directory(fileSystem.path.dirname(newPath)).createSync(recursive: true);
     copySync(newPath);
   }
 }
@@ -639,16 +505,13 @@ Matcher processStdout(String stdout) {
 }
 
 final class _ProcessSucceedsAndOutputs extends Matcher {
-  _ProcessSucceedsAndOutputs(String stdout)
-    : _expected = collapseWhitespace(stdout);
+  _ProcessSucceedsAndOutputs(String stdout) : _expected = collapseWhitespace(stdout);
 
   final String _expected;
 
   @override
   bool matches(Object? item, _) {
-    if (item is! io.ProcessResult ||
-        item.exitCode != 0 ||
-        item.stdout is! String) {
+    if (item is! io.ProcessResult || item.exitCode != 0 || item.stdout is! String) {
       return false;
     }
     final String actual = item.stdout as String;

--- a/dev/tools/test/content_aware_hash_test.dart
+++ b/dev/tools/test/content_aware_hash_test.dart
@@ -30,7 +30,8 @@ void main() {
   // linux: https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-linux
   //
   // Then, set this variable to true:
-  final bool usePowershellOnPosix = io.Platform.environment['FORCE_POWERSHELL'] == 'true';
+  final bool usePowershellOnPosix =
+      io.Platform.environment['FORCE_POWERSHELL'] == 'true';
 
   print('env: ${io.Platform.environment}');
 
@@ -49,8 +50,14 @@ void main() {
     }
   }
 
-  io.ProcessResult run(String executable, List<String> args, {String? workingPath}) {
-    print('Running "$executable ${args.join(" ")}"${workingPath != null ? ' $workingPath' : ''}');
+  io.ProcessResult run(
+    String executable,
+    List<String> args, {
+    String? workingPath,
+  }) {
+    print(
+      'Running "$executable ${args.join(" ")}"${workingPath != null ? ' $workingPath' : ''}',
+    );
     final io.ProcessResult result = io.Process.runSync(
       executable,
       args,
@@ -72,20 +79,30 @@ void main() {
 
   setUpAll(() async {
     if (usePowershellOnPosix) {
-      final io.ProcessResult result = io.Process.runSync('pwsh', <String>['--version']);
-      print('Using Powershell (${result.stdout}) on POSIX for local debugging and testing');
+      final io.ProcessResult result = io.Process.runSync('pwsh', <String>[
+        '--version',
+      ]);
+      print(
+        'Using Powershell (${result.stdout}) on POSIX for local debugging and testing',
+      );
     }
   });
 
   setUp(() async {
     tmpDir = localFs.systemTempDirectory.createTempSync('content_aware_hash.');
-    testRoot = _FlutterRootUnderTest.fromPath(tmpDir.childDirectory('flutter').path);
+    testRoot = _FlutterRootUnderTest.fromPath(
+      tmpDir.childDirectory('flutter').path,
+    );
 
     environment = <String, String>{};
 
     if (const LocalPlatform().isWindows || usePowershellOnPosix) {
       // Copy a minimal set of environment variables needed to run the update_engine_version script in PowerShell.
-      const List<String> powerShellVariables = <String>['SystemRoot', 'PATH', 'PATHEXT'];
+      const List<String> powerShellVariables = <String>[
+        'SystemRoot',
+        'PATH',
+        'PATHEXT',
+      ];
       for (final String key in powerShellVariables) {
         final String? value = io.Platform.environment[key];
         if (value != null) {
@@ -127,7 +144,12 @@ void main() {
       executable = 'powershell';
       // "ExecutionPolicy Bypass" is required to execute scripts from temp
       // folders on Windows 11 machines.
-      args = <String>['-ExecutionPolicy', 'Bypass', '-File', testRoot.contentAwareHashPs1.path];
+      args = <String>[
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        testRoot.contentAwareHashPs1.path,
+      ];
     } else if (usePowershellOnPosix) {
       executable = 'pwsh';
       args = <String>[testRoot.contentAwareHashPs1.path];
@@ -157,16 +179,29 @@ void main() {
     String branch = 'master',
     String remote = 'upstream',
   }) {
-    run('git', <String>['init', '--initial-branch', branch], workingPath: workingPath);
+    run('git', <String>[
+      'init',
+      '--initial-branch',
+      branch,
+    ], workingPath: workingPath);
     // autocrlf is very important for tests to work on windows.
-    run('git', 'config --local core.autocrlf true'.split(' '), workingPath: workingPath);
+    run(
+      'git',
+      'config --local core.autocrlf true'.split(' '),
+      workingPath: workingPath,
+    );
     run('git', <String>[
       'config',
       '--local',
       'user.email',
       'test@example.com',
     ], workingPath: workingPath);
-    run('git', <String>['config', '--local', 'user.name', 'Test User'], workingPath: workingPath);
+    run('git', <String>[
+      'config',
+      '--local',
+      'user.name',
+      'Test User',
+    ], workingPath: workingPath);
     run('git', <String>['add', '.'], workingPath: workingPath);
     run('git', <String>[
       'commit',
@@ -179,14 +214,23 @@ void main() {
   }
 
   String gitShaFor(String ref, {String? workingPath}) {
-    return (run('git', <String>['rev-parse', ref], workingPath: workingPath).stdout as String)
+    return (run('git', <String>[
+              'rev-parse',
+              ref,
+            ], workingPath: workingPath).stdout
+            as String)
         .trim();
   }
 
   void writeFileAndCommit(File file, String contents) {
     file.writeAsStringSync(contents);
     run('git', <String>['add', '--all']);
-    run('git', <String>['commit', '--all', '-m', 'changed ${file.basename} to $contents']);
+    run('git', <String>[
+      'commit',
+      '--all',
+      '-m',
+      'changed ${file.basename} to $contents',
+    ]);
   }
 
   void gitSwitchBranch(String branch, {bool create = true}) {
@@ -198,22 +242,34 @@ void main() {
 
   test('generates a hash or upstream/master', () async {
     initGitRepoWithBlankInitialCommit();
-    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    expect(
+      runContentAwareHash(),
+      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+    );
   });
 
   test('generates a hash for origin/master', () {
     initGitRepoWithBlankInitialCommit(remote: 'origin');
-    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    expect(
+      runContentAwareHash(),
+      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+    );
   });
 
   test('generates a hash for origin/main', () {
     initGitRepoWithBlankInitialCommit(remote: 'origin', branch: 'main');
-    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    expect(
+      runContentAwareHash(),
+      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+    );
   });
 
   test('generates a hash for upstream/main', () {
     initGitRepoWithBlankInitialCommit(branch: 'main');
-    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    expect(
+      runContentAwareHash(),
+      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+    );
   });
 
   test('generates a hash for CI/CD from HEAD', () {
@@ -224,15 +280,25 @@ void main() {
 
     final String headSha = gitShaFor('HEAD');
     run('git', <String>['checkout', '-f', headSha]);
-    run('git', <String>['--no-pager', 'log', '--decorate=short', '--pretty=oneline']);
+    run('git', <String>[
+      '--no-pager',
+      'log',
+      '--decorate=short',
+      '--pretty=oneline',
+    ]);
     expect(
-      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout as String).trim(),
+      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout
+              as String)
+          .trim(),
       equals('HEAD'),
     );
 
     // Simulate being in a LUCI environment.
     environment['LUCI_CI'] = 'true';
-    expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+    expect(
+      runContentAwareHash(),
+      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+    );
   });
 
   test('generates a hash based on merge-base in local detached HEAD', () {
@@ -243,20 +309,33 @@ void main() {
 
     final String headSha = gitShaFor('HEAD');
     run('git', <String>['checkout', '-f', headSha]);
-    run('git', <String>['--no-pager', 'log', '--decorate=short', '--pretty=oneline']);
+    run('git', <String>[
+      '--no-pager',
+      'log',
+      '--decorate=short',
+      '--pretty=oneline',
+    ]);
     expect(
-      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout as String).trim(),
+      (run('git', <String>['rev-parse', '--abbrev-ref', 'HEAD']).stdout
+              as String)
+          .trim(),
       equals('HEAD'),
     );
 
-    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    expect(
+      runContentAwareHash(),
+      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+    );
   });
 
   group('stable branches calculate hash locally', () {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
       gitSwitchBranch('stable');
-      expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+      expect(
+        runContentAwareHash(),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+      );
     });
 
     test('with engine changes', () {
@@ -264,7 +343,10 @@ void main() {
       gitSwitchBranch('stable');
       writeFileAndCommit(testRoot.deps, 'deps changed');
 
-      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+      expect(
+        runContentAwareHash(),
+        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+      );
     });
   });
 
@@ -272,7 +354,10 @@ void main() {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
       gitSwitchBranch('beta');
-      expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+      expect(
+        runContentAwareHash(),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+      );
     });
 
     test('with engine changes', () {
@@ -280,7 +365,10 @@ void main() {
       gitSwitchBranch('beta');
       writeFileAndCommit(testRoot.deps, 'deps changed');
 
-      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+      expect(
+        runContentAwareHash(),
+        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+      );
     });
   });
 
@@ -288,7 +376,10 @@ void main() {
     test('with no changes', () {
       initGitRepoWithBlankInitialCommit(branch: 'main');
       gitSwitchBranch('flutter-4.35-candidate.2');
-      expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+      expect(
+        runContentAwareHash(),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+      );
     });
 
     test('with engine changes', () {
@@ -296,7 +387,10 @@ void main() {
       gitSwitchBranch('flutter-4.35-candidate.2');
       writeFileAndCommit(testRoot.deps, 'deps changed');
 
-      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+      expect(
+        runContentAwareHash(),
+        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+      );
     });
   });
 
@@ -307,7 +401,10 @@ void main() {
     );
     writeFileAndCommit(testRoot.deps, 'deps changed');
 
-    expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+    expect(
+      runContentAwareHash(),
+      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+    );
   });
 
   test('generates a hash for shallow clones', () {
@@ -317,7 +414,10 @@ void main() {
         .childFile(localFs.path.joinAll('.git/shallow'.split('/')))
         .writeAsStringSync(headSha);
     writeFileAndCommit(testRoot.deps, 'deps changed');
-    expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+    expect(
+      runContentAwareHash(),
+      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+    );
   });
 
   group('ignores local engine for', () {
@@ -327,14 +427,14 @@ void main() {
       testRoot.deps.writeAsStringSync('deps changed');
       expect(
         runContentAwareHash(),
-        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
         reason: 'content hash from master for non-committed file',
       );
 
       writeFileAndCommit(testRoot.deps, 'deps changed');
       expect(
         runContentAwareHash(),
-        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
         reason: 'content hash from master for committed file',
       );
     });
@@ -345,14 +445,14 @@ void main() {
       testRoot.deps.writeAsStringSync('deps changed');
       expect(
         runContentAwareHash(),
-        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
         reason: 'content hash from master for non-committed file',
       );
 
       writeFileAndCommit(testRoot.deps, 'deps changed');
       expect(
         runContentAwareHash(),
-        processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'),
+        processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
         reason: 'content hash from master for committed file',
       );
     });
@@ -365,17 +465,23 @@ void main() {
 
     test('DEPS is changed', () async {
       writeFileAndCommit(testRoot.deps, 'deps changed');
-      expect(runContentAwareHash(), processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'));
+      expect(
+        runContentAwareHash(),
+        processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
+      );
     });
 
     test('an engine file changes', () async {
       writeFileAndCommit(testRoot.engineReadMe, 'engine file changed');
-      expect(runContentAwareHash(), processStdout('49e58f425cb039e745614d7ea10c369387c43681'));
+      expect(
+        runContentAwareHash(),
+        processStdout('bc993ee46320d3831092bc2c3dd86881d5c15d5f'),
+      );
     });
 
     test('a new engine file is added', () async {
-      final List<String> gibberish = ('_abcdefghijklmnopqrstuvqxyz0123456789' * 20).split('')
-        ..shuffle();
+      final List<String> gibberish =
+          ('_abcdefghijklmnopqrstuvqxyz0123456789' * 20).split('')..shuffle();
       final String newFileName = gibberish.take(20).join();
 
       writeFileAndCommit(
@@ -391,29 +497,45 @@ void main() {
 
     test('bin/internal/release-candidate-branch.version is present', () {
       writeFileAndCommit(
-        testRoot.contentAwareHashPs1.parent.childFile('release-candidate-branch.version'),
+        testRoot.contentAwareHashPs1.parent.childFile(
+          'release-candidate-branch.version',
+        ),
         'sup',
       );
-      expect(runContentAwareHash(), processStdout('3b81cd2164f26a8db3271d46c7022c159193417d'));
+      expect(
+        runContentAwareHash(),
+        processStdout('ec994692b9e9610655484436cecd691cecee4c78'),
+      );
     });
   });
 
   test('does not hash non-engine files', () async {
     initGitRepoWithBlankInitialCommit();
     testRoot.flutterReadMe.writeAsStringSync('codefu was here');
-    expect(runContentAwareHash(), processStdout('3bbeb6a394378478683ece4f8e8663c42f8dc814'));
+    expect(
+      runContentAwareHash(),
+      processStdout('fa69812cddffc076be3aa477a93942cb8d233ccc'),
+    );
   });
 
   test('missing merge-base defaults to HEAD', () {
     initGitRepoWithBlankInitialCommit();
 
-    run('git', <String>['branch', '-m', 'no-merge-base'], workingPath: testRoot.root.path);
-    run('git', <String>['remote', 'remove', 'upstream'], workingPath: testRoot.root.path);
+    run('git', <String>[
+      'branch',
+      '-m',
+      'no-merge-base',
+    ], workingPath: testRoot.root.path);
+    run('git', <String>[
+      'remote',
+      'remove',
+      'upstream',
+    ], workingPath: testRoot.root.path);
 
     writeFileAndCommit(testRoot.deps, 'deps changed');
     expect(
       runContentAwareHash(),
-      processStdout('f049fdcd4300c8c0d5041b5e35b3d11c2d289bdf'),
+      processStdout('63a6c6dc494d9a2fc3e78e8505e878d129429246'),
       reason: 'content hash from HEAD when no merge-base',
     );
   });
@@ -435,12 +557,18 @@ final class _FlutterRootUnderTest {
     return _FlutterRootUnderTest._(
       root,
       contentAwareHashPs1: root.childFile(
-        fileSystem.path.joinAll('bin/internal/content_aware_hash.ps1'.split('/')),
+        fileSystem.path.joinAll(
+          'bin/internal/content_aware_hash.ps1'.split('/'),
+        ),
       ),
       contentAwareHashSh: root.childFile(
-        fileSystem.path.joinAll('bin/internal/content_aware_hash.sh'.split('/')),
+        fileSystem.path.joinAll(
+          'bin/internal/content_aware_hash.sh'.split('/'),
+        ),
       ),
-      engineReadMe: root.childFile(fileSystem.path.joinAll('engine/README.md'.split('/'))),
+      engineReadMe: root.childFile(
+        fileSystem.path.joinAll('engine/README.md'.split('/')),
+      ),
       deps: root.childFile(fileSystem.path.join('DEPS')),
       flutterReadMe: root.childFile(
         fileSystem.path.joinAll('packages/flutter/README.md'.split('/')),
@@ -456,7 +584,11 @@ final class _FlutterRootUnderTest {
     Directory current = fileSystem.directory(path);
     while (!current.childFile('DEPS').existsSync()) {
       if (current.path == current.parent.path) {
-        throw ArgumentError.value(path, 'path', 'Could not resolve flutter root');
+        throw ArgumentError.value(
+          path,
+          'path',
+          'Could not resolve flutter root',
+        );
       }
       current = current.parent;
     }
@@ -489,7 +621,9 @@ final class _FlutterRootUnderTest {
 
 extension on File {
   void copySyncRecursive(String newPath) {
-    fileSystem.directory(fileSystem.path.dirname(newPath)).createSync(recursive: true);
+    fileSystem
+        .directory(fileSystem.path.dirname(newPath))
+        .createSync(recursive: true);
     copySync(newPath);
   }
 }
@@ -505,13 +639,16 @@ Matcher processStdout(String stdout) {
 }
 
 final class _ProcessSucceedsAndOutputs extends Matcher {
-  _ProcessSucceedsAndOutputs(String stdout) : _expected = collapseWhitespace(stdout);
+  _ProcessSucceedsAndOutputs(String stdout)
+    : _expected = collapseWhitespace(stdout);
 
   final String _expected;
 
   @override
   bool matches(Object? item, _) {
-    if (item is! io.ProcessResult || item.exitCode != 0 || item.stdout is! String) {
+    if (item is! io.ProcessResult ||
+        item.exitCode != 0 ||
+        item.stdout is! String) {
       return false;
     }
     final String actual = item.stdout as String;


### PR DESCRIPTION
content aware hash was using --format which isn't present in older, but still supported operating systems. this pr removes the format string which basically reduces the output before hasing to:

```shell
100644 blob 198d80926b6e873c327f71350a0cdefee6a8402f	DEPS
040000 tree 139c1f10f92e4b9d4ac3ec7d4d27b2aa9775c5cd	engine
```

this format is still stable across all platforms and passed into `git hash-object` - which produces the actual hash fingerprint of the engine.

safety: this is the only scripts that produce this hash, so all downstream consumers keep consuming a sha1 output. Since this changes the sha, an engine version shouldn't exist for it and cocoon will build the artifacts for it.

fixes: #175265
