### PR TITLE
feat: add interfaces for overlay window

### DIFF
--- a/examples/multiple_windows/lib/app/main_window.dart
+++ b/examples/multiple_windows/lib/app/main_window.dart
@@ -141,6 +141,7 @@ class _WindowsTable extends StatelessWidget {
         controller: tooltip,
       ),
       PopupWindowController() => null,
+      OverlayWindowController() => null,
     };
   }
 
@@ -150,6 +151,7 @@ class _WindowsTable extends StatelessWidget {
       DialogWindowController() => 'Dialog',
       TooltipWindowController() => 'Tooltip',
       PopupWindowController() => 'Popup',
+      OverlayWindowController() => 'Overlay',
     };
   }
 

--- a/examples/multiple_windows/lib/app/window_content.dart
+++ b/examples/multiple_windows/lib/app/window_content.dart
@@ -49,6 +49,7 @@ class WindowContent extends StatelessWidget {
         ),
       ),
       PopupWindowController() => throw UnimplementedError(),
+      OverlayWindowController() => throw UnimplementedError(),
     };
   }
 }

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -422,6 +422,50 @@ mixin class DialogWindowControllerDelegate {
   }
 }
 
+/// Delegate class for overlay window controller.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+///
+/// See also:
+///
+///  * [OverlayWindowController], the controller that creates and manages overlay windows.
+///  * [OverlayWindow], the widget for an overlay window.
+@internal
+mixin class OverlayWindowControllerDelegate {
+  /// Invoked when the user attempts to close the window.
+  ///
+  /// The default implementation destroys the window. Subclasses
+  /// can override the behavior to delay or prevent the window from closing.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  ///
+  /// See also:
+  ///
+  /// * [onWindowDestroyed], which is invoked after the window is closed.
+  @internal
+  void onWindowCloseRequested(OverlayWindowController controller) {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+
+    controller.destroy();
+  }
+
+  /// Invoked after the window is closed.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  ///
+  /// See also:
+  ///
+  /// * [onWindowCloseRequested], which is invoked when the user attempts to close the window.
+  @internal
+  void onWindowDestroyed() {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+  }
+}
+
 /// A controller for a dialog window.
 ///
 /// Two types of dialogs are supported:
@@ -890,6 +934,183 @@ abstract class PopupWindowController extends BaseWindowController {
   void setConstraints(BoxConstraints constraints);
 }
 
+/// A controller for an overlay window.
+///
+/// An overlay window is a frameless, floating window that automatically adjusts
+/// size based on content dimensions and appears above other windows. Unlike
+/// existing archetypes, overlay windows can have parent-child relationships and
+/// persist independently while maintaining always-on-top behavior as optional
+/// behavior.
+///
+/// This class does not interact with the widget tree. Instead, it is typically
+/// provided to the [OverlayWindow] widget, which renders the content inside the
+/// overlay window.
+///
+/// The user of this class is responsible for managing the lifecycle of the window.
+/// When the window is no longer needed, the user should call [destroy] on this
+/// controller to release the resources associated with the window.
+///
+/// {@tool snippet}
+/// An example usage might look like:
+///
+/// ```dart
+/// // TODO(mattkae): remove invalid_use_of_internal_member ignore comment when this API is stable.
+/// // ignore_for_file: invalid_use_of_internal_member
+/// import 'package:flutter/widgets.dart';
+/// import 'package:flutter/material.dart';
+/// import 'package:flutter/src/widgets/_window.dart';
+/// import 'package:flutter/src/widgets/_window_positioner.dart';
+///
+/// void main() {
+///   runWidget(
+///     OverlayWindow(
+///       controller: OverlayWindowController(
+///         anchorRect: const Rect.fromLTWH(100, 100, 200, 100),
+///         positioner: const WindowPositioner(
+///           parentAnchor: WindowPositionerAnchor.bottomRight,
+///           childAnchor: WindowPositionerAnchor.topLeft,
+///         ),
+///         contentSizeConstraints: const BoxConstraints(
+///           minWidth: 200,
+///           minHeight: 100,
+///         ),
+///         alwaysOnTop: true,
+///       ),
+///       child: Container(
+///         padding: const EdgeInsets.all(16),
+///         child: const Text('Overlay Content'),
+///       ),
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// Children of an [OverlayWindow] widget can access the [OverlayWindowController]
+/// via the [WindowScope] inherited widget.
+///
+/// {@macro flutter.widgets.windowing.experimental}
+abstract class OverlayWindowController extends BaseWindowController {
+  /// Creates an [OverlayWindowController] with the provided properties.
+  ///
+  /// Upon construction, the window is created by the platform.
+  ///
+  /// The [anchorRect] argument specifies the rectangle used as reference
+  /// for positioning the overlay window.
+  ///
+  /// The [positioner] argument handles intelligent positioning of the
+  /// overlay window relative to the anchor rectangle.
+  ///
+  /// The [contentSizeConstraints] argument specifies constraints for
+  /// the window content size.
+  ///
+  /// The [parent] argument specifies the parent window of this overlay.
+  /// If null, the overlay window is independent.
+  ///
+  /// The [alwaysOnTop] argument determines whether the overlay window
+  /// should stay on top of other windows. Defaults to false.
+  ///
+  /// The [title] argument configures the window's initial title.
+  /// If omitted, some platforms might fall back to the app's name.
+  ///
+  /// The [delegate] argument can be used to listen to the window's
+  /// lifecycle. For example, it can be used to save state before
+  /// a window is closed.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  factory OverlayWindowController({
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    BoxConstraints? contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+    OverlayWindowControllerDelegate? delegate,
+  }) {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+
+    final WindowingOwner owner = WidgetsBinding.instance.windowingOwner;
+    return owner.createOverlayWindowController(
+      delegate: delegate ?? OverlayWindowControllerDelegate(),
+      anchorRect: anchorRect,
+      positioner: positioner,
+      contentSizeConstraints: contentSizeConstraints ?? const BoxConstraints(),
+      parent: parent,
+      title: title,
+      alwaysOnTop: alwaysOnTop,
+    );
+  }
+
+  /// Creates an empty [OverlayWindowController].
+  ///
+  /// This method is only intended to be used by subclasses of the
+  /// [OverlayWindowController].
+  ///
+  /// Users who want to instantiate a new [OverlayWindowController] should
+  /// always use the factory method to create a controller that is valid
+  /// for their particular platform.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  @protected
+  OverlayWindowController.empty();
+
+  /// The parent controller of this overlay, if any.
+  BaseWindowController? get parent;
+
+  /// The current title of the overlay window.
+  ///
+  /// This might differ from the requested title.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  String get title;
+
+  /// Request change for the window title.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  void setTitle(String title);
+
+  /// Whether the overlay window is activated (has focus).
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  bool get isActivated;
+
+  /// Activates the overlay window (brings to front and gives focus).
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  void activate();
+
+  /// Whether the overlay window is minimized.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  bool get isMinimized;
+
+  /// Requests window to be minimized.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  void setMinimized(bool minimized);
+
+  /// Whether the overlay window is always on top of other windows.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  bool get alwaysOnTop;
+
+  /// Sets whether the overlay window should be always on top of other windows.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  void setAlwaysOnTop(bool alwaysOnTop);
+}
+
 /// [WindowingOwner] is responsible for creating and managing window controllers.
 ///
 /// A custom implementation can be provided by setting [WidgetsBinding.windowingOwner].
@@ -960,6 +1181,24 @@ abstract class WindowingOwner {
     required WindowPositioner positioner,
     required BaseWindowController parent,
   });
+
+  /// Creates an [OverlayWindowController] with the provided properties.
+  ///
+  /// Most app developers should use [OverlayWindowController]'s constructor
+  /// instead of calling this method directly. This method allows platforms
+  /// to inject platform-specific logic.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  OverlayWindowController createOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  });
 }
 
 /// Creates default windowing owner for standard desktop embedders.
@@ -1027,6 +1266,19 @@ class _WindowingOwnerUnsupported extends WindowingOwner {
     required BaseWindowController parent,
   }) {
     throw UnimplementedError(errorMessage);
+  }
+
+  @override
+  OverlayWindowController createOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  }) {
+    throw UnsupportedError(errorMessage);
   }
 }
 
@@ -1320,6 +1572,100 @@ class PopupWindow extends StatelessWidget {
   }
 }
 
+/// The [OverlayWindow] widget provides a way to render an overlay window in the
+/// widget tree.
+///
+/// The provided [controller] creates the native window that backs
+/// the widget. The [child] widget is rendered into this newly created window.
+///
+/// When an [OverlayWindow] widget is removed from the tree, the window that was created
+/// by the [controller] remains valid until the caller destroys it by calling
+/// [OverlayWindowController.destroy].
+///
+/// Widgets in the same tree as the [child] widget will have access to the
+/// [OverlayWindowController] via the [WindowScope] widget.
+///
+/// {@tool snippet}
+/// An example usage might look like:
+///
+/// ```dart
+/// // TODO(mattkae): remove invalid_use_of_internal_member ignore comment when this API is stable.
+/// // ignore_for_file: invalid_use_of_internal_member
+/// import 'package:flutter/widgets.dart';
+/// import 'package:flutter/material.dart';
+/// import 'package:flutter/src/widgets/_window.dart';
+/// import 'package:flutter/src/widgets/_window_positioner.dart';
+///
+/// void main() {
+///   runWidget(
+///     OverlayWindow(
+///       controller: OverlayWindowController(
+///         anchorRect: const Rect.fromLTWH(100, 100, 200, 100),
+///         positioner: const WindowPositioner(
+///           parentAnchor: WindowPositionerAnchor.bottomRight,
+///           childAnchor: WindowPositionerAnchor.topLeft,
+///         ),
+///         contentSizeConstraints: const BoxConstraints(
+///           minWidth: 200,
+///           minHeight: 100,
+///         ),
+///         alwaysOnTop: true,
+///       ),
+///       child: Container(
+///         padding: const EdgeInsets.all(16),
+///         child: const Text('Overlay Content'),
+///       ),
+///     ),
+///   );
+/// }
+/// ```
+/// {@end-tool}
+///
+/// {@macro flutter.widgets.windowing.experimental}
+@internal
+class OverlayWindow extends StatelessWidget {
+  /// Creates an overlay window widget.
+  ///
+  /// The [controller] creates the native backing window into which the
+  /// [child] widget is rendered.
+  ///
+  /// It is up to the caller to destroy the window by calling
+  /// [OverlayWindowController.destroy] when the window is no longer needed.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  OverlayWindow({super.key, required this.controller, required this.child}) {
+    if (!isWindowingEnabled) {
+      throw UnsupportedError(_kWindowingDisabledErrorMessage);
+    }
+  }
+
+  /// Controller for this widget.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  final OverlayWindowController controller;
+
+  /// The content rendered into this window.
+  ///
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  final Widget child;
+
+  /// {@macro flutter.widgets.windowing.experimental}
+  @internal
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: controller,
+      builder: (BuildContext context, Widget? widget) => WindowScope(
+        controller: controller,
+        child: View(view: controller.rootView, child: child),
+      ),
+    );
+  }
+}
+
 enum _WindowControllerAspect { contentSize, title, activated, maximized, minimized, fullscreen }
 
 /// Provides descendants with access to the [BaseWindowController] associated with
@@ -1453,6 +1799,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => controller.title,
       TooltipWindowController() => '',
       PopupWindowController() => '',
+      OverlayWindowController() => controller.title,
     };
   }
 
@@ -1476,6 +1823,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => controller.title,
       TooltipWindowController() => '',
       PopupWindowController() => '',
+      OverlayWindowController() => controller.title,
     };
   }
 
@@ -1500,6 +1848,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => controller.isActivated,
       TooltipWindowController() => false,
       PopupWindowController() => controller.isActivated,
+      OverlayWindowController() => controller.isActivated,
     };
   }
 
@@ -1524,6 +1873,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => controller.isActivated,
       TooltipWindowController() => false,
       PopupWindowController() => controller.isActivated,
+      OverlayWindowController() => controller.isActivated,
     };
   }
 
@@ -1548,6 +1898,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => controller.isMinimized,
       TooltipWindowController() => false,
       PopupWindowController() => false,
+      OverlayWindowController() => controller.isMinimized,
     };
   }
 
@@ -1572,6 +1923,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => controller.isMinimized,
       TooltipWindowController() => false,
       PopupWindowController() => false,
+      OverlayWindowController() => controller.isMinimized,
     };
   }
 
@@ -1596,6 +1948,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => false,
       TooltipWindowController() => false,
       PopupWindowController() => false,
+      OverlayWindowController() => false,
     };
   }
 
@@ -1620,6 +1973,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => false,
       TooltipWindowController() => false,
       PopupWindowController() => false,
+      OverlayWindowController() => false,
     };
   }
 
@@ -1645,6 +1999,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => false,
       TooltipWindowController() => false,
       PopupWindowController() => false,
+      OverlayWindowController() => false,
     };
   }
 
@@ -1669,6 +2024,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
       DialogWindowController() => false,
       TooltipWindowController() => false,
       PopupWindowController() => false,
+      OverlayWindowController() => false,
     };
   }
 
@@ -1734,6 +2090,8 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
                 dialog.title != (oldWidget.controller as DialogWindowController).title,
               TooltipWindowController() => false,
               PopupWindowController() => false,
+              final OverlayWindowController overlay =>
+                overlay.title != (oldWidget.controller as OverlayWindowController).title,
             },
             _WindowControllerAspect.activated => switch (controller) {
               final RegularWindowController regular =>
@@ -1744,6 +2102,9 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
               TooltipWindowController() => false,
               final PopupWindowController popup =>
                 popup.isActivated != (oldWidget.controller as PopupWindowController).isActivated,
+              final OverlayWindowController overlay =>
+                overlay.isActivated !=
+                    (oldWidget.controller as OverlayWindowController).isActivated,
             },
             _WindowControllerAspect.maximized => switch (controller) {
               final RegularWindowController regular =>
@@ -1752,6 +2113,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
               DialogWindowController() => false,
               TooltipWindowController() => false,
               PopupWindowController() => false,
+              OverlayWindowController() => false,
             },
             _WindowControllerAspect.minimized => switch (controller) {
               final RegularWindowController regular =>
@@ -1761,6 +2123,9 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
                 dialog.isMinimized != (oldWidget.controller as DialogWindowController).isMinimized,
               TooltipWindowController() => false,
               PopupWindowController() => false,
+              final OverlayWindowController overlay =>
+                overlay.isMinimized !=
+                    (oldWidget.controller as OverlayWindowController).isMinimized,
             },
             _WindowControllerAspect.fullscreen => switch (controller) {
               final RegularWindowController regular =>
@@ -1769,6 +2134,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
               DialogWindowController() => false,
               TooltipWindowController() => false,
               PopupWindowController() => false,
+              OverlayWindowController() => false,
             },
           },
     );
@@ -1986,6 +2352,10 @@ class _WindowManagerState extends State<WindowManager> {
               ),
               final PopupWindowController popup => PopupWindow(
                 controller: popup,
+                child: entry.builder(context),
+              ),
+              final OverlayWindowController overlay => OverlayWindow(
+                controller: overlay,
                 child: entry.builder(context),
               ),
             };

--- a/packages/flutter/lib/src/widgets/_window_linux.dart
+++ b/packages/flutter/lib/src/widgets/_window_linux.dart
@@ -148,6 +148,19 @@ class WindowingOwnerLinux extends WindowingOwner {
   }) {
     throw UnimplementedError('Popup windows are not yet implemented on Linux.');
   }
+
+  @override
+  OverlayWindowController createOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  }) {
+    throw UnimplementedError('Overlay windows are not yet implemented on Linux.');
+  }
 }
 
 /// Implementation of [RegularWindowController] for the Linux platform.

--- a/packages/flutter/lib/src/widgets/_window_macos.dart
+++ b/packages/flutter/lib/src/widgets/_window_macos.dart
@@ -144,6 +144,20 @@ class WindowingOwnerMacOS extends WindowingOwner {
     throw UnimplementedError('Popup windows are not yet implemented on MacOS.');
   }
 
+  @internal
+  @override
+  OverlayWindowController createOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  }) {
+    throw UnimplementedError('Overlay windows are not yet implemented on MacOS.');
+  }
+
   final List<_WindowControllerMixin> _activeControllers = <_WindowControllerMixin>[];
 
   /// Returns the window handle for the given [view], or null is the window

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -206,6 +206,20 @@ class WindowingOwnerWin32 extends WindowingOwner {
     throw UnimplementedError('Popup windows are not yet implemented on Windows.');
   }
 
+  @internal
+  @override
+  OverlayWindowController createOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  }) {
+    throw UnimplementedError('Overlay windows are not yet implemented on Windows.');
+  }
+
   /// Register a new [WindowsMessageHandler].
   ///
   /// The handler will be triggered for unhandled messages for all top level

--- a/packages/flutter/test/widgets/windowing_test.dart
+++ b/packages/flutter/test/widgets/windowing_test.dart
@@ -10,6 +10,9 @@ import 'package:flutter/src/widgets/_window.dart'
         DialogWindow,
         DialogWindowController,
         DialogWindowControllerDelegate,
+        OverlayWindow,
+        OverlayWindowController,
+        OverlayWindowControllerDelegate,
         PopupWindow,
         PopupWindowController,
         RegularWindow,
@@ -162,6 +165,45 @@ class _StubPopupWindowController extends PopupWindowController {
   void destroy() {}
 }
 
+class _StubOverlayWindowController extends OverlayWindowController {
+  _StubOverlayWindowController(WidgetTester tester) : super.empty() {
+    rootView = FakeView(tester.view);
+  }
+
+  @override
+  BaseWindowController? get parent => null;
+
+  @override
+  Size get contentSize => Size.zero;
+
+  @override
+  String get title => 'Stub Overlay Window';
+
+  @override
+  bool get isActivated => true;
+
+  @override
+  bool get isMinimized => false;
+
+  @override
+  bool get alwaysOnTop => false;
+
+  @override
+  void setTitle(String title) {}
+
+  @override
+  void activate() {}
+
+  @override
+  void setMinimized(bool minimized) {}
+
+  @override
+  void setAlwaysOnTop(bool alwaysOnTop) {}
+
+  @override
+  void destroy() {}
+}
+
 void main() {
   group('Windowing', () {
     group('isWindowingEnabled is false', () {
@@ -186,6 +228,19 @@ void main() {
         final WindowingOwner owner = createDefaultWindowingOwner();
         expect(
           () => owner.createDialogWindowController(delegate: DialogWindowControllerDelegate()),
+          throwsUnsupportedError,
+        );
+      });
+
+      test('default WindowingOwner throws when accessing createOverlayWindowController', () {
+        final WindowingOwner owner = createDefaultWindowingOwner();
+        expect(
+          () => owner.createOverlayWindowController(
+            delegate: OverlayWindowControllerDelegate(),
+            anchorRect: const Rect.fromLTWH(0, 0, 100, 100),
+            positioner: const WindowPositioner(),
+            contentSizeConstraints: const BoxConstraints(),
+          ),
           throwsUnsupportedError,
         );
       });
@@ -220,6 +275,16 @@ void main() {
         );
       });
 
+      testWidgets('OverlayWindow throws UnsupportedError', (WidgetTester tester) async {
+        expect(
+          () => OverlayWindow(
+            controller: _StubOverlayWindowController(tester),
+            child: const Text('Test'),
+          ),
+          throwsUnsupportedError,
+        );
+      });
+
       testWidgets('Accessing WindowScope.of throws UnsupportedError', (WidgetTester tester) async {
         await tester.pumpWidget(LookupBoundary(child: Container()));
         final BuildContext context = tester.element(find.byType(Container));
@@ -248,6 +313,15 @@ void main() {
         await tester.pumpWidget(
           wrapWithView: false,
           DialogWindow(controller: controller, child: Container()),
+        );
+      });
+
+      testWidgets('Overlay does not throw', (WidgetTester tester) async {
+        final controller = _StubOverlayWindowController(tester);
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          OverlayWindow(controller: controller, child: Container()),
         );
       });
 
@@ -329,6 +403,24 @@ void main() {
         );
 
         expect(scope, isA<PopupWindowController>());
+      });
+
+      testWidgets('Can access WindowScope.of for overlay windows', (WidgetTester tester) async {
+        final controller = _StubOverlayWindowController(tester);
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          OverlayWindow(
+            controller: controller,
+            child: Builder(
+              builder: (BuildContext context) {
+                final BaseWindowController scope = WindowScope.of(context);
+                expect(scope, isA<OverlayWindowController>());
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
       });
 
       testWidgets('Can access WindowScope.maybeOf for regular windows', (
@@ -413,6 +505,26 @@ void main() {
         );
 
         expect(scope, isA<PopupWindowController>());
+      });
+
+      testWidgets('Can access WindowScope.maybeOf for overlay windows', (
+        WidgetTester tester,
+      ) async {
+        final controller = _StubOverlayWindowController(tester);
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          OverlayWindow(
+            controller: controller,
+            child: Builder(
+              builder: (BuildContext context) {
+                final BaseWindowController? scope = WindowScope.maybeOf(context);
+                expect(scope, isA<OverlayWindowController>());
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
       });
 
       testWidgets('Can access WindowScope.contentSizeOf for regular windows', (
@@ -1465,6 +1577,66 @@ void main() {
         );
 
         expect(isFullscreen, equals(false));
+      });
+
+      testWidgets('Can access WindowScope.titleOf for overlay windows', (
+        WidgetTester tester,
+      ) async {
+        final controller = _StubOverlayWindowController(tester);
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          OverlayWindow(
+            controller: controller,
+            child: Builder(
+              builder: (BuildContext context) {
+                final String title = WindowScope.titleOf(context);
+                expect(title, equals('Stub Overlay Window'));
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      });
+
+      testWidgets('Can access WindowScope.isActivatedOf for overlay windows', (
+        WidgetTester tester,
+      ) async {
+        final controller = _StubOverlayWindowController(tester);
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          OverlayWindow(
+            controller: controller,
+            child: Builder(
+              builder: (BuildContext context) {
+                final bool isActivated = WindowScope.isActivatedOf(context);
+                expect(isActivated, equals(true));
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
+      });
+
+      testWidgets('Can access WindowScope.isMinimizedOf for overlay windows', (
+        WidgetTester tester,
+      ) async {
+        final controller = _StubOverlayWindowController(tester);
+        addTearDown(controller.dispose);
+        await tester.pumpWidget(
+          wrapWithView: false,
+          OverlayWindow(
+            controller: controller,
+            child: Builder(
+              builder: (BuildContext context) {
+                final bool isMinimized = WindowScope.isMinimizedOf(context);
+                expect(isMinimized, equals(false));
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        );
       });
     });
   });

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -291,6 +291,13 @@ mixin _ChildWindowHierarchyMixin {
           }
           activateable = (popupChild as _TestPopupWindowController).getFirstActivatableChild();
           foundPopup = true;
+        case final OverlayWindowController overlayChild:
+          if (foundPopup) {
+            // Already found a popup, skip anything else.
+            break;
+          }
+          activateable = (overlayChild as _TestOverlayWindowController).getFirstActivatableChild();
+          foundPopup = true;
       }
     }
 
@@ -429,6 +436,8 @@ void _addChildToParent(BaseWindowController? parent, BaseWindowController child)
         (testParent as _TestPopupWindowController).addChild(child);
       case TooltipWindowController _:
         fail('TooltipWindowController cannot be a parent of another window controller.');
+      case final OverlayWindowController testParent:
+        (testParent as _TestOverlayWindowController).addChild(child);
     }
   }
 }
@@ -444,6 +453,8 @@ void _removeChildFromParent(BaseWindowController? parent, BaseWindowController c
         (testParent as _TestPopupWindowController).removeChild(child);
       case TooltipWindowController _:
         fail('TooltipWindowController cannot be a parent of another window controller.');
+      case final OverlayWindowController testParent:
+        (testParent as _TestOverlayWindowController).removeChild(child);
     }
   }
 }
@@ -687,6 +698,102 @@ class _TestPopupWindowController extends PopupWindowController with _ChildWindow
   }
 }
 
+class _TestOverlayWindowController extends OverlayWindowController with _ChildWindowHierarchyMixin {
+  _TestOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required TestPlatformDispatcher platformDispatcher,
+    required this.windowingOwner,
+    required ui.Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  }) : _delegate = delegate,
+       _parent = parent,
+       _constraints = contentSizeConstraints,
+       _anchorRect = anchorRect,
+       _positioner = positioner,
+       _title = title ?? 'Test Overlay Window',
+       _alwaysOnTop = alwaysOnTop,
+       super.empty() {
+    rootView = _TestFlutterView(
+      controller: this,
+      platformDispatcher: platformDispatcher,
+      constraints: _constraints,
+    );
+    _addChildToParent(parent, this);
+
+    // Automatically activate the window when created.
+    activate();
+  }
+
+  final OverlayWindowControllerDelegate _delegate;
+  final BaseWindowController? _parent;
+  final _TestWindowingOwner windowingOwner;
+  final BoxConstraints _constraints;
+  // ignore: unused_field
+  final ui.Rect _anchorRect;
+  // ignore: unused_field
+  final WindowPositioner _positioner;
+  String _title;
+  bool _alwaysOnTop;
+  bool _isMinimized = false;
+
+  @override
+  Size get contentSize => _constraints.biggest;
+
+  @override
+  BaseWindowController? get parent => _parent;
+
+  @override
+  String get title => _title;
+
+  @override
+  bool get isActivated => windowingOwner.isWindowControllerActive(this);
+
+  @override
+  bool get isMinimized => _isMinimized;
+
+  @override
+  bool get alwaysOnTop => _alwaysOnTop;
+
+  @override
+  void setTitle(String title) {
+    _title = title;
+    notifyListeners();
+  }
+
+  @override
+  void activate() {
+    final BaseWindowController activated = windowingOwner.activateWindowController(this);
+    activated.notifyListeners();
+  }
+
+  @override
+  void setMinimized(bool minimized) {
+    _isMinimized = minimized;
+    if (_isMinimized) {
+      windowingOwner.deactivateWindowController(this);
+    }
+    notifyListeners();
+  }
+
+  @override
+  void setAlwaysOnTop(bool alwaysOnTop) {
+    _alwaysOnTop = alwaysOnTop;
+    notifyListeners();
+  }
+
+  @override
+  void destroy() {
+    _delegate.onWindowDestroyed();
+    removeAllChildren();
+    windowingOwner.deactivateWindowController(this);
+    _removeChildFromParent(_parent, this);
+  }
+}
+
 /// A [WindowingOwner] used for tests.
 ///
 /// This windowing owner will behave as a perfect windowing system, with no
@@ -731,6 +838,11 @@ class _TestWindowingOwner extends WindowingOwner {
             .getFirstActivatableChild();
         _activeWindowController = leaf;
         return _activeWindowController!;
+      case final OverlayWindowController _:
+        final BaseWindowController leaf = (controller as _TestOverlayWindowController)
+            .getFirstActivatableChild();
+        _activeWindowController = leaf;
+        return _activeWindowController!;
     }
   }
 
@@ -748,6 +860,8 @@ class _TestWindowingOwner extends WindowingOwner {
         fail('TooltipWindowController cannot be a parent of DialogWindowController.');
       case final PopupWindowController popupParent:
         popupParent.activate();
+      case final OverlayWindowController overlayParent:
+        overlayParent.activate();
     }
 
     return true;
@@ -781,6 +895,10 @@ class _TestWindowingOwner extends WindowingOwner {
         );
       case final PopupWindowController popupController:
         if (!_tryActivateParent(popupController.parent)) {
+          _activeWindowController = null;
+        }
+      case final OverlayWindowController overlayController:
+        if (!_tryActivateParent(overlayController.parent)) {
           _activeWindowController = null;
         }
     }
@@ -866,6 +984,29 @@ class _TestWindowingOwner extends WindowingOwner {
       anchorRect: anchorRect,
       positioner: positioner,
       parent: parent,
+    );
+  }
+
+  @override
+  OverlayWindowController createOverlayWindowController({
+    required OverlayWindowControllerDelegate delegate,
+    required Rect anchorRect,
+    required WindowPositioner positioner,
+    required BoxConstraints contentSizeConstraints,
+    BaseWindowController? parent,
+    String? title,
+    bool alwaysOnTop = false,
+  }) {
+    return _TestOverlayWindowController(
+      delegate: delegate,
+      platformDispatcher: _platformDispatcher,
+      windowingOwner: this,
+      anchorRect: anchorRect,
+      positioner: positioner,
+      contentSizeConstraints: contentSizeConstraints,
+      parent: parent,
+      title: title,
+      alwaysOnTop: alwaysOnTop,
     );
   }
 }


### PR DESCRIPTION
## What's new?
* Added the concept of overlay to the windowing API. New symbols:
  * OverlayWindowControllerDelegate
  * OverlayWindowController
  * WindowingOwner.createOverlayWindowController
  * OverlayWindow

*  This pull request ONLY adds the idea to the API. Win32 implementation to follow :)

## Design doc

You can read more about overlay window [here](https://flutter.dev/go/multi-window-overlay).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.