### PR TITLE
Announce text and button together when DropdownMenu is treated as a button

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1129,18 +1129,26 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         final Widget trailingButton = widget.showTrailingIcon
             ? Padding(
                 padding: isCollapsed ? EdgeInsets.zero : const EdgeInsets.all(4.0),
-                child: IconButton(
-                  focusNode: _trailingIconButtonFocusNode,
-                  isSelected: controller.isOpen,
-                  constraints: widget.inputDecorationTheme?.suffixIconConstraints,
-                  padding: isCollapsed ? EdgeInsets.zero : null,
-                  icon: widget.trailingIcon ?? const Icon(Icons.arrow_drop_down),
-                  selectedIcon: widget.selectedTrailingIcon ?? const Icon(Icons.arrow_drop_up),
-                  onPressed: !widget.enabled
-                      ? null
-                      : () {
-                          handlePressed(controller);
-                        },
+                child: ExcludeSemantics(
+                  // When the text field is treated as a button (i.e., it can
+                  // not be focused), the trailing button should become part of
+                  // the text field button by excluding semantics. Otherwise,
+                  // it will inappropriately announce whether this icon button
+                  // is selected or not.
+                  excluding: !canRequestFocus(),
+                  child: IconButton(
+                    focusNode: _trailingIconButtonFocusNode,
+                    isSelected: controller.isOpen,
+                    constraints: widget.inputDecorationTheme?.suffixIconConstraints,
+                    padding: isCollapsed ? EdgeInsets.zero : null,
+                    icon: widget.trailingIcon ?? const Icon(Icons.arrow_drop_down),
+                    selectedIcon: widget.selectedTrailingIcon ?? const Icon(Icons.arrow_drop_up),
+                    onPressed: !widget.enabled
+                        ? null
+                        : () {
+                            handlePressed(controller);
+                          },
+                  ),
                 ),
               )
             : const SizedBox.shrink();
@@ -1150,48 +1158,52 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           child: widget.leadingIcon ?? const SizedBox.shrink(),
         );
 
-        final Widget textField = TextField(
-          key: _anchorKey,
-          enabled: widget.enabled,
-          mouseCursor: effectiveMouseCursor,
-          focusNode: widget.focusNode,
-          canRequestFocus: canRequestFocus(),
-          enableInteractiveSelection: canRequestFocus(),
-          readOnly: !canRequestFocus(),
-          keyboardType: widget.keyboardType,
-          textAlign: widget.textAlign,
-          textAlignVertical: TextAlignVertical.center,
-          maxLines: widget.maxLines,
-          textInputAction: widget.textInputAction,
-          cursorHeight: widget.cursorHeight,
-          style: effectiveTextStyle,
-          controller: _effectiveTextEditingController,
-          onEditingComplete: _handleEditingComplete,
-          onTap: !widget.enabled
-              ? null
-              : () {
-                  handlePressed(controller, focusForKeyboard: !canRequestFocus());
-                },
-          onChanged: (String text) {
-            controller.open();
-            setState(() {
-              filteredEntries = widget.dropdownMenuEntries;
-              _enableFilter = widget.enableFilter;
-              _enableSearch = widget.enableSearch;
-            });
-          },
-          inputFormatters: widget.inputFormatters,
-          decoration: InputDecoration(
-            label: widget.label,
-            hintText: widget.hintText,
-            helperText: widget.helperText,
-            errorText: widget.errorText,
-            prefixIcon: widget.leadingIcon != null
-                ? SizedBox(key: _leadingKey, child: widget.leadingIcon)
-                : null,
-            suffixIcon: widget.showTrailingIcon ? trailingButton : null,
-          ).applyDefaults(effectiveInputDecorationTheme),
-          restorationId: widget.restorationId,
+        final Widget textField = Semantics(
+          button: !canRequestFocus(),
+          hint: _controller.isOpen ? 'Expanded' : 'Collapsed',
+          child: TextField(
+            key: _anchorKey,
+            enabled: widget.enabled,
+            mouseCursor: effectiveMouseCursor,
+            focusNode: widget.focusNode,
+            canRequestFocus: canRequestFocus(),
+            enableInteractiveSelection: canRequestFocus(),
+            readOnly: !canRequestFocus(),
+            keyboardType: widget.keyboardType,
+            textAlign: widget.textAlign,
+            textAlignVertical: TextAlignVertical.center,
+            maxLines: widget.maxLines,
+            textInputAction: widget.textInputAction,
+            cursorHeight: widget.cursorHeight,
+            style: effectiveTextStyle,
+            controller: _effectiveTextEditingController,
+            onEditingComplete: _handleEditingComplete,
+            onTap: !widget.enabled
+                ? null
+                : () {
+                    handlePressed(controller, focusForKeyboard: !canRequestFocus());
+                  },
+            onChanged: (String text) {
+              controller.open();
+              setState(() {
+                filteredEntries = widget.dropdownMenuEntries;
+                _enableFilter = widget.enableFilter;
+                _enableSearch = widget.enableSearch;
+              });
+            },
+            inputFormatters: widget.inputFormatters,
+            decoration: InputDecoration(
+              label: widget.label,
+              hintText: widget.hintText,
+              helperText: widget.helperText,
+              errorText: widget.errorText,
+              prefixIcon: widget.leadingIcon != null
+                  ? SizedBox(key: _leadingKey, child: widget.leadingIcon)
+                  : null,
+              suffixIcon: widget.showTrailingIcon ? trailingButton : null,
+            ).applyDefaults(effectiveInputDecorationTheme),
+            restorationId: widget.restorationId,
+          ),
         );
 
         // If [expandedInsets] is not null, the width of the text field should depend

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -17,6 +17,7 @@ import 'icon_button.dart';
 import 'icons.dart';
 import 'input_border.dart';
 import 'input_decorator.dart';
+import 'material_localizations.dart';
 import 'material_state.dart';
 import 'menu_anchor.dart';
 import 'menu_button_theme.dart';
@@ -1158,6 +1159,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           child: widget.leadingIcon ?? const SizedBox.shrink(),
         );
 
+        final MaterialLocalizations localizations = MaterialLocalizations.of(context);
         final Widget textField = Semantics(
           button: !canRequestFocus(),
           // Some platforms may still treat this as text field if both `textField`
@@ -1168,8 +1170,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
           // APIs to show whether the menu is expanded or collapsed.
           hint: Theme.of(context).platform == TargetPlatform.iOS
               ? _controller.isOpen
-                    ? 'Expanded'
-                    : 'Collapsed'
+                    ? localizations.collapsedHint
+                    : localizations.expandedHint
               : null,
           expanded: _controller.isOpen,
           onExpand: _controller.isOpen

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1183,6 +1183,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                   _controller.close();
                 },
           child: ExcludeSemantics(
+            // When both `isTextField` and `isButton` are true, this widget will
+            // still be treated as a text field on web. So excluding the semantics
+            // of the `TextField` on web is needed.
             excluding: isButton && kIsWeb,
             child: TextField(
               key: _anchorKey,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1182,48 +1182,51 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
               : () {
                   _controller.close();
                 },
-          child: TextField(
-            key: _anchorKey,
-            enabled: widget.enabled,
-            mouseCursor: effectiveMouseCursor,
-            focusNode: widget.focusNode,
-            canRequestFocus: canRequestFocus(),
-            enableInteractiveSelection: canRequestFocus(),
-            readOnly: !canRequestFocus(),
-            keyboardType: widget.keyboardType,
-            textAlign: widget.textAlign,
-            textAlignVertical: TextAlignVertical.center,
-            maxLines: widget.maxLines,
-            textInputAction: widget.textInputAction,
-            cursorHeight: widget.cursorHeight,
-            style: effectiveTextStyle,
-            controller: _effectiveTextEditingController,
-            onEditingComplete: _handleEditingComplete,
-            onTap: !widget.enabled
-                ? null
-                : () {
-                    handlePressed(controller, focusForKeyboard: !canRequestFocus());
-                  },
-            onChanged: (String text) {
-              controller.open();
-              setState(() {
-                filteredEntries = widget.dropdownMenuEntries;
-                _enableFilter = widget.enableFilter;
-                _enableSearch = widget.enableSearch;
-              });
-            },
-            inputFormatters: widget.inputFormatters,
-            decoration: InputDecoration(
-              label: widget.label,
-              hintText: widget.hintText,
-              helperText: widget.helperText,
-              errorText: widget.errorText,
-              prefixIcon: widget.leadingIcon != null
-                  ? SizedBox(key: _leadingKey, child: widget.leadingIcon)
-                  : null,
-              suffixIcon: widget.showTrailingIcon ? trailingButton : null,
-            ).applyDefaults(effectiveInputDecorationTheme),
-            restorationId: widget.restorationId,
+          child: ExcludeSemantics(
+            excluding: isButton && kIsWeb,
+            child: TextField(
+              key: _anchorKey,
+              enabled: widget.enabled,
+              mouseCursor: effectiveMouseCursor,
+              focusNode: widget.focusNode,
+              canRequestFocus: canRequestFocus(),
+              enableInteractiveSelection: canRequestFocus(),
+              readOnly: !canRequestFocus(),
+              keyboardType: widget.keyboardType,
+              textAlign: widget.textAlign,
+              textAlignVertical: TextAlignVertical.center,
+              maxLines: widget.maxLines,
+              textInputAction: widget.textInputAction,
+              cursorHeight: widget.cursorHeight,
+              style: effectiveTextStyle,
+              controller: _effectiveTextEditingController,
+              onEditingComplete: _handleEditingComplete,
+              onTap: !widget.enabled
+                  ? null
+                  : () {
+                      handlePressed(controller, focusForKeyboard: !canRequestFocus());
+                    },
+              onChanged: (String text) {
+                controller.open();
+                setState(() {
+                  filteredEntries = widget.dropdownMenuEntries;
+                  _enableFilter = widget.enableFilter;
+                  _enableSearch = widget.enableSearch;
+                });
+              },
+              inputFormatters: widget.inputFormatters,
+              decoration: InputDecoration(
+                label: widget.label,
+                hintText: widget.hintText,
+                helperText: widget.helperText,
+                errorText: widget.errorText,
+                prefixIcon: widget.leadingIcon != null
+                    ? SizedBox(key: _leadingKey, child: widget.leadingIcon)
+                    : null,
+                suffixIcon: widget.showTrailingIcon ? trailingButton : null,
+              ).applyDefaults(effectiveInputDecorationTheme),
+              restorationId: widget.restorationId,
+            ),
           ),
         );
 

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1160,7 +1160,28 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
 
         final Widget textField = Semantics(
           button: !canRequestFocus(),
-          hint: _controller.isOpen ? 'Expanded' : 'Collapsed',
+          // Some platforms may still treat this as text field if both `textField`
+          // and `button` are true. So manually set `textField` to false when
+          // `button` is true.
+          textField: canRequestFocus(),
+          // This is set specificly for iOS because iOS does not have any native
+          // APIs to show whether the menu is expanded or collapsed.
+          hint: Theme.of(context).platform == TargetPlatform.iOS
+              ? _controller.isOpen
+                    ? 'Expanded'
+                    : 'Collapsed'
+              : null,
+          expanded: _controller.isOpen,
+          onExpand: _controller.isOpen
+              ? null
+              : () {
+                  _controller.open();
+                },
+          onCollapse: !_controller.isOpen
+              ? null
+              : () {
+                  _controller.close();
+                },
           child: TextField(
             key: _anchorKey,
             enabled: widget.enabled,

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -7,6 +7,7 @@ library;
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
@@ -1160,12 +1161,9 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
         );
 
         final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+        final bool isButton = !canRequestFocus();
         final Widget textField = Semantics(
-          button: !canRequestFocus(),
-          // Some platforms may still treat this as text field if both `textField`
-          // and `button` are true. So manually set `textField` to false when
-          // `button` is true.
-          textField: canRequestFocus(),
+          button: isButton,
           // This is set specificly for iOS because iOS does not have any native
           // APIs to show whether the menu is expanded or collapsed.
           hint: Theme.of(context).platform == TargetPlatform.iOS

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3846,6 +3846,7 @@ void main() {
     expect(
       tester.getSemantics(find.byType(TextField)),
       matchesSemantics(
+        isButton: true,
         hasFocusAction: true,
         isTextField: true,
         isFocusable: true,
@@ -4435,26 +4436,12 @@ void main() {
                             SemanticsFlag.hasEnabledState,
                             SemanticsFlag.isEnabled,
                             SemanticsFlag.isReadOnly,
+                            SemanticsFlag.isButton,
                           ],
+                          hint: 'Collapsed',
                           actions: <SemanticsAction>[SemanticsAction.focus],
                           textDirection: TextDirection.ltr,
                           currentValueLength: 0,
-                          children: <TestSemantics>[
-                            TestSemantics(
-                              id: 6,
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.hasSelectedState,
-                                SemanticsFlag.isButton,
-                                SemanticsFlag.hasEnabledState,
-                                SemanticsFlag.isEnabled,
-                                SemanticsFlag.isFocusable,
-                              ],
-                              actions: <SemanticsAction>[
-                                SemanticsAction.tap,
-                                SemanticsAction.focus,
-                              ],
-                            ),
-                          ],
                         ),
                       ],
                     ),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3829,16 +3829,7 @@ void main() {
 
     expect(
       tester.getSemantics(find.byType(TextField)),
-      matchesSemantics(
-        hasFocusAction: true,
-        hasTapAction: true,
-        isTextField: true,
-        isFocusable: true,
-        hasEnabledState: true,
-        isEnabled: true,
-        label: 'Test',
-        textDirection: TextDirection.ltr,
-      ),
+      matchesSemantics(hasExpandedState: true, isTextField: true),
     );
 
     await tester.pumpWidget(buildDropdownMenu(requestFocusOnTap: false));
@@ -3847,6 +3838,7 @@ void main() {
       tester.getSemantics(find.byType(TextField)),
       matchesSemantics(
         isButton: true,
+        hasExpandedState: true,
         hasFocusAction: true,
         isTextField: true,
         isFocusable: true,
@@ -4437,9 +4429,9 @@ void main() {
                             SemanticsFlag.isEnabled,
                             SemanticsFlag.isReadOnly,
                             SemanticsFlag.isButton,
+                            SemanticsFlag.hasExpandedState,
                           ],
-                          hint: 'Collapsed',
-                          actions: <SemanticsAction>[SemanticsAction.focus],
+                          actions: <SemanticsAction>[SemanticsAction.focus, SemanticsAction.expand],
                           textDirection: TextDirection.ltr,
                           currentValueLength: 0,
                         ),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -3829,7 +3829,17 @@ void main() {
 
     expect(
       tester.getSemantics(find.byType(TextField)),
-      matchesSemantics(hasExpandedState: true, isTextField: true),
+      matchesSemantics(
+        hasFocusAction: true,
+        hasTapAction: true,
+        isTextField: true,
+        isFocusable: true,
+        hasEnabledState: true,
+        isEnabled: true,
+        label: 'Test',
+        textDirection: TextDirection.ltr,
+        hasExpandedState: true,
+      ),
     );
 
     await tester.pumpWidget(buildDropdownMenu(requestFocusOnTap: false));

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -3807,7 +3808,7 @@ void main() {
   });
 
   // This is a regression test for https://github.com/flutter/flutter/issues/151686.
-  testWidgets('Setting DropdownMenu.requestFocusOnTap to false makes TextField read only', (
+  testWidgets('Setting DropdownMenu.requestFocusOnTap to false makes TextField a button', (
     WidgetTester tester,
   ) async {
     const String label = 'Test';
@@ -3846,18 +3847,20 @@ void main() {
 
     expect(
       tester.getSemantics(find.byType(TextField)),
-      matchesSemantics(
-        isButton: true,
-        hasExpandedState: true,
-        hasFocusAction: true,
-        isTextField: true,
-        isFocusable: true,
-        hasEnabledState: true,
-        isEnabled: true,
-        label: 'Test',
-        isReadOnly: true,
-        textDirection: TextDirection.ltr,
-      ),
+      kIsWeb
+          ? matchesSemantics(isButton: true, hasExpandedState: true)
+          : matchesSemantics(
+              isButton: true,
+              hasExpandedState: true,
+              hasFocusAction: true,
+              isTextField: true,
+              isFocusable: true,
+              hasEnabledState: true,
+              isEnabled: true,
+              label: 'Test',
+              isReadOnly: true,
+              textDirection: TextDirection.ltr,
+            ),
     );
   });
 
@@ -4429,22 +4432,34 @@ void main() {
                       id: 3,
                       flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                       children: <TestSemantics>[
-                        TestSemantics(
-                          id: 5,
-                          inputType: SemanticsInputType.text,
-                          flags: <SemanticsFlag>[
-                            SemanticsFlag.isTextField,
-                            SemanticsFlag.isFocusable,
-                            SemanticsFlag.hasEnabledState,
-                            SemanticsFlag.isEnabled,
-                            SemanticsFlag.isReadOnly,
-                            SemanticsFlag.isButton,
-                            SemanticsFlag.hasExpandedState,
-                          ],
-                          actions: <SemanticsAction>[SemanticsAction.focus, SemanticsAction.expand],
-                          textDirection: TextDirection.ltr,
-                          currentValueLength: 0,
-                        ),
+                        if (kIsWeb)
+                          TestSemantics(
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.isButton,
+                              SemanticsFlag.hasExpandedState,
+                            ],
+                            actions: <SemanticsAction>[SemanticsAction.expand],
+                          )
+                        else
+                          TestSemantics(
+                            id: 5,
+                            inputType: SemanticsInputType.text,
+                            flags: <SemanticsFlag>[
+                              SemanticsFlag.isTextField,
+                              SemanticsFlag.isFocusable,
+                              SemanticsFlag.hasEnabledState,
+                              SemanticsFlag.isEnabled,
+                              SemanticsFlag.isReadOnly,
+                              SemanticsFlag.isButton,
+                              SemanticsFlag.hasExpandedState,
+                            ],
+                            actions: <SemanticsAction>[
+                              SemanticsAction.focus,
+                              SemanticsAction.expand,
+                            ],
+                            textDirection: TextDirection.ltr,
+                            currentValueLength: 0,
+                          ),
                       ],
                     ),
                   ],


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/175950.

This PR is to make screen reader announce the text field content and the trailing button together on `DropdownMenu`. When the `DropdownMenu` cannot be focused (`canRequestFocus()` is set to false), the "text field" should be treated as if it is a button, and the trailing button should **not** be announced separately. When the text field is focusable, it's reasonable to separate text field and the trailing button, so I leave it as is.

The native app doesn't announce "expanded"/"collapsed", so I use `Semantics.hint` to achieve the goal.

This demo is to show the screen reader announcement.

https://github.com/user-attachments/assets/e7a9da8f-acf8-4018-a778-1ded1b07103c




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
