### PR TITLE
Fix InputDecoration helper/error padding is not compliant

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -975,7 +975,10 @@ class _RenderDecoration extends RenderBox
       EdgeInsets.only(left: iconWidth),
     );
     final BoxConstraints contentConstraints = containerConstraints.deflate(
-      EdgeInsets.only(left: contentPadding.horizontal),
+      EdgeInsetsDirectional.only(
+        start: contentPadding.start + decoration.inputGap,
+        end: contentPadding.end + decoration.inputGap,
+      ),
     );
 
     // The helper or error text can occupy the full width less the space
@@ -1264,7 +1267,7 @@ class _RenderDecoration extends RenderBox
     final double suffixIconHeight = _minHeight(suffixIcon, width);
     final double suffixIconWidth = _minWidth(suffixIcon, suffixIconHeight);
 
-    width = math.max(width - contentPadding.horizontal, 0.0);
+    width = math.max(width - contentPadding.horizontal - decoration.inputGap * 2, 0.0);
 
     // TODO(LongCatIsLooong): use _computeSubtextSizes for subtext intrinsic sizes.
     // See https://github.com/flutter/flutter/issues/13715.

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -15807,7 +15807,7 @@ void main() {
     expect(tester.getTopRight(errorFinder).dx, inputWidth - defaultPadding);
 
     // Error in RTL.
-    await buildDecorator(direction: TextDirection.ltr, errorText: longText);
+    await buildDecorator(direction: TextDirection.rtl, errorText: longText);
 
     expect(tester.getTopLeft(errorFinder).dx, defaultPadding);
     expect(tester.getTopRight(errorFinder).dx, inputWidth - defaultPadding);


### PR DESCRIPTION
## Description

This PR fixes the InputDecoration helper/error padding.
When a counter is defined, this PR fixes the width of the gap between helper/error and the counter.

M3 specs:

<img width="1090" height="430" alt="Screenshot 2025-10-07 at 5 36 05 PM" src="https://github.com/user-attachments/assets/cf83b30b-4cfb-4379-8cb0-7e35cd5fe414" />


## Before

<img width="759" height="172" alt="image" src="https://github.com/user-attachments/assets/b8f733f5-4688-478a-b475-06130e4f6691" />

## After

<img width="759" height="172" alt="image" src="https://github.com/user-attachments/assets/a40eb328-8447-4c24-9ced-95ea619f2e1c" />

## Related Issue

Fixes [InputDecoration helper/error end padding is not compliant with M3 spec](https://github.com/flutter/flutter/issues/175993) 

## Tests

- Adds 2 tests. One to verify the new padding. Another to verify the change in intrinsic height calculation. This second test does not fail without the PR but it would have failed if the PR changes only the padding and did not update the intrinsic height logic.
- Updates 1 test related to the gap between error/helper and counter.