### PR TITLE
Fix TextFormField does not inherit local InputDecorationTheme

### DIFF
--- a/examples/api/lib/material/input_decorator/input_decoration.widget_state.1.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.widget_state.1.dart
@@ -27,17 +27,12 @@ class MaterialStateExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
-    return Theme(
-      data: themeData.copyWith(
-        inputDecorationTheme: themeData.inputDecorationTheme.copyWith(
-          prefixIconColor: const WidgetStateColor.fromMap(<WidgetStatesConstraint, Color>{
-            WidgetState.error: Colors.red,
-            WidgetState.focused: Colors.blue,
-            WidgetState.any: Colors.grey,
-          }),
-        ),
-      ),
+    return InputDecorationTheme(
+      prefixIconColor: const WidgetStateColor.fromMap(<WidgetStatesConstraint, Color>{
+        WidgetState.error: Colors.red,
+        WidgetState.focused: Colors.blue,
+        WidgetState.any: Colors.grey,
+      }),
       child: TextFormField(
         initialValue: 'example.com',
         decoration: const InputDecoration(prefixIcon: Icon(Icons.web)),

--- a/packages/flutter/lib/src/material/text_form_field.dart
+++ b/packages/flutter/lib/src/material/text_form_field.dart
@@ -12,7 +12,6 @@ import 'adaptive_text_selection_toolbar.dart';
 import 'input_decorator.dart';
 import 'material_state.dart';
 import 'text_field.dart';
-import 'theme.dart';
 
 export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 
@@ -42,7 +41,7 @@ export 'package:flutter/services.dart' show SmartDashesType, SmartQuotesType;
 /// when it is no longer needed. This will ensure any resources used by the object
 /// are discarded.
 ///
-/// By default, `decoration` will apply the [ThemeData.inputDecorationTheme] for
+/// By default, `decoration` will apply the ambient [InputDecorationThemeData] for
 /// the current context to the [InputDecoration], see
 /// [InputDecoration.applyDefaults].
 ///
@@ -213,7 +212,7 @@ class TextFormField extends FormField<String> {
          builder: (FormFieldState<String> field) {
            final _TextFormFieldState state = field as _TextFormFieldState;
            InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
-               .applyDefaults(Theme.of(field.context).inputDecorationTheme);
+               .applyDefaults(InputDecorationTheme.of(field.context));
 
            final String? errorText = field.errorText;
            if (errorText != null) {

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1848,4 +1848,31 @@ void main() {
     variant: TargetPlatformVariant.all(),
     skip: kIsWeb, // [intended] on web the browser handles the context menu.
   );
+
+  // Regression test for https://github.com/flutter/flutter/issues/176391.
+  testWidgets('TextFormField can inherit decoration from local InputDecorationThemeData', (
+    WidgetTester tester,
+  ) async {
+    const InputDecoration decoration = InputDecoration(labelText: 'Label');
+    const InputDecorationThemeData decorationTheme = InputDecorationThemeData(
+      labelStyle: TextStyle(color: Colors.green),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InputDecorationTheme(
+            data: decorationTheme,
+            child: TextFormField(decoration: decoration),
+          ),
+        ),
+      ),
+    );
+
+    final InputDecorator decorator = tester.widget(find.byType(InputDecorator));
+    final InputDecoration expectedDecoration = decoration
+        .applyDefaults(decorationTheme)
+        .copyWith(enabled: true, hintMaxLines: 1);
+    expect(decorator.decoration, expectedDecoration);
+  });
 }


### PR DESCRIPTION
## Description

This PR replaces global `ThemeData.inputDecorationTheme` usage in `TextFormField` with `InputDecorationTheme.of ` which returns the ambient `InputDecorationTheme`.
It is a follow up to https://github.com/flutter/flutter/pull/168981 which introduces `InputDecorationTheme.of `.

## Related Issue

Fixes [TextFormField does not inherit local InputDecorationTheme](https://github.com/flutter/flutter/issues/176391)

## Tests

- Adds 1 test
