### PR TITLE
Fix create_updated_flutter_deps.py

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -282,9 +282,6 @@ deps = {
   'engine/src/flutter/third_party/boringssl/src':
   'https://boringssl.googlesource.com/boringssl.git' + '@' + Var('dart_boringssl_rev'),
 
-  'engine/src/flutter/third_party/dart/third_party/perfetto/src':
-   Var('flutter_git') + "/third_party/perfetto" + '@' + Var('dart_perfetto_rev'),
-
   'engine/src/flutter/third_party/protobuf':
    Var('flutter_git') + '/third_party/protobuf' + '@' + Var('dart_libprotobuf_rev'),
 
@@ -303,6 +300,9 @@ deps = {
 
   'engine/src/flutter/third_party/dart/third_party/devtools':
    {'dep_type': 'cipd', 'packages': [{'package': 'dart/third_party/flutter/devtools', 'version': 'git_revision:0327830448901920f739259364c3f2f624df5a03'}]},
+
+  'engine/src/flutter/third_party/dart/third_party/perfetto/src':
+   Var('flutter_git') + "/third_party/perfetto" + '@' + Var('dart_perfetto_rev'),
 
   'engine/src/flutter/third_party/dart/third_party/pkg/ai':
    Var('dart_git') + '/ai.git' + '@' + Var('dart_ai_rev'),

--- a/engine/src/tools/dart/create_updated_flutter_deps.py
+++ b/engine/src/tools/dart/create_updated_flutter_deps.py
@@ -115,6 +115,13 @@ def Main(argv):
                 updated_value = dart_v.replace(new_vars["dart_git"], "Var('dart_git') + '/")
                 updated_value = updated_value.replace(old_vars["chromium_git"], "Var('chromium_git') + '")
 
+                # We are aiming to produce a quoted string. The code below
+                # will add a closing ', however if we did not collapse dart_git
+                # or chromium_git paths into a Var(...) ref we need to add
+                # an opening '.
+                if updated_value == dart_v:
+                  updated_value = "'" + updated_value
+
                 plain_v = dart_k[dart_k.rfind('/') + 1:]
                 # This dependency has to be special-cased here because the
                 # repository name is not the same as the directory name.


### PR DESCRIPTION
1. Make sure that perfetto dependency is in Dart section. If it is in the wrong section the script duplicates it.
2. Fix the logic in the script which produced incorrectly quoted strings.

I am not entirely sure who still uses this script. Dart monorepo has a custom copy, which I am going to fix as well. 