### PR TITLE
Fix computeDistanceToActualBaseline throws when accessing child size

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2262,6 +2262,7 @@ abstract class RenderBox extends RenderObject {
             !doingRegularLayout ||
             debugDoingThisResize ||
             debugDoingThisLayout ||
+            _debugDoingBaseline ||
             RenderObject.debugActiveLayout == parent && size._canBeUsedByParent;
         assert(
           sizeAccessAllowed,

--- a/packages/flutter/test/rendering/box_test.dart
+++ b/packages/flutter/test/rendering/box_test.dart
@@ -60,8 +60,8 @@ class InvalidSizeAccessInDryLayoutBox extends RenderBox {
   }
 }
 
-class BaselineSizeAccessRootRenderBox extends RenderProxyBox {
-  BaselineSizeAccessRootRenderBox({required RenderBox child}) : super(child);
+class _BaselineSizeAccessRootRenderBox extends RenderProxyBox {
+  _BaselineSizeAccessRootRenderBox({required RenderBox child}) : super(child);
 
   @override
   void performLayout() {
@@ -70,8 +70,8 @@ class BaselineSizeAccessRootRenderBox extends RenderProxyBox {
   }
 }
 
-class BaselineSizeAccessChildRenderBox extends RenderProxyBox {
-  BaselineSizeAccessChildRenderBox({required RenderBox child}) : super(child);
+class _BaselineSizeAccessChildRenderBox extends RenderProxyBox {
+  _BaselineSizeAccessChildRenderBox({required RenderBox child}) : super(child);
 
   @override
   double? computeDistanceToActualBaseline(TextBaseline baseline) {
@@ -290,8 +290,8 @@ void main() {
   // Regression test for https://github.com/flutter/flutter/issues/157915.
   test('Does not throw when accessing child size from computeDistanceToActualBaseline', () {
     final RenderBox leaf = RenderPadding(padding: const EdgeInsets.all(10.0));
-    final BaselineSizeAccessChildRenderBox child = BaselineSizeAccessChildRenderBox(child: leaf);
-    final BaselineSizeAccessRootRenderBox root = BaselineSizeAccessRootRenderBox(child: child);
+    final _BaselineSizeAccessChildRenderBox child = _BaselineSizeAccessChildRenderBox(child: leaf);
+    final _BaselineSizeAccessRootRenderBox root = _BaselineSizeAccessRootRenderBox(child: child);
 
     bool hadErrors = false;
     void expectSizeAccessErrors() {


### PR DESCRIPTION
## Description

This PR fixes an assertion triggered when accessing `RenderBox.size` during baseline computation.
See https://github.com/flutter/flutter/issues/157915#issuecomment-3387808748 for context.

## Related Issue

Fixes [Layout with ListTile -> subtitle -> InputDecorator -> Container (without child) throws RenderBox.size accessed beyond the scope of resize](https://github.com/flutter/flutter/issues/157915)
Fixes [DropdownButtonFormField triggers assertion when nested in InputDecorator](https://github.com/flutter/flutter/issues/176696#top)

## Tests

- Adds 1 test
