### PR TITLE
Removes built-in jpeg codec from iOS

### DIFF
--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -85,20 +85,6 @@ std::unique_ptr<Engine> CreateEngine(
                                   runtime_stage_backend);
 }
 
-void RegisterCodecsWithSkia() {
-  // These are in the order they will be attempted to be decoded from.
-  // If we have data to back it up, we can order these by "frequency used in
-  // the wild" for a very small performance bump, but for now we mirror the
-  // order Skia had them in.
-  SkCodecs::Register(SkPngDecoder::Decoder());
-  SkCodecs::Register(SkJpegDecoder::Decoder());
-  SkCodecs::Register(SkWebpDecoder::Decoder());
-  SkCodecs::Register(SkGifDecoder::Decoder());
-  SkCodecs::Register(SkBmpDecoder::Decoder());
-  SkCodecs::Register(SkWbmpDecoder::Decoder());
-  SkCodecs::Register(SkIcoDecoder::Decoder());
-}
-
 // Though there can be multiple shells, some settings apply to all components in
 // the process. These have to be set up before the shell or any of its
 // sub-components can be initialized. In a perfect world, this would be empty.
@@ -131,7 +117,6 @@ void PerformInitializationTasks(Settings& settings) {
     } else {
       FML_DLOG(INFO) << "Skia deterministic rendering is enabled.";
     }
-    RegisterCodecsWithSkia();
 
     if (settings.icu_initialization_required) {
       if (!settings.icu_data_path.empty()) {

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -469,7 +469,7 @@ def to_gn_args(args):
     gn_args['enable_unittests'] = False
 
   # Skia GN args.
-  if args.target_os == 'ios':
+  if args.target_os == 'ios' or (is_host_build(args) and get_host_os() == 'mac'):
     gn_args['skia_use_libjpeg_turbo_decode'] = False
     gn_args['skia_use_libjpeg_turbo_encode'] = False
   gn_args['skia_use_libpng_decode'] = True

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -469,6 +469,8 @@ def to_gn_args(args):
     gn_args['enable_unittests'] = False
 
   # Skia GN args.
+  if args.target_os == 'ios':
+    gn_args['skia_use_libjpeg_turbo_decode'] = False
   gn_args['skia_use_libpng_decode'] = True
   gn_args['skia_use_libpng_encode'] = True
   gn_args['skia_use_rust_png_decode'] = False

--- a/engine/src/flutter/tools/gn
+++ b/engine/src/flutter/tools/gn
@@ -471,6 +471,7 @@ def to_gn_args(args):
   # Skia GN args.
   if args.target_os == 'ios':
     gn_args['skia_use_libjpeg_turbo_decode'] = False
+    gn_args['skia_use_libjpeg_turbo_encode'] = False
   gn_args['skia_use_libpng_decode'] = True
   gn_args['skia_use_libpng_encode'] = True
   gn_args['skia_use_rust_png_decode'] = False


### PR DESCRIPTION
Partially addresses #144438

- Removes the RegisterCodecsWithSkia() function in shell.cc. This function is redundant because SkCodec.cpp already automatically registers all codecs that are included based on build rules.
- Updates the build rules so that the jpeg encoder and decoder is not included on iOS.