### PR TITLE
Fix DropdownMenuFormField triggers assertion when nested in an InputDecorator

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1562,9 +1562,12 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     // If value is null (then _selectedIndex is null) then we
     // display the hint or nothing at all.
+    final int? effectiveSelectedIndex = _selectedIndex ?? hintIndex;
     final Widget innerItemsWidget;
-    if (items.isEmpty) {
-      innerItemsWidget = const SizedBox.shrink();
+    if (items.isEmpty || effectiveSelectedIndex == null) {
+      // TODO(bleroux): replace the empty text with SizedBox.shrink once
+      // https://github.com/flutter/flutter/issues/157915 is solved.
+      innerItemsWidget = const Text('');
     } else {
       innerItemsWidget = IndexedStack(
         index: _selectedIndex ?? hintIndex,
@@ -1654,7 +1657,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
           minWidth: widget.iconSize + suffixIconEndMargin,
           minHeight: widget.iconSize,
         ),
-        // suffixIconGap: 0.0,
         suffixIcon: Padding(
           padding: EdgeInsetsGeometry.directional(end: suffixIconEndMargin),
           child: effectiveSuffixIcon,

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1459,4 +1459,30 @@ void main() {
 
     expect(tester.getCenter(find.text(labelText)).dy, tester.getCenter(find.byType(Icon).last).dy);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/176696.
+  testWidgets('DropdownButtonFormField can be nested in an InputDecorator', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: InputDecorator(
+              decoration: const InputDecoration(),
+              child: DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: 'Label'),
+                items: <String>['One', 'Two'].map<DropdownMenuItem<String>>((String value) {
+                  return DropdownMenuItem<String>(value: value, child: Text(value));
+                }).toList(),
+                onChanged: (String? value) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), null);
+  });
 }


### PR DESCRIPTION
## Description

This PR updates DropdownMenuFormField to add a workaround until https://github.com/flutter/flutter/issues/157915 is fixed.

## Related Issue

Fixes [DropdownButtonFormField triggers assertion when nested in InputDecorator](https://github.com/flutter/flutter/issues/176696#top)

## Tests

- Adds 1 test
