### PR TITLE
Fix ExpansionTile semantics hint for mismatched platforms

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -100,6 +100,17 @@ typedef ExpansionTileController = ExpansibleController;
 /// ** See code in examples/api/lib/material/expansion_tile/expansion_tile.1.dart **
 /// {@end-tool}
 ///
+/// ## Accessibility
+///
+/// [ExpansionTile] uses the device's platform (via [defaultTargetPlatform])
+/// rather than [ThemeData.platform] to determine platform-specific accessibility
+/// behavior. This ensures that assistive technologies like VoiceOver on iOS and
+/// macOS receive correct semantics hints, even when the app's theme is configured
+/// to use a different platform's visual appearance. For example, if an app uses
+/// `ThemeData(platform: TargetPlatform.android)` on an iOS device to achieve an
+/// Android look and feel, VoiceOver will still receive iOS-appropriate semantics
+/// hints to work properly.
+///
 /// See also:
 ///
 ///  * [ListTile], useful for creating expansion tile [children] when the

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -102,14 +102,11 @@ typedef ExpansionTileController = ExpansibleController;
 ///
 /// ## Accessibility
 ///
-/// [ExpansionTile] uses the device's platform (via [defaultTargetPlatform])
-/// rather than [ThemeData.platform] to determine platform-specific accessibility
-/// behavior. This ensures that assistive technologies like VoiceOver on iOS and
-/// macOS receive correct semantics hints, even when the app's theme is configured
-/// to use a different platform's visual appearance. For example, if an app uses
-/// `ThemeData(platform: TargetPlatform.android)` on an iOS device to achieve an
-/// Android look and feel, VoiceOver will still receive iOS-appropriate semantics
-/// hints to work properly.
+/// The accessibility behavior of [ExpansionTile] is platform adaptive, based on
+/// the device's actual platform rather than the theme's platform setting. This
+/// ensures that assistive technologies like VoiceOver on iOS and macOS receive
+/// the correct platform-specific semantics hints, even when the app's theme is
+/// configured to mimic a different platform's appearance.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -584,13 +584,12 @@ class _ExpansionTileState extends State<ExpansionTile> {
   Widget _buildHeader(BuildContext context, Animation<double> animation) {
     _iconColor = animation.drive(_iconColorTween.chain(_easeInTween));
     _headerColor = animation.drive(_headerColorTween.chain(_easeInTween));
-    final ThemeData theme = Theme.of(context);
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final String onTapHint = _tileController.isExpanded
         ? localizations.expansionTileExpandedTapHint
         : localizations.expansionTileCollapsedTapHint;
     String? semanticsHint;
-    switch (theme.platform) {
+    switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         semanticsHint = _tileController.isExpanded

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -1850,4 +1850,58 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Child 0'), findsOne);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'ExpansionTile semantics hint uses defaultTargetPlatform for VoiceOver regardless of theme platform',
+    (WidgetTester tester) async {
+      // Regression test for VoiceOver accessibility when theme platform differs from device platform.
+      // When someone sets theme.platform to TargetPlatform.android on an iOS device,
+      // VoiceOver should still work correctly by using the actual device platform for semantics hints.
+
+      final SemanticsHandle handle = tester.ensureSemantics();
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: const Material(
+            child: Column(
+              children: <Widget>[
+                ExpansionTile(title: Text('First Expansion Tile')),
+                ExpansionTile(initiallyExpanded: true, title: Text('Second Expansion Tile')),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      SemanticsNode semantics = tester.getSemantics(
+        find.ancestor(of: find.byType(ListTile).first, matching: find.byType(Semantics)).first,
+      );
+
+      expect(semantics, isNotNull);
+      // On iOS/macOS platform, the semantics hint should include expanded/collapsed state guidance
+      // even theme platform is set to Android.
+      expect(
+        semantics.hint,
+        '${localizations.expandedHint}\n ${localizations.expansionTileCollapsedHint}',
+      );
+
+      semantics = tester.getSemantics(
+        find.ancestor(of: find.byType(ListTile).last, matching: find.byType(Semantics)).first,
+      );
+
+      expect(semantics, isNotNull);
+      expect(
+        semantics.hint,
+        '${localizations.collapsedHint}\n ${localizations.expansionTileExpandedHint}',
+      );
+      handle.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
 }


### PR DESCRIPTION
- Address a partial issue within https://github.com/flutter/flutter/issues/176566
- This PR proposes using `defaultTargetPlatform` instead of platform from theme for Semantics hint in ExpansionTile widget (see use case at https://github.com/flutter/flutter/issues/176566#issue-3486244630); also add a test for it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
