### PR TITLE
Configure FfiNative resolver on dart:io

### DIFF
--- a/engine/src/flutter/lib/io/dart_io.cc
+++ b/engine/src/flutter/lib/io/dart_io.cc
@@ -17,6 +17,7 @@ namespace flutter {
 
 void DartIO::InitForIsolate(bool may_insecurely_connect_to_all_domains,
                             const std::string& domain_network_policy) {
+  // TODO(https://dartbug.com/61694): move this code into dart_io_api.h
   Dart_Handle io_lib = Dart_LookupLibrary(ToDart("dart:io"));
   Dart_Handle result = Dart_SetNativeResolver(io_lib, dart::bin::LookupIONative,
                                               dart::bin::LookupIONativeSymbol);

--- a/engine/src/flutter/lib/io/dart_io.cc
+++ b/engine/src/flutter/lib/io/dart_io.cc
@@ -21,6 +21,8 @@ void DartIO::InitForIsolate(bool may_insecurely_connect_to_all_domains,
   Dart_Handle result = Dart_SetNativeResolver(io_lib, dart::bin::LookupIONative,
                                               dart::bin::LookupIONativeSymbol);
   FML_CHECK(!CheckAndHandleError(result));
+  result = Dart_SetFfiNativeResolver(io_lib, dart::bin::LookupIOFfiNative);
+  FML_CHECK(!CheckAndHandleError(result));
 
   Dart_Handle ui_lib = Dart_LookupLibrary(ToDart("dart:ui"));
   Dart_Handle dart_validate_args[1];


### PR DESCRIPTION
This is needed by file watching implementation after dart-lang/sdk@ed6bab847ba2a94a295a3c959157040f6c917fde

Ideally we should actually move this whole code into `io_natives.{h,cc}` on the Dart runtime side to avoid duplication. 



