### PR TITLE
Implements uniform-by-name for web

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/painting.dart
@@ -993,13 +993,12 @@ abstract class FragmentProgram {
   FragmentShader fragmentShader();
 }
 
-base class UniformFloatSlot {
+abstract class UniformFloatSlot {
   UniformFloatSlot(this.name, this.index);
-  void set(double val) {
-    throw UnsupportedError('UniformFloatSlot is not supported on the web.');
-  }
 
-  int get shaderIndex => -1;
+  void set(double val);
+
+  int get shaderIndex;
 
   final String name;
 
@@ -1023,7 +1022,7 @@ abstract class FragmentShader implements Shader {
   @override
   bool get debugDisposed;
 
-  UniformFloatSlot getUniformFloat(String name, [int? index]) => UniformFloatSlot(name, index ?? 0);
+  UniformFloatSlot getUniformFloat(String name, [int? index]);
 
   ImageSamplerSlot getImageSampler(String name);
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -323,21 +323,36 @@ class CkFragmentProgram implements ui.FragmentProgram {
 
   @override
   ui.FragmentShader fragmentShader() {
-    return CkFragmentShader(name, effect, floatCount, textureCount);
+    return CkFragmentShader(name, effect, this);
+  }
+
+  int _getShaderIndex(String name, int index) {
+    int result = 0;
+    for (final uniform in uniforms) {
+      if (uniform.name == name) {
+        if (index < 0 || index >= uniform.floatCount) {
+          throw IndexError.withLength(index, uniform.floatCount);
+        }
+        break;
+      }
+      result += uniform.floatCount;
+    }
+    return result;
   }
 }
 
 class CkFragmentShader implements ui.FragmentShader, CkShader {
-  CkFragmentShader(this.name, this.effect, int floatCount, int textureCount)
-    : floats = mallocFloat32List(floatCount + textureCount * 2),
-      samplers = List<SkShader?>.filled(textureCount, null),
-      lastFloatIndex = floatCount;
+  CkFragmentShader(this.name, this.effect, this._program)
+    : floats = mallocFloat32List(_program.floatCount + _program.textureCount * 2),
+      samplers = List<SkShader?>.filled(_program.textureCount, null),
+      lastFloatIndex = _program.floatCount;
 
   final String name;
   final SkRuntimeEffect effect;
   final int lastFloatIndex;
   final SkFloat32List floats;
   final List<SkShader?> samplers;
+  final CkFragmentProgram _program;
 
   @visibleForTesting
   UniqueRef<SkShader>? ref;
@@ -404,11 +419,33 @@ class CkFragmentShader implements ui.FragmentShader, CkShader {
 
   @override
   ui.UniformFloatSlot getUniformFloat(String name, [int? index]) {
-    throw UnsupportedError('getUniformFloat is not supported on the web.');
+    index ??= 0;
+    final int shaderIndex = _program._getShaderIndex(name, index);
+    return CkUniformFloatSlot._(this, index, name, shaderIndex);
   }
 
   @override
   ui.ImageSamplerSlot getImageSampler(String name) {
     throw UnsupportedError('getImageSampler is not supported on the web.');
   }
+}
+
+class CkUniformFloatSlot implements ui.UniformFloatSlot {
+  CkUniformFloatSlot._(this._shader, this.index, this.name, this.shaderIndex);
+
+  final CkFragmentShader _shader;
+
+  @override
+  final int index;
+
+  @override
+  final String name;
+
+  @override
+  void set(double val) {
+    _shader.setFloat(shaderIndex, val);
+  }
+
+  @override
+  final int shaderIndex;
 }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -333,6 +333,7 @@ class CkFragmentProgram implements ui.FragmentProgram {
         if (index < 0 || index >= uniform.floatCount) {
           throw IndexError.withLength(index, uniform.floatCount);
         }
+        result += index;
         break;
       }
       result += uniform.floatCount;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/shader_data.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/shader_data.dart
@@ -52,6 +52,7 @@ class ShaderData {
       if (type == null) {
         throw const FormatException('Invalid Shader Data');
       }
+      int uniformFloatCount = 0;
       if (type == UniformType.SampledImage) {
         textureCount += 1;
       } else {
@@ -67,15 +68,20 @@ class ShaderData {
 
         final int units = rows * columns;
 
-        int value = (bitWidth ~/ 32) * units;
+        uniformFloatCount = (bitWidth ~/ 32) * units;
 
         if (arrayElements > 1) {
-          value *= arrayElements;
+          uniformFloatCount *= arrayElements;
         }
 
-        floatCount += value;
+        floatCount += uniformFloatCount;
       }
-      uniforms[i] = UniformData(name: name, location: location, type: type);
+      uniforms[i] = UniformData(
+        name: name,
+        location: location,
+        type: type,
+        floatCount: uniformFloatCount,
+      );
     }
     return ShaderData(
       source: source,
@@ -92,13 +98,24 @@ class ShaderData {
 }
 
 class UniformData {
-  const UniformData({required this.name, required this.location, required this.type});
+  const UniformData({
+    required this.name,
+    required this.location,
+    required this.type,
+    required this.floatCount,
+  });
 
   final String name;
   final UniformType type;
   final int location;
+  final int floatCount;
 
-  static const UniformData empty = UniformData(name: '', location: -1, type: UniformType.Float);
+  static const UniformData empty = UniformData(
+    name: '',
+    location: -1,
+    type: UniformType.Float,
+    floatCount: -1,
+  );
 }
 
 enum UniformType {

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -257,6 +257,7 @@ class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
         if (index < 0 || index >= uniform.floatCount) {
           throw IndexError.withLength(index, uniform.floatCount);
         }
+        result += index;
         break;
       }
       result += uniform.floatCount;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/skwasm/skwasm_impl/shaders.dart
@@ -215,11 +215,8 @@ class SkwasmImageShader extends SkwasmNativeShader implements ui.ImageShader {
 
 class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
     implements ui.FragmentProgram {
-  SkwasmFragmentProgram._(
-    this.name,
-    RuntimeEffectHandle handle,
-    this._shaderData,
-  ) : super(handle, _registry);
+  SkwasmFragmentProgram._(this.name, RuntimeEffectHandle handle, this._shaderData)
+    : super(handle, _registry);
 
   factory SkwasmFragmentProgram.fromBytes(String name, Uint8List bytes) {
     final ShaderData shaderData = ShaderData.fromBytes(bytes);
@@ -252,7 +249,7 @@ class SkwasmFragmentProgram extends SkwasmObjectWrapper<RawRuntimeEffect>
   ui.FragmentShader fragmentShader() => SkwasmFragmentShader(this);
 
   int get uniformSize => runtimeEffectGetUniformSize(handle);
-  
+
   int _getShaderIndex(String name, int index) {
     int result = 0;
     for (final uniform in _shaderData.uniforms) {

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -327,6 +327,9 @@ void testMain() {
         isNot(same(skShader2)),
       );
 
+      final ui.UniformFloatSlot slot = shader.getUniformFloat('u_rotation1');
+      expect(slot.shaderIndex, equals(2));
+
       shader.dispose();
       expect(shader.debugDisposed, true);
       expect(

--- a/engine/src/flutter/lib/web_ui/test/canvaskit/fragment_program_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/canvaskit/fragment_program_test.dart
@@ -327,8 +327,8 @@ void testMain() {
         isNot(same(skShader2)),
       );
 
-      final ui.UniformFloatSlot slot = shader.getUniformFloat('u_rotation1');
-      expect(slot.shaderIndex, equals(2));
+      final ui.UniformFloatSlot slot = shader.getUniformFloat('u_rotation1', 1);
+      expect(slot.shaderIndex, equals(3));
 
       shader.dispose();
       expect(shader.debugDisposed, true);


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/176417 (for web)

Now on the web the `FragmentShader.getUniformFloat(String name, [int? index])` can be used.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
