### PR TITLE
Remove references to dart:_js_annotations

### DIFF
--- a/engine/src/flutter/sky/packages/sky_engine/BUILD.gn
+++ b/engine/src/flutter/sky/packages/sky_engine/BUILD.gn
@@ -22,7 +22,6 @@ import("$dart_src/sdk/lib/html/html_sources.gni")
 import("$dart_src/sdk/lib/internal/internal_sources.gni")
 import("$dart_src/sdk/lib/io/io_sources.gni")
 import("$dart_src/sdk/lib/isolate/isolate_sources.gni")
-import("$dart_src/sdk/lib/js/js_annotations_sources.gni")
 import("$dart_src/sdk/lib/js/js_sources.gni")
 import("$dart_src/sdk/lib/js_interop/js_interop_sources.gni")
 import("$dart_src/sdk/lib/js_interop_unsafe/js_interop_unsafe_sources.gni")
@@ -101,12 +100,6 @@ copy("_interceptors") {
   outputs = [
     "$root_gen_dir/dart-pkg/sky_engine/lib/_interceptors/{{source_file_part}}",
   ]
-}
-
-copy("_js_annotations") {
-  lib_path = rebase_path("js", "", dart_sdk_lib_path)
-  sources = rebase_path(js_annotations_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/_js_annotations/{{source_file_part}}" ]
 }
 
 copy("_js_types") {
@@ -224,7 +217,6 @@ group("copy_dart_sdk") {
   deps = [
     ":_http",
     ":_interceptors",
-    ":_js_annotations",
     ":_js_types",
     ":async",
     ":collection",
@@ -280,8 +272,6 @@ generated_file("_embedder_yaml") {
     "  # public API, e.g. List being Iterable by virtue of implementing",
     "  # EfficientLengthIterable. Not including this library yields analysis errors.",
     "  \"dart:_internal\": \"internal/internal.dart\"",
-    "  # The _js_annotations library is also needed for the same reasons as _internal.",
-    "  \"dart:_js_annotations\": \"_js_annotations/_js_annotations.dart\"",
     "  # The _js_types library is also needed for the same reasons as _internal.",
     "  \"dart:_js_types\": \"_js_types/js_types.dart\"",
     "  \"dart:nativewrappers\": \"_empty.dart\"",

--- a/engine/src/flutter/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/engine/src/flutter/sky/packages/sky_engine/lib/_embedder.yaml
@@ -25,8 +25,6 @@ embedded_libs:
   # public API, e.g. List being Iterable by virtue of implementing
   # EfficientLengthIterable. Not including this library yields analysis errors.
   "dart:_internal": "../../../../third_party/dart/sdk/lib/internal/internal.dart"
-  # The _js_annotations library is also needed for the same reasons as _internal.
-  "dart:_js_annotations": "../../../../third_party/dart/sdk/lib/js/_js_annotations.dart"
   # The _js_types library is also needed for the same reasons as _internal.
   "dart:_js_types": "../../../../third_party/dart/sdk/lib/_internal/js_shared/lib/js_types.dart"
   "dart:nativewrappers": "../../../../third_party/dart/sdk/lib/html/dartium/nativewrappers.dart"


### PR DESCRIPTION
This library is now unused in Flutter and will shortly no longer build with dart2wasm anyway.

cc @srujzs