### PR TITLE
[CP] Flutter analyze --suggestions update for 3.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ docs/releases/Hotfix-Documentation-Best-Practices.md
 
 ### [3.35.5](https://github.com/flutter/flutter/releases/tag/3.35.5)
 
+[flutter/175669](https://github.com/flutter/flutter/issues/175669) Flutter analyze --suggestions supports versions up to Java 25, Gradle 9 and AGP 9, Kotlin 2.2.20.
+
+### [3.35.5](https://github.com/flutter/flutter/releases/tag/3.35.5)
+
  - [flutter/172105](https://github.com/flutter/flutter/issues/172105) Flutter view no longer hangs after multiple transitions on iOS add-to-app.
  - [flutter/173106](https://github.com/flutter/flutter/issues/173106) Multiple cursors display correctly.
 

--- a/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
+++ b/dev/devicelab/bin/tasks/android_java17_dependency_smoke_tests.dart
@@ -21,7 +21,7 @@ List<VersionTuple> versionTuples = <VersionTuple>[
   // Template
   VersionTuple(agpVersion: '8.9.1', gradleVersion: '8.12', kotlinVersion: '2.1.0'),
   // Max known
-  VersionTuple(agpVersion: '8.10.0', gradleVersion: '9.0.0-rc-2', kotlinVersion: '2.2.0'),
+  VersionTuple(agpVersion: '8.10.0', gradleVersion: '9.1.0', kotlinVersion: '2.2.0'),
   /* Others */
   VersionTuple(agpVersion: '8.4.0', gradleVersion: '8.6', kotlinVersion: '1.8.22'),
   VersionTuple(agpVersion: '8.6.0', gradleVersion: '8.7', kotlinVersion: '1.8.22'),

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -72,7 +72,7 @@ const maxKnownAndSupportedGradleVersion = '9.1.0';
 //
 // Supported here means supported by the tooling for
 // flutter analyze --suggestions and does not imply broader flutter support.
-const maxKnownAndSupportedKgpVersion = '2.1.20';
+const maxKnownAndSupportedKgpVersion = '2.2.20';
 
 // Update this when new versions of AGP come out.
 //
@@ -554,9 +554,19 @@ bool validateGradleAndKGP(Logger logger, {required String? kgpV, required String
   // add a comment with the documented value.
   // Continuous KGP version handling is prefered in case an emergency patch to a
   // past release is shipped this code will assume the version range that is closest.
-  if (isWithinVersionRange(kgpV, min: '2.1.20', max: '2.1.20')) {
-    // Documented max is 8.11, using 8.12 non inclusive covers patch versions.
-    return isWithinVersionRange(gradleV, min: '7.6.3', max: '8.12', inclusiveMax: false);
+
+  // Documented max is 2.20, using 2.2.29 covers patch versions.
+  if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.2.29')) {
+    // Documented max is 8.14, using 8.14.99 non inclusive covers patch versions.
+    return isWithinVersionRange(gradleV, min: '7.6.3', max: '8.14.99', inclusiveMax: false);
+  }
+  if (isWithinVersionRange(kgpV, min: '2.2.0', max: '2.2.10')) {
+    // Documented max is 8.14, using 8.14.99 non inclusive covers patch versions.
+    return isWithinVersionRange(gradleV, min: '7.6.3', max: '8.14.99', inclusiveMax: false);
+  }
+  if (isWithinVersionRange(kgpV, min: '2.1.20', max: '2.1.21')) {
+    // Documented max is 8.12.1, using 8.12.99 non inclusive covers patch versions.
+    return isWithinVersionRange(gradleV, min: '7.6.3', max: '8.12.99', inclusiveMax: false);
   }
   if (isWithinVersionRange(kgpV, min: '2.1.0', max: '2.1.10')) {
     // Documented max is 8.10, using 8.11 non inclusive covers patch versions.
@@ -654,7 +664,19 @@ bool validateAgpAndKgp(Logger logger, {required String? kgpV, required String? a
   // add a comment with the documented value.
   // Continuous KGP version handling is prefered in case an emergency patch to a
   // past release is shipped this code will assume the version range that is closest.
-  if (isWithinVersionRange(kgpV, min: '2.1.0', max: '2.1.20')) {
+
+  // Documented max is 2.2.20
+  if (isWithinVersionRange(kgpV, min: '2.2.20', max: '2.2.29')) {
+    // Documented max is 8.11.1
+    return isWithinVersionRange(agpV, min: '7.3.1', max: '8.12', inclusiveMax: false);
+  }
+  // Documented max is 2.2.10
+  if (isWithinVersionRange(kgpV, min: '2.2.0', max: '2.2.19')) {
+    // Documented max is 8.10.0
+    return isWithinVersionRange(agpV, min: '7.3.1', max: '8.11', inclusiveMax: false);
+  }
+  // Documented max is 2.1.21
+  if (isWithinVersionRange(kgpV, min: '2.1.0', max: '2.1.21')) {
     return isWithinVersionRange(agpV, min: '7.3.1', max: '8.7.2');
   }
   // Documented max is 2.0.21
@@ -934,7 +956,7 @@ JavaGradleCompat? getValidGradleVersionRangeForJavaVersion(Logger logger, {requi
 /// compatible with each other.
 ///
 /// Returns true when the specified Java and AGP versions are
-/// definitely compatible; otherwise, false is assumed by default. In addition,
+/// definitely compatible; True if AGP is newer than known, otherwise, false. In addition,
 /// this will return false when either a null Java or AGP version is provided.
 ///
 /// Source of truth are the AGP release notes:
@@ -963,7 +985,7 @@ bool validateJavaAndAgp(Logger logger, {required String? javaV, required String?
     inclusiveMin: false,
   )) {
     logger.printTrace('AGP Version: $agpV is too new to determine Java compatibility.');
-    return false;
+    return true;
   }
 
   // Begin known Java <-> AGP evaluation.
@@ -1242,6 +1264,9 @@ String getGradlewFileName(Platform platform) {
   }
 }
 
+@visibleForTesting
+const maxGradleVersionForJavaPre17 = '8.14.100';
+
 /// List of compatible Java/Gradle versions.
 ///
 /// Should be updated when a new version of Java is supported by a new version
@@ -1261,56 +1286,56 @@ var _javaGradleCompatList = const <JavaGradleCompat>[
     javaMin: '16',
     javaMax: '17',
     gradleMin: '7.0',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '15',
     javaMax: '16',
     gradleMin: '6.7',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '14',
     javaMax: '15',
     gradleMin: '6.3',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '13',
     javaMax: '14',
     gradleMin: '6.0',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '12',
     javaMax: '13',
     gradleMin: '5.4',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '11',
     javaMax: '12',
     gradleMin: '5.0',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   // 1.11 is a made up java version to cover everything in 1.10.*
   JavaGradleCompat(
     javaMin: '1.10',
     javaMax: '1.11',
     gradleMin: '4.7',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '1.9',
     javaMax: '1.10',
     gradleMin: '4.3',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
   JavaGradleCompat(
     javaMin: '1.8',
     javaMax: '1.9',
     gradleMin: '2.0',
-    gradleMax: maxKnownAndSupportedGradleVersion,
+    gradleMax: maxGradleVersionForJavaPre17,
   ),
 ];
 

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -79,10 +79,10 @@ const maxKnownAndSupportedKgpVersion = '2.1.20';
 // Supported here means tooling is aware of this version's Java <-> AGP
 // compatibility.
 @visibleForTesting
-const maxKnownAndSupportedAgpVersion = '8.9.1';
+const maxKnownAndSupportedAgpVersion = '9.0';
 
 // Update this when new versions of AGP come out.
-const maxKnownAgpVersion = '8.9.1';
+const maxKnownAgpVersion = '9.0';
 
 // Supported here means tooling is aware of this versions
 // Java <-> AGP compatibility and does not imply broader flutter support.
@@ -735,13 +735,14 @@ bool validateGradleAndAgp(Logger logger, {required String? gradleV, required Str
   }
 
   // Check highest supported version before checking unknown versions.
-  if (isWithinVersionRange(agpV, min: '8.0', max: maxKnownAndSupportedAgpVersion)) {
-    return isWithinVersionRange(gradleV, min: '8.0', max: maxKnownAndSupportedGradleVersion);
+  // https://developer.android.com/build/releases/agp-preview#android-gradle-plugin-compatibility
+  if (isWithinVersionRange(agpV, min: '9.0', max: '9.0.99')) {
+    return isWithinVersionRange(gradleV, min: '9.0', max: maxKnownAndSupportedGradleVersion);
   }
   // Check if versions are newer than the max known versions.
   if (isWithinVersionRange(agpV, min: maxKnownAndSupportedAgpVersion, max: '100.100')) {
     // Assume versions we do not know about are valid but log.
-    final bool validGradle = isWithinVersionRange(gradleV, min: '8.0', max: '100.00');
+    final bool validGradle = isWithinVersionRange(gradleV, min: '9.1.0', max: '100.00');
     logger.printTrace(
       'Newer than known AGP version ($agpV), gradle ($gradleV).'
       '\n Treating as valid configuration.',
@@ -750,6 +751,33 @@ bool validateGradleAndAgp(Logger logger, {required String? gradleV, required Str
   }
 
   // Begin Known Gradle <-> AGP validation.
+  if (isWithinVersionRange(agpV, min: '8.13.0', max: '8.13.99')) {
+    return isWithinVersionRange(gradleV, min: '8.13', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.12.0', max: '8.12.99')) {
+    return isWithinVersionRange(gradleV, min: '8.13', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.11.0', max: '8.11.99')) {
+    return isWithinVersionRange(gradleV, min: '8.13', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.10.0', max: '8.10.99')) {
+    return isWithinVersionRange(gradleV, min: '8.11.1', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.9.0', max: '8.9.99')) {
+    return isWithinVersionRange(gradleV, min: '8.11.1', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.8.0', max: '8.8.99')) {
+    return isWithinVersionRange(gradleV, min: '8.10.2', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.7.0', max: '8.7.99')) {
+    return isWithinVersionRange(gradleV, min: '8.9', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.6.0', max: '8.6.99')) {
+    return isWithinVersionRange(gradleV, min: '8.7', max: maxKnownAndSupportedGradleVersion);
+  }
+  if (isWithinVersionRange(agpV, min: '8.5.0', max: '8.5.99')) {
+    return isWithinVersionRange(gradleV, min: '8.7', max: maxKnownAndSupportedGradleVersion);
+  }
   if (isWithinVersionRange(agpV, min: '8.4.0', max: '8.4.99')) {
     return isWithinVersionRange(gradleV, min: '8.6', max: maxKnownAndSupportedGradleVersion);
   }
@@ -869,7 +897,12 @@ bool validateJavaAndGradle(
       max: data.javaMax,
       inclusiveMax: false,
     )) {
-      return isWithinVersionRange(gradleVersion, min: data.gradleMin, max: data.gradleMax);
+      // Null max value should be treated as unbounded on the max side.
+      return isWithinVersionRange(
+        gradleVersion,
+        min: data.gradleMin,
+        max: data.gradleMax ?? '100.100',
+      );
     }
   }
 
@@ -987,7 +1020,7 @@ VersionRange getJavaVersionFor({required String gradleV, required String agpV}) 
 /// Returns the Gradle version that is required by the given Android Gradle plugin version
 /// by picking the largest compatible version from
 /// https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
-String getGradleVersionFor(String androidPluginVersion) {
+String getGradleVersionFor(String agpV) {
   final compatList = <GradleForAgp>[
     GradleForAgp(agpMin: '1.0.0', agpMax: '1.1.3', minRequiredGradle: '2.3'),
     GradleForAgp(agpMin: '1.2.0', agpMax: '1.3.1', minRequiredGradle: '2.9'),
@@ -1013,7 +1046,12 @@ String getGradleVersionFor(String androidPluginVersion) {
     GradleForAgp(agpMin: '8.7.0', agpMax: '8.7.99', minRequiredGradle: '8.9'),
     GradleForAgp(agpMin: '8.8.0', agpMax: '8.8.99', minRequiredGradle: '8.10.2'),
     GradleForAgp(agpMin: '8.9.0', agpMax: '8.9.99', minRequiredGradle: '8.11.1'),
-    // Assume if AGP is newer than this code know about return the highest gradle
+    GradleForAgp(agpMin: '8.10.0', agpMax: '8.10.99', minRequiredGradle: '8.11.1'),
+    GradleForAgp(agpMin: '8.11.0', agpMax: '8.11.99', minRequiredGradle: '8.13'),
+    GradleForAgp(agpMin: '8.12.0', agpMax: '8.12.99', minRequiredGradle: '8.13'),
+    GradleForAgp(agpMin: '8.13.0', agpMax: '8.13.99', minRequiredGradle: '8.13'),
+    GradleForAgp(agpMin: '9.0', agpMax: '9.0.99', minRequiredGradle: '9.0.0'),
+    // Assume if AGP is newer than this code knows about return the highest gradle
     // version we know about.
     GradleForAgp(
       agpMin: maxKnownAgpVersion,
@@ -1022,14 +1060,14 @@ String getGradleVersionFor(String androidPluginVersion) {
     ),
   ];
   for (final data in compatList) {
-    if (isWithinVersionRange(androidPluginVersion, min: data.agpMin, max: data.agpMax)) {
+    if (isWithinVersionRange(agpV, min: data.agpMin, max: data.agpMax)) {
       return data.minRequiredGradle;
     }
   }
-  if (isWithinVersionRange(androidPluginVersion, min: maxKnownAgpVersion, max: '100.100')) {
+  if (isWithinVersionRange(agpV, min: maxKnownAgpVersion, max: '100.100')) {
     return maxKnownAndSupportedGradleVersion;
   }
-  throwToolExit('Unsupported Android Plugin version: $androidPluginVersion.');
+  throwToolExit('Unsupported Android Plugin version: $agpV.');
 }
 
 /// Overwrite local.properties in the specified Flutter project's Android
@@ -1125,19 +1163,20 @@ void exitWithNoSdkMessage() {
 //
 // The [javaMax] is exclusive in terms of supporting the noted [gradleMin],
 // whereas [javaMin] is inclusive.
+// Gradle Max is not required and when unset should mean unbound.
 @immutable
 class JavaGradleCompat {
   const JavaGradleCompat({
     required this.javaMin,
     required this.javaMax,
     required this.gradleMin,
-    required this.gradleMax,
+    this.gradleMax,
   });
 
   final String javaMin;
   final String javaMax;
   final String gradleMin;
-  final String gradleMax;
+  final String? gradleMax;
 
   @override
   bool operator ==(Object other) =>
@@ -1149,6 +1188,11 @@ class JavaGradleCompat {
 
   @override
   int get hashCode => Object.hash(javaMin, javaMax, gradleMin, gradleMax);
+
+  @override
+  String toString() {
+    return '$javaMin, $javaMax, $gradleMin, $gradleMax';
+  }
 }
 
 // Data class to hold defined Java <-> AGP compatibility criteria.
@@ -1204,60 +1248,15 @@ String getGradlewFileName(Platform platform) {
 /// of Gradle, as https://docs.gradle.org/current/userguide/compatibility.html
 /// details.
 var _javaGradleCompatList = const <JavaGradleCompat>[
-  JavaGradleCompat(
-    javaMin: '25',
-    javaMax: '26',
-    gradleMin: '9.1.0',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '24',
-    javaMax: '25',
-    gradleMin: '8.14',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '23',
-    javaMax: '24',
-    gradleMin: '8.10',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '22',
-    javaMax: '23',
-    gradleMin: '8.7',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '21',
-    javaMax: '22',
-    gradleMin: '8.4',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '20',
-    javaMax: '21',
-    gradleMin: '8.1',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '19',
-    javaMax: '20',
-    gradleMin: '7.6',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '18',
-    javaMax: '19',
-    gradleMin: '7.5',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
-  JavaGradleCompat(
-    javaMin: '17',
-    javaMax: '18',
-    gradleMin: '7.3',
-    gradleMax: maxKnownAndSupportedGradleVersion,
-  ),
+  JavaGradleCompat(javaMin: '25', javaMax: '26', gradleMin: '9.1.0'),
+  JavaGradleCompat(javaMin: '24', javaMax: '25', gradleMin: '8.14'),
+  JavaGradleCompat(javaMin: '23', javaMax: '24', gradleMin: '8.10'),
+  JavaGradleCompat(javaMin: '22', javaMax: '23', gradleMin: '8.7'),
+  JavaGradleCompat(javaMin: '21', javaMax: '22', gradleMin: '8.4'),
+  JavaGradleCompat(javaMin: '20', javaMax: '21', gradleMin: '8.1'),
+  JavaGradleCompat(javaMin: '19', javaMax: '20', gradleMin: '7.6'),
+  JavaGradleCompat(javaMin: '18', javaMax: '19', gradleMin: '7.5'),
+  JavaGradleCompat(javaMin: '17', javaMax: '18', gradleMin: '7.3'),
   JavaGradleCompat(
     javaMin: '16',
     javaMax: '17',

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -59,14 +59,14 @@ const ndkVersion = '27.0.12077973';
 // Update these when new major versions of Java are supported by new Gradle
 // versions that we support.
 // Source of truth: https://docs.gradle.org/current/userguide/compatibility.html
-const oneMajorVersionHigherJavaVersion = '24';
+const oneMajorVersionHigherJavaVersion = '26';
 
 // Update this when new versions of Gradle come out including minor versions
 // and should correspond to the maximum Gradle version we test in CI.
 //
 // Supported here means supported by the tooling for
 // flutter analyze --suggestions and does not imply broader flutter support.
-const maxKnownAndSupportedGradleVersion = '8.12';
+const maxKnownAndSupportedGradleVersion = '9.1.0';
 
 // Update this with new KGP versions come out including minor versions.
 //
@@ -1204,6 +1204,18 @@ String getGradlewFileName(Platform platform) {
 /// of Gradle, as https://docs.gradle.org/current/userguide/compatibility.html
 /// details.
 var _javaGradleCompatList = const <JavaGradleCompat>[
+  JavaGradleCompat(
+    javaMin: '25',
+    javaMax: '26',
+    gradleMin: '9.1.0',
+    gradleMax: maxKnownAndSupportedGradleVersion,
+  ),
+  JavaGradleCompat(
+    javaMin: '24',
+    javaMax: '25',
+    gradleMin: '8.14',
+    gradleMax: maxKnownAndSupportedGradleVersion,
+  ),
   JavaGradleCompat(
     javaMin: '23',
     javaMax: '24',

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -7,7 +7,6 @@ import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/android/gradle.dart';
 import 'package:flutter_tools/src/android/gradle_utils.dart' as gradle_utils;
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -567,70 +566,6 @@ flutter:
           treeShakeIcons: false,
           packageConfigPath: '.dart_tool/package_config.json',
         ),
-      );
-    });
-  });
-
-  group('gradle version', () {
-    testWithoutContext('should be compatible with the Android plugin version', () {
-      // Granular versions.
-      expect(gradle_utils.getGradleVersionFor('1.0.0'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.0.1'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.0.2'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.0.4'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.0.8'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.1.0'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.1.2'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.1.2'), '2.3');
-      expect(gradle_utils.getGradleVersionFor('1.1.3'), '2.3');
-      // Version Ranges.
-      expect(gradle_utils.getGradleVersionFor('1.2.0'), '2.9');
-      expect(gradle_utils.getGradleVersionFor('1.3.1'), '2.9');
-
-      expect(gradle_utils.getGradleVersionFor('1.5.0'), '2.2.1');
-
-      expect(gradle_utils.getGradleVersionFor('2.0.0'), '2.13');
-      expect(gradle_utils.getGradleVersionFor('2.1.2'), '2.13');
-
-      expect(gradle_utils.getGradleVersionFor('2.1.3'), '2.14.1');
-      expect(gradle_utils.getGradleVersionFor('2.2.3'), '2.14.1');
-
-      expect(gradle_utils.getGradleVersionFor('2.3.0'), '3.3');
-
-      expect(gradle_utils.getGradleVersionFor('3.0.0'), '4.1');
-
-      expect(gradle_utils.getGradleVersionFor('3.1.0'), '4.4');
-
-      expect(gradle_utils.getGradleVersionFor('3.2.0'), '4.6');
-      expect(gradle_utils.getGradleVersionFor('3.2.1'), '4.6');
-
-      expect(gradle_utils.getGradleVersionFor('3.3.0'), '4.10.2');
-      expect(gradle_utils.getGradleVersionFor('3.3.2'), '4.10.2');
-
-      expect(gradle_utils.getGradleVersionFor('3.4.0'), '5.6.2');
-      expect(gradle_utils.getGradleVersionFor('3.5.0'), '5.6.2');
-
-      expect(gradle_utils.getGradleVersionFor('4.0.0'), '6.7');
-      expect(gradle_utils.getGradleVersionFor('4.1.0'), '6.7');
-
-      expect(gradle_utils.getGradleVersionFor('7.0'), '7.5');
-      expect(gradle_utils.getGradleVersionFor('7.1.2'), '7.5');
-      expect(gradle_utils.getGradleVersionFor('7.2'), '7.5');
-      expect(gradle_utils.getGradleVersionFor('8.0'), '8.0');
-      expect(gradle_utils.getGradleVersionFor('8.1'), '8.0');
-      expect(gradle_utils.getGradleVersionFor('8.2'), '8.2');
-      expect(gradle_utils.getGradleVersionFor('8.3'), '8.4');
-      expect(gradle_utils.getGradleVersionFor('8.4'), '8.6');
-      expect(gradle_utils.getGradleVersionFor('8.5'), '8.7');
-      expect(gradle_utils.getGradleVersionFor('8.7'), '8.9');
-      expect(gradle_utils.getGradleVersionFor('8.8'), '8.10.2');
-      expect(gradle_utils.getGradleVersionFor(gradle_utils.maxKnownAgpVersion), '8.11.1');
-    });
-
-    testWithoutContext('throws on unsupported versions', () {
-      expect(
-        () => gradle_utils.getGradleVersionFor('3.6.0'),
-        throwsA(predicate<Exception>((Exception e) => e is ToolExit)),
       );
     });
   });

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -1226,21 +1226,21 @@ allprojects {
         // Maximum known Java version.
         // *The test case that follows needs to be updated* when higher versions of Java are supported:
         expect(
-          getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '24'),
+          getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '26'),
           allOf(
-            equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '24.0.2')),
+            equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '26.0.2')),
             isNull,
           ),
         );
         expect(
-          getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '23'),
+          getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '24'),
           allOf(
-            equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '23.0.2')),
+            equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '24.0.2')),
             equals(
               const JavaGradleCompat(
-                javaMin: '23',
-                javaMax: '24',
-                gradleMin: '8.10',
+                javaMin: '24',
+                javaMax: '25',
+                gradleMin: '8.14',
                 gradleMax: maxKnownAndSupportedGradleVersion,
               ),
             ),
@@ -1562,20 +1562,20 @@ allprojects {
       );
       // Strictly too new Gradle and AGP versions.
       expect(
-        getJavaVersionFor(gradleV: '8.13', agpV: '9.0'),
+        getJavaVersionFor(gradleV: '10.0', agpV: '9.0'),
         equals(const VersionRange(null, null)),
       );
       // Strictly too new Gradle version and maximum version of AGP.
       //*This test case will need its expected Java range updated when a new version of AGP is supported.*
       expect(
-        getJavaVersionFor(gradleV: '8.13', agpV: maxKnownAndSupportedAgpVersion),
+        getJavaVersionFor(gradleV: '9.2.0', agpV: maxKnownAndSupportedAgpVersion),
         equals(const VersionRange('17', null)),
       );
       // Strictly too new AGP version and maximum version of Gradle.
       //*This test case will need its expected Java range updated when a new version of Gradle is supported.*
       expect(
         getJavaVersionFor(gradleV: maxKnownAndSupportedGradleVersion, agpV: '9.0'),
-        equals(const VersionRange(null, '24')),
+        equals(const VersionRange(null, '26')),
       );
       // Tests with a known compatible Gradle/AGP version pair.
       expect(

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/gradle_utils.dart';
+import 'package:flutter_tools/src/base/common.dart' show ToolExit;
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -622,12 +623,16 @@ dependencies {
       final testData = <GradleAgpTestData>[
         // Values too new *these need to be updated* when
         // max known gradle and max known agp versions are updated:
-        // Newer tools version supports max gradle version.
-        GradleAgpTestData(true, agpVersion: '8.2', gradleVersion: '8.0'),
-        // Newer tools version does not even meet current gradle version requirements.
-        GradleAgpTestData(false, agpVersion: '8.2', gradleVersion: '7.3'),
-        // Newer tools version requires newer gradle version.
-        GradleAgpTestData(true, agpVersion: '8.3', gradleVersion: '8.1'),
+        // Newer AGP version supports max gradle version.
+        GradleAgpTestData(
+          true,
+          agpVersion: '9.1',
+          gradleVersion: maxKnownAndSupportedGradleVersion,
+        ),
+        // Newer AGP version does not even meet current gradle version requirements.
+        GradleAgpTestData(false, agpVersion: '9.1', gradleVersion: '7.3'),
+        // Newer AGP version requires newer gradle version.
+        GradleAgpTestData(true, agpVersion: '9.1', gradleVersion: '9.1'),
 
         // Template versions of Gradle/AGP.
         GradleAgpTestData(
@@ -643,6 +648,18 @@ dependencies {
 
         // Minimums as defined in
         // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
+        GradleAgpTestData(true, agpVersion: '9.0', gradleVersion: '9.0.0'),
+        GradleAgpTestData(true, agpVersion: '8.13', gradleVersion: '8.13'),
+        GradleAgpTestData(true, agpVersion: '8.12', gradleVersion: '8.13'),
+        GradleAgpTestData(true, agpVersion: '8.11', gradleVersion: '8.13'),
+        GradleAgpTestData(true, agpVersion: '8.10', gradleVersion: '8.11.1'),
+        GradleAgpTestData(true, agpVersion: '8.9', gradleVersion: '8.11.1'),
+        GradleAgpTestData(true, agpVersion: '8.8', gradleVersion: '8.10.2'),
+        GradleAgpTestData(true, agpVersion: '8.7', gradleVersion: '8.9'),
+        GradleAgpTestData(true, agpVersion: '8.5', gradleVersion: '8.7'),
+        GradleAgpTestData(true, agpVersion: '8.4', gradleVersion: '8.6'),
+        GradleAgpTestData(true, agpVersion: '8.3', gradleVersion: '8.4'),
+        GradleAgpTestData(true, agpVersion: '8.2', gradleVersion: '8.2'),
         GradleAgpTestData(true, agpVersion: '8.1', gradleVersion: '8.0'),
         GradleAgpTestData(true, agpVersion: '8.0', gradleVersion: '8.0'),
         GradleAgpTestData(true, agpVersion: '7.4', gradleVersion: '7.5'),
@@ -684,6 +701,19 @@ dependencies {
         GradleAgpTestData(true, agpVersion: '3.3.1', gradleVersion: '4.10.1'),
 
         // Higher gradle cases:
+        GradleAgpTestData(true, agpVersion: '9.0', gradleVersion: '9.0.0'),
+        GradleAgpTestData(true, agpVersion: '8.13', gradleVersion: '8.14'),
+        GradleAgpTestData(true, agpVersion: '8.12', gradleVersion: '9.0'),
+        GradleAgpTestData(true, agpVersion: '8.11', gradleVersion: '8.14'),
+        GradleAgpTestData(true, agpVersion: '8.10', gradleVersion: '8.13'),
+        GradleAgpTestData(true, agpVersion: '8.9', gradleVersion: '8.13'),
+        GradleAgpTestData(true, agpVersion: '8.8', gradleVersion: '8.11.1'),
+        GradleAgpTestData(true, agpVersion: '8.7', gradleVersion: '8.10'),
+        GradleAgpTestData(true, agpVersion: '8.5', gradleVersion: '8.8'),
+        GradleAgpTestData(true, agpVersion: '8.4', gradleVersion: '8.7'),
+        GradleAgpTestData(true, agpVersion: '8.3', gradleVersion: '8.5'),
+        GradleAgpTestData(true, agpVersion: '8.2', gradleVersion: '8.3'),
+        GradleAgpTestData(true, agpVersion: '8.1', gradleVersion: '8.1'),
         GradleAgpTestData(true, agpVersion: '7.4', gradleVersion: '8.0'),
         GradleAgpTestData(true, agpVersion: '7.3', gradleVersion: '7.5'),
         GradleAgpTestData(true, agpVersion: '7.2', gradleVersion: '7.4'),
@@ -1047,6 +1077,9 @@ pluginManagement {
         JavaGradleTestData(true, javaVersion: '1.10', gradleVersion: '5.4'),
         JavaGradleTestData(true, javaVersion: '1.9', gradleVersion: '5.0'),
         JavaGradleTestData(true, javaVersion: '1.8', gradleVersion: '4.3'),
+        // https://github.com/flutter/flutter/issues/175669
+        JavaGradleTestData(true, javaVersion: '17.0.15', gradleVersion: '8.13'),
+        JavaGradleTestData(true, javaVersion: '21.0.7', gradleVersion: '8.13'),
       ];
 
       for (final data in testData) {
@@ -1137,19 +1170,43 @@ allprojects {
       JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '4.1'),
       JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '2.3'),
       // Strictly too new Java versions for defined AGP versions.
-      JavaAgpTestData(true, javaVersion: '18', agpVersion: '8.1'),
-      JavaAgpTestData(true, javaVersion: '18', agpVersion: '7.4'),
       JavaAgpTestData(true, javaVersion: '18', agpVersion: '4.2'),
+      JavaAgpTestData(true, javaVersion: '11', agpVersion: '4.2.0'),
+      JavaAgpTestData(true, javaVersion: '12', agpVersion: '7.0'),
+      JavaAgpTestData(true, javaVersion: '13', agpVersion: '7.1.3'),
+      JavaAgpTestData(true, javaVersion: '14', agpVersion: '7.2.2'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '7.3'),
+      JavaAgpTestData(true, javaVersion: '18', agpVersion: '7.4'),
+      JavaAgpTestData(true, javaVersion: '19', agpVersion: '8.0'),
+      JavaAgpTestData(true, javaVersion: '19', agpVersion: '8.1'),
+      JavaAgpTestData(true, javaVersion: '19', agpVersion: '8.2'),
+      JavaAgpTestData(true, javaVersion: '20', agpVersion: '8.3'),
+      JavaAgpTestData(true, javaVersion: '21', agpVersion: '8.4'),
+      JavaAgpTestData(true, javaVersion: '21', agpVersion: '8.5'),
+      JavaAgpTestData(true, javaVersion: '21', agpVersion: '8.6'),
+      JavaAgpTestData(true, javaVersion: '22', agpVersion: '8.7'),
+      JavaAgpTestData(true, javaVersion: '23', agpVersion: '8.8'),
+      JavaAgpTestData(true, javaVersion: '23', agpVersion: '8.9'),
+      JavaAgpTestData(true, javaVersion: '23', agpVersion: '8.10'),
+      JavaAgpTestData(true, javaVersion: '23', agpVersion: '8.11'),
+      JavaAgpTestData(true, javaVersion: '23', agpVersion: '8.12'),
+      JavaAgpTestData(true, javaVersion: '23', agpVersion: '8.13'),
+      JavaAgpTestData(true, javaVersion: '25', agpVersion: '9.0'),
       // Strictly too new AGP versions.
       // *The tests that follow need to be updated* when max supported AGP versions are updated:
-      JavaAgpTestData(false, javaVersion: '24', agpVersion: '9.0'),
-      JavaAgpTestData(false, javaVersion: '20', agpVersion: '9.0'),
-      JavaAgpTestData(false, javaVersion: '17', agpVersion: '9.0'),
+      JavaAgpTestData(false, javaVersion: '26', agpVersion: '10.0'),
+      JavaAgpTestData(false, javaVersion: '21', agpVersion: '10.0'),
+      JavaAgpTestData(true, javaVersion: '25', agpVersion: maxKnownAndSupportedAgpVersion),
       // Java 17 & patch versions compatibility cases
       // *The tests that follow need to be updated* when maxKnownAndSupportedAgpVersion is
       // updated:
-      JavaAgpTestData(false, javaVersion: '17', agpVersion: '9.0'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: maxKnownAndSupportedAgpVersion),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '9.0'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.13'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.12'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.11'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.10'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.9.1'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.8'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.7'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.6'),
@@ -1159,8 +1216,8 @@ allprojects {
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.1'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.0'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '7.4'),
-      JavaAgpTestData(false, javaVersion: '17.0.3', agpVersion: '9.0'),
-      JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: maxKnownAndSupportedAgpVersion),
+      JavaAgpTestData(false, javaVersion: '17.0.3', agpVersion: '10.0'),
+      JavaAgpTestData(true, javaVersion: '25', agpVersion: maxKnownAndSupportedAgpVersion),
       JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: '8.8'),
       JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: '8.7'),
       JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: '8.6'),
@@ -1189,6 +1246,27 @@ allprojects {
         javaVersion: '1.8',
         agpVersion: oldestDocumentedJavaAgpCompatibilityVersion,
       ), // agpVersion = 4.2
+      // Java versions too old for the AGP versions
+      JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '7.0'),
+      JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '7.1.3'),
+      JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '7.2.2'),
+      JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '7.3'),
+      JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '7.4'),
+      JavaAgpTestData(false, javaVersion: '12', agpVersion: '8.0'),
+      JavaAgpTestData(false, javaVersion: '13', agpVersion: '8.1'),
+      JavaAgpTestData(false, javaVersion: '14', agpVersion: '8.2'),
+      JavaAgpTestData(false, javaVersion: '15', agpVersion: '8.3'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.4'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.5'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.6'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.7'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.8'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.9'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.10'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.11'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.12'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '8.13'),
+      JavaAgpTestData(false, javaVersion: '16', agpVersion: '9.0'),
       JavaAgpTestData(false, javaVersion: '1.8', agpVersion: '4.1'),
       // Null value cases
       // ignore: avoid_redundant_argument_values
@@ -1204,12 +1282,80 @@ allprojects {
         expect(
           validateJavaAndAgp(BufferLogger.test(), javaV: data.javaVersion, agpV: data.agpVersion),
           data.validPair ? isTrue : isFalse,
-          reason: 'J: ${data.javaVersion}, G: ${data.agpVersion}',
+          reason: 'J: ${data.javaVersion}, AGP: ${data.agpVersion}',
         );
       });
     }
   });
 
+  group('gradle version', () {
+    testWithoutContext('should be compatible with the Android plugin version', () {
+      // Granular versions.
+      expect(getGradleVersionFor('1.0.0'), '2.3');
+      expect(getGradleVersionFor('1.0.1'), '2.3');
+      expect(getGradleVersionFor('1.0.2'), '2.3');
+      expect(getGradleVersionFor('1.0.4'), '2.3');
+      expect(getGradleVersionFor('1.0.8'), '2.3');
+      expect(getGradleVersionFor('1.1.0'), '2.3');
+      expect(getGradleVersionFor('1.1.2'), '2.3');
+      expect(getGradleVersionFor('1.1.2'), '2.3');
+      expect(getGradleVersionFor('1.1.3'), '2.3');
+      // Version Ranges.
+      expect(getGradleVersionFor('1.2.0'), '2.9');
+      expect(getGradleVersionFor('1.3.1'), '2.9');
+
+      expect(getGradleVersionFor('1.5.0'), '2.2.1');
+
+      expect(getGradleVersionFor('2.0.0'), '2.13');
+      expect(getGradleVersionFor('2.1.2'), '2.13');
+
+      expect(getGradleVersionFor('2.1.3'), '2.14.1');
+      expect(getGradleVersionFor('2.2.3'), '2.14.1');
+
+      expect(getGradleVersionFor('2.3.0'), '3.3');
+
+      expect(getGradleVersionFor('3.0.0'), '4.1');
+
+      expect(getGradleVersionFor('3.1.0'), '4.4');
+
+      expect(getGradleVersionFor('3.2.0'), '4.6');
+      expect(getGradleVersionFor('3.2.1'), '4.6');
+
+      expect(getGradleVersionFor('3.3.0'), '4.10.2');
+      expect(getGradleVersionFor('3.3.2'), '4.10.2');
+
+      expect(getGradleVersionFor('3.4.0'), '5.6.2');
+      expect(getGradleVersionFor('3.5.0'), '5.6.2');
+
+      expect(getGradleVersionFor('4.0.0'), '6.7');
+      expect(getGradleVersionFor('4.1.0'), '6.7');
+
+      expect(getGradleVersionFor('7.0'), '7.5');
+      expect(getGradleVersionFor('7.1.2'), '7.5');
+      expect(getGradleVersionFor('7.2'), '7.5');
+      expect(getGradleVersionFor('8.0'), '8.0');
+      expect(getGradleVersionFor('8.1'), '8.0');
+      expect(getGradleVersionFor('8.2'), '8.2');
+      expect(getGradleVersionFor('8.3'), '8.4');
+      expect(getGradleVersionFor('8.4'), '8.6');
+      expect(getGradleVersionFor('8.5'), '8.7');
+      expect(getGradleVersionFor('8.7'), '8.9');
+      expect(getGradleVersionFor('8.8'), '8.10.2');
+      expect(getGradleVersionFor('8.9'), '8.11.1');
+      expect(getGradleVersionFor('8.10'), '8.11.1');
+      expect(getGradleVersionFor('8.11'), '8.13');
+      expect(getGradleVersionFor('8.12'), '8.13');
+      expect(getGradleVersionFor('8.13'), '8.13');
+      expect(getGradleVersionFor('9.0'), '9.0.0');
+    });
+
+    testWithoutContext('throws on unsupported versions', () {
+      expect(
+        () => getGradleVersionFor('3.6.0'),
+        throwsA(predicate<Exception>((Exception e) => e is ToolExit)),
+      );
+    });
+  });
   group('detecting valid Gradle/AGP versions for given Java version and vice versa', () {
     testWithoutContext(
       'getValidGradleVersionRangeForJavaVersion returns valid Gradle version range for Java version',
@@ -1232,103 +1378,68 @@ allprojects {
             isNull,
           ),
         );
+        // Known supported Java versions.
+        expect(
+          getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '25'),
+          allOf(
+            equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '25.0.2')),
+            equals(const JavaGradleCompat(javaMin: '25', javaMax: '26', gradleMin: '9.1.0')),
+          ),
+        );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '24'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '24.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '24',
-                javaMax: '25',
-                gradleMin: '8.14',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '24', javaMax: '25', gradleMin: '8.14')),
           ),
         );
-        // Known supported Java versions.
+        expect(
+          getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '23'),
+          allOf(
+            equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '23.0.2')),
+            equals(const JavaGradleCompat(javaMin: '23', javaMax: '24', gradleMin: '8.10')),
+          ),
+        );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '22'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '22.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '22',
-                javaMax: '23',
-                gradleMin: '8.7',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '22', javaMax: '23', gradleMin: '8.7')),
           ),
         );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '21'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '21.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '21',
-                javaMax: '22',
-                gradleMin: '8.4',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '21', javaMax: '22', gradleMin: '8.4')),
           ),
         );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '20'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '20.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '20',
-                javaMax: '21',
-                gradleMin: '8.1',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '20', javaMax: '21', gradleMin: '8.1')),
           ),
         );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '19'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '19.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '19',
-                javaMax: '20',
-                gradleMin: '7.6',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '19', javaMax: '20', gradleMin: '7.6')),
           ),
         );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '18'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '18.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '18',
-                javaMax: '19',
-                gradleMin: '7.5',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '18', javaMax: '19', gradleMin: '7.5')),
           ),
         );
         expect(
           getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '17'),
           allOf(
             equals(getValidGradleVersionRangeForJavaVersion(testLogger, javaV: '17.0.2')),
-            equals(
-              const JavaGradleCompat(
-                javaMin: '17',
-                javaMax: '18',
-                gradleMin: '7.3',
-                gradleMax: maxKnownAndSupportedGradleVersion,
-              ),
-            ),
+            equals(const JavaGradleCompat(javaMin: '17', javaMax: '18', gradleMin: '7.3')),
           ),
         );
         expect(
@@ -1562,53 +1673,79 @@ allprojects {
       );
       // Strictly too new Gradle and AGP versions.
       expect(
-        getJavaVersionFor(gradleV: '10.0', agpV: '9.0'),
+        getJavaVersionFor(gradleV: '9.10', agpV: '10.0'),
         equals(const VersionRange(null, null)),
       );
       // Strictly too new Gradle version and maximum version of AGP.
       //*This test case will need its expected Java range updated when a new version of AGP is supported.*
       expect(
-        getJavaVersionFor(gradleV: '9.2.0', agpV: maxKnownAndSupportedAgpVersion),
+        getJavaVersionFor(gradleV: '9.10', agpV: maxKnownAndSupportedAgpVersion),
         equals(const VersionRange('17', null)),
       );
       // Strictly too new AGP version and maximum version of Gradle.
       //*This test case will need its expected Java range updated when a new version of Gradle is supported.*
       expect(
-        getJavaVersionFor(gradleV: maxKnownAndSupportedGradleVersion, agpV: '9.0'),
-        equals(const VersionRange(null, '26')),
+        getJavaVersionFor(gradleV: maxKnownAndSupportedGradleVersion, agpV: '10.0'),
+        equals(const VersionRange(null, oneMajorVersionHigherJavaVersion)),
       );
-      // Tests with a known compatible Gradle/AGP version pair.
+    });
+    // Tests with a known compatible Gradle/AGP version pair.
+    final List<({String agpV, String gradleV, VersionRange expected})> agpGradleData = [
+      (agpV: '4.2.0', gradleV: '6.7.1', expected: const VersionRange('1.8', '16')),
+      (agpV: '4.2.0', gradleV: '7.0', expected: const VersionRange('1.8', '17')),
+      (agpV: '4.2.0', gradleV: '8.0', expected: const VersionRange('1.8', '20')),
+      (agpV: '4.2.0', gradleV: '8.5', expected: const VersionRange('1.8', '22')),
+      (agpV: '4.2.0', gradleV: '8.9.1', expected: const VersionRange('1.8', '23')),
+      (agpV: '4.2.0', gradleV: '8.11', expected: const VersionRange('1.8', '24')),
+      (agpV: '4.2.0', gradleV: '8.13', expected: const VersionRange('1.8', '24')),
+      (agpV: '7.0', gradleV: '7.1', expected: const VersionRange('11', '17')),
+      (agpV: '7.2', gradleV: '7.0', expected: const VersionRange('11', '17')),
+      (agpV: '7.2', gradleV: '7.1', expected: const VersionRange('11', '17')),
+      (agpV: '7.4', gradleV: '7.1', expected: const VersionRange('11', '17')),
+      (agpV: '7.4', gradleV: '7.5', expected: const VersionRange('11', '19')),
+      (agpV: '7.4', gradleV: '8.0', expected: const VersionRange('11', '20')),
+      (agpV: '7.4', gradleV: '8.4', expected: const VersionRange('11', '22')),
+      (agpV: '7.4', gradleV: '8.9.1', expected: const VersionRange('11', '23')),
+      (agpV: '7.4', gradleV: '8.10', expected: const VersionRange('11', '24')),
+      (agpV: '7.4', gradleV: '8.12', expected: const VersionRange('11', '24')),
+      (agpV: '7.4', gradleV: '8.14', expected: const VersionRange('11', '25')),
+      (agpV: '8.0', gradleV: '8.0', expected: const VersionRange('17', '20')),
+      (agpV: '8.0', gradleV: '8.4', expected: const VersionRange('17', '22')),
+      (agpV: '8.0', gradleV: '8.9.1', expected: const VersionRange('17', '23')),
+      (agpV: '8.0', gradleV: '8.10', expected: const VersionRange('17', '24')),
+      (agpV: '8.0', gradleV: '8.12', expected: const VersionRange('17', '24')),
+      (agpV: '8.0', gradleV: '8.14', expected: const VersionRange('17', '25')),
+      (agpV: '8.1', gradleV: '8.4', expected: const VersionRange('17', '22')),
+      (agpV: '8.1', gradleV: '8.7', expected: const VersionRange('17', '23')),
+      (agpV: '8.9.1', gradleV: '8.11.1', expected: const VersionRange('17', '24')),
+      (agpV: '8.9.1', gradleV: '8.12', expected: const VersionRange('17', '24')),
+      (agpV: '8.9.1', gradleV: '8.13', expected: const VersionRange('17', '24')),
+      (agpV: '9.0', gradleV: '9.0', expected: const VersionRange('17', '25')),
+      // Granular versions.
+      (agpV: '8.0.1', gradleV: '8.1.1', expected: const VersionRange('17', '21')),
+      (agpV: '7.2', gradleV: '7.2.2', expected: const VersionRange('11', '17')),
+    ];
+    for (final data in agpGradleData) {
+      testWithoutContext('for AGP ${data.agpV}, gradle ${data.gradleV}', () {
+        expect(getJavaVersionFor(agpV: data.agpV, gradleV: data.gradleV), data.expected);
+      });
+    }
+    testWithoutContext('for agp/gradle', () {
+      // Max values
       expect(
-        getJavaVersionFor(gradleV: '7.0', agpV: '7.2'),
-        equals(const VersionRange('11', '17')),
+        getJavaVersionFor(
+          agpV: maxKnownAndSupportedAgpVersion,
+          gradleV: maxKnownAndSupportedGradleVersion,
+        ).versionMin,
+        '17',
       );
+      // Template versions.
       expect(
-        getJavaVersionFor(gradleV: '7.1', agpV: '7.2'),
-        equals(const VersionRange('11', '17')),
-      );
-      expect(
-        getJavaVersionFor(gradleV: '7.2.2', agpV: '7.2'),
-        equals(const VersionRange('11', '17')),
-      );
-      expect(
-        getJavaVersionFor(gradleV: '7.1', agpV: '7.0'),
-        equals(const VersionRange('11', '17')),
-      );
-      expect(
-        getJavaVersionFor(gradleV: '7.1', agpV: '7.2'),
-        equals(const VersionRange('11', '17')),
-      );
-      expect(
-        getJavaVersionFor(gradleV: '7.1', agpV: '7.4'),
-        equals(const VersionRange('11', '17')),
-      );
-      expect(
-        getJavaVersionFor(gradleV: '8.4', agpV: '8.1'),
-        equals(const VersionRange('17', '22')),
-      );
-      expect(
-        getJavaVersionFor(gradleV: '8.7', agpV: '8.1'),
-        equals(const VersionRange('17', '23')),
+        getJavaVersionFor(
+          agpV: templateAndroidGradlePluginVersion,
+          gradleV: templateAndroidGradlePluginVersion,
+        ).versionMin,
+        '17',
       );
     });
   });

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -808,6 +808,11 @@ pluginManagement {
         ),
 
         // Kotlin version at the edge of support window.
+        GradleKgpTestData(true, kgpVersion: '2.2.20', gradleVersion: '8.14'),
+        GradleKgpTestData(true, kgpVersion: '2.2.10', gradleVersion: '8.14'),
+        GradleKgpTestData(true, kgpVersion: '2.2.20', gradleVersion: '7.6.3'),
+        GradleKgpTestData(true, kgpVersion: '2.2.10', gradleVersion: '7.6.3'),
+        GradleKgpTestData(true, kgpVersion: '2.2.0', gradleVersion: '7.6.3'),
         GradleKgpTestData(true, kgpVersion: '2.1.20', gradleVersion: '8.1'),
         GradleKgpTestData(true, kgpVersion: '2.1.10', gradleVersion: '8.3'),
         GradleKgpTestData(true, kgpVersion: '2.0.21', gradleVersion: '7.6.3'),
@@ -827,8 +832,11 @@ pluginManagement {
         GradleKgpTestData(true, kgpVersion: '1.7.0', gradleVersion: '6.7.1'),
         GradleKgpTestData(true, kgpVersion: '1.6.21', gradleVersion: '6.1.1'),
         GradleKgpTestData(true, kgpVersion: '1.6.20', gradleVersion: '7.0.2'),
-        // Gradle versions inspired by
-        // https://developer.android.com/build/releases/gradle-plugin#expandable-1
+        // Gradle at the edge of the suppport window.
+        GradleKgpTestData(true, kgpVersion: '2.2.20', gradleVersion: '8.14'),
+        GradleKgpTestData(true, kgpVersion: '2.2.10', gradleVersion: '8.14'),
+        GradleKgpTestData(true, kgpVersion: '2.2.0', gradleVersion: '8.14'),
+        GradleKgpTestData(true, kgpVersion: '2.1.21', gradleVersion: '8.12.1'),
         GradleKgpTestData(true, kgpVersion: '2.1.20', gradleVersion: '8.11.1'),
         GradleKgpTestData(true, kgpVersion: '2.1.10', gradleVersion: '8.10.2'),
         GradleKgpTestData(true, kgpVersion: '2.1.10', gradleVersion: '8.9'),
@@ -849,8 +857,11 @@ pluginManagement {
         GradleKgpTestData(true, kgpVersion: '1.6.21', gradleVersion: '6.7.1'),
         GradleKgpTestData(true, kgpVersion: '1.6.21', gradleVersion: '6.5'),
         // Kotlin newer than max known.
-        GradleKgpTestData(true, kgpVersion: '2.1.21', gradleVersion: '8.12.1'),
+        GradleKgpTestData(true, kgpVersion: '2.2.29', gradleVersion: '8.12.1'),
         // Kotlin too new for gradle version.
+        GradleKgpTestData(false, kgpVersion: '2.2.20', gradleVersion: '7.6.2'),
+        GradleKgpTestData(false, kgpVersion: '2.2.10', gradleVersion: '7.6.2'),
+        GradleKgpTestData(false, kgpVersion: '2.2.0', gradleVersion: '7.6.2'),
         GradleKgpTestData(false, kgpVersion: '2.1.20', gradleVersion: '7.6.2'),
         GradleKgpTestData(false, kgpVersion: '2.1.0', gradleVersion: '7.6.2'),
         GradleKgpTestData(false, kgpVersion: '2.0.20', gradleVersion: '6.8.2'),
@@ -912,11 +923,15 @@ pluginManagement {
         ),
 
         // Kotlin version at the edge of support window.
+        KgpAgpTestData(true, kgpVersion: '2.2.20', agpVersion: '8.11.1'),
+        KgpAgpTestData(true, kgpVersion: '2.2.20', agpVersion: '7.3.1'),
+        KgpAgpTestData(true, kgpVersion: '2.2.0', agpVersion: '8.10.0'),
+        KgpAgpTestData(true, kgpVersion: '2.1.21', agpVersion: '7.3.1'),
         KgpAgpTestData(true, kgpVersion: '2.1.20', agpVersion: '8.7.2'),
         KgpAgpTestData(true, kgpVersion: '2.1.20', agpVersion: '7.3.1'),
         // AGP Versions not "fully supported" by kotlin
-        KgpAgpTestData(true, kgpVersion: '2.1.20', agpVersion: '8.9'),
-        KgpAgpTestData(true, kgpVersion: '2.1.20', agpVersion: '8.8'),
+        KgpAgpTestData(true, kgpVersion: '2.2.20', agpVersion: '8.13'),
+        KgpAgpTestData(true, kgpVersion: '2.2.20', agpVersion: '8.12'),
         // Gradle versions inspired by
         // https://developer.android.com/build/releases/gradle-plugin#expandable-1
         KgpAgpTestData(true, kgpVersion: '2.1.5', agpVersion: '8.7'),
@@ -938,8 +953,10 @@ pluginManagement {
         KgpAgpTestData(true, kgpVersion: '1.8.22', agpVersion: '4.2.0'),
         KgpAgpTestData(true, kgpVersion: '1.6.20', agpVersion: '4.1.0'),
         // Kotlin newer than max known.
-        KgpAgpTestData(true, kgpVersion: '2.1.21', agpVersion: '8.7.2'),
+        KgpAgpTestData(true, kgpVersion: '2.2.29', agpVersion: '8.7.2'),
         // Kotlin too new for AGP version.
+        KgpAgpTestData(false, kgpVersion: '2.2.20', agpVersion: '7.3.0'),
+        KgpAgpTestData(false, kgpVersion: '2.2.0', agpVersion: '7.3.0'),
         KgpAgpTestData(false, kgpVersion: '2.1.20', agpVersion: '7.3.0'),
         KgpAgpTestData(false, kgpVersion: '2.1.10', agpVersion: '7.3.0'),
         KgpAgpTestData(false, kgpVersion: '2.0.21', agpVersion: '7.1.2'),
@@ -1194,9 +1211,10 @@ allprojects {
       JavaAgpTestData(true, javaVersion: '25', agpVersion: '9.0'),
       // Strictly too new AGP versions.
       // *The tests that follow need to be updated* when max supported AGP versions are updated:
-      JavaAgpTestData(false, javaVersion: '26', agpVersion: '10.0'),
-      JavaAgpTestData(false, javaVersion: '21', agpVersion: '10.0'),
-      JavaAgpTestData(true, javaVersion: '25', agpVersion: maxKnownAndSupportedAgpVersion),
+      JavaAgpTestData(true, javaVersion: '26', agpVersion: '10.0'),
+      JavaAgpTestData(true, javaVersion: '21', agpVersion: '10.0'),
+      JavaAgpTestData(true, javaVersion: '17', agpVersion: '10.0'),
+      JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: '10.0'),
       // Java 17 & patch versions compatibility cases
       // *The tests that follow need to be updated* when maxKnownAndSupportedAgpVersion is
       // updated:
@@ -1216,7 +1234,6 @@ allprojects {
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.1'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '8.0'),
       JavaAgpTestData(true, javaVersion: '17', agpVersion: '7.4'),
-      JavaAgpTestData(false, javaVersion: '17.0.3', agpVersion: '10.0'),
       JavaAgpTestData(true, javaVersion: '25', agpVersion: maxKnownAndSupportedAgpVersion),
       JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: '8.8'),
       JavaAgpTestData(true, javaVersion: '17.0.3', agpVersion: '8.7'),
@@ -1451,7 +1468,7 @@ allprojects {
                 javaMin: '16',
                 javaMax: '17',
                 gradleMin: '7.0',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1465,7 +1482,7 @@ allprojects {
                 javaMin: '15',
                 javaMax: '16',
                 gradleMin: '6.7',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1479,7 +1496,7 @@ allprojects {
                 javaMin: '14',
                 javaMax: '15',
                 gradleMin: '6.3',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1493,7 +1510,7 @@ allprojects {
                 javaMin: '13',
                 javaMax: '14',
                 gradleMin: '6.0',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1507,7 +1524,7 @@ allprojects {
                 javaMin: '12',
                 javaMax: '13',
                 gradleMin: '5.4',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1521,7 +1538,7 @@ allprojects {
                 javaMin: '11',
                 javaMax: '12',
                 gradleMin: '5.0',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1535,7 +1552,7 @@ allprojects {
                 javaMin: '1.10',
                 javaMax: '1.11',
                 gradleMin: '4.7',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1549,7 +1566,7 @@ allprojects {
                 javaMin: '1.9',
                 javaMax: '1.10',
                 gradleMin: '4.3',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),
@@ -1564,7 +1581,7 @@ allprojects {
                 javaMin: '1.8',
                 javaMax: '1.9',
                 gradleMin: '2.0',
-                gradleMax: maxKnownAndSupportedGradleVersion,
+                gradleMax: maxGradleVersionForJavaPre17,
               ),
             ),
           ),


### PR DESCRIPTION
Fixes #175669 

Changelog entry
- [flutter/175669](https://github.com/flutter/flutter/issues/175669) When running `flutter analyze --suggestions` include compatibility info for Gradle 9.1, AGP 9.0, Java 25 and Kotlin 2.2.20 and below.

Cherry pick the following prs. 
- **Update maximum known Gradle version to 9.1.0 (#175543)**
- **Update AGP/Java/Gradle comparison when using analyze --suggestions (#175808)**
- **Add kotlin/kgp 2.2.* evaluation criteria.  (#176094)**
- **Update java version ranges with the top end limitation for java pre 17 (#176049)**

Cherry pick info: 
Yes this is covered by tests. 
Risk: low, this code is run as part of a seldom used command and any bugs are likely better than false negatives. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

