### PR TITLE
fix: build windows_arm artifacts for cah

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -542,6 +542,7 @@ targets:
       # Don't run this on release branches
       - master
     properties:
+      release_build: "true"
       add_recipes_cq: "true"
       config_name: windows_arm_host_engine
     drone_dimensions:


### PR DESCRIPTION
Adds target to merge queue, the only place that the CAH is used to produce artifacts. Today this is built in post submit and only uploads to the githash artifact.

This should not add these artifacts to release builders as the `enabled_branches` is set to "master"

fixes #176603