### PR TITLE
Roll SwiftShader to 794b0cfce1d8

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -519,7 +519,7 @@ deps = {
    Var('flutter_git') + '/third_party/pyyaml.git' + '@' + '03c67afd452cdff45b41bfe65e19a2fb5b80a0e8',
 
   'engine/src/flutter/third_party/swiftshader':
-  Var('swiftshader_git') + '/SwiftShader.git' + '@' + 'd040a5bab638bf7c226235c95787ba6288bb6416',
+  Var('swiftshader_git') + '/SwiftShader.git' + '@' + '794b0cfce1d828d187637e6d932bae484fbe0976',
 
   'engine/src/flutter/third_party/angle':
   Var('flutter_git') + '/third_party/angle' + '@' + 'e28922c5e71eb32594c2562076cd5b15383e24d4',

--- a/engine/src/flutter/sky/packages/sky_engine/LICENSE
+++ b/engine/src/flutter/sky/packages/sky_engine/LICENSE
@@ -14947,11 +14947,6 @@ Copyright 2014-2022 The Khronos Group Inc.
 SPDX-License-Identifier: Apache-2.0
 --------------------------------------------------------------------------------
 swiftshader
-
-Copyright 2014-2023 The Khronos Group Inc.
-
-SPDX-License-Identifier: Apache-2.0
---------------------------------------------------------------------------------
 vulkan
 vulkan-headers
 
@@ -15074,12 +15069,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 --------------------------------------------------------------------------------
 swiftshader
-
-Copyright 2015-2023 The Khronos Group Inc.
-
-SPDX-License-Identifier: Apache-2.0
---------------------------------------------------------------------------------
-swiftshader
 vulkan
 vulkan-headers
 
@@ -15089,6 +15078,7 @@ Copyright 2015-2023 LunarG, Inc.
 
 SPDX-License-Identifier: Apache-2.0
 --------------------------------------------------------------------------------
+swiftshader
 vulkan
 vulkan-headers
 
@@ -16910,6 +16900,7 @@ Copyright 2023-2025 The Khronos Group Inc.
 
 SPDX-License-Identifier: Apache-2.0
 --------------------------------------------------------------------------------
+swiftshader
 vulkan-utility-libraries
 
 Copyright 2023-2025 The Khronos Group Inc.


### PR DESCRIPTION
This is required to fix issues affecting the pending ANGLE roll and to allow removal of the -Wno-deprecated-this-capture compiler flag.

See https://github.com/flutter/flutter/issues/174665