### PR TITLE
Fix drawer Semantics for mismatched platforms

### DIFF
--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -14,6 +14,7 @@
 /// @docImport 'scaffold.dart';
 library;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/widgets.dart';
 
@@ -250,7 +251,7 @@ class Drawer extends StatelessWidget {
     assert(debugCheckHasMaterialLocalizations(context));
     final DrawerThemeData drawerTheme = DrawerTheme.of(context);
     String? label = semanticLabel;
-    switch (Theme.of(context).platform) {
+    switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         break;
@@ -685,7 +686,7 @@ class DrawerControllerState extends State<DrawerController> with SingleTickerPro
       }
     } else {
       final bool platformHasBackButton;
-      switch (Theme.of(context).platform) {
+      switch (defaultTargetPlatform) {
         case TargetPlatform.android:
           platformHasBackButton = true;
         case TargetPlatform.iOS:

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -970,15 +970,12 @@ void main() {
   );
 
   // Regression test for https://github.com/flutter/flutter/issues/177005
-  group('Drawer semantics label for mismatched platforms', () {
-    Future<void> testDrawerSemanticsLabel({
+  group('Drawer semantics for mismatched platforms', () {
+    Future<void> pumpDrawer({
       required WidgetTester tester,
       required TargetPlatform themePlatform,
-      required Matcher expected,
     }) async {
-      const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
       final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-
       await tester.pumpWidget(
         MaterialApp(
           theme: ThemeData(platform: themePlatform),
@@ -989,139 +986,133 @@ void main() {
           ),
         ),
       );
-
       expect(find.text('Drawer'), findsNothing);
 
       scaffoldKey.currentState!.openDrawer();
       await tester.pumpAndSettle();
       expect(find.text('Drawer'), findsOneWidget);
-
-      final Finder popupFinder = find.bySemanticsLabel(localizations.drawerLabel);
-      expect(popupFinder, expected);
     }
 
-    testWidgets(
-      'Semantics label is null by default on Apple platforms',
-      (WidgetTester tester) async {
-        // When someone sets theme.platform to TargetPlatform.android on an Apple device,
-        // assistive technology like VoiceOver should work correctly by having
-        // a null semantics label value by default.
-        await testDrawerSemanticsLabel(
-          tester: tester,
-          themePlatform: TargetPlatform.android,
-          expected: findsNothing,
-        );
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{
-        TargetPlatform.iOS,
-        TargetPlatform.macOS,
-      }),
-    );
-
-    testWidgets(
-      'Semantics label is non-null by default on non-Apple platforms',
-      (WidgetTester tester) async {
-        // When someone sets theme.platform to TargetPlatform.iOS on a non-Apple device,
-        // assistive technologies (Talk Back/NVDA/JAWS...) should work correctly
-        // by having a non-null semantics label value by default.
-        await testDrawerSemanticsLabel(
-          tester: tester,
-          themePlatform: TargetPlatform.iOS,
-          expected: findsOneWidget,
-        );
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{
-        TargetPlatform.android,
-        TargetPlatform.fuchsia,
-        TargetPlatform.linux,
-        TargetPlatform.windows,
-      }),
-    );
-  });
-
-  // Regression test for https://github.com/flutter/flutter/issues/177005
-  group('Drawer barrier semantics for mismatched platforms', () {
-    Future<void> testDrawerSemanticsBarrier({
-      required WidgetTester tester,
-      required TargetPlatform themePlatform,
-      required Matcher expected,
-    }) async {
-      final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
-      final SemanticsTester semantics = SemanticsTester(tester);
-
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(platform: themePlatform),
-          home: Scaffold(
-            key: scaffoldKey,
-            drawer: const Drawer(child: Text('Drawer')),
-            body: Container(),
-          ),
-        ),
-      );
-
-      expect(find.text('Drawer'), findsNothing);
-
-      scaffoldKey.currentState!.openDrawer();
-      await tester.pumpAndSettle();
-      expect(find.text('Drawer'), findsOneWidget);
-
-      expect(semantics, expected);
-
-      semantics.dispose();
-    }
-
-    testWidgets(
-      'Barrier is excluded from semantics on Android platform',
-      (WidgetTester tester) async {
-        // When theme.platform is set to iOS but the real device is Android,
-        // the barrier should be excluded from semantics because Android
-        // user may use the hardware back button to dismiss the modal.
+    group('Semantics label', () {
+      Future<void> testDrawerSemanticsLabel({
+        required WidgetTester tester,
+        required TargetPlatform themePlatform,
+        required Matcher expected,
+      }) async {
         const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
-        // The barrier should NOT have the dismiss label in semantics
-        // because it's excluded on Android.
-        await testDrawerSemanticsBarrier(
-          tester: tester,
-          themePlatform: TargetPlatform.iOS,
-          expected: isNot(
-            includesNodeWith(
-              label: localizations.modalBarrierDismissLabel,
-              actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+        await pumpDrawer(tester: tester, themePlatform: themePlatform);
+
+        final Finder popupFinder = find.bySemanticsLabel(localizations.drawerLabel);
+        expect(popupFinder, expected);
+      }
+
+      testWidgets(
+        'Semantics label is null by default on Apple platforms',
+        (WidgetTester tester) async {
+          // When someone sets theme.platform to TargetPlatform.android on an Apple device,
+          // assistive technology like VoiceOver should work correctly by having
+          // a null semantics label value by default.
+          await testDrawerSemanticsLabel(
+            tester: tester,
+            themePlatform: TargetPlatform.android,
+            expected: findsNothing,
+          );
+        },
+        variant: const TargetPlatformVariant(<TargetPlatform>{
+          TargetPlatform.iOS,
+          TargetPlatform.macOS,
+        }),
+      );
+
+      testWidgets(
+        'Semantics label is non-null by default on non-Apple platforms',
+        (WidgetTester tester) async {
+          // When someone sets theme.platform to TargetPlatform.iOS on a non-Apple device,
+          // assistive technologies (Talk Back/NVDA/JAWS...) should work correctly
+          // by having a non-null semantics label value by default.
+          await testDrawerSemanticsLabel(
+            tester: tester,
+            themePlatform: TargetPlatform.iOS,
+            expected: findsOneWidget,
+          );
+        },
+        variant: const TargetPlatformVariant(<TargetPlatform>{
+          TargetPlatform.android,
+          TargetPlatform.fuchsia,
+          TargetPlatform.linux,
+          TargetPlatform.windows,
+        }),
+      );
+    });
+
+    group('Semantics barrier', () {
+      Future<void> testDrawerSemanticsBarrier({
+        required WidgetTester tester,
+        required TargetPlatform themePlatform,
+        required Matcher expected,
+      }) async {
+        final SemanticsTester semantics = SemanticsTester(tester);
+
+        await pumpDrawer(tester: tester, themePlatform: themePlatform);
+
+        expect(semantics, expected);
+
+        semantics.dispose();
+      }
+
+      testWidgets(
+        'Barrier is excluded from semantics on Android platform',
+        (WidgetTester tester) async {
+          // When theme.platform is set to iOS but the real device is Android,
+          // the barrier should be excluded from semantics because Android
+          // user may use the hardware back button to dismiss the modal.
+          const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+
+          // The barrier should NOT have the dismiss label in semantics
+          // because it's excluded on Android.
+          await testDrawerSemanticsBarrier(
+            tester: tester,
+            themePlatform: TargetPlatform.iOS,
+            expected: isNot(
+              includesNodeWith(
+                label: localizations.modalBarrierDismissLabel,
+                actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.focus],
+              ),
             ),
-          ),
-        );
-      },
-      variant: TargetPlatformVariant.only(TargetPlatform.android),
-    );
+          );
+        },
+        variant: TargetPlatformVariant.only(TargetPlatform.android),
+      );
 
-    testWidgets(
-      'Barrier is included in semantics on non-Android platforms',
-      (WidgetTester tester) async {
-        // When theme.platform is set to Android but the real device is non-Android,
-        // the barrier should be included in semantics because these platforms
-        // don't have a hardware back button and need the semantic information.
-        const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
+      testWidgets(
+        'Barrier is included in semantics on non-Android platforms',
+        (WidgetTester tester) async {
+          // When theme.platform is set to Android but the real device is non-Android,
+          // the barrier should be included in semantics because these platforms
+          // don't have a hardware back button and need the semantic information.
+          const DefaultMaterialLocalizations localizations = DefaultMaterialLocalizations();
 
-        // The barrier SHOULD have the dismiss label in semantics
-        // because it's not excluded on non-Android platforms.
-        await testDrawerSemanticsBarrier(
-          tester: tester,
-          themePlatform: TargetPlatform.android,
-          expected: includesNodeWith(
-            label: localizations.modalBarrierDismissLabel,
-            actions: <SemanticsAction>[SemanticsAction.tap],
-          ),
-        );
-      },
-      variant: const TargetPlatformVariant(<TargetPlatform>{
-        TargetPlatform.iOS,
-        TargetPlatform.macOS,
-        TargetPlatform.fuchsia,
-        TargetPlatform.linux,
-        TargetPlatform.windows,
-      }),
-    );
+          // The barrier SHOULD have the dismiss label in semantics
+          // because it's not excluded on non-Android platforms.
+          await testDrawerSemanticsBarrier(
+            tester: tester,
+            themePlatform: TargetPlatform.android,
+            expected: includesNodeWith(
+              label: localizations.modalBarrierDismissLabel,
+              actions: <SemanticsAction>[SemanticsAction.tap],
+            ),
+          );
+        },
+        variant: const TargetPlatformVariant(<TargetPlatform>{
+          TargetPlatform.iOS,
+          TargetPlatform.macOS,
+          TargetPlatform.fuchsia,
+          TargetPlatform.linux,
+          TargetPlatform.windows,
+        }),
+      );
+    });
   });
 
   group('Material 2', () {


### PR DESCRIPTION
- Address a partial issue within https://github.com/flutter/flutter/issues/176566
- Fix  https://github.com/flutter/flutter/issues/177005
- In this PR:
    - proposes using `defaultTargetPlatform` instead of platform from theme for Semantics label in Drawer widget  
    -  add some new tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
