### PR TITLE
Fix Dialog Semantics label and flags for mismatched platforms

### DIFF
--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -406,14 +406,6 @@ class Dialog extends StatelessWidget {
 /// For finer-grained control over the sizing of a dialog, consider using
 /// [Dialog] directly.
 ///
-/// ## Accessibility
-///
-/// The accessibility behavior of [AlertDialog] is platform adaptive, based on
-/// the device's actual platform rather than the theme's platform setting. This
-/// ensures that assistive technologies like VoiceOver on iOS and macOS receive
-/// the correct platform-specific semantics label and appropriate flags, even
-/// when the app's theme is configured to mimic a different platform's appearance.
-///
 /// See also:
 ///
 ///  * [SimpleDialog], which handles the scrolling of the contents but has no [actions].
@@ -1162,14 +1154,6 @@ class SimpleDialogOption extends StatelessWidget {
 /// }
 /// ```
 /// {@end-tool}
-///
-/// ## Accessibility
-///
-/// The accessibility behavior of [SimpleDialog] is platform adaptive, based on
-/// the device's actual platform rather than the theme's platform setting. This
-/// ensures that assistive technologies like VoiceOver on iOS and macOS receive
-/// the correct platform-specific semantics label and appropriate flags, even
-/// when the app's theme is configured to mimic a different platform's appearance.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -13,6 +13,7 @@ library;
 import 'dart:ui' show SemanticsRole, clampDouble, lerpDouble;
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 
 import 'color_scheme.dart';
 import 'colors.dart';
@@ -405,6 +406,14 @@ class Dialog extends StatelessWidget {
 /// For finer-grained control over the sizing of a dialog, consider using
 /// [Dialog] directly.
 ///
+/// ## Accessibility
+///
+/// The accessibility behavior of [AlertDialog] is platform adaptive, based on
+/// the device's actual platform rather than the theme's platform setting. This
+/// ensures that assistive technologies like VoiceOver on iOS and macOS receive
+/// the correct platform-specific semantics label and appropriate flags, even
+/// when the app's theme is configured to mimic a different platform's appearance.
+///
 /// See also:
 ///
 ///  * [SimpleDialog], which handles the scrolling of the contents but has no [actions].
@@ -771,7 +780,7 @@ class AlertDialog extends StatelessWidget {
         : _DialogDefaultsM2(context);
 
     String? label = semanticLabel;
-    switch (theme.platform) {
+    switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         break;
@@ -848,7 +857,7 @@ class AlertDialog extends StatelessWidget {
           child: Semantics(
             // For iOS platform, the focus always lands on the title.
             // Set nameRoute to false to avoid title being announce twice.
-            namesRoute: label == null && theme.platform != TargetPlatform.iOS,
+            namesRoute: label == null && defaultTargetPlatform != TargetPlatform.iOS,
             container: true,
             child: title,
           ),
@@ -1154,6 +1163,14 @@ class SimpleDialogOption extends StatelessWidget {
 /// ```
 /// {@end-tool}
 ///
+/// ## Accessibility
+///
+/// The accessibility behavior of [SimpleDialog] is platform adaptive, based on
+/// the device's actual platform rather than the theme's platform setting. This
+/// ensures that assistive technologies like VoiceOver on iOS and macOS receive
+/// the correct platform-specific semantics label and appropriate flags, even
+/// when the app's theme is configured to mimic a different platform's appearance.
+///
 /// See also:
 ///
 ///  * [SimpleDialogOption], which are options used in this type of dialog.
@@ -1273,7 +1290,7 @@ class SimpleDialog extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
 
     String? label = semanticLabel;
-    switch (theme.platform) {
+    switch (defaultTargetPlatform) {
       case TargetPlatform.macOS:
       case TargetPlatform.iOS:
         break;
@@ -1312,7 +1329,7 @@ class SimpleDialog extends StatelessWidget {
           child: Semantics(
             // For iOS platform, the focus always lands on the title.
             // Set nameRoute to false to avoid title being announce twice.
-            namesRoute: label == null && theme.platform != TargetPlatform.iOS,
+            namesRoute: label == null && defaultTargetPlatform != TargetPlatform.iOS,
             container: true,
             child: title,
           ),

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -76,6 +76,35 @@ final ShapeBorder _defaultM3DialogShape = RoundedRectangleBorder(
   borderRadius: BorderRadius.circular(28.0),
 );
 
+Future<void> _pumpDialogWithTheme({
+  required WidgetTester tester,
+  required Widget dialog,
+  required TargetPlatform themePlatform,
+}) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      theme: ThemeData(platform: themePlatform),
+      home: Material(
+        child: Builder(
+          builder: (BuildContext context) {
+            return Center(
+              child: ElevatedButton(
+                child: const Text('X'),
+                onPressed: () {
+                  showDialog<void>(context: context, builder: (BuildContext context) => dialog);
+                },
+              ),
+            );
+          },
+        ),
+      ),
+    ),
+  );
+
+  await tester.tap(find.text('X'));
+  await tester.pumpAndSettle();
+}
+
 void main() {
   final ThemeData material3Theme = ThemeData(brightness: Brightness.dark);
   final ThemeData material2Theme = ThemeData(useMaterial3: false, brightness: Brightness.dark);
@@ -3196,37 +3225,11 @@ void main() {
       const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
       // Test with Android theme on Apple platforms.
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      showDialog<void>(
-                        context: context,
-                        builder: (BuildContext context) {
-                          return const AlertDialog(
-                            title: Text('Title'),
-                            content: Text('Y'),
-                            actions: <Widget>[],
-                          );
-                        },
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
+      await _pumpDialogWithTheme(
+        tester: tester,
+        themePlatform: TargetPlatform.android,
+        dialog: const AlertDialog(title: Text('Title'), content: Text('Y'), actions: <Widget>[]),
       );
-
-      await tester.tap(find.text('X'));
-      await tester.pumpAndSettle();
 
       // On iOS/macOS, the semantic label should not be added,
       // and namesRoute flag should not exist.
@@ -3260,37 +3263,11 @@ void main() {
       const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
       // Test with iOS theme but on non-Apple platforms.
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.iOS),
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      showDialog<void>(
-                        context: context,
-                        builder: (BuildContext context) {
-                          return const AlertDialog(
-                            title: Text('Title'),
-                            content: Text('Y'),
-                            actions: <Widget>[],
-                          );
-                        },
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
+      await _pumpDialogWithTheme(
+        tester: tester,
+        themePlatform: TargetPlatform.iOS,
+        dialog: const AlertDialog(title: Text('Title'), content: Text('Y'), actions: <Widget>[]),
       );
-
-      await tester.tap(find.text('X'));
-      await tester.pumpAndSettle();
 
       // On Android and other platforms, the default semantic label should be added
       // and namesRoute should also exist, although it is false as label is non-null.
@@ -3325,39 +3302,17 @@ void main() {
       const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
       // Test with Android theme on Apple platforms.
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      showDialog<void>(
-                        context: context,
-                        builder: (BuildContext context) {
-                          return const SimpleDialog(
-                            title: Text('Title'),
-                            children: <Widget>[
-                              Text('content'),
-                              TextButton(onPressed: null, child: Text('action')),
-                            ],
-                          );
-                        },
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
-          ),
+      await _pumpDialogWithTheme(
+        tester: tester,
+        themePlatform: TargetPlatform.android,
+        dialog: const SimpleDialog(
+          title: Text('Title'),
+          children: <Widget>[
+            Text('content'),
+            TextButton(onPressed: null, child: Text('action')),
+          ],
         ),
       );
-
-      await tester.tap(find.text('X'));
-      await tester.pumpAndSettle();
 
       // On iOS/macOS, the semantic label should not be added,
       // and namesRoute flag should not exist.
@@ -3391,39 +3346,17 @@ void main() {
       const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
       // Test with iOS theme but on non-Apple platforms.
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.iOS),
-          home: Material(
-            child: Builder(
-              builder: (BuildContext context) {
-                return Center(
-                  child: ElevatedButton(
-                    child: const Text('X'),
-                    onPressed: () {
-                      showDialog<void>(
-                        context: context,
-                        builder: (BuildContext context) {
-                          return const SimpleDialog(
-                            title: Text('Title'),
-                            children: <Widget>[
-                              Text('content'),
-                              TextButton(onPressed: null, child: Text('action')),
-                            ],
-                          );
-                        },
-                      );
-                    },
-                  ),
-                );
-              },
-            ),
-          ),
+      await _pumpDialogWithTheme(
+        tester: tester,
+        themePlatform: TargetPlatform.iOS,
+        dialog: const SimpleDialog(
+          title: Text('Title'),
+          children: <Widget>[
+            Text('content'),
+            TextButton(onPressed: null, child: Text('action')),
+          ],
         ),
       );
-
-      await tester.tap(find.text('X'));
-      await tester.pumpAndSettle();
 
       // On Android and other platforms, the default semantic label should be added
       // and namesRoute should also exist, although it is false as label is non-null.

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -5,6 +5,7 @@
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -1598,6 +1599,14 @@ void main() {
   // Regression test for https://github.com/flutter/flutter/issues/78229.
   testWidgets('AlertDialog has correct semantics for content in iOS', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+    // With the change to defaultTargetPlatform
+    // (see https://github.com/flutter/flutter/issues/176566),
+    // the actual platform (not theme.platform) determines the semantics.
+    // By default:
+    // On iOS/macOS, no "Alert" label should be added in title.
+    // On other platforms, an "Alert" label is added.
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1609,6 +1618,10 @@ void main() {
         ),
       ),
     );
+
+    final bool isIOSorMacOS =
+        defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS;
 
     expect(
       semantics,
@@ -1629,35 +1642,82 @@ void main() {
                         TestSemantics(
                           id: 4,
                           role: SemanticsRole.alertDialog,
-                          children: <TestSemantics>[
-                            TestSemantics(id: 5, label: 'title', textDirection: TextDirection.ltr),
-                            // The content semantics does not merge into the semantics
-                            // node 4.
-                            TestSemantics(
-                              id: 6,
-                              children: <TestSemantics>[
-                                TestSemantics(
-                                  id: 7,
-                                  label: 'some content',
-                                  textDirection: TextDirection.ltr,
-                                ),
-                                TestSemantics(
-                                  id: 8,
-                                  label: 'more content',
-                                  textDirection: TextDirection.ltr,
-                                ),
-                              ],
-                            ),
-                            TestSemantics(
-                              id: 9,
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isButton,
-                                SemanticsFlag.hasEnabledState,
-                              ],
-                              label: 'action',
-                              textDirection: TextDirection.ltr,
-                            ),
-                          ],
+                          children: isIOSorMacOS
+                              ? <TestSemantics>[
+                                  TestSemantics(
+                                    id: 5,
+                                    label: 'title',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                  // The content semantics does not merge into the semantics
+                                  // node 4.
+                                  TestSemantics(
+                                    id: 6,
+                                    children: <TestSemantics>[
+                                      TestSemantics(
+                                        id: 7,
+                                        label: 'some content',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                      TestSemantics(
+                                        id: 8,
+                                        label: 'more content',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                    ],
+                                  ),
+                                  TestSemantics(
+                                    id: 9,
+                                    flags: <SemanticsFlag>[
+                                      SemanticsFlag.isButton,
+                                      SemanticsFlag.hasEnabledState,
+                                    ],
+                                    label: 'action',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                ]
+                              : <TestSemantics>[
+                                  TestSemantics(
+                                    id: 5,
+                                    flags: <SemanticsFlag>[
+                                      SemanticsFlag.scopesRoute,
+                                      SemanticsFlag.namesRoute,
+                                    ],
+                                    label: localizations.alertDialogLabel,
+                                    textDirection: TextDirection.ltr,
+                                    children: <TestSemantics>[
+                                      TestSemantics(
+                                        id: 6,
+                                        label: 'title',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                      TestSemantics(
+                                        id: 7,
+                                        children: <TestSemantics>[
+                                          TestSemantics(
+                                            id: 8,
+                                            label: 'some content',
+                                            textDirection: TextDirection.ltr,
+                                          ),
+                                          TestSemantics(
+                                            id: 9,
+                                            label: 'more content',
+                                            textDirection: TextDirection.ltr,
+                                          ),
+                                        ],
+                                      ),
+                                      TestSemantics(
+                                        id: 10,
+                                        flags: <SemanticsFlag>[
+                                          SemanticsFlag.isButton,
+                                          SemanticsFlag.hasEnabledState,
+                                        ],
+                                        label: 'action',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                    ],
+                                  ),
+                                ],
                         ),
                       ],
                     ),
@@ -1787,6 +1847,14 @@ void main() {
   // Regression test for https://github.com/flutter/flutter/issues/78229.
   testWidgets('SimpleDialog has correct semantics for title in iOS', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
+    const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+    // With the change to defaultTargetPlatform
+    // (see https://github.com/flutter/flutter/issues/176566),
+    // the actual platform (not theme.platform) determines the semantics.
+    // By default:
+    // On iOS/macOS, no "Alert" label should be added in title.
+    // On other platforms, an "Alert" label is added.
 
     await tester.pumpWidget(
       MaterialApp(
@@ -1800,6 +1868,10 @@ void main() {
         ),
       ),
     );
+
+    final bool isIOSorMacOS =
+        defaultTargetPlatform == TargetPlatform.iOS ||
+        defaultTargetPlatform == TargetPlatform.macOS;
 
     expect(
       semantics,
@@ -1820,31 +1892,74 @@ void main() {
                         TestSemantics(
                           id: 4,
                           role: SemanticsRole.dialog,
-                          children: <TestSemantics>[
-                            // Title semantics does not merge into the semantics
-                            // node 4.
-                            TestSemantics(id: 5, label: 'title', textDirection: TextDirection.ltr),
-                            TestSemantics(
-                              id: 6,
-                              flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                              children: <TestSemantics>[
-                                TestSemantics(
-                                  id: 7,
-                                  label: 'content',
-                                  textDirection: TextDirection.ltr,
-                                ),
-                                TestSemantics(
-                                  id: 8,
-                                  flags: <SemanticsFlag>[
-                                    SemanticsFlag.isButton,
-                                    SemanticsFlag.hasEnabledState,
-                                  ],
-                                  label: 'action',
-                                  textDirection: TextDirection.ltr,
-                                ),
-                              ],
-                            ),
-                          ],
+                          children: isIOSorMacOS
+                              ? <TestSemantics>[
+                                  // Title semantics does not merge into the semantics
+                                  // node 4.
+                                  TestSemantics(
+                                    id: 5,
+                                    label: 'title',
+                                    textDirection: TextDirection.ltr,
+                                  ),
+                                  TestSemantics(
+                                    id: 6,
+                                    flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                                    children: <TestSemantics>[
+                                      TestSemantics(
+                                        id: 7,
+                                        label: 'content',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                      TestSemantics(
+                                        id: 8,
+                                        flags: <SemanticsFlag>[
+                                          SemanticsFlag.isButton,
+                                          SemanticsFlag.hasEnabledState,
+                                        ],
+                                        label: 'action',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                    ],
+                                  ),
+                                ]
+                              : <TestSemantics>[
+                                  TestSemantics(
+                                    id: 5,
+                                    flags: <SemanticsFlag>[
+                                      SemanticsFlag.scopesRoute,
+                                      SemanticsFlag.namesRoute,
+                                    ],
+                                    label: localizations.dialogLabel,
+                                    textDirection: TextDirection.ltr,
+                                    children: <TestSemantics>[
+                                      TestSemantics(
+                                        id: 6,
+                                        label: 'title',
+                                        textDirection: TextDirection.ltr,
+                                      ),
+                                      TestSemantics(
+                                        id: 7,
+                                        flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                                        children: <TestSemantics>[
+                                          TestSemantics(
+                                            id: 8,
+                                            label: 'content',
+                                            textDirection: TextDirection.ltr,
+                                          ),
+                                          TestSemantics(
+                                            id: 9,
+                                            flags: <SemanticsFlag>[
+                                              SemanticsFlag.isButton,
+                                              SemanticsFlag.hasEnabledState,
+                                            ],
+                                            label: 'action',
+                                            textDirection: TextDirection.ltr,
+                                          ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
+                                ],
                         ),
                       ],
                     ),
@@ -3067,6 +3182,268 @@ void main() {
     );
     expect(tester.getSize(find.byType(AlertDialog)).isEmpty, isTrue);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'AlertDialog semantic label and namesRoute should be omitted on '
+    'iOS/macOS platforms, regardless of theme platform',
+    (WidgetTester tester) async {
+      // Regression test for VoiceOver accessibility when theme platform differs from device platform.
+      // When users set theme.platform to TargetPlatform.android on an iOS/macOS device,
+      // VoiceOver should still work correctly by not having a label and namesRoute flag
+      // in the the Dialog title's semantics.
+      final SemanticsTester semantics = SemanticsTester(tester);
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      // Test with Android theme on Apple platforms.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: ElevatedButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      showDialog<void>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return const AlertDialog(
+                            title: Text('Title'),
+                            content: Text('Y'),
+                            actions: <Widget>[],
+                          );
+                        },
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      // On iOS/macOS, the semantic label should not be added,
+      // and namesRoute flag should not exist.
+      expect(
+        semantics,
+        isNot(
+          includesNodeWith(
+            label: localizations.alertDialogLabel,
+            flags: <SemanticsFlag>[SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
+          ),
+        ),
+      );
+
+      semantics.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'AlertDialog semantic label and namesRoute should be present on '
+    'Android/Fuchsia/Linux/Windows platforms, regardless of theme platform',
+    (WidgetTester tester) async {
+      // When users set theme.platform to TargetPlatform.iOS on an Android device,
+      // TalkBack should still work correctly by having a label and namesRoute flag
+      // in the Dialog title's semantics.
+      final SemanticsTester semantics = SemanticsTester(tester);
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      // Test with iOS theme but on non-Apple platforms.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: ElevatedButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      showDialog<void>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return const AlertDialog(
+                            title: Text('Title'),
+                            content: Text('Y'),
+                            actions: <Widget>[],
+                          );
+                        },
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      // On Android and other platforms, the default semantic label should be added
+      // and namesRoute should also exist, although it is false as label is non-null.
+      expect(
+        semantics,
+        includesNodeWith(
+          label: localizations.alertDialogLabel,
+          flags: <SemanticsFlag>[SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
+        ),
+      );
+
+      semantics.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+    }),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'SimpleDialog semantic label and namesRoute should be omitted on '
+    'iOS/macOS platforms, regardless of theme platform',
+    (WidgetTester tester) async {
+      // Regression test for VoiceOver accessibility when theme platform differs from device platform.
+      // When users set theme.platform to TargetPlatform.android on an iOS/macOS device,
+      // VoiceOver should still work correctly by not having a label and namesRoute flag
+      // in the the Dialog title's semantics.
+      final SemanticsTester semantics = SemanticsTester(tester);
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      // Test with Android theme on Apple platforms.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: ElevatedButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      showDialog<void>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return const SimpleDialog(
+                            title: Text('Title'),
+                            children: <Widget>[
+                              Text('content'),
+                              TextButton(onPressed: null, child: Text('action')),
+                            ],
+                          );
+                        },
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      // On iOS/macOS, the semantic label should not be added,
+      // and namesRoute flag should not exist.
+      expect(
+        semantics,
+        isNot(
+          includesNodeWith(
+            label: localizations.dialogLabel,
+            flags: <SemanticsFlag>[SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
+          ),
+        ),
+      );
+
+      semantics.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/176566
+  testWidgets(
+    'SimpleDialog semantic label/namesRoute should be present on '
+    'Android/Fuchsia/Linux/Windows platforms, regardless of theme platform',
+    (WidgetTester tester) async {
+      // When users set theme.platform to TargetPlatform.iOS on an Android device,
+      // TalkBack should still work correctly by having a label and namesRoute flag
+      // in the Dialog title's semantics.
+      final SemanticsTester semantics = SemanticsTester(tester);
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      // Test with iOS theme but on non-Apple platforms.
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: Material(
+            child: Builder(
+              builder: (BuildContext context) {
+                return Center(
+                  child: ElevatedButton(
+                    child: const Text('X'),
+                    onPressed: () {
+                      showDialog<void>(
+                        context: context,
+                        builder: (BuildContext context) {
+                          return const SimpleDialog(
+                            title: Text('Title'),
+                            children: <Widget>[
+                              Text('content'),
+                              TextButton(onPressed: null, child: Text('action')),
+                            ],
+                          );
+                        },
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      // On Android and other platforms, the default semantic label should be added
+      // and namesRoute should also exist, although it is false as label is non-null.
+      expect(
+        semantics,
+        includesNodeWith(
+          label: localizations.dialogLabel,
+          flags: <SemanticsFlag>[SemanticsFlag.namesRoute, SemanticsFlag.scopesRoute],
+        ),
+      );
+
+      semantics.dispose();
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+    }),
+  );
 }
 
 @pragma('vm:entry-point')


### PR DESCRIPTION
- Address a partial issue within https://github.com/flutter/flutter/issues/176566
- Fix  https://github.com/flutter/flutter/issues/177001
- In this PR:
    - proposes using `defaultTargetPlatform` instead of platform from theme for Semantics title's `label` and `namesRoute` flag in AlertDialog and SimpleDialog widgets (see use case at https://github.com/flutter/flutter/issues/176566#issue-3486244630); 
    - improve documentation on each widget for more accessible to users
    -  add some new tests for this change, and also update existing tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
