### PR TITLE
Updates `sliver_tree.1.dart‎` to use `MediaQuery.widthOf(context)` 

### DIFF
--- a/examples/api/lib/widgets/sliver/sliver_tree.1.dart
+++ b/examples/api/lib/widgets/sliver/sliver_tree.1.dart
@@ -131,7 +131,7 @@ class _TreeSliverExampleState extends State<TreeSliverExample> {
   @override
   Widget build(BuildContext context) {
     // This example is assumes the full screen is available.
-    final double screenSizeWidth = MediaQuery.widthOf(context);
+    final double screenWidth = MediaQuery.widthOf(context);
     final List<Widget> selectedChildren = <Widget>[];
     if (_selectedNode != null) {
       selectedChildren.addAll(<Widget>[
@@ -146,14 +146,14 @@ class _TreeSliverExampleState extends State<TreeSliverExample> {
       body: Row(
         children: <Widget>[
           SizedBox(
-            width: screenSizeWidth / 2,
+            width: screenWidth / 2,
             height: double.infinity,
             child: CustomScrollView(slivers: <Widget>[_getTree()]),
           ),
           DecoratedBox(
             decoration: BoxDecoration(border: Border.all()),
             child: SizedBox(
-              width: screenSizeWidth / 2,
+              width: screenWidth / 2,
               height: double.infinity,
               child: Center(child: Column(children: selectedChildren)),
             ),

--- a/examples/api/lib/widgets/sliver/sliver_tree.1.dart
+++ b/examples/api/lib/widgets/sliver/sliver_tree.1.dart
@@ -131,7 +131,7 @@ class _TreeSliverExampleState extends State<TreeSliverExample> {
   @override
   Widget build(BuildContext context) {
     // This example is assumes the full screen is available.
-    final Size screenSize = MediaQuery.sizeOf(context);
+    final double screenSizeWidth = MediaQuery.sizeOf(context).width;
     final List<Widget> selectedChildren = <Widget>[];
     if (_selectedNode != null) {
       selectedChildren.addAll(<Widget>[
@@ -146,14 +146,14 @@ class _TreeSliverExampleState extends State<TreeSliverExample> {
       body: Row(
         children: <Widget>[
           SizedBox(
-            width: screenSize.width / 2,
+            width: screenSizeWidth / 2,
             height: double.infinity,
             child: CustomScrollView(slivers: <Widget>[_getTree()]),
           ),
           DecoratedBox(
             decoration: BoxDecoration(border: Border.all()),
             child: SizedBox(
-              width: screenSize.width / 2,
+              width: screenSizeWidth / 2,
               height: double.infinity,
               child: Center(child: Column(children: selectedChildren)),
             ),

--- a/examples/api/lib/widgets/sliver/sliver_tree.1.dart
+++ b/examples/api/lib/widgets/sliver/sliver_tree.1.dart
@@ -131,7 +131,7 @@ class _TreeSliverExampleState extends State<TreeSliverExample> {
   @override
   Widget build(BuildContext context) {
     // This example is assumes the full screen is available.
-    final double screenSizeWidth = MediaQuery.sizeOf(context).width;
+    final double screenSizeWidth = MediaQuery.widthOf(context);
     final List<Widget> selectedChildren = <Widget>[];
     if (_selectedNode != null) {
       selectedChildren.addAll(<Widget>[


### PR DESCRIPTION
this change updates `sliver_tree.1.dart`to use  `MediaQuery.widthOf(context)` directly instead of `MediaQuery.sizeOf(context)` then doing a `.size` .

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
