### PR TITLE
Fix DropdownButtonFormField does not inherit local InputDecorationTheme

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1640,10 +1640,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     // https://m2.material.io/components/menus#dropdown-menu
     if (widget._inputDecoration != null) {
       final bool filled =
-          widget._inputDecoration?.filled ?? Theme.of(context).inputDecorationTheme.filled;
+          widget._inputDecoration?.filled ?? InputDecorationTheme.of(context).filled;
       final bool oulined =
           widget._inputDecoration?.border?.isOutline ??
-          Theme.of(context).inputDecorationTheme.border?.isOutline ??
+          InputDecorationTheme.of(context).border?.isOutline ??
           false;
 
       final double suffixIconEndMargin = (filled || oulined) ? 12.0 : 0.0;
@@ -1812,7 +1812,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
          builder: (FormFieldState<T> field) {
            final _DropdownButtonFormFieldState<T> state = field as _DropdownButtonFormFieldState<T>;
            InputDecoration effectiveDecoration = (decoration ?? const InputDecoration())
-               .applyDefaults(Theme.of(field.context).inputDecorationTheme);
+               .applyDefaults(InputDecorationTheme.of(field.context));
 
            final bool showSelectedItem =
                items != null &&

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -167,6 +167,7 @@ Widget buildFrame({
   Alignment dropdownAlignment = Alignment.center,
   bool? useMaterial3,
   InputDecoration? decoration,
+  InputDecorationThemeData? localInputDecorationTheme,
 }) {
   return Theme(
     data: ThemeData(useMaterial3: useMaterial3),
@@ -177,33 +178,36 @@ Widget buildFrame({
         child: Align(
           alignment: dropdownAlignment,
           child: RepaintBoundary(
-            child: buildDropdown(
-              isFormField: isFormField,
-              buttonKey: buttonKey,
-              initialValue: initialValue,
-              hint: hint,
-              disabledHint: disabledHint,
-              onChanged: onChanged,
-              onTap: onTap,
-              icon: icon,
-              iconSize: iconSize,
-              iconDisabledColor: iconDisabledColor,
-              iconEnabledColor: iconEnabledColor,
-              isDense: isDense,
-              isExpanded: isExpanded,
-              underline: underline,
-              focusNode: focusNode,
-              autofocus: autofocus,
-              focusColor: focusColor,
-              dropdownColor: dropdownColor,
-              items: items,
-              selectedItemBuilder: selectedItemBuilder,
-              itemHeight: itemHeight,
-              menuWidth: menuWidth,
-              alignment: alignment,
-              menuMaxHeight: menuMaxHeight,
-              padding: padding,
-              decoration: decoration,
+            child: InputDecorationTheme(
+              data: localInputDecorationTheme,
+              child: buildDropdown(
+                isFormField: isFormField,
+                buttonKey: buttonKey,
+                initialValue: initialValue,
+                hint: hint,
+                disabledHint: disabledHint,
+                onChanged: onChanged,
+                onTap: onTap,
+                icon: icon,
+                iconSize: iconSize,
+                iconDisabledColor: iconDisabledColor,
+                iconEnabledColor: iconEnabledColor,
+                isDense: isDense,
+                isExpanded: isExpanded,
+                underline: underline,
+                focusNode: focusNode,
+                autofocus: autofocus,
+                focusColor: focusColor,
+                dropdownColor: dropdownColor,
+                items: items,
+                selectedItemBuilder: selectedItemBuilder,
+                itemHeight: itemHeight,
+                menuWidth: menuWidth,
+                alignment: alignment,
+                menuMaxHeight: menuMaxHeight,
+                padding: padding,
+                decoration: decoration,
+              ),
             ),
           ),
         ),
@@ -4694,4 +4698,29 @@ void main() {
       expect(fieldKey.currentState!.value, 'one');
     },
   );
+
+  testWidgets('DropdownButtonFormField can inherit from local InputDecorationThemeData', (
+    WidgetTester tester,
+  ) async {
+    const String labelText = 'Label';
+    const Color labelColor = Colors.green;
+    const InputDecoration decoration = InputDecoration(labelText: labelText);
+    const InputDecorationThemeData decorationTheme = InputDecorationThemeData(
+      labelStyle: TextStyle(color: labelColor),
+    );
+
+    await tester.pumpWidget(
+      buildFrame(
+        isFormField: true,
+        decoration: decoration,
+        onChanged: (_) {},
+        localInputDecorationTheme: decorationTheme,
+      ),
+    );
+
+    final TextStyle labelStyle = DefaultTextStyle.of(
+      tester.firstElement(find.text(labelText)),
+    ).style;
+    expect(labelStyle.color, labelColor);
+  });
 }


### PR DESCRIPTION
## Description

This PR replaces global `ThemeData.inputDecorationTheme` usage in `DropdownButtonFormField` with `InputDecorationTheme.of ` which returns the ambient `InputDecorationTheme`.
It is a follow up to https://github.com/flutter/flutter/pull/168981 which introduces `InputDecorationTheme.of `.

## Related Issue

Fixes [DropdownButtonFormField does not inherit local InputDecorationTheme](https://github.com/flutter/flutter/issues/176561)

## Tests

- Adds 1 test
