### PR TITLE
Handle the new location of Perfetto in create_updated_flutter_deps.py

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -8,6 +8,7 @@
 # to list the dependency's destination directory.
 
 vars = {
+  'android_git': 'https://android.googlesource.com',
   'chromium_git': 'https://chromium.googlesource.com',
   'swiftshader_git': 'https://swiftshader.googlesource.com',
   'dart_git': 'https://dart.googlesource.com',
@@ -282,9 +283,6 @@ deps = {
   'engine/src/flutter/third_party/boringssl/src':
   'https://boringssl.googlesource.com/boringssl.git' + '@' + Var('dart_boringssl_rev'),
 
-  'engine/src/flutter/third_party/dart/third_party/perfetto/src':
-   Var('flutter_git') + "/third_party/perfetto" + '@' + Var('dart_perfetto_rev'),
-
   'engine/src/flutter/third_party/protobuf':
    Var('flutter_git') + '/third_party/protobuf' + '@' + Var('dart_libprotobuf_rev'),
 
@@ -299,10 +297,13 @@ deps = {
   # WARNING: Unused Dart dependencies in the list below till "WARNING:" marker are removed automatically - see create_updated_flutter_deps.py.
 
   'engine/src/flutter/third_party/dart/third_party/binaryen/src':
-   Var('chromium_git') + '/external/github.com/WebAssembly/binaryen.git@1d2e23d5e55788091a51420ba3a9889d4efe7509',
+   Var('chromium_git') + '/external/github.com/WebAssembly/binaryen.git' + '@' + Var('dart_binaryen_rev'),
 
   'engine/src/flutter/third_party/dart/third_party/devtools':
    {'dep_type': 'cipd', 'packages': [{'package': 'dart/third_party/flutter/devtools', 'version': 'git_revision:0327830448901920f739259364c3f2f624df5a03'}]},
+
+  'engine/src/flutter/third_party/dart/third_party/perfetto/src':
+   Var('android_git') + '/platform/external/perfetto' + '@' + Var('dart_perfetto_rev'),
 
   'engine/src/flutter/third_party/dart/third_party/pkg/ai':
    Var('dart_git') + '/ai.git' + '@' + Var('dart_ai_rev'),

--- a/engine/src/tools/dart/create_updated_flutter_deps.py
+++ b/engine/src/tools/dart/create_updated_flutter_deps.py
@@ -12,7 +12,6 @@
 
 import argparse
 import os
-import re
 import sys
 
 DART_SCRIPT_DIR = os.path.dirname(sys.argv[0])
@@ -114,14 +113,14 @@ def Main(argv):
             if (k.endswith(dart_k_suffix)):
               if (isinstance(dart_v, str)):
                 updated_value = dart_v.replace(new_vars["dart_git"], "Var('dart_git') + '/")
-                updated_value = updated_value.replace(old_vars["chromium_git"], "Var('chromium_git') + '")
-                updated_value = updated_value.replace(old_vars["android_git"], "Var('android_git') + '")
+                updated_value = updated_value.replace(new_vars["chromium_git"], "Var('chromium_git') + '")
+                updated_value = updated_value.replace(new_vars["android_git"], "Var('android_git') + '")
 
-                plain_v = dart_k[dart_k.rfind('/') + 1:]
+                plain_v = os.path.basename(dart_k)
                 # Some dependencies are placed in a subdirectory named "src"
                 # within a directory named for the package.
                 if plain_v == 'src':
-                  plain_v = re.match('^.*/(.*)/src$', dart_k).group(1)
+                  plain_v = os.path.basename(os.path.dirname(dart_k))
                 # This dependency has to be special-cased here because the
                 # repository name is not the same as the directory name.
                 if plain_v == "quiver":

--- a/engine/src/tools/dart/create_updated_flutter_deps.py
+++ b/engine/src/tools/dart/create_updated_flutter_deps.py
@@ -12,6 +12,7 @@
 
 import argparse
 import os
+import re
 import sys
 
 DART_SCRIPT_DIR = os.path.dirname(sys.argv[0])
@@ -114,8 +115,13 @@ def Main(argv):
               if (isinstance(dart_v, str)):
                 updated_value = dart_v.replace(new_vars["dart_git"], "Var('dart_git') + '/")
                 updated_value = updated_value.replace(old_vars["chromium_git"], "Var('chromium_git') + '")
+                updated_value = updated_value.replace(old_vars["android_git"], "Var('android_git') + '")
 
                 plain_v = dart_k[dart_k.rfind('/') + 1:]
+                # Some dependencies are placed in a subdirectory named "src"
+                # within a directory named for the package.
+                if plain_v == 'src':
+                  plain_v = re.match('^.*/(.*)/src$', dart_k).group(1)
                 # This dependency has to be special-cased here because the
                 # repository name is not the same as the directory name.
                 if plain_v == "quiver":


### PR DESCRIPTION
Dart recently moved Perfetto to dart/third_party/perfetto/src (see https://dart.googlesource.com/sdk/+/07c9599ead52a2eea7164552e9525e3860a3aed5)

This PR extends create_updated_flutter_deps to handle dependencies placed in an "src" subdirectory within the directory named for the package.

It also adds a mapping for packages hosted at android.googlesource.com. (Perfetto no longer needs to be fetched from Flutter's mirror repository)