### PR TITLE
feat: Add `mainAxisExtent` parameter to `GridView` constructors

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -2056,6 +2056,7 @@ class GridView extends BoxScrollView {
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
     double childAspectRatio = 1.0,
+    double? mainAxisExtent,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
@@ -2072,6 +2073,7 @@ class GridView extends BoxScrollView {
          mainAxisSpacing: mainAxisSpacing,
          crossAxisSpacing: crossAxisSpacing,
          childAspectRatio: childAspectRatio,
+         mainAxisExtent: mainAxisExtent,
        ),
        childrenDelegate = SliverChildListDelegate(
          children,
@@ -2108,6 +2110,7 @@ class GridView extends BoxScrollView {
     double mainAxisSpacing = 0.0,
     double crossAxisSpacing = 0.0,
     double childAspectRatio = 1.0,
+    double? mainAxisExtent,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
     bool addSemanticIndexes = true,
@@ -2124,6 +2127,7 @@ class GridView extends BoxScrollView {
          mainAxisSpacing: mainAxisSpacing,
          crossAxisSpacing: crossAxisSpacing,
          childAspectRatio: childAspectRatio,
+         mainAxisExtent: mainAxisExtent,
        ),
        childrenDelegate = SliverChildListDelegate(
          children,

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -795,6 +795,54 @@ void main() {
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 
+  testWidgets('GridView.count respects mainAxisExtent', (WidgetTester tester) async {
+    const crossAxisCount = 4;
+    const mainAxisExtent = 100.0;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GridView.count(
+          crossAxisCount: crossAxisCount,
+          mainAxisExtent: mainAxisExtent,
+          children: List<Widget>.generate(20, (int i) {
+            return Builder(
+              builder: (BuildContext context) {
+                return Text('$i');
+              },
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.text('4')), equals(const Size(200.0, mainAxisExtent)));
+  });
+
+  testWidgets('GridView.extent respects mainAxisExtent', (WidgetTester tester) async {
+    const maxCrossAxisExtent = 200.0;
+    const mainAxisExtent = 100.0;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GridView.extent(
+          maxCrossAxisExtent: maxCrossAxisExtent,
+          mainAxisExtent: mainAxisExtent,
+          children: List<Widget>.generate(20, (int i) {
+            return Builder(
+              builder: (BuildContext context) {
+                return Text('$i');
+              },
+            );
+          }),
+        ),
+      ),
+    );
+
+    expect(tester.getSize(find.text('4')), equals(const Size(200.0, mainAxisExtent)));
+  });
+
   testWidgets('SliverGridDelegateWithFixedCrossAxisCount mainAxisExtent works as expected', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
Fixes #55290.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
