### PR TITLE
Make sure that a NavigationRail doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -6127,6 +6127,24 @@ void main() {
       expect(updatedWidthRTL, defaultWidth + safeAreaPadding);
     });
   }); // End Material 2 group
+
+  testWidgets('NavigationRail does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: NavigationRail(
+              destinations: const <NavigationRailDestination>[
+                NavigationRailDestination(icon: Icon(Icons.abc), label: Text('X')),
+              ],
+              selectedIndex: 0,
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(NavigationRail)), Size.zero);
+  });
 }
 
 TestSemantics _expectedSemantics({bool scrollable = false}) {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the NavigationRail widget.