### PR TITLE
[web] Match the behavior of other platforms in Web Locale.toString if the country code is an empty string

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -530,10 +530,10 @@ class Locale {
 
   String _rawToString(String separator) {
     final StringBuffer out = StringBuffer(languageCode);
-    if (scriptCode != null) {
+    if (scriptCode != null && scriptCode!.isNotEmpty) {
       out.write('$separator$scriptCode');
     }
-    if (_countryCode != null) {
+    if (_countryCode != null && countryCode!.isNotEmpty) {
       out.write('$separator$countryCode');
     }
     return out.toString();

--- a/engine/src/flutter/lib/web_ui/test/engine/locale_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/locale_test.dart
@@ -20,6 +20,7 @@ void testMain() {
     // TODO(het): This fails on web because "".hashCode == null.hashCode == 0
     //expect(const Locale('en').hashCode, isNot(const Locale('en', '').hashCode));
     expect(const Locale('en', 'US').toString(), 'en_US');
+    expect(const Locale('en', '').toString(), 'en');
     expect(const Locale('iw').toString(), 'he');
     expect(const Locale('iw', 'DD').toString(), 'he_DE');
     expect(const Locale('iw', 'DD'), const Locale('he', 'DE'));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/176666