### PR TITLE
Fix InputDatePickerFormField does not inherit local InputDecorationTheme

### DIFF
--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -259,10 +259,10 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
     final bool useMaterial3 = theme.useMaterial3;
     final MaterialLocalizations localizations = MaterialLocalizations.of(context);
     final DatePickerThemeData datePickerTheme = theme.datePickerTheme;
-    final InputDecorationThemeData inputTheme = theme.inputDecorationTheme;
+    final InputDecorationThemeData inputTheme = InputDecorationTheme.of(context);
     final InputBorder effectiveInputBorder =
         datePickerTheme.inputDecorationTheme?.border ??
-        theme.inputDecorationTheme.border ??
+        inputTheme.border ??
         (useMaterial3 ? const OutlineInputBorder() : const UnderlineInputBorder());
 
     return Semantics(

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -522,6 +522,28 @@ void main() {
     );
     expect(tester.getSize(find.byType(InputDatePickerFormField)), Size.zero);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177088.
+  testWidgets('Local InputDecorationTheme is honored', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: InputDecorationTheme(
+              data: const InputDecorationThemeData(filled: true),
+              child: InputDatePickerFormField(
+                firstDate: DateTime(2025, DateTime.february),
+                lastDate: DateTime(2026, DateTime.may),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final InputDecoration decoration = tester.widget<TextField>(find.byType(TextField)).decoration!;
+    expect(decoration.filled, isTrue);
+  });
 }
 
 class TestCalendarDelegate extends GregorianCalendarDelegate {


### PR DESCRIPTION
## Description

This PR replaces global `ThemeData.inputDecorationTheme` usage in `InputDatePickerFormField` with `InputDecorationTheme.of ` which returns the ambient `InputDecorationTheme`.
It is a follow up to https://github.com/flutter/flutter/pull/168981 which introduces `InputDecorationTheme.of `.

## Related Issue

Fixes  [InputDatePickerFormField does not inherit local InputDecorationTheme](https://github.com/flutter/flutter/issues/177088)

## Tests

- Adds 1 test
