### PR TITLE
Fix platform specific semantics for time picker buttons

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -802,7 +802,9 @@ class _AmPmButton extends StatelessWidget {
     final TextScaler buttonTextScaler = MediaQuery.textScalerOf(context).clamp(maxScaleFactor: 2.0);
 
     return Semantics(
-      checked: selected,
+      // Platform-specific semantics vary slightly here on iOS.
+      selected: defaultTargetPlatform == TargetPlatform.iOS ? selected : null,
+      checked: defaultTargetPlatform == TargetPlatform.iOS ? null : selected,
       inMutuallyExclusiveGroup: true,
       button: true,
       child: Padding(

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2602,11 +2602,7 @@ void main() {
       bool? getPlatformSemanticProperty(Semantics semantics) {
         return switch (defaultTargetPlatform) {
           TargetPlatform.iOS => semantics.properties.selected,
-          TargetPlatform.android ||
-          TargetPlatform.fuchsia ||
-          TargetPlatform.linux ||
-          TargetPlatform.macOS ||
-          TargetPlatform.windows => semantics.properties.checked,
+          _ => semantics.properties.checked,
         };
       }
 

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -2559,6 +2559,62 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'AM/PM buttons have correct selected/checked semantics for platform variant',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/173302
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              return TextButton(
+                onPressed: () {
+                  showTimePicker(
+                    context: context,
+                    initialTime: const TimeOfDay(hour: 14, minute: 0),
+                  );
+                },
+                child: const Text('Open Picker'),
+              );
+            },
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open Picker'));
+      await tester.pumpAndSettle();
+
+      final Finder pmButtonSemantics = find.ancestor(
+        of: find.widgetWithText(InkWell, 'PM'),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && (widget.properties.button ?? false),
+        ),
+      );
+
+      final Finder amButtonSemantics = find.ancestor(
+        of: find.widgetWithText(InkWell, 'AM'),
+        matching: find.byWidgetPredicate(
+          (Widget widget) => widget is Semantics && (widget.properties.button ?? false),
+        ),
+      );
+
+      bool? getPlatformSemanticProperty(Semantics semantics) {
+        return switch (defaultTargetPlatform) {
+          TargetPlatform.iOS => semantics.properties.selected,
+          TargetPlatform.android ||
+          TargetPlatform.fuchsia ||
+          TargetPlatform.linux ||
+          TargetPlatform.macOS ||
+          TargetPlatform.windows => semantics.properties.checked,
+        };
+      }
+
+      expect(getPlatformSemanticProperty(tester.widget<Semantics>(pmButtonSemantics)), isTrue);
+      expect(getPlatformSemanticProperty(tester.widget<Semantics>(amButtonSemantics)), isFalse);
+    },
+    variant: TargetPlatformVariant.all(),
+  );
 }
 
 final Finder findDialPaint = find.descendant(


### PR DESCRIPTION
Updated from https://github.com/flutter/flutter/pull/173418
Fixes https://github.com/flutter/flutter/issues/173302
Applied review feedback and modified for time licker refactor that landed somewhere in between.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
