### PR TITLE
fix: delay exiting microbenchmark

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/benchmark_collection.dart
+++ b/dev/benchmarks/microbenchmarks/lib/benchmark_collection.dart
@@ -119,5 +119,12 @@ Future<void> main() async {
   }
 
   print('\n\n╡ ••• Done ••• ╞\n\n');
+
+  // Ensure stdout buffers are flushed so the collecting process gets Done
+  await stdout.flush();
+
+  // Now we're just being paranoid here and letting the process churn through
+  // log lines before handling the exit code.
+  await Future<void>.delayed(const Duration(seconds: 5));
   exit(0);
 }


### PR DESCRIPTION
Give the collecting process a chance to catch Done