### PR TITLE
Remove the C99 flag from the compiler configuration for C sources on Mac/iOS

### DIFF
--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -98,6 +98,8 @@ config("compiler") {
       "/guard:cf",  # Enable control flow guard security checks.
     ]
   } else {
+    cflags_c += [ "-std=c11" ]
+
     # Common GCC compiler flags setup.
     # --------------------------------
     cflags += [ "-fno-strict-aliasing" ]  # See http://crbug.com/32204

--- a/engine/src/build/config/compiler/BUILD.gn
+++ b/engine/src/build/config/compiler/BUILD.gn
@@ -213,8 +213,6 @@ config("compiler") {
     # an Objective C struct won't be called, which is very bad.
     cflags_objcc += [ "-fobjc-call-cxx-cdtors" ]
 
-    cflags_c += [ "-std=c99" ]
-
     ldflags += common_mac_flags
   } else if (is_posix) {
     # CPU architecture. We may or may not be doing a cross compile now, so for


### PR DESCRIPTION
This was imported from the original Chromium buildroot and appears to be obsolete.