### PR TITLE
Fix DropdownMenuFormField triggers assertion when nested in an InputDecoration

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1567,7 +1567,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     if (items.isEmpty || effectiveSelectedIndex == null) {
       // TODO(bleroux): replace the empty text with SizedBox.shrink once
       // https://github.com/flutter/flutter/issues/157915 is solved.
-      innerItemsWidget = const Text('');
+      innerItemsWidget = const ExcludeSemantics(child: Text(''));
     } else {
       innerItemsWidget = IndexedStack(
         index: effectiveSelectedIndex,

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1562,12 +1562,15 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
 
     // If value is null (then _selectedIndex is null) then we
     // display the hint or nothing at all.
+    final int? effectiveSelectedIndex = _selectedIndex ?? hintIndex;
     final Widget innerItemsWidget;
-    if (items.isEmpty) {
-      innerItemsWidget = const SizedBox.shrink();
+    if (items.isEmpty || effectiveSelectedIndex == null) {
+      // TODO(bleroux): replace the empty text with SizedBox.shrink once
+      // https://github.com/flutter/flutter/issues/157915 is solved.
+      innerItemsWidget = const Text('');
     } else {
       innerItemsWidget = IndexedStack(
-        index: _selectedIndex ?? hintIndex,
+        index: effectiveSelectedIndex,
         alignment: widget.alignment,
         children: widget.isDense
             ? items
@@ -1654,7 +1657,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
           minWidth: widget.iconSize + suffixIconEndMargin,
           minHeight: widget.iconSize,
         ),
-        // suffixIconGap: 0.0,
         suffixIcon: Padding(
           padding: EdgeInsetsGeometry.directional(end: suffixIconEndMargin),
           child: effectiveSuffixIcon,

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1459,4 +1459,30 @@ void main() {
 
     expect(tester.getCenter(find.text(labelText)).dy, tester.getCenter(find.byType(Icon).last).dy);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/176696.
+  testWidgets('DropdownButtonFormField can be nested in an InputDecorator', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: InputDecorator(
+              decoration: const InputDecoration(),
+              child: DropdownButtonFormField<String>(
+                decoration: const InputDecoration(labelText: 'Label'),
+                items: <String>['One', 'Two'].map<DropdownMenuItem<String>>((String value) {
+                  return DropdownMenuItem<String>(value: value, child: Text(value));
+                }).toList(),
+                onChanged: (String? value) {},
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), null);
+  });
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1634,18 +1634,13 @@ void main() {
     await tester.pumpWidget(build(items: menuItems, hint: const Text('hint')));
     expect(tester.getCenter(find.text('hint')).dy, tester.getCenter(find.byType(Icon)).dy);
 
-    int? getIndex() {
-      final IndexedStack stack = tester.element(find.byType(IndexedStack)).widget as IndexedStack;
-      return stack.index;
-    }
-
     // If [value], [hint] and [disabledHint] are null, the button is disabled, nothing displayed.
     await tester.pumpWidget(build(items: menuItems));
-    expect(getIndex(), null);
+    expect(find.byType(IndexedStack), findsNothing);
 
     // If [value], [hint] and [disabledHint] are null, the button is enabled, nothing displayed.
     await tester.pumpWidget(build(items: menuItems, onChanged: onChanged));
-    expect(getIndex(), null);
+    expect(find.byType(IndexedStack), findsNothing);
   });
 
   testWidgets('DropdownButton selected item color test', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR updates `DropdownMenuFormField` to add a workaround until https://github.com/flutter/flutter/issues/157915 is fixed.

## Related Issue

Fixes [DropdownButtonFormField triggers assertion when nested in InputDecorator](https://github.com/flutter/flutter/issues/176696#top)

## Tests

- Adds 1 test
