### PR TITLE
Added support for ios-min-version

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -201,8 +201,8 @@ class ConfigCommand extends FlutterCommand {
         globals.printStatus('Removing "ios-min-version" value.');
       } else {
         // Validate the version format (basic validation)
-        if (!RegExp(r'^\d+\.\d+$').hasMatch(iosMinVersion)) {
-          throwToolExit('ios-min-version must be in format "X.Y" (e.g., "13.0")');
+        if (!RegExp(r'^\d+(\.\d+){0,2}$').hasMatch(iosMinVersion)) {
+          throwToolExit('ios-min-version must be in a valid version format (e.g., "13.0")');
         }
         _updateConfig('ios-min-version', iosMinVersion);
       }

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -284,7 +284,7 @@ class CocoaPods {
     if (xcodeProject is IosProject) {
       // Get the iOS minimum version from config, defaulting to '13.0' if not set or empty
       final String? configValue = globals.config.getValue('ios-min-version') as String?;
-      final String iosMinVersion = (configValue?.isNotEmpty == true) ? configValue! : '13.0';
+      final String iosMinVersion = (configValue?.isNotEmpty == true) ? configValue! : '13.0'; // TODO: Use a constant for the default value
 
       // For iOS projects, replace the commented platform line with the configured version
       final String platformLine = "platform :ios, '$iosMinVersion'";


### PR DESCRIPTION
Refers to https://github.com/flutter/flutter/issues/176826

Added support for ios-min-version

For now (as per my knowledge) it sets the version number in iOS/Podfile . if it is set, the Podfile will use the version number supplied.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
