### PR TITLE
[Android 16] Update `android_engine_vulkan_tests` to Test Against SDK 36 Emulator

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -73,28 +73,7 @@ platform_properties:
         [
           {"dependency": "android_sdk", "version": "version:36v3"},
           {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8719362231152674241"},
-          {"dependency": "open_jdk", "version": "version:21"}
-        ]
-      os: Ubuntu
-      cores: "8"
-      device_type: none
-      kvm: "1"
-
-  # linux_android_emu_vulkan_stable temporarily depends on an API 35 AVD while all
-  # other linux_android_emu test targets depend on an API 36 AVD due to a potential issue with
-  # virtual display on API 36: https://github.com/flutter/flutter/issues/170024.
-  linux_android_emu_vulkan_stable:
-    properties:
-      contexts: >-
-        [
-          "android_virtual_device"
-        ]
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v3"},
-          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8701084295319811169"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Ubuntu
@@ -1688,8 +1667,9 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux_android_emu_vulkan_stable android_engine_vulkan_tests
+  - name: Linux_android_emu_unstable android_engine_vulkan_tests
     recipe: flutter/flutter_drone
+    bringup: true
     timeout: 60
     properties:
       shard: android_engine_vulkan_tests

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -73,28 +73,7 @@ platform_properties:
         [
           {"dependency": "android_sdk", "version": "version:36v3"},
           {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8719362231152674241"},
-          {"dependency": "open_jdk", "version": "version:21"}
-        ]
-      os: Ubuntu
-      cores: "8"
-      device_type: none
-      kvm: "1"
-
-  # linux_android_emu_vulkan_stable temporarily depends on an API 35 AVD while all
-  # other linux_android_emu test targets depend on an API 36 AVD due to a potential issue with
-  # virtual display on API 36: https://github.com/flutter/flutter/issues/170024.
-  linux_android_emu_vulkan_stable:
-    properties:
-      contexts: >-
-        [
-          "android_virtual_device"
-        ]
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:36v3"},
-          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8701084295319811169"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Ubuntu
@@ -1688,7 +1667,7 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux_android_emu_vulkan_stable android_engine_vulkan_tests
+  - name: Linux_android_emu_unstable android_engine_vulkan_tests
     recipe: flutter/flutter_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1669,6 +1669,7 @@ targets:
 
   - name: Linux_android_emu_unstable android_engine_vulkan_tests
     recipe: flutter/flutter_drone
+    bringup: true
     timeout: 60
     properties:
       shard: android_engine_vulkan_tests


### PR DESCRIPTION
Update `android_engine_vulkan_tests` to test against a system image and an AVD that supports Android 16. With that all android tests in CI test against a 36 emulator. 

`android_engine_vulkan_tests` will dogfood the `Linux_android_emu_unstable` configurations, including the latest from https://chrome-infra-packages.appspot.com/p/chromium/tools/android/avd/linux-amd64 . If there are no flakes after around ~200 commits, then I will update `Linux_android_emu` with `Linux_android_emu_unstable` configs.

Fixes https://github.com/flutter/flutter/issues/170024
Partially Addresses https://github.com/flutter/flutter/issues/163071

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
