### PR TITLE
[stable] [Impeller] Fix app crash on some Android devices due to VK cache corruption

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.cc
@@ -107,7 +107,11 @@ vk::UniquePipeline PipelineCacheVK::CreatePipeline(
   return std::move(pipeline);
 }
 
-void PipelineCacheVK::PersistCacheToDisk() const {
+void PipelineCacheVK::PersistCacheToDisk() {
+  // PersistCacheToDisk is run on a worker thread pool.  Calls to
+  // PipelineCacheDataPersist should be serialized so that multiple worker
+  // threads do not concurrently write to the cache file.
+  Lock persist_lock(persist_mutex_);
   if (!is_valid_) {
     return;
   }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/pipeline_cache_vk.h
@@ -6,6 +6,7 @@
 #define FLUTTER_IMPELLER_RENDERER_BACKEND_VULKAN_PIPELINE_CACHE_VK_H_
 
 #include "flutter/fml/file.h"
+#include "impeller/base/thread.h"
 #include "impeller/renderer/backend/vulkan/capabilities_vk.h"
 #include "impeller/renderer/backend/vulkan/device_holder_vk.h"
 
@@ -31,7 +32,7 @@ class PipelineCacheVK {
 
   const CapabilitiesVK* GetCapabilities() const;
 
-  void PersistCacheToDisk() const;
+  void PersistCacheToDisk();
 
  private:
   const std::shared_ptr<const Capabilities> caps_;
@@ -39,6 +40,7 @@ class PipelineCacheVK {
   const fml::UniqueFD cache_directory_;
   vk::UniquePipelineCache cache_;
   bool is_valid_ = false;
+  Mutex persist_mutex_;
 
   PipelineCacheVK(const PipelineCacheVK&) = delete;
 

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/test/mock_vulkan.cc
@@ -764,6 +764,23 @@ void vkTrimCommandPool(VkDevice device,
   mock_device->AddCalledFunction("vkTrimCommandPool");
 }
 
+VkResult vkGetPipelineCacheData(VkDevice device,
+                                VkPipelineCache pipelineCache,
+                                size_t* pDataSize,
+                                void* pData) {
+  if (pData) {
+    const std::array<uint8_t, 5> cache_data{1, 2, 3, 4, 5};
+    size_t dst_buffer_size = *pDataSize;
+    size_t length = std::min(dst_buffer_size, cache_data.size());
+    std::memcpy(pData, cache_data.data(), length);
+    *pDataSize = length;
+    return (dst_buffer_size >= length) ? VK_SUCCESS : VK_INCOMPLETE;
+  } else {
+    *pDataSize = 10;
+    return VK_SUCCESS;
+  }
+}
+
 PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
                                             const char* pName) {
   if (strcmp("vkEnumerateInstanceExtensionProperties", pName) == 0) {
@@ -917,6 +934,8 @@ PFN_vkVoidFunction GetMockVulkanProcAddress(VkInstance instance,
     return reinterpret_cast<PFN_vkVoidFunction>(vkDestroyFramebuffer);
   } else if (strcmp("vkTrimCommandPool", pName) == 0) {
     return reinterpret_cast<PFN_vkVoidFunction>(vkTrimCommandPool);
+  } else if (strcmp("vkGetPipelineCacheData", pName) == 0) {
+    return reinterpret_cast<PFN_vkVoidFunction>(vkGetPipelineCacheData);
   }
   return noop;
 }


### PR DESCRIPTION
## Stable Cherry Pick
Cherry-picks https://github.com/flutter/flutter/pull/173014 to stable to fix unhandled crash on Android Snapdragon 845 devices due to a corrupted cache, preventing apps from starting. 

Fixes https://github.com/flutter/flutter/issues/172624

Impacted Users: All users with Android Snapdragon 845
Impact Description: the app can crash on start because of a corrupted cache.
Workaround: None
Risk: Low
Test Coverage: A test is included that checks succesful reads of an incomplete vk cache 
Validation Steps: https://github.com/flutter/flutter/issues/172624#issuecomment-3130214789

This crash has unfortunately prevented our app from using Flutter 3.35 and even 3.32, missing out a whole new set of fixes from these last Flutter releases for quite some time now.

cc @jason-simmons (PR author) @chinmaygarde (PR reviewer) in case there is something I could have missed with the CP request and description 