### PR TITLE
`SelectableRegion` should not show flutter rendered context menu when web context menu is enabled

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -408,6 +408,9 @@ class SelectableRegionState extends State<SelectableRegion>
   Orientation? _lastOrientation;
   SelectedContent? _lastSelectedContent;
 
+  /// Whether the native browser context menu is enabled.
+  bool get _webContextMenuEnabled => kIsWeb && BrowserContextMenu.enabled;
+
   /// The [SelectionOverlay] that is currently visible on the screen.
   ///
   /// Can be null if there is no visible [SelectionOverlay].
@@ -506,7 +509,7 @@ class SelectableRegionState extends State<SelectableRegion>
 
   void _handleFocusChanged() {
     if (!_focusNode.hasFocus) {
-      if (kIsWeb) {
+      if (_webContextMenuEnabled) {
         PlatformSelectableRegionContextMenu.detach(_selectionDelegate);
       }
       if (SchedulerBinding.instance.lifecycleState == AppLifecycleState.resumed) {
@@ -522,7 +525,7 @@ class SelectableRegionState extends State<SelectableRegion>
         _finalizeSelectableRegionStatus();
       }
     }
-    if (kIsWeb) {
+    if (_webContextMenuEnabled) {
       PlatformSelectableRegionContextMenu.attach(_selectionDelegate);
     }
   }
@@ -1125,17 +1128,12 @@ class SelectableRegionState extends State<SelectableRegion>
     if (widget.selectionControls is! TextSelectionHandleControls) {
       if (!draggingHandles) {
         _selectionOverlay!.hideMagnifier();
-        _selectionOverlay!.showToolbar();
+        _showToolbar();
       }
     } else {
       if (!draggingHandles) {
         _selectionOverlay!.hideMagnifier();
-        _selectionOverlay!.showToolbar(
-          context: context,
-          contextMenuBuilder: (BuildContext context) {
-            return widget.contextMenuBuilder!(context, this);
-          },
-        );
+        _showToolbar();
       }
     }
     _finalizeSelection();
@@ -1357,7 +1355,7 @@ class SelectableRegionState extends State<SelectableRegion>
     // functionality depending on the browser (such as translate). Due to this,
     // we should not show a Flutter toolbar for the editable text elements
     // unless the browser's context menu is explicitly disabled.
-    if (kIsWeb && BrowserContextMenu.enabled) {
+    if (_webContextMenuEnabled) {
       return false;
     }
 
@@ -1940,7 +1938,7 @@ class SelectableRegionState extends State<SelectableRegion>
       selectionStatusNotifier: _selectionStatusNotifier,
       child: SelectionContainer(registrar: this, delegate: _selectionDelegate, child: widget.child),
     );
-    if (kIsWeb) {
+    if (_webContextMenuEnabled) {
       result = PlatformSelectableRegionContextMenu(child: result);
     }
     return CompositedTransformTarget(

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1125,16 +1125,9 @@ class SelectableRegionState extends State<SelectableRegion>
     final bool draggingHandles =
         _selectionOverlay != null &&
         (_selectionOverlay!.isDraggingStartHandle || _selectionOverlay!.isDraggingEndHandle);
-    if (widget.selectionControls is! TextSelectionHandleControls) {
-      if (!draggingHandles) {
-        _selectionOverlay!.hideMagnifier();
-        _showToolbar();
-      }
-    } else {
-      if (!draggingHandles) {
-        _selectionOverlay!.hideMagnifier();
-        _showToolbar();
-      }
+    if (!draggingHandles) {
+      _selectionOverlay!.hideMagnifier();
+      _showToolbar();
     }
     _finalizeSelection();
     _updateSelectedContentIfNeeded();

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -1357,6 +1357,9 @@ class SelectableRegionState extends State<SelectableRegion>
     }
 
     _selectionOverlay!.toolbarLocation = location;
+    // TODO(Renzo-Olivares): Remove the logic below that does a runtimeType
+    // check for TextSelectionHandleControls when TextSelectionHandleControls
+    // is fully removed, see: https://github.com/flutter/flutter/pull/124262.
     if (widget.selectionControls is! TextSelectionHandleControls) {
       _selectionOverlay!.showToolbar();
       return true;

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -570,8 +570,8 @@ class TextSelectionOverlay {
     _selectionOverlay.markNeedsBuild();
   }
 
-  /// Whether the handles are currently visible.
-  bool get handlesAreVisible => _selectionOverlay._handles != null && handlesVisible;
+  /// {@macro flutter.widgets.SelectionOverlay.handlesAreVisible}
+  bool get handlesAreVisible => _selectionOverlay.handlesAreVisible;
 
   /// {@macro flutter.widgets.SelectionOverlay.toolbarIsVisible}
   ///
@@ -1124,6 +1124,14 @@ class SelectionOverlay {
         ? _contextMenuController.isShown || _spellCheckToolbarController.isShown
         : _toolbar != null || _spellCheckToolbarController.isShown;
   }
+
+  /// {@template flutter.widgets.SelectionOverlay.handlesAreVisible}
+  /// Whether the selection handles are currently visible.
+  /// {@endtemplate}
+  bool get handlesAreVisible =>
+      _handles != null &&
+      (endHandlesVisible?.value ?? false) &&
+      (startHandlesVisible?.value ?? false);
 
   /// {@template flutter.widgets.SelectionOverlay.magnifierIsVisible}
   /// Whether the magnifier is currently visible.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1130,8 +1130,8 @@ class SelectionOverlay {
   /// {@endtemplate}
   bool get handlesAreVisible =>
       _handles != null &&
-      (endHandlesVisible?.value ?? false) &&
-      (startHandlesVisible?.value ?? false);
+      (endHandlesVisible?.value ?? true) &&
+      (startHandlesVisible?.value ?? true);
 
   /// {@template flutter.widgets.SelectionOverlay.magnifierIsVisible}
   /// Whether the magnifier is currently visible.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -570,8 +570,8 @@ class TextSelectionOverlay {
     _selectionOverlay.markNeedsBuild();
   }
 
-  /// {@macro flutter.widgets.SelectionOverlay.handlesAreVisible}
-  bool get handlesAreVisible => _selectionOverlay.handlesAreVisible;
+  /// Whether the handles are currently visible.
+  bool get handlesAreVisible => _selectionOverlay._handles != null && handlesVisible;
 
   /// {@macro flutter.widgets.SelectionOverlay.toolbarIsVisible}
   ///
@@ -1124,14 +1124,6 @@ class SelectionOverlay {
         ? _contextMenuController.isShown || _spellCheckToolbarController.isShown
         : _toolbar != null || _spellCheckToolbarController.isShown;
   }
-
-  /// {@template flutter.widgets.SelectionOverlay.handlesAreVisible}
-  /// Whether the selection handles are currently visible.
-  /// {@endtemplate}
-  bool get handlesAreVisible =>
-      _handles != null &&
-      (endHandlesVisible?.value ?? true) &&
-      (startHandlesVisible?.value ?? true);
 
   /// {@template flutter.widgets.SelectionOverlay.magnifierIsVisible}
   /// Whether the magnifier is currently visible.

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -624,10 +624,18 @@ void main() {
         expect(paragraph.selections, isNotEmpty);
         expect(paragraph.selections.length, 1);
         expect(paragraph.selections.first, const TextSelection(baseOffset: 6, extentOffset: 11));
-        final SelectableRegionState state = tester.state<SelectableRegionState>(
-          find.byType(SelectableRegion),
-        );
-        expect(state.selectionOverlay?.handlesAreVisible, isTrue);
+        final List<FadeTransition> transitions = find
+            .descendant(
+              of: find.byWidgetPredicate(
+                (Widget w) => '${w.runtimeType}' == '_SelectionHandleOverlay',
+              ),
+              matching: find.byType(FadeTransition),
+            )
+            .evaluate()
+            .map((Element e) => e.widget)
+            .cast<FadeTransition>()
+            .toList();
+        expect(transitions.length, 2);
         expect(find.byKey(toolbarKey), findsNothing);
 
         // Drag start handle.


### PR DESCRIPTION
This change fixes an issue where the flutter rendered menu would show up when ending a drag on a selection handle, even when the web context menu was enabled. This led to issues where both context menus would show up leading to a unfavorable experience.

Fixes #175114

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.