### PR TITLE
[ Widget Preview ] Fix resolution for workspace "hosted" dependencies

### DIFF
--- a/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
@@ -112,13 +112,15 @@ class PreviewPubspecBuilder {
         rootProject,
         ...rootProject.workspaceProjects,
       ])
-        // Use `json.encode` to handle escapes correctly.
-        project.manifest.appName: json.encode(<String, Object?>{
-          // `pub add` interprets relative paths relative to the current directory.
-          'path': widgetPreviewScaffoldProject.directory.fileSystem.path.relative(
-            project.directory.path,
-          ),
-        }),
+        // Don't try and depend on unnamed projects.
+        if (project.manifest.appName.isNotEmpty)
+          // Use `json.encode` to handle escapes correctly.
+          project.manifest.appName: json.encode(<String, Object?>{
+            // `pub add` interprets relative paths relative to the current directory.
+            'path': widgetPreviewScaffoldProject.directory.fileSystem.path.relative(
+              project.directory.path,
+            ),
+          }),
     };
 
     final PubOutputMode outputMode = verbose ? PubOutputMode.all : PubOutputMode.failuresOnly;
@@ -130,8 +132,13 @@ class PreviewPubspecBuilder {
         widgetPreviewScaffoldProject.directory.path,
         // Ensure the path using POSIX separators, otherwise the "path_not_posix" check will fail.
         for (final MapEntry<String, String>(:String key, :String value)
-            in workspacePackages.entries)
+            in workspacePackages.entries) ...[
           '$key:$value',
+          // Add dependency overrides to handle "hosted" dependencies on other projects within the
+          // workspace. These dependencies take the form of "my_workspace_project: " in the
+          // pubspec's dependency list. See https://github.com/flutter/flutter/issues/176018.
+          'override:$key:$value',
+        ],
       ],
       context: PubContext.pubAdd,
       command: pubAdd,

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_pubspec_builder_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_pubspec_builder_test.dart
@@ -18,7 +18,7 @@ import '../../../src/context.dart';
 import '../../../src/package_config.dart';
 
 void main() {
-  group('WidgetPreviewStartCommand', () {
+  group('$PreviewPubspecBuilder', () {
     late MemoryFileSystem fileSystem;
     late ProcessManager processManager;
     late PreviewPubspecBuilder pubspecBuilder;

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
@@ -92,7 +92,7 @@ dependencies:
         final yaml =
             loadYaml(rootProject.widgetPreviewScaffoldProject.pubspecFile.readAsStringSync())
                 as YamlMap;
-        const expectedDependencies = <String, Map<String, String>>{
+        const expectedDependencies = <String, Object?>{
           'abcd': {'path': '../../packages/$kPackageProjectName'},
           'example': {'path': '../../packages/$kExampleProjectName'},
         };
@@ -103,10 +103,13 @@ dependencies:
         // dependency (e.g., a dependency of the form "some_workspace_package: " with no version
         // constraint or path).
         if (yaml case {
-          'dependencies': expectedDependencies,
-          'dependency_overrides': expectedDependencies,
+          'dependencies': final YamlMap dependencies,
+          'dependency_overrides': final YamlMap dependencyOverrides,
         }) {
-          // Do nothing.
+          for (final MapEntry(key: package, value: constraint) in expectedDependencies.entries) {
+            expect(dependencies[package], constraint);
+            expect(dependencyOverrides[package], constraint);
+          }
         } else {
           fail('''
 Did not find the following dependencies for "dependencies" or "dependency_overrides":

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/regress_176018_test.dart
@@ -1,0 +1,139 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/signals.dart';
+import 'package:flutter_tools/src/dart/pub.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/widget_preview/preview_manifest.dart';
+import 'package:flutter_tools/src/widget_preview/preview_pubspec_builder.dart';
+import 'package:process/process.dart';
+import 'package:test/fake.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../../src/common.dart';
+import '../../../src/context.dart';
+import '../../../src/fakes.dart';
+import 'utils/preview_project.dart';
+
+// Regression test for https://github.com/flutter/flutter/issues/176018.
+
+void main() {
+  group('$PreviewPubspecBuilder', () {
+    late final LocalFileSystem fs;
+    late final Directory root;
+    late final Logger logger;
+    late final ProcessManager processManager;
+
+    setUp(() {
+      fs = LocalFileSystem.test(signals: Signals.test());
+      root = fs.systemTempDirectory.createTempSync();
+      logger = BufferLogger.test();
+      processManager = const LocalProcessManager();
+    });
+
+    tearDown(() {
+      root.deleteSync(recursive: true);
+    });
+
+    testUsingContext(
+      'creates dependency_overrides for previewed project dependencies',
+      () async {
+        const kPackageProjectName = 'abcd';
+        const kExampleProjectName = 'example';
+        final workspace = WidgetPreviewWorkspace(workspaceRoot: root);
+        final WidgetPreviewProject packageProject = await workspace.createWorkspaceProject(
+          name: kPackageProjectName,
+        );
+        final WidgetPreviewProject exampleProject = await workspace.createWorkspaceProject(
+          name: kExampleProjectName,
+        );
+
+        // Add a dependency on the package project from the example project.
+        exampleProject.writePubspec('''
+${exampleProject.initialPubspecContents}
+  ${packageProject.packageName}: # This resolves to the other package in the workspace
+''');
+
+        final FlutterProject rootProject = FlutterProject.fromDirectory(root);
+        final pubspecBuilder = PreviewPubspecBuilder(
+          logger: logger,
+          verbose: true,
+          offline: false,
+          rootProject: rootProject,
+          previewManifest: FakePreviewManifest(),
+        );
+
+        // Bare minimum initialization of the widget_preview_scaffold project.
+        rootProject.widgetPreviewScaffold.childFile('pubspec.yaml')
+          ..createSync(recursive: true)
+          ..writeAsStringSync('''
+name: widget_preview_scaffold
+environment:
+  sdk: ^3.7.0
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+''');
+
+        // Populate .dart_tool/widget_preview_scaffold/pubspec.yaml with the dependencies on the
+        // local projects.
+        await pubspecBuilder.populatePreviewPubspec(rootProject: rootProject);
+        final yaml =
+            loadYaml(rootProject.widgetPreviewScaffoldProject.pubspecFile.readAsStringSync())
+                as YamlMap;
+        const expectedDependencies = <String, Map<String, String>>{
+          'abcd': {'path': '../../packages/$kPackageProjectName'},
+          'example': {'path': '../../packages/$kExampleProjectName'},
+        };
+
+        // The generated pubspec.yaml should have path dependencies on both the package and example
+        // projects, but should also have dependency_overrides set to handle cases where one
+        // project in a workspace depends on another without explicitly specifying a path
+        // dependency (e.g., a dependency of the form "some_workspace_package: " with no version
+        // constraint or path).
+        if (yaml case {
+          'dependencies': expectedDependencies,
+          'dependency_overrides': expectedDependencies,
+        }) {
+          // Do nothing.
+        } else {
+          fail('''
+Did not find the following dependencies for "dependencies" or "dependency_overrides":
+$expectedDependencies
+
+Actual pubspec:
+$yaml
+''');
+        }
+      },
+      overrides: {
+        Pub: () => Pub.test(
+          fileSystem: fs,
+          logger: logger,
+          processManager: processManager,
+          botDetector: const FakeBotDetector(true),
+          platform: const LocalPlatform(),
+          stdio: Stdio.test(stdout: stdout, stderr: stderr),
+        ),
+      },
+    );
+  });
+}
+
+class FakePreviewManifest extends Fake implements PreviewManifest {
+  @override
+  void updatePubspecHash({String? updatedPubspecPath}) {
+    // Do nothing.
+  }
+}

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_project.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_project.dart
@@ -45,7 +45,7 @@ class WidgetPreviewWorkspace {
       inWorkspace: true,
       packageName: name,
     );
-    project._writePubspec(project.pubspecContents);
+    project.writePubspec(project.initialPubspecContents);
     _packages[name] = project;
     await _updatePubspec();
     return project;
@@ -108,7 +108,7 @@ class WidgetPreviewProject {
   final String packageName;
 
   /// The initial contents of the pubspec.yaml for the project.
-  String get pubspecContents =>
+  String get initialPubspecContents =>
       '''
 name: $packageName
 
@@ -123,6 +123,9 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 ''';
+
+  /// The current contents of the pubspec.yaml for the project.
+  String get pubspecContents => _pubspecYaml.readAsStringSync();
 
   /// The root of the fake project.
   ///
@@ -155,7 +158,7 @@ dependencies:
 
   /// Writes `pubspec.yaml` and `.dart_tool/package_config.json` at [projectRoot].
   Future<void> initializePubspec() async {
-    _writePubspec(pubspecContents);
+    writePubspec(initialPubspecContents);
     final String flutterRoot = getFlutterRoot();
     await savePackageConfig(
       PackageConfig(
@@ -189,7 +192,7 @@ dependencies:
   }
 
   /// Updates the content of the project's pubspec.yaml.
-  void _writePubspec(String contents) {
+  void writePubspec(String contents) {
     projectRoot.childFile(_kPubspec)
       ..createSync(recursive: true)
       ..writeAsStringSync(contents);


### PR DESCRIPTION
Projects within the same workspace can depend on each other without explicitly specifying path dependencies or dependency overrides using the following syntax:

```
dependencies:
  my_workspace_project: # No constraint or path
```

This is treated as a "hosted" dependency, which conflicts with the path dependencies used by the widget_preview_scaffold.

This change introduces dependency_overrides for each package in the workspace watched by the widget previewer to allow for dependencies to be resolved correctly.

Fixes https://github.com/flutter/flutter/issues/176018