### PR TITLE
Set up a version of build_ios_framework_module_test that only runs on x64 machines and extend its timeout

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3717,6 +3717,7 @@ targets:
 
   - name: Mac_x64 build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
+    bringup: true
     timeout: 60
     properties:
       add_recipes_cq: "true"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3715,7 +3715,7 @@ targets:
     properties:
       task_name: basic_material_app_macos__compile
 
-  - name: Mac build_ios_framework_module_test
+  - name: Mac_x64 build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -3727,6 +3727,7 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac"]
       task_name: build_ios_framework_module_test
+      test_timeout_secs: "2700"
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
The "Mac build_ios_framework_module_test" builder was being scheduled on either x64 or arm64 machines.  The test takes longer when run on an x64 machine and would sometimes exceed the default 30 minute timeout.

This PR changes that builder to only run on x64 and use a 45 minute timeout.  (There is already a separate "Mac_arm64 build_ios_framework_module_test" that runs only on arm64)