### PR TITLE
[ios][platform_view]block gesture with hitTest by overlay layers

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -267,6 +267,23 @@ typedef enum {
    * but never recognizing the gesture (and never invoking actions).
    */
   FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded,
+
+  // TODO(hellohuanlin): a complete solution should rely on FFI to query from Flutter's gesture
+  // arena to decide whether to block the gesture or not.
+  /**
+   * Flutter blocks gestures on the platform view if touch location is inside the overlaps between
+   * Flutter widgets and the platform view, and allows them if touch location is outside the
+   * overlaps.
+   *
+   * This may not always be desired behavior, because in some
+   * scenarios, we may still want to block a gesture even if touch outside the overlap.
+   *
+   * Multiple overlaps are merged to a single touch blocking area as of current
+   * implementation. Therefore, use this policy when there can only be one overlap. Otherwise, the
+   * blocking area will be a bounding box containing all the overlaps.
+   */
+  FlutterPlatformViewGestureRecognizersBlockingPolicyNaiveHitTestByOverlay,
+
   // NOLINTEND(readability-identifier-naming)
 } FlutterPlatformViewGestureRecognizersBlockingPolicy;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsController.mm
@@ -861,13 +861,19 @@ static CGRect GetCGRectFromDlRect(const DlRect& clipDlRect) {
       [desiredPlatformSubviews addObject:platformViewRoot];
     }
 
+    NSMutableArray<UIView*>* overlays = [NSMutableArray array];
     auto maybeLayerData = layerMap.find(platformViewId);
     if (maybeLayerData != layerMap.end()) {
       auto view = maybeLayerData->second.layer->overlay_view_wrapper;
       if (view != nil) {
         [desiredPlatformSubviews addObject:view];
+        [overlays addObject:view];
       }
     }
+
+    FlutterTouchInterceptingView* touchInterceptor =
+        self.platformViews[platformViewId].touch_interceptor;
+    touchInterceptor.overlays = overlays;
   }
 
   NSSet* desiredPlatformSubviewsSet = [NSSet setWithArray:desiredPlatformSubviews];

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -148,6 +148,7 @@
 
 // Sets flutterAccessibilityContainer as this view's accessibilityContainer.
 @property(nonatomic, retain) id flutterAccessibilityContainer;
+@property(nonatomic, copy) NSArray<UIView*>* overlays;
 @end
 
 @interface UIView (FirstResponder)


### PR DESCRIPTION
This PR is an MVP version to address web view not tappable issue on iOS 26 (https://github.com/flutter/flutter/issues/175099). This issue cannot be fixed with `pointer_interceptor`, so if your issue can be fixed by it, it would be a different issue. 

This PR performance a **naive** hit test that decides to block platform view gestures if the touch falls within the "overlap" region between Flutter widgets and platform view. This is not a **complete** solution since there are a few drawback: 

1. There can be use cases where even if we touch outside of "overlap" (or no overlap at all), we still want to block gestures. 
2. overlaps are merged into a single UIView in our current implementation. This means if you have multiple overlaps, the blocking region would be a bounding box that contains all overlaps. 

To address the above drawbacks, a complete solution would require accessing Flutter's gesture arena, which will take longer time. 

https://github.com/user-attachments/assets/2fa26d8f-5342-4d87-bba2-5f5e5849816c

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Part of https://github.com/flutter/flutter/issues/175099


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
