### PR TITLE
Fix DateRangePickerDialog does not inherit local InputDecorationTheme

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -3436,7 +3436,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     final ThemeData theme = Theme.of(context);
     final bool useMaterial3 = theme.useMaterial3;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
-    final InputDecorationThemeData inputTheme = theme.inputDecorationTheme;
+    final InputDecorationThemeData inputTheme = InputDecorationTheme.of(context);
     final InputBorder inputBorder =
         inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1980,6 +1980,31 @@ void main() {
     );
     expect(tester.getSize(find.byType(DateRangePickerDialog)), Size.zero);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177083.
+  testWidgets('Local InputDecorationTheme is honored', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: InputDecorationTheme(
+            data: const InputDecorationThemeData(filled: true),
+            child: DateRangePickerDialog(
+              firstDate: firstDate,
+              lastDate: lastDate,
+              currentDate: DateTime(2016, DateTime.january, 30),
+              initialEntryMode: DatePickerEntryMode.inputOnly,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final InputDecoration startDateDecoration = tester
+        .widget<TextField>(find.byType(TextField).first)
+        .decoration!;
+
+    expect(startDateDecoration.filled, isTrue);
+  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {


### PR DESCRIPTION
## Description

This PR replaces global `ThemeData.inputDecorationTheme` usage in `DateRangePickerDialog` with `InputDecorationTheme.of ` which returns the ambient `InputDecorationTheme`.
It is a follow up to https://github.com/flutter/flutter/pull/168981 which introduces `InputDecorationTheme.of `.

## Related Issue

Fixes  [DateRangePickerDialog does not inherit local InputDecorationTheme](https://github.com/flutter/flutter/issues/177083)

## Tests

- Adds 1 test
