### PR TITLE
[tool/dap] Forward app.warning events from Flutter to DAP client

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -72,6 +72,10 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter with VmServiceInfoFile
     // that should be launched (including a flag for whether it has been
     // launched by the tool or needs launching by the editor).
     'app.webLaunchUrl',
+    // app.warning is used to pass warnings that should be shown more
+    // prominently by clients (for example warning about slow wireless
+    // debugging).
+    'app.warning',
   };
 
   /// Completers for reverse requests from Flutter that may need to be handled by the client.

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -574,6 +574,33 @@ void main() {
           'params': <String, Object?>{'url': 'http://localhost:123/', 'launched': false},
         });
       });
+
+      test('app.warning', () async {
+        final adapter = FakeFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+
+        // Start listening for the forwarded event (don't await it yet, it won't
+        // be triggered until the call below).
+        final Future<Map<String, Object?>> forwardedEvent = adapter.dapToClientMessages.firstWhere(
+          (Map<String, Object?> data) => data['event'] == 'flutter.forwardedEvent',
+        );
+
+        // Simulate Flutter emitting an `app.warning` event.
+        adapter.simulateStdoutMessage(<String, Object?>{
+          'event': 'app.warning',
+          'params': <String, Object?>{'warning': 'This is a test warning'},
+        });
+
+        // Expect the message to be forwarded to the DAP client as the body of
+        // the forwarded event.
+        final Map<String, Object?> message = await forwardedEvent;
+        expect(message['body'], <String, Object?>{
+          'event': 'app.warning',
+          'params': <String, Object?>{'warning': 'This is a test warning'},
+        });
+      });
     });
 
     group('handles reverse requests', () {


### PR DESCRIPTION
This change is to support https://github.com/Dart-Code/Dart-Code/issues/5730. It ensures the `app.warning` event emitted by `flutter run` (added for https://github.com/flutter/flutter/issues/176206) is forwarded through the debug adapter to the client (for ex. the VS Code extension) where it can be displayed.

With the corresponding Dart-Code changes, it will allow the warning to show up like this (instead of just in text output that scrolls past in the terminal):

<img width="602" height="343" alt="image" src="https://github.com/user-attachments/assets/eac199ad-e562-4e98-b8f0-ee51103cc166" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
