### PR TITLE
Fix Popup menu Semantics label for mismatched platforms

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1192,7 +1192,7 @@ Future<T?> showMenu<T>({
     'Either position or positionBuilder must be provided.',
   );
 
-  switch (Theme.of(context).platform) {
+  switch (defaultTargetPlatform) {
     case TargetPlatform.iOS:
     case TargetPlatform.macOS:
       break;

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4852,18 +4852,17 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/177003
-  testWidgets(
-    'PopupMenu should have a null semantic label by default on Apple platforms',
-    (WidgetTester tester) async {
-      // When someone sets theme.platform to TargetPlatform.android on an Apple device,
-      // assistive technology like VoiceOver should work correctly by having
-      // a null semantics label value by default.
-
+  group('PopupMenu semantics label for mismatched platforms', () {
+    Future<void> testPopupMenuSemanticsLabel({
+      required WidgetTester tester,
+      required TargetPlatform themePlatform,
+      required Matcher expected,
+    }) async {
       const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
       await tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.android),
+          theme: ThemeData(platform: themePlatform),
           home: Scaffold(
             body: Builder(
               builder: (BuildContext context) {
@@ -4887,59 +4886,47 @@ void main() {
       await tester.pumpAndSettle();
 
       final Finder popupFinder = find.bySemanticsLabel(localizations.popupMenuLabel);
-      expect(popupFinder, findsNothing);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.iOS,
-      TargetPlatform.macOS,
-    }),
-  );
+      expect(popupFinder, expected);
+    }
 
-  // Regression test for https://github.com/flutter/flutter/issues/177003
-  testWidgets(
-    'PopupMenu should have a non-null semantic label by default on non-Apple platforms',
-    (WidgetTester tester) async {
-      // When someone sets theme.platform to TargetPlatform.iOS on a non-Apple device,
-      // assistive technologies (Talk Back/NVDA/JAWS...) should work correctly
-      // by having a non-null semantics label value by default.
+    testWidgets(
+      'Semantics label is null by default on Apple platforms',
+      (WidgetTester tester) async {
+        // When someone sets theme.platform to TargetPlatform.android on an Apple device,
+        // assistive technology like VoiceOver should work correctly by having
+        // a null semantics label value by default.
+        await testPopupMenuSemanticsLabel(
+          tester: tester,
+          themePlatform: TargetPlatform.android,
+          expected: findsNothing,
+        );
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{
+        TargetPlatform.iOS,
+        TargetPlatform.macOS,
+      }),
+    );
 
-      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
-
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: TargetPlatform.iOS),
-          home: Scaffold(
-            body: Builder(
-              builder: (BuildContext context) {
-                return OutlinedButton(
-                  onPressed: () {
-                    showMenu<void>(
-                      context: context,
-                      position: RelativeRect.fill,
-                      items: const <PopupMenuItem<void>>[PopupMenuItem<void>(child: Text('foo'))],
-                    );
-                  },
-                  child: const Text('open'),
-                );
-              },
-            ),
-          ),
-        ),
-      );
-
-      await tester.tap(find.text('open'));
-      await tester.pumpAndSettle();
-
-      final Finder popupFinder = find.bySemanticsLabel(localizations.popupMenuLabel);
-      expect(popupFinder, findsOneWidget);
-    },
-    variant: const TargetPlatformVariant(<TargetPlatform>{
-      TargetPlatform.android,
-      TargetPlatform.fuchsia,
-      TargetPlatform.linux,
-      TargetPlatform.windows,
-    }),
-  );
+    testWidgets(
+      'Semantics label is non-null by default on non-Apple platforms',
+      (WidgetTester tester) async {
+        // When someone sets theme.platform to TargetPlatform.iOS on a non-Apple device,
+        // assistive technologies (Talk Back/NVDA/JAWS...) should work correctly
+        // by having a non-null semantics label value by default.
+        await testPopupMenuSemanticsLabel(
+          tester: tester,
+          themePlatform: TargetPlatform.iOS,
+          expected: findsOneWidget,
+        );
+      },
+      variant: const TargetPlatformVariant(<TargetPlatform>{
+        TargetPlatform.android,
+        TargetPlatform.fuchsia,
+        TargetPlatform.linux,
+        TargetPlatform.windows,
+      }),
+    );
+  });
 }
 
 Matcher overlaps(Rect other) => OverlapsMatcher(other);

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -4850,6 +4850,96 @@ void main() {
 
     checkPopupMenu(popupMenuTheme2);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177003
+  testWidgets(
+    'PopupMenu should have a null semantic label by default on Apple platforms',
+    (WidgetTester tester) async {
+      // When someone sets theme.platform to TargetPlatform.android on an Apple device,
+      // assistive technology like VoiceOver should work correctly by having
+      // a null semantics label value by default.
+
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return OutlinedButton(
+                  onPressed: () {
+                    showMenu<void>(
+                      context: context,
+                      position: RelativeRect.fill,
+                      items: const <PopupMenuItem<void>>[PopupMenuItem<void>(child: Text('foo'))],
+                    );
+                  },
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final Finder popupFinder = find.bySemanticsLabel(localizations.popupMenuLabel);
+      expect(popupFinder, findsNothing);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.iOS,
+      TargetPlatform.macOS,
+    }),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/177003
+  testWidgets(
+    'PopupMenu should have a non-null semantic label by default on non-Apple platforms',
+    (WidgetTester tester) async {
+      // When someone sets theme.platform to TargetPlatform.iOS on a non-Apple device,
+      // assistive technologies (Talk Back/NVDA/JAWS...) should work correctly
+      // by having a non-null semantics label value by default.
+
+      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.iOS),
+          home: Scaffold(
+            body: Builder(
+              builder: (BuildContext context) {
+                return OutlinedButton(
+                  onPressed: () {
+                    showMenu<void>(
+                      context: context,
+                      position: RelativeRect.fill,
+                      items: const <PopupMenuItem<void>>[PopupMenuItem<void>(child: Text('foo'))],
+                    );
+                  },
+                  child: const Text('open'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      final Finder popupFinder = find.bySemanticsLabel(localizations.popupMenuLabel);
+      expect(popupFinder, findsOneWidget);
+    },
+    variant: const TargetPlatformVariant(<TargetPlatform>{
+      TargetPlatform.android,
+      TargetPlatform.fuchsia,
+      TargetPlatform.linux,
+      TargetPlatform.windows,
+    }),
+  );
 }
 
 Matcher overlaps(Rect other) => OverlapsMatcher(other);


### PR DESCRIPTION
- Address a partial issue within https://github.com/flutter/flutter/issues/176566
- Fix  https://github.com/flutter/flutter/issues/177003
- In this PR:
    - proposes using `defaultTargetPlatform` instead of platform from theme for Semantics label in _PopupMenu widget  
    -  add some new tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
