### PR TITLE
[`FlexibleSpaceBar`] `expandedTitlePadding` and `titleCurve`

### DIFF
--- a/packages/flutter/.vscode/settings.json
+++ b/packages/flutter/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dart.flutterSdkPath": null
+}

--- a/packages/flutter/.vscode/settings.json
+++ b/packages/flutter/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "dart.flutterSdkPath": null
-}

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -128,8 +128,9 @@ class FlexibleSpaceBar extends StatefulWidget {
   /// This curve can be used to prevent the title from colliding with another
   /// widget, like [SliverAppBar.leading].
   ///
-  /// The `out` of the curve hereby is the collapsed state and the `in` is the
-  /// expanded state.
+  /// The curve is applied to the transition between the expanded and collapsed
+  /// states. A value of 0.0 corresponds to the expanded state, and 1.0
+  /// corresponds to the collapsed state.
   ///
   /// For example, using [Curves.easeOutSine] will allow the title to flee
   /// quickly to the collapsed position, making space for a leading widget.
@@ -350,25 +351,21 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
             titleStyle = titleStyle.copyWith(color: titleStyle.color!.withOpacity(opacity));
             final bool effectiveCenterTitle = _getEffectiveCenterTitle(theme);
             final leadingPadding = (settings.hasLeading ?? true) ? 72.0 : 16.0;
-            final curveTween = CurveTween(curve: widget.titleCurve ?? Curves.linear);
-            final EdgeInsetsGeometry padding = EdgeInsetsGeometryTween(
-              begin:
-                  widget.expandedTitlePadding ??
+            final double curveValue = (widget.titleCurve ?? Curves.linear).transform(t);
+            final EdgeInsetsGeometry padding = EdgeInsetsGeometry.lerp(
+              widget.expandedTitlePadding ??
                   EdgeInsetsDirectional.only(
                     start: effectiveCenterTitle ? 0.0 : 16.0,
                     bottom: 16.0,
                   ),
-              end:
-                  widget.titlePadding ??
+              widget.titlePadding ??
                   EdgeInsetsDirectional.only(
                     start: effectiveCenterTitle ? 0.0 : leadingPadding,
                     bottom: 16.0,
                   ),
-            ).chain(curveTween).transform(t);
-            final double scaleValue = Tween<double>(
-              begin: widget.expandedTitleScale,
-              end: 1.0,
-            ).chain(curveTween).transform(t);
+              curveValue,
+            )!;
+            final double scaleValue = ui.lerpDouble(widget.expandedTitleScale, 1.0, curveValue)!;
             final scaleTransform = Matrix4.identity()
               ..scaleByDouble(scaleValue, scaleValue, 1.0, 1);
             final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -138,22 +138,21 @@ class FlexibleSpaceBar extends StatefulWidget {
   /// If null, defaults to [Curves.linear].
   final Curve? titleCurve;
 
-  /// Defines how far the [title] is inset from either the widget's
-  /// bottom-left or its center.
+  /// Defines how far the [title] is inset from either the widget's bottom-left
+  /// or its center.
   ///
   /// {@template flutter.material.FlexibleSpaceBar.titlePadding}
-  /// Typically this property is used to adjust how far the title is
-  /// inset from the bottom-left and it is specified along with
-  /// [centerTitle] false.
+  /// Typically this property is used to adjust how far the title is inset from
+  /// the bottom-left if it is specified along with [centerTitle] false.
   ///
-  /// If [centerTitle] is true, then the title is centered within the
-  /// flexible space bar with a bottom padding of 16.0 pixels.
+  /// If [centerTitle] is true, then the title is centered within the flexible
+  /// space bar with a bottom padding of 16.0 pixels.
   /// {@endtemplate}
   ///
-  /// If [centerTitle] is false and [FlexibleSpaceBarSettings.hasLeading] is true,
-  /// then the title is aligned to the start of the flexible space bar with the
-  /// [titlePadding] applied. If [titlePadding] is null, then defaults to start
-  /// padding of 72.0 pixels and bottom padding of 16.0 pixels.
+  /// If [centerTitle] is false and [FlexibleSpaceBarSettings.hasLeading] is
+  /// true, then the title is aligned to the start of the flexible space bar
+  /// with the [titlePadding] applied. If [titlePadding] is null, then defaults
+  /// to start padding of 72.0 pixels and bottom padding of 16.0 pixels.
   final EdgeInsetsGeometry? titlePadding;
 
   /// Defines how far the [title] is inset from either the widget's
@@ -161,10 +160,10 @@ class FlexibleSpaceBar extends StatefulWidget {
   ///
   /// {@macro flutter.material.FlexibleSpaceBar.titlePadding}
   ///
-  /// If [centerTitle] is false, then the title is aligned to the start of the
-  /// flexible space bar with the [expandedTitlePadding] applied. If
-  /// [expandedTitlePadding] is null, then defaults to start padding of 16.0
-  /// pixels and bottom padding of 16.0 pixels.
+  /// If [centerTitle] is false, then the title is aligned to the bottom-left
+  /// with [expandedTitlePadding] applied. If [expandedTitlePadding] is null,
+  /// then defaults to start padding of 16.0 pixels and bottom padding of 16.0
+  /// pixels.
   final EdgeInsetsGeometry? expandedTitlePadding;
 
   /// Defines how much the title is scaled when the FlexibleSpaceBar is expanded
@@ -355,7 +354,10 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
             final EdgeInsetsGeometry padding = EdgeInsetsGeometryTween(
               begin:
                   widget.expandedTitlePadding ??
-                  const EdgeInsetsDirectional.only(start: 16, bottom: 16),
+                  EdgeInsetsDirectional.only(
+                    start: effectiveCenterTitle ? 0.0 : 16.0,
+                    bottom: 16.0,
+                  ),
               end:
                   widget.titlePadding ??
                   EdgeInsetsDirectional.only(

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -85,7 +85,9 @@ class FlexibleSpaceBar extends StatefulWidget {
     this.title,
     this.background,
     this.centerTitle,
+    this.titleCurve,
     this.titlePadding,
+    this.expandedTitlePadding,
     this.collapseMode = CollapseMode.parallax,
     this.stretchModes = const <StretchMode>[StretchMode.zoomBackground],
     this.expandedTitleScale = 1.5,
@@ -121,21 +123,49 @@ class FlexibleSpaceBar extends StatefulWidget {
   /// Defaults to include [StretchMode.zoomBackground].
   final List<StretchMode> stretchModes;
 
+  /// The curve used to animate the title padding and scale.
+  ///
+  /// This curve can be used to prevent the title from colliding with another
+  /// widget, like [SliverAppBar.leading].
+  ///
+  /// The `out` of the curve hereby is the collapsed state and the `in` is the
+  /// expanded state.
+  ///
+  /// For example, using [Curves.easeOutSine] will allow the title to flee
+  /// quickly to the collapsed position, making space for a leading widget.
+  /// [Curves.easeInSine] can be used to create a more gentle transition.
+  ///
+  /// If null, defaults to [Curves.linear].
+  final Curve? titleCurve;
+
   /// Defines how far the [title] is inset from either the widget's
   /// bottom-left or its center.
   ///
+  /// {@template flutter.material.FlexibleSpaceBar.titlePadding}
   /// Typically this property is used to adjust how far the title is
   /// inset from the bottom-left and it is specified along with
   /// [centerTitle] false.
   ///
   /// If [centerTitle] is true, then the title is centered within the
   /// flexible space bar with a bottom padding of 16.0 pixels.
+  /// {@endtemplate}
   ///
   /// If [centerTitle] is false and [FlexibleSpaceBarSettings.hasLeading] is true,
   /// then the title is aligned to the start of the flexible space bar with the
   /// [titlePadding] applied. If [titlePadding] is null, then defaults to start
   /// padding of 72.0 pixels and bottom padding of 16.0 pixels.
   final EdgeInsetsGeometry? titlePadding;
+
+  /// Defines how far the [title] is inset from either the widget's
+  /// bottom-left or its center when the FlexibleSpaceBar is fully expanded.
+  ///
+  /// {@macro flutter.material.FlexibleSpaceBar.titlePadding}
+  ///
+  /// If [centerTitle] is false, then the title is aligned to the start of the
+  /// flexible space bar with the [expandedTitlePadding] applied. If
+  /// [expandedTitlePadding] is null, then defaults to start padding of 16.0
+  /// pixels and bottom padding of 16.0 pixels.
+  final EdgeInsetsGeometry? expandedTitlePadding;
 
   /// Defines how much the title is scaled when the FlexibleSpaceBar is expanded
   /// due to the user scrolling downwards. The title is scaled uniformly on the
@@ -320,18 +350,24 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
                 : theme.primaryTextTheme.titleLarge!;
             titleStyle = titleStyle.copyWith(color: titleStyle.color!.withOpacity(opacity));
             final bool effectiveCenterTitle = _getEffectiveCenterTitle(theme);
-            final leadingPadding = (settings.hasLeading ?? true) ? 72.0 : 0.0;
-            final EdgeInsetsGeometry padding =
-                widget.titlePadding ??
-                EdgeInsetsDirectional.only(
-                  start: effectiveCenterTitle ? 0.0 : leadingPadding,
-                  bottom: 16.0,
-                );
+            final double leadingPadding = (settings.hasLeading ?? true) ? 72.0 : 16.0;
+            final CurveTween curveTween = CurveTween(curve: widget.titleCurve ?? Curves.linear);
+            final EdgeInsetsGeometry padding = EdgeInsetsGeometryTween(
+              begin:
+                  widget.expandedTitlePadding ??
+                  const EdgeInsetsDirectional.only(start: 16, bottom: 16),
+              end:
+                  widget.titlePadding ??
+                  EdgeInsetsDirectional.only(
+                    start: effectiveCenterTitle ? 0.0 : leadingPadding,
+                    bottom: 16.0,
+                  ),
+            ).chain(curveTween).transform(t);
             final double scaleValue = Tween<double>(
               begin: widget.expandedTitleScale,
               end: 1.0,
-            ).transform(t);
-            final scaleTransform = Matrix4.identity()
+            ).chain(curveTween).transform(t);
+            final Matrix4 scaleTransform = Matrix4.identity()
               ..scaleByDouble(scaleValue, scaleValue, 1.0, 1);
             final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);
             children.add(

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -349,8 +349,8 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
                 : theme.primaryTextTheme.titleLarge!;
             titleStyle = titleStyle.copyWith(color: titleStyle.color!.withOpacity(opacity));
             final bool effectiveCenterTitle = _getEffectiveCenterTitle(theme);
-            final double leadingPadding = (settings.hasLeading ?? true) ? 72.0 : 16.0;
-            final CurveTween curveTween = CurveTween(curve: widget.titleCurve ?? Curves.linear);
+            final leadingPadding = (settings.hasLeading ?? true) ? 72.0 : 16.0;
+            final curveTween = CurveTween(curve: widget.titleCurve ?? Curves.linear);
             final EdgeInsetsGeometry padding = EdgeInsetsGeometryTween(
               begin:
                   widget.expandedTitlePadding ??
@@ -369,7 +369,7 @@ class _FlexibleSpaceBarState extends State<FlexibleSpaceBar> {
               begin: widget.expandedTitleScale,
               end: 1.0,
             ).chain(curveTween).transform(t);
-            final Matrix4 scaleTransform = Matrix4.identity()
+            final scaleTransform = Matrix4.identity()
               ..scaleByDouble(scaleValue, scaleValue, 1.0, 1);
             final Alignment titleAlignment = _getTitleAlignment(effectiveCenterTitle);
             children.add(

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -779,6 +779,7 @@ void main() {
                     stretch: true,
                     flexibleSpace: FlexibleSpaceBar(
                       titlePadding: EdgeInsets.zero,
+                      expandedTitlePadding: EdgeInsets.zero,
                       title: Text(
                         'X' * 2000,
                         maxLines: 1,
@@ -832,6 +833,7 @@ void main() {
                     stretch: true,
                     flexibleSpace: FlexibleSpaceBar(
                       titlePadding: EdgeInsets.zero,
+                      expandedTitlePadding: EdgeInsets.zero,
                       title: Text(
                         'X' * 2000,
                         maxLines: 1,
@@ -881,6 +883,7 @@ void main() {
                   flexibleSpace: FlexibleSpaceBar(
                     expandedTitleScale: expandedTitleScale,
                     titlePadding: EdgeInsets.zero,
+                    expandedTitlePadding: EdgeInsets.zero,
                     title: Text(
                       'X' * 41,
                       maxLines: 1,
@@ -951,6 +954,7 @@ void main() {
                   flexibleSpace: FlexibleSpaceBar(
                     expandedTitleScale: expandedTitleScale,
                     titlePadding: EdgeInsets.zero,
+                    expandedTitlePadding: EdgeInsets.zero,
                     title: Text(
                       'X' * 41,
                       maxLines: 1,

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -1640,6 +1640,288 @@ void main() {
     );
     expect(tester.getSize(find.byType(FlexibleSpaceBar)), Size.zero);
   });
+
+  testWidgets('FlexibleSpaceBar titleCurve affects title position during collapse', (
+    WidgetTester tester,
+  ) async {
+    const height = 300.0;
+    Widget buildFrame({Curve? titleCurve}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: const Text('Title'),
+                  centerTitle: false,
+                  titleCurve: titleCurve,
+                ),
+              ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    await tester.drag(find.text('Item 0'), const Offset(0, -150.0));
+    await tester.pumpAndSettle();
+
+    final Offset linearTitlePosition = tester.getTopLeft(find.text('Title'));
+
+    await tester.drag(find.text('Item 1'), const Offset(0, 150.0));
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(Container(key: UniqueKey()));
+
+    await tester.pumpWidget(buildFrame(titleCurve: Curves.easeOut));
+    await tester.drag(find.text('Item 0'), const Offset(0, -150.0));
+    await tester.pumpAndSettle();
+
+    final Offset easeOutTitlePosition = tester.getTopLeft(find.text('Title'));
+
+    expect(linearTitlePosition.dx, isNot(equals(easeOutTitlePosition.dx)));
+  });
+
+  testWidgets('FlexibleSpaceBar titleCurve defaults to Curves.linear', (WidgetTester tester) async {
+    const height = 300.0;
+    Widget buildFrame({Curve? titleCurve}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: const Text('Title'),
+                  centerTitle: false,
+                  titleCurve: titleCurve,
+                ),
+              ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    await tester.drag(find.text('Item 0'), const Offset(0, -150.0));
+    await tester.pumpAndSettle();
+
+    final Offset defaultTitlePosition = tester.getTopLeft(find.text('Title'));
+
+    await tester.drag(find.text('Item 1'), const Offset(0, 150.0));
+    await tester.pumpAndSettle();
+    await tester.pumpWidget(Container(key: UniqueKey()));
+
+    await tester.pumpWidget(buildFrame(titleCurve: Curves.linear));
+    await tester.drag(find.text('Item 0'), const Offset(0, -150.0));
+    await tester.pumpAndSettle();
+
+    final Offset linearTitlePosition = tester.getTopLeft(find.text('Title'));
+
+    expect(defaultTitlePosition, equals(linearTitlePosition));
+  });
+
+  testWidgets('Material3 - FlexibleSpaceBar expandedTitlePadding', (WidgetTester tester) async {
+    const height = 300.0;
+    Widget buildFrame({EdgeInsetsGeometry? expandedTitlePadding}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: const Text('Title'),
+                  centerTitle: false,
+                  expandedTitlePadding: expandedTitlePadding,
+                ),
+              ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final Finder title = find.text('Title');
+    final Finder flexibleSpaceBar = find.byType(FlexibleSpaceBar);
+
+    Offset getTitleBottomLeft() {
+      return Offset(
+        tester.getTopLeft(title).dx,
+        tester.getBottomRight(flexibleSpaceBar).dy - tester.getBottomRight(title).dy,
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    expect(getTitleBottomLeft(), const Offset(16.0, 16.0));
+
+    await tester.pumpWidget(
+      buildFrame(expandedTitlePadding: const EdgeInsets.only(left: 32.0, bottom: 24.0)),
+    );
+    await tester.pumpAndSettle();
+    expect(getTitleBottomLeft(), const Offset(32.0, 24.0));
+
+    await tester.pumpWidget(buildFrame(expandedTitlePadding: EdgeInsets.zero));
+    await tester.pumpAndSettle();
+    expect(getTitleBottomLeft(), Offset.zero);
+  });
+
+  testWidgets('Material2 - FlexibleSpaceBar expandedTitlePadding', (WidgetTester tester) async {
+    const height = 300.0;
+    Widget buildFrame({EdgeInsetsGeometry? expandedTitlePadding}) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: false),
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: const Text('Title'),
+                  centerTitle: false,
+                  expandedTitlePadding: expandedTitlePadding,
+                ),
+              ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final Finder title = find.text('Title');
+    final Finder flexibleSpaceBar = find.byType(FlexibleSpaceBar);
+
+    Offset getTitleBottomLeft() {
+      return Offset(
+        tester.getTopLeft(title).dx,
+        tester.getBottomRight(flexibleSpaceBar).dy - tester.getBottomRight(title).dy,
+      );
+    }
+
+    await tester.pumpWidget(buildFrame());
+    expect(getTitleBottomLeft(), const Offset(16.0, 16.0));
+
+    await tester.pumpWidget(
+      buildFrame(expandedTitlePadding: const EdgeInsets.only(left: 32.0, bottom: 24.0)),
+    );
+    await tester.pumpAndSettle();
+    expect(getTitleBottomLeft(), const Offset(32.0, 24.0));
+
+    await tester.pumpWidget(buildFrame(expandedTitlePadding: EdgeInsets.zero));
+    await tester.pumpAndSettle();
+    expect(getTitleBottomLeft(), Offset.zero);
+  });
+
+  testWidgets('FlexibleSpaceBar expandedTitlePadding lerps to titlePadding when collapsed', (
+    WidgetTester tester,
+  ) async {
+    const height = 300.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              const SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: Text('Title'),
+                  centerTitle: false,
+                  expandedTitlePadding: EdgeInsets.only(left: 16.0, bottom: 16.0),
+                  titlePadding: EdgeInsets.only(left: 72.0, bottom: 16.0),
+                ),
+              ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder title = find.text('Title');
+
+    expect(tester.getTopLeft(title).dx, 16.0);
+
+    await tester.drag(find.text('Item 0'), const Offset(0, -600.0));
+    await tester.pumpAndSettle();
+
+    expect(tester.getTopLeft(title).dx, 72.0);
+  });
+
+  testWidgets('FlexibleSpaceBar expandedTitlePadding with centerTitle true', (
+    WidgetTester tester,
+  ) async {
+    const height = 300.0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            slivers: <Widget>[
+              const SliverAppBar(
+                expandedHeight: height,
+                pinned: true,
+                flexibleSpace: FlexibleSpaceBar(
+                  title: Text('Title'),
+                  centerTitle: true,
+                  expandedTitlePadding: EdgeInsets.only(bottom: 32.0),
+                ),
+              ),
+              SliverList.builder(
+                itemCount: 10,
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(height: 200.0, child: Center(child: Text('Item $index')));
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Finder title = find.text('Title');
+    final Finder flexibleSpaceBar = find.byType(FlexibleSpaceBar);
+
+    final double bottomOffset =
+        tester.getBottomRight(flexibleSpaceBar).dy - tester.getBottomRight(title).dy;
+    expect(bottomOffset, 32.0);
+
+    expect(tester.getCenter(flexibleSpaceBar).dx, tester.getCenter(title).dx);
+  });
 }
 
 class TestDelegate extends SliverPersistentHeaderDelegate {


### PR DESCRIPTION
This PR adds…
- `FlexibleSpaceBar.expandedTitlePadding`
  - This fixes visual inconsistency with Material Specifications. Also, it looks better. *Also*, why is such an easy so solve issue still not resolved five years after its opening?
  - Closes #69017
- `FlexibleSpaceBar.titleCurve`
  - The curve is applied to the new padding tween as well as the text sizing tween.
  - There's no issue for this specifically. I think it goes hand in hand with the property mentioned above. If you don't think that's the case, I can create a new issue.
  - The default value right now is `Curves.linear`, because I didn't want to set default to something too fancy. But I could also see `Curves.easeOutSine` or `Curves.easeInSine` being the default, that should be discussed. Comparison below.

<details><summary>Code sample</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MainApp());
}

class MainApp extends StatelessWidget {
  const MainApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: CustomScrollView(
          slivers: [
            SliverAppBar.large(
              leading: BackButton(onPressed: () {}),
              // automaticallyImplyLeading: false,
              flexibleSpace: FlexibleSpaceBar(
                title: Text("Page Title"),
                // centerTitle: true,

                // titleCurve: Curves.easeInSine,
                // titleCurve: Curves.easeOutSine,
                // titleCurve: Curves.bounceInOut, // More clearly visible effect
              ),
            ),
            SliverList.list(
              children: List.generate(
                30,
                (index) => ListTile(
                  enabled: false,
                  title: Text(index.toString()),
                  dense: true,
                ),
              ),
            ),
          ],
        ),
      ),
    );
  }
}
```

</details>

![flexibleOldNew](https://github.com/user-attachments/assets/7af9d2f8-c660-4ddc-86f2-bfc54a8df25a)

### Consistency

The padding of 16 on the left seems to be consistent with the normal `AppBar.title`. Here's an overlay:

![flexibleOverlay](https://github.com/user-attachments/assets/35363086-76df-4e77-80c8-b2420be57e2b)

### Curves

Examples:

| Linear | Ease In (Sine) | Ease Out (Sine) | Bounce In Out |
|-|-|-|-|
| Default || Best for preventing collision | _Movement test_ |
| ![flexibleLeading](https://github.com/user-attachments/assets/498256d8-d7af-451c-8d9e-5e6594bd2e7a) | ![flexibleCurveInSine](https://github.com/user-attachments/assets/f08ac760-0be7-4c2d-9779-01c74291dda6) | ![flexibleCurveOutSine](https://github.com/user-attachments/assets/34a89601-e90d-484e-b78e-9267d8a2c668) | ![flexibleCurveBounce](https://github.com/user-attachments/assets/6463ec76-b0a4-4513-ae53-e638603dc9f2) |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
