### PR TITLE
feat(assets): add platform-specific asset filtering in pubspec.yaml

### DIFF
--- a/packages/flutter_tools/lib/src/base/deferred_component.dart
+++ b/packages/flutter_tools/lib/src/base/deferred_component.dart
@@ -108,6 +108,9 @@ class DeferredComponent {
       if (asset.flavors.isNotEmpty) {
         out.write(' (flavors: ${asset.flavors.join(', ')})');
       }
+      if (asset.platforms.isNotEmpty) {
+        out.write(' (platforms: ${asset.platforms.join(', ')})');
+      }
     }
     return out.toString();
   }

--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -269,7 +269,10 @@ class CopyAssets extends Target {
   List<String> get depfiles => const <String>['flutter_assets.d'];
 
   @override
-  Future<void> build(Environment environment) async {
+  Future<void> build(
+    Environment environment, {
+    TargetPlatform targetPlatform = TargetPlatform.android,
+  }) async {
     final String? buildModeEnvironment = environment.defines[kBuildMode];
     if (buildModeEnvironment == null) {
       throw MissingDefineException(kBuildMode, name);
@@ -282,7 +285,7 @@ class CopyAssets extends Target {
       environment,
       output,
       dartHookResult: dartHookResult,
-      targetPlatform: TargetPlatform.android,
+      targetPlatform: targetPlatform,
       buildMode: buildMode,
       flavor: environment.defines[kFlavor],
       additionalContent: <String, DevFSContent>{

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -108,7 +108,7 @@ Future<AssetBundle?> buildAssets({
   required String manifestPath,
   String? assetDirPath,
   required String packageConfigPath,
-  TargetPlatform? targetPlatform,
+  required TargetPlatform targetPlatform,
   String? flavor,
 }) async {
   assetDirPath ??= getAssetBuildDirectory();

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -769,6 +769,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       packageConfigPath: packageConfigPath,
       flavor: flavor,
       includeAssetsFromDevDependencies: true,
+      targetPlatform: TargetPlatform.tester,
     );
     if (build != 0) {
       throwToolExit('Error: Failed to build asset bundle');

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -499,6 +499,7 @@ class HotRunner extends ResidentRunner {
         ),
         packageConfigPath: debuggingOptions.buildInfo.packageConfigPath,
         flavor: debuggingOptions.buildInfo.flavor,
+        targetPlatform: targetPlatform,
       );
       if (result != 0) {
         return UpdateFSReport();

--- a/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/preview_pubspec_builder.dart
@@ -76,6 +76,7 @@ class PreviewPubspecBuilder {
     return AssetsEntry(
       uri: transformAssetUri(asset.uri),
       flavors: asset.flavors,
+      platforms: asset.platforms,
       transformers: asset.transformers,
     );
   }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_flavors_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/project.dart';
 
@@ -37,6 +38,7 @@ void main() {
       packageConfigPath: '.dart_tool/package_config.json',
       flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
       flavor: flavor,
+      targetPlatform: TargetPlatform.tester,
     );
     return bundle;
   }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_fonts_test.dart
@@ -9,6 +9,7 @@ import 'package:file/memory.dart';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_info.dart';
 
 import 'package:flutter_tools/src/globals.dart' as globals;
 
@@ -62,7 +63,10 @@ $fontsSection
     String expectedAssetManifest,
   ) async {
     final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-    await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+    await bundle.build(
+      packageConfigPath: '.dart_tool/package_config.json',
+      targetPlatform: TargetPlatform.tester,
+    );
 
     for (final packageName in packages) {
       for (final packageFont in packageFonts) {
@@ -114,7 +118,10 @@ $fontsSection
         writePubspecFile('p/p/pubspec.yaml', 'test_package');
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>['AssetManifest.bin', 'FontManifest.json', 'NOTICES.Z']),

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -10,6 +10,7 @@ import 'package:file/memory.dart';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_info.dart';
 
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:standard_message_codec/standard_message_codec.dart';
@@ -83,7 +84,11 @@ $assetsSection
     String? flavor,
   }) async {
     final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-    await bundle.build(packageConfigPath: '.dart_tool/package_config.json', flavor: flavor);
+    await bundle.build(
+      packageConfigPath: '.dart_tool/package_config.json',
+      flavor: flavor,
+      targetPlatform: TargetPlatform.tester,
+    );
 
     for (final packageName in packages) {
       for (final asset in assets) {
@@ -138,7 +143,10 @@ $assetsSection
         writePubspecFile('p/p/pubspec.yaml', 'test_package');
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>['NOTICES.Z', 'AssetManifest.bin', 'FontManifest.json']),
@@ -166,7 +174,10 @@ $assetsSection
         writeAssets('p/p/', assets);
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>['NOTICES.Z', 'AssetManifest.bin', 'FontManifest.json']),
@@ -665,7 +676,10 @@ $assetsSection
         writeAssets('p/p/', assetsOnDisk);
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
 
         expect(
           bundle.entries['AssetManifest.bin'],
@@ -754,7 +768,10 @@ $assetsSection
         writePubspecFile('p/p/pubspec.yaml', 'test_package', assets: assetOnManifest);
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
       },
       overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -44,7 +44,13 @@ void main() {
       'nonempty',
       () async {
         final AssetBundle ab = AssetBundleFactory.instance.createBundle();
-        expect(await ab.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+        expect(
+          await ab.build(
+            packageConfigPath: '.dart_tool/package_config.json',
+            targetPlatform: TargetPlatform.tester,
+          ),
+          0,
+        );
         expect(ab.entries.length, greaterThan(0));
       },
       overrides: <Type, Generator>{
@@ -62,7 +68,10 @@ void main() {
           ..writeAsStringSync('');
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(bundle.entries.keys, unorderedEquals(<String>['AssetManifest.bin']));
         const expectedBinAssetManifest = <Object, Object>{};
         expect(
@@ -109,7 +118,10 @@ flutter:
         }
 
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
 
         expect(
           bundle.entries.keys,
@@ -149,7 +161,10 @@ flutter:
     - assets/foo/
 ''');
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>[
@@ -165,7 +180,10 @@ flutter:
           ..setLastModifiedSync(packageFile.lastModifiedSync().add(const Duration(hours: 1)));
 
         expect(bundle.needsBuild(), true);
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>[
@@ -203,7 +221,10 @@ flutter:
           mainLibName: 'my_app',
         );
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>[
@@ -231,7 +252,10 @@ name: my_app''')
         // asset manifest and not updated. This is due to the devfs not
         // supporting file deletion.
         expect(bundle.needsBuild(), true);
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>[
@@ -269,7 +293,10 @@ flutter:
 ''');
         writePackageConfigFiles(directory: globals.fs.currentDirectory, mainLibName: 'my_app');
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>[
@@ -323,6 +350,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           deferredComponentsEnabled: true,
+          targetPlatform: TargetPlatform.tester,
         );
         expect(
           bundle.entries.keys,
@@ -371,7 +399,10 @@ flutter:
         - assets/wild/
 ''');
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-        await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        );
         expect(
           bundle.entries.keys,
           unorderedEquals(<String>[
@@ -431,6 +462,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           deferredComponentsEnabled: true,
+          targetPlatform: TargetPlatform.tester,
         );
         expect(
           bundle.entries.keys,
@@ -454,6 +486,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           deferredComponentsEnabled: true,
+          targetPlatform: TargetPlatform.tester,
         );
 
         expect(
@@ -507,6 +540,7 @@ flutter:
         () => bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         ),
         throwsToolExit(
           message:
@@ -546,6 +580,7 @@ flutter:
         () => bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         ),
         throwsToolExit(
           message:
@@ -590,6 +625,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
 
         expect(bundle.entries['my-asset.txt']!.content.isModified, isTrue);
@@ -597,6 +633,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
 
         expect(bundle.entries['my-asset.txt']!.content.isModified, isFalse);
@@ -614,6 +651,7 @@ flutter:
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
 
         expect(bundle.entries['my-asset.txt']!.content.isModified, isTrue);
@@ -762,12 +800,18 @@ assets:
   - assets/foo/bar.txt
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-      await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+      await bundle.build(
+        packageConfigPath: '.dart_tool/package_config.json',
+        targetPlatform: TargetPlatform.tester,
+      );
 
       final AssetBundleEntry? fontManifest = bundle.entries['FontManifest.json'];
       final AssetBundleEntry? license = bundle.entries['NOTICES'];
 
-      await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+      await bundle.build(
+        packageConfigPath: '.dart_tool/package_config.json',
+        targetPlatform: TargetPlatform.tester,
+      );
 
       expect(fontManifest, bundle.entries['FontManifest.json']);
       expect(license, bundle.entries['NOTICES']);
@@ -795,7 +839,13 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        0,
+      );
       expect(
         bundle.additionalDependencies.single.path,
         contains('DOES_NOT_EXIST_RERUN_FOR_WILDCARD'),
@@ -824,7 +874,13 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        0,
+      );
       expect(bundle.additionalDependencies, isEmpty);
     },
     overrides: <Type, Generator>{
@@ -871,7 +927,13 @@ flutter:
   ''');
         final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-        expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+        expect(
+          await bundle.build(
+            packageConfigPath: '.dart_tool/package_config.json',
+            targetPlatform: TargetPlatform.tester,
+          ),
+          0,
+        );
 
         await writeBundle(
           output,
@@ -1097,7 +1159,13 @@ flutter:
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       globals.fs.file('foo/bar/fizz.txt').createSync(recursive: true);
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        0,
+      );
       expect(bundle.additionalDependencies, isEmpty);
     },
     overrides: <Type, Generator>{
@@ -1135,7 +1203,10 @@ flutter:
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
       globals.fs.file('foo/bar/fizz.txt').createSync(recursive: true);
 
-      await bundle.build(packageConfigPath: '.dart_tool/package_config.json');
+      await bundle.build(
+        packageConfigPath: '.dart_tool/package_config.json',
+        targetPlatform: TargetPlatform.tester,
+      );
 
       expect(
         bundle.entries.keys,
@@ -1188,7 +1259,13 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 1);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        1,
+      );
       expect(testLogger.errorText, contains('This asset was included from package foo'));
     },
     overrides: <Type, Generator>{
@@ -1217,7 +1294,13 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 1);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        1,
+      );
       expect(testLogger.errorText, isNot(contains('This asset was included from')));
     },
     overrides: <Type, Generator>{
@@ -1256,7 +1339,13 @@ flutter:
 ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        0,
+      );
       expect((bundle.entries['FontManifest.json']!.content as DevFSStringContent).string, '[]');
       expect(testLogger.errorText, contains('package:foo has `uses-material-design: true` set'));
     },
@@ -1292,7 +1381,13 @@ flutter:
 
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        0,
+      );
       expect(
         bundle.entries.keys,
         unorderedEquals(<String>[
@@ -1336,7 +1431,13 @@ flutter:
       globals.fs.file('assets/zebra.jpg').createSync();
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
-      expect(await bundle.build(packageConfigPath: '.dart_tool/package_config.json'), 0);
+      expect(
+        await bundle.build(
+          packageConfigPath: '.dart_tool/package_config.json',
+          targetPlatform: TargetPlatform.tester,
+        ),
+        0,
+      );
       expect((bundle.entries['FontManifest.json']!.content as DevFSStringContent).string, '[]');
     },
     overrides: <Type, Generator>{
@@ -1375,6 +1476,7 @@ flutter:
         () => bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         ),
         throwsToolExit(
           message:

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 
 import 'package:flutter_tools/src/project.dart';
@@ -86,6 +87,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
 
         final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(
@@ -133,6 +135,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
         await bundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
 
         final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(
@@ -176,6 +179,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
         flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
+        targetPlatform: TargetPlatform.tester,
       );
 
       final Map<Object?, Object?> smcBinManifest = await extractAssetManifestSmcBinFromBundle(
@@ -215,6 +219,7 @@ ${assets.map((String entry) => '    - $entry').join('\n')}
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
         flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
+        targetPlatform: TargetPlatform.tester,
       );
 
       final expectedManifest = <String, List<Map<String, Object>>>{
@@ -282,6 +287,7 @@ flutter:
       await bundle.build(
         packageConfigPath: '.dart_tool/package_config.json',
         flutterProject: FlutterProject.fromDirectoryTest(fs.currentDirectory),
+        targetPlatform: TargetPlatform.tester,
       );
 
       final expectedAssetManifest = <String, List<Map<String, Object>>>{

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -96,6 +96,7 @@ dependencies:
           packageConfigPath: packageConfigPath,
           manifestPath: manifestPath,
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.directory('main')),
+          targetPlatform: TargetPlatform.tester,
         );
 
         expect(assetBundle.entries, contains('FontManifest.json'));
@@ -254,6 +255,7 @@ flutter:
             packageConfigPath: packageConfigPath,
             manifestPath: manifestPath,
             flutterProject: FlutterProject.fromDirectoryTest(fileSystem.directory('main')),
+            targetPlatform: TargetPlatform.tester,
           );
 
           expect(assetBundle.entries, contains('FontManifest.json'));
@@ -298,6 +300,7 @@ flutter:
           manifestPath: manifestPath, // file doesn't exist
           packageConfigPath: packageConfigPath,
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.file(manifestPath).parent),
+          targetPlatform: TargetPlatform.tester,
         );
 
         expect(assetBundle.wasBuiltOnce(), true);
@@ -397,6 +400,7 @@ flutter:
         final int result = await assetBundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
         expect(result, isNot(0));
         expect(
@@ -426,6 +430,7 @@ flutter:
         final int result = await assetBundle.build(
           packageConfigPath: '.dart_tool/package_config.json',
           flutterProject: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+          targetPlatform: TargetPlatform.tester,
         );
         expect(result, isNot(0));
         expect(


### PR DESCRIPTION
## Description

This PR introduces platform-specific asset support in `pubspec.yaml`.

Currently, Flutter does not allow specifying which platforms an asset should be included for.  
This results in all declared assets being bundled for every target platform, even if some are irrelevant (e.g. desktop-only or mobile-only images).  

### What this PR changes
- Adds a new optional `platforms` field under each asset in `pubspec.yaml`.
- The field accepts a list of strings (platform identifiers, e.g. `["android", "ios", "web", "windows", "macos", "linux"]`).
- Assets with a `platforms` restriction are only included in the bundle when building for a matching platform.
- Invalid values (non-strings or unknown platform names) log an error.

### Example
```yaml
flutter:
  assets:
    - path: assets/logo.png
   
    - path: assets/web_worker.js
      platforms: [web]

    - path: assets/desktop_icon.png
      platforms: [windows, linux, macos]
```

#### Before
All assets (`logo.png`, `web_worker.js`, `desktop_icon.png`) are bundled into **every build**, regardless of platform.

#### After
- `logo.png` is included on all platforms.
- `web_worker.js` is included only on web builds.
- `desktop_icon.png` is included only on desktop builds.

### Why this is useful
This significantly improves bundle size, prevents unused resources from being shipped, and gives developers better control over asset management.  

## Issues
Fixes #65065

## Reviewer note
Would a design document be helpful for this change, or is the current explanation sufficient?

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
