### PR TITLE
Fix random crash in Scaffold's persistent bottom sheet when popping a route

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2369,6 +2369,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
           if (_persistentSheetHistoryEntry == null) {
             _persistentSheetHistoryEntry = LocalHistoryEntry(
               onRemove: () {
+                if (!notification.context.mounted) return;
                 DraggableScrollableActuator.reset(notification.context);
                 showBodyScrim(false, 0.0);
                 _floatingActionButtonVisibilityController.value = 1.0;
@@ -2856,6 +2857,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   @protected
   @override
   void dispose() {
+    _persistentSheetHistoryEntry?.remove();
     _geometryNotifier.dispose();
     _floatingActionButtonMoveController.dispose();
     _floatingActionButtonVisibilityController.dispose();


### PR DESCRIPTION
This PR fixes a rare, random crash in Scaffold's persistent bottom sheet when popping a route. 
The crash occurs because `_persistentSheetHistoryEntry` is not removed on `dispose` and 
`notification.context` can be unmounted during `persistentBottomSheetExtentChanged`.

## Summary

This PR fixes a rare, random crash in Scaffold's persistent bottom sheet when popping a route.  The crash occurs because `_persistentSheetHistoryEntry` is not removed on `dispose` and  `notification.context` can be unmounted during `persistentBottomSheetExtentChanged`.

### Issue

Fixes #154067

### Changes

- In `ScaffoldState._maybeBuildPersistentBottomSheet`, added: ```if (!notification.context.mounted) return;```
- In `ScaffoldState.dispose`, added: ```dart _persistentSheetHistoryEntry?.remove();```

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
