### PR TITLE
[a11y] fix table semantics cache for cells 

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1555,8 +1555,24 @@ class RenderTable extends RenderBox {
 }
 
 /// Index for a cell.
+@immutable
 class _Index {
-  _Index(this.y, this.x);
-  int y;
-  int x;
+  const _Index(this.y, this.x);
+  final int y;
+  final int x;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    if (other is! _Index) {
+      return false;
+    }
+    final _Index otherIndex = other;
+    return y == otherIndex.y && x == otherIndex.x;
+  }
+
+  @override
+  int get hashCode => Object.hash(y, x);
 }

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1569,8 +1569,7 @@ class _Index {
     if (other is! _Index) {
       return false;
     }
-    final _Index otherIndex = other;
-    return y == otherIndex.y && x == otherIndex.x;
+    return y == other.y && x == other.x;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -722,14 +722,17 @@ class RenderTable extends RenderBox {
             (rawChildrens.single.role != SemanticsRole.cell &&
                 rawChildrens.single.role != SemanticsRole.columnHeader);
 
-        final SemanticsNode cell = addCellWrapper
-            ? (_cachedCells[_Index(y, x)] ??
-                  (_cachedCells[_Index(y, x)] = SemanticsNode()
-                    ..updateWith(
-                      config: SemanticsConfiguration()..role = SemanticsRole.cell,
-                      childrenInInversePaintOrder: rawChildrens,
-                    )))
-            : rawChildrens.single;
+        late final SemanticsNode cell;
+        if (!addCellWrapper) {
+          cell = rawChildrens.single;
+        } else {
+          final _Index index = _Index(y, x);
+          cell = _cachedCells.putIfAbsent(index, () => SemanticsNode())
+            ..updateWith(
+              config: SemanticsConfiguration()..role = SemanticsRole.cell,
+              childrenInInversePaintOrder: rawChildrens,
+            );
+        }
 
         final double cellWidth = x == _columns - 1
             ? rowBox.width - _columnLefts!.elementAt(x)

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -1027,8 +1027,6 @@ void main() {
   });
 
   testWidgets('Table reuse the semantics nodes for cell wrappers', (WidgetTester tester) async {
-    final SemanticsTester semantics = SemanticsTester(tester);
-
     final FocusNode focusNode = FocusNode();
     addTearDown(focusNode.dispose);
     await tester.pumpWidget(
@@ -1059,7 +1057,5 @@ void main() {
 
     final int? cellWrapperIdAfterUIchanges = textFieldSemanticsNodeNew.parent?.id;
     expect(cellWrapperIdAfterUIchanges, cellWrapperId);
-
-    semantics.dispose();
   });
 }

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -1025,4 +1025,41 @@ void main() {
 
     semantics.dispose();
   });
+
+  testWidgets('Table reuse the semantics nodes for cell wrappers', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+
+    final FocusNode focusNode = FocusNode();
+    addTearDown(focusNode.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Table(
+            children: <TableRow>[
+              TableRow(children: <Widget>[TextField(focusNode: focusNode)]),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final SemanticsNode textFieldSemanticsNode = find.semantics
+        .byFlag(SemanticsFlag.isTextField)
+        .evaluate()
+        .first;
+    final int? cellWrapperId = textFieldSemanticsNode.parent?.id;
+
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+
+    final SemanticsNode textFieldSemanticsNodeNew = find.semantics
+        .byFlag(SemanticsFlag.isTextField)
+        .evaluate()
+        .first;
+
+    final int? cellWrapperIdAfterUIchanges = textFieldSemanticsNodeNew.parent?.id;
+    expect(cellWrapperIdAfterUIchanges, cellWrapperId);
+
+    semantics.dispose();
+  });
 }


### PR DESCRIPTION
will fix https://github.com/flutter/flutter/issues/170575 
The issue is caused by: 

when caching the cell wrapper semantics nodes in table, it's using cell index to cache them in a map. But the cell index class was not set to immutable and override the `==`, so the cache logic was wrong, they were always creating new semantics nodes for cell wrapper. 

fixing this by fixing the index class to an immutable value type with proper == and hashCode




## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
