### PR TITLE
Fix AppBar Semantics namesRoute for mismatched platforms

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -640,11 +640,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// [AppBar] uses the device's platform (via [defaultTargetPlatform])
   /// rather than [ThemeData.platform] to determine platform-specific accessibility
   /// behavior. This ensures that assistive technologies like VoiceOver on iOS and
-  /// macOS receive correct semantics namesRoute, even when the app's theme is configured
-  /// to use a different platform's visual appearance. For example, if an app uses
+  /// macOS receive the correct `namesRoute` semantic information,
+  /// even when the app's theme is configured to use a different
+  /// platform's visual appearance. For example, if an app uses
   /// `ThemeData(platform: TargetPlatform.android)` on an iOS device to achieve an
-  /// Android look and feel, VoiceOver is able to detect iOS-appropriate semantics
-  /// namesRoute value to work properly.
+  /// Android look and feel, VoiceOver can still use the iOS-appropriate `namesRoute`
+  /// value to work properly.
   ///
   /// Defaults to false.
   /// {@endtemplate}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -633,6 +633,19 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@template flutter.material.appbar.excludeHeaderSemantics}
   /// Whether the title should be wrapped with header [Semantics].
   ///
+  /// When false (the default), the title is wrapped with [Semantics] that
+  /// includes the [SemanticsProperties.namesRoute] flag on Android, Fuchsia,
+  /// Linux, and Windows, but not on iOS and macOS.
+  ///
+  /// [AppBar] uses the device's platform (via [defaultTargetPlatform])
+  /// rather than [ThemeData.platform] to determine platform-specific accessibility
+  /// behavior. This ensures that assistive technologies like VoiceOver on iOS and
+  /// macOS receive correct semantics namesRoute, even when the app's theme is configured
+  /// to use a different platform's visual appearance. For example, if an app uses
+  /// `ThemeData(platform: TargetPlatform.android)` on an iOS device to achieve an
+  /// Android look and feel, VoiceOver is able to detect iOS-appropriate semantics
+  /// namesRoute value to work properly.
+  ///
   /// Defaults to false.
   /// {@endtemplate}
   final bool excludeHeaderSemantics;
@@ -1066,7 +1079,7 @@ class _AppBarState extends State<AppBar> {
       title = _AppBarTitleBox(child: title);
       if (!widget.excludeHeaderSemantics) {
         title = Semantics(
-          namesRoute: switch (theme.platform) {
+          namesRoute: switch (defaultTargetPlatform) {
             TargetPlatform.android ||
             TargetPlatform.fuchsia ||
             TargetPlatform.linux ||

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -633,19 +633,15 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// {@template flutter.material.appbar.excludeHeaderSemantics}
   /// Whether the title should be wrapped with header [Semantics].
   ///
-  /// When false (the default), the title is wrapped with [Semantics] that
-  /// includes the [SemanticsProperties.namesRoute] flag on Android, Fuchsia,
-  /// Linux, and Windows, but not on iOS and macOS.
+  /// If false, the title will be used as [SemanticsProperties.namesRoute]
+  /// for Android, Fuchsia, Linux, and Windows platform. This means the title is
+  /// announced by screen reader when transition to this route.
   ///
-  /// [AppBar] uses the device's platform (via [defaultTargetPlatform])
-  /// rather than [ThemeData.platform] to determine platform-specific accessibility
-  /// behavior. This ensures that assistive technologies like VoiceOver on iOS and
-  /// macOS receive the correct `namesRoute` semantic information,
-  /// even when the app's theme is configured to use a different
-  /// platform's visual appearance. For example, if an app uses
-  /// `ThemeData(platform: TargetPlatform.android)` on an iOS device to achieve an
-  /// Android look and feel, VoiceOver can still use the iOS-appropriate `namesRoute`
-  /// value to work properly.
+  /// The accessibility behavior is platform adaptive, based on the device's
+  /// actual platform rather than the theme's platform setting. This ensures that
+  /// assistive technologies like VoiceOver on iOS and macOS receive the correct
+  /// `namesRoute` semantic information, even when the app's theme is configured
+  /// to mimic a different platform's appearance.
   ///
   /// Defaults to false.
   /// {@endtemplate}

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1495,6 +1495,71 @@ void main() {
     semantics.dispose();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'AppBar title Semantics.namesRoute flag should be null on iOS/macOS platforms regardless of theme platform',
+    (WidgetTester tester) async {
+      // Regression test for VoiceOver accessibility when theme platform differs from device platform.
+      // When someone sets theme.platform to TargetPlatform.android on an iOS/macOS device,
+      // VoiceOver should still work correctly by not having a namesRoute flag in the title's semantics.
+      final SemanticsTester semantics = SemanticsTester(tester);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: AppBar(title: const Text('Title')),
+        ),
+      );
+
+      final List<SemanticsFlag> expectedFlags = <SemanticsFlag>[SemanticsFlag.isHeader];
+
+      expect(
+        semantics,
+        hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics(
+                id: 1,
+                textDirection: TextDirection.ltr,
+                children: <TestSemantics>[
+                  TestSemantics(
+                    id: 2,
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        id: 3,
+                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            id: 4,
+                            children: <TestSemantics>[
+                              TestSemantics(
+                                id: 5,
+                                flags: expectedFlags,
+                                label: 'Title',
+                                textDirection: TextDirection.ltr,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+          ignoreRect: true,
+          ignoreTransform: true,
+        ),
+      );
+
+      semantics.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+
   testWidgets('Material3 - AppBar draws a light system bar for a dark background', (
     WidgetTester tester,
   ) async {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -1560,6 +1560,75 @@ void main() {
     }),
   );
 
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'AppBar title Semantics.namesRoute flag should be non-null on Android/Fuchsia/Linux/Windows platforms regardless of theme platform',
+    (WidgetTester tester) async {
+      // When someone sets theme.platform to TargetPlatform.iOS on an Android device,
+      // TalkBack should still work correctly by having a namesRoute flag in the title's semantics.
+      final SemanticsTester semantics = SemanticsTester(tester);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: AppBar(title: const Text('Title')),
+        ),
+      );
+
+      final List<SemanticsFlag> expectedFlags = <SemanticsFlag>[
+        SemanticsFlag.isHeader,
+        SemanticsFlag.namesRoute,
+      ];
+
+      expect(
+        semantics,
+        hasSemantics(
+          TestSemantics.root(
+            children: <TestSemantics>[
+              TestSemantics(
+                id: 1,
+                textDirection: TextDirection.ltr,
+                children: <TestSemantics>[
+                  TestSemantics(
+                    id: 2,
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        id: 3,
+                        flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
+                        children: <TestSemantics>[
+                          TestSemantics(
+                            id: 4,
+                            children: <TestSemantics>[
+                              TestSemantics(
+                                id: 5,
+                                flags: expectedFlags,
+                                label: 'Title',
+                                textDirection: TextDirection.ltr,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+          ignoreRect: true,
+          ignoreTransform: true,
+        ),
+      );
+
+      semantics.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+    }),
+  );
+
   testWidgets('Material3 - AppBar draws a light system bar for a dark background', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
- Address a partial issue within https://github.com/flutter/flutter/issues/176566
- Fix https://github.com/flutter/flutter/issues/177000
- In this PR:
    - proposes using `defaultTargetPlatform` instead of platform from theme for Semantics namesRoute in AppBar widget (see use case at https://github.com/flutter/flutter/issues/176566#issue-3486244630); 
    - improve documentation for this at `excludeHeaderSemantics` property.
    -  add a test for this change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
