### PR TITLE
Upgrade packages

### DIFF
--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -110,7 +110,7 @@ dependencies:
   term_glyph: 1.2.2
   typed_data: 1.4.0
   vm_service_interface: 2.0.1
-  watcher: 1.1.3
+  watcher: 1.1.4
   web: 1.1.1
   web_socket: 1.0.1
   yaml_edit: 2.2.2
@@ -127,4 +127,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: 37t3vr
+# PUBSPEC CHECKSUM: ho7nke

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -510,10 +510,10 @@ packages:
     dependency: "direct main"
     description:
       name: native_toolchain_c
-      sha256: "7e8358a4f6ec69a4f2d366bb971af298aca50d6c2e8a07be7c12d7f6d40460aa"
+      sha256: f8872ea6c7a50ce08db9ae280ca2b8efdd973157ce462826c82f3c3051d154ce
       url: "https://pub.dev"
     source: hosted
-    version: "0.17.1"
+    version: "0.17.2"
   nested:
     dependency: "direct main"
     description:
@@ -939,10 +939,10 @@ packages:
     dependency: "direct main"
     description:
       name: video_player_android
-      sha256: "59e5a457ddcc1688f39e9aef0efb62aa845cf0cbbac47e44ac9730dc079a2385"
+      sha256: "6cfe0b1e102522eda1e139b82bf00602181c5844fd2885340f595fb213d74842"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.13"
+    version: "2.8.14"
   video_player_avfoundation:
     dependency: "direct main"
     description:
@@ -987,10 +987,10 @@ packages:
     dependency: "direct main"
     description:
       name: watcher
-      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
+      sha256: "592ab6e2892f67760543fb712ff0177f4ec76c031f02f5b4ff8d3fc5eb9fb61a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   web:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -133,7 +133,7 @@ dependencies:
   meta: 1.17.0
   metrics_center: 1.0.13
   mime: 2.0.0
-  native_toolchain_c: 0.17.1
+  native_toolchain_c: 0.17.2
   nested: 1.0.0
   node_preamble: 2.0.2
   package_config: 2.2.0
@@ -184,13 +184,13 @@ dependencies:
   url_launcher_windows: 3.1.4
   vector_math: 2.2.0
   video_player: 2.10.0
-  video_player_android: 2.8.13
+  video_player_android: 2.8.14
   video_player_avfoundation: 2.8.4
   video_player_platform_interface: 6.4.0
   video_player_web: 2.4.0
   vm_service: 15.0.2
   vm_snapshot_analysis: 0.7.6
-  watcher: 1.1.3
+  watcher: 1.1.4
   web: 1.1.1
   web_socket: 1.0.1
   web_socket_channel: 3.0.3
@@ -212,4 +212,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.2
-# PUBSPEC CHECKSUM: 9hqic
+# PUBSPEC CHECKSUM: pb0r15


### PR DESCRIPTION
Changes to the Dart IO require picking up newer version of `package:watcher`.

