### PR TITLE
 feat(table): add support for colSpan and rowSpan in TableCell

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -49,7 +49,7 @@ class TableCellParentData extends BoxParentData {
 
   /// Whether this cell is visible (not hidden by spanning cells).
   /// Hidden cells have both [rowSpan] and [colSpan] set to 0.
-  bool get _isVisible => _rowSpan != 0 && _colSpan != 0;
+  bool get _isVisible => rowSpan != 0 && colSpan != 0;
 
   /// Whether this cell spans multiple rows or columns.
   bool get _hasSpan => colSpan > 1 || rowSpan > 1;
@@ -1286,29 +1286,18 @@ class RenderTable extends RenderBox {
   Iterable<double>? _columnLefts;
   late double _tableWidth;
 
-  // Two bitmaps of hidden cells for border painting, both in logical row-major
-  // order (bit = y * columns + x). They differ in *why* a cell is hidden:
-  //
-  //  _cachedColSpanHiddenCells – cell is covered by a horizontal (colSpan) span,
-  //    i.e. the span origin is in the same row.  Used to skip *vertical* inner
-  //    borders that fall inside a spanning cell.
-  //
-  //  _cachedRowSpanHiddenCells – cell is covered by a vertical (rowSpan) span,
-  //    i.e. the span origin is in an earlier row.  Used to skip *horizontal*
-  //    inner borders that fall inside a spanning cell.
-  //
-  //  A cell at the corner of a rectangular span (colSpan > 1 AND rowSpan > 1)
-  //  has its bit set in **both** bitmaps.
+  // Records which cells are covered by a colSpan and/or rowSpan, used to skip
+  // the inner borders that fall inside a span while painting. Rebuilt during
+  // layout and null when the table has no spanning cells. See
+  // [TableSpannedCells].
   //
   // Row heights are not cached; they are computed on-the-fly as
   // _rowTops[i + 1] - _rowTops[i], which is O(1) per row.
-  Uint8List? _cachedColSpanHiddenCells;
-  Uint8List? _cachedRowSpanHiddenCells;
+  TableSpannedCells? _cachedSpannedCells;
 
   /// Invalidates the cached span information when the table structure changes.
   void _invalidateSpanCache() {
-    _cachedColSpanHiddenCells = null;
-    _cachedRowSpanHiddenCells = null;
+    _cachedSpannedCells = null;
   }
 
   @override
@@ -1467,16 +1456,10 @@ class RenderTable extends RenderBox {
       return;
     }
     final List<double> widths = _computeColumnWidths(constraints);
-    // Two flat bitmaps for hidden-cell detection.
-    // colSpanHiddenBitmap: cells covered by a horizontal (colSpan) span;
-    //   used to skip vertical inner borders during painting.
-    // rowSpanHiddenBitmap: cells covered by a vertical (rowSpan) span;
-    //   used to skip horizontal inner borders during painting.
-    // Both are in logical row-major order: bit = y * columns + x.
-    // A cell at the corner of a rectangular span is set in both bitmaps.
-    final colSpanHiddenBitmap = Uint8List((rows * columns + 7) >> 3);
-    final rowSpanHiddenBitmap = Uint8List((rows * columns + 7) >> 3);
-    var hasCellSpans = false;
+    // Tracks which cells are covered by a colSpan and/or rowSpan so the inner
+    // borders that fall inside a span can be skipped while painting. See
+    // [TableSpannedCells].
+    final spannedCells = TableSpannedCells(rows: rows, columns: columns);
     // Use typed lists for predictable memory layout and faster indexed access.
     final columnStartPositions = Float64List(columns);
     final remainingRowSpanHeights = Float64List(rows);
@@ -1576,26 +1559,20 @@ class RenderTable extends RenderBox {
               if (dx == 0 && dy == 0) {
                 continue;
               }
-              hasCellSpans = true;
-              final int bit = (y + dy) * columns + (x + dx);
-              // dx > 0: covered by horizontal (colSpan) extent.
-              // dy > 0: covered by vertical (rowSpan) extent.
-              // Corner cells (dx > 0 AND dy > 0) get set in both.
+              // dx > 0: this cell is covered by the horizontal (colSpan) extent.
+              // dy > 0: this cell is covered by the vertical (rowSpan) extent.
+              // Corner cells (dx > 0 AND dy > 0) are marked as both.
               if (dx > 0) {
-                colSpanHiddenBitmap[bit >> 3] |= 1 << (bit & 7);
+                spannedCells.markColumnSpanned(x + dx, y + dy);
               }
               if (dy > 0) {
-                rowSpanHiddenBitmap[bit >> 3] |= 1 << (bit & 7);
+                spannedCells.markRowSpanned(x + dx, y + dy);
               }
             }
           }
         }
 
-        final int cellBit = y * columns + x;
-        final isHiddenCell =
-            (colSpanHiddenBitmap[cellBit >> 3] | rowSpanHiddenBitmap[cellBit >> 3]) &
-                (1 << (cellBit & 7)) !=
-            0;
+        final bool isHiddenCell = spannedCells.isSpanned(x, y);
         if (isHiddenCell) {
           assert(
             !childParentData._isVisible,
@@ -1703,11 +1680,7 @@ class RenderTable extends RenderBox {
 
         final childParentData = child.parentData! as TableCellParentData;
         final int rowSpan = childParentData.rowSpan;
-        final int cellBit = y * columns + x;
-        final isHiddenCell =
-            (colSpanHiddenBitmap[cellBit >> 3] | rowSpanHiddenBitmap[cellBit >> 3]) &
-                (1 << (cellBit & 7)) !=
-            0;
+        final bool isHiddenCell = spannedCells.isSpanned(x, y);
         if (isHiddenCell) {
           assert(
             !childParentData._isVisible,
@@ -1761,14 +1734,9 @@ class RenderTable extends RenderBox {
     size = constraints.constrain(Size(_tableWidth, rowTop));
     assert(_rowTops.length == rows + 1);
 
-    // Publish the two hidden-cell bitmaps for use during border painting.
-    if (hasCellSpans) {
-      _cachedColSpanHiddenCells = colSpanHiddenBitmap;
-      _cachedRowSpanHiddenCells = rowSpanHiddenBitmap;
-    } else {
-      _cachedColSpanHiddenCells = null;
-      _cachedRowSpanHiddenCells = null;
-    }
+    // Publish the spanned-cell map for use during border painting, or clear it
+    // when the table has no spanning cells.
+    _cachedSpannedCells = spannedCells.hasSpannedCells ? spannedCells : null;
   }
 
   @override
@@ -1851,8 +1819,7 @@ class RenderTable extends RenderBox {
         rows: rows,
         columns: columns,
         rowTops: _rowTops,
-        colSpanHiddenCells: _cachedColSpanHiddenCells,
-        rowSpanHiddenCells: _cachedRowSpanHiddenCells,
+        spannedCells: _cachedSpannedCells,
         textDirection: textDirection,
       );
     }

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -25,9 +25,41 @@ class TableCellParentData extends BoxParentData {
   /// The row that the child was in the last time it was laid out.
   int? y;
 
+  /// The number of columns this cell should span.
+  ///
+  /// Must be either 0 (hidden placeholder cell) or >= 1 (normal or spanning cell).
+  /// A hidden cell must have both [colSpan] and [rowSpan] set to 0.
+  int get colSpan => _colSpan;
+  int _colSpan = 1;
+  set colSpan(int value) {
+    assert(value >= 0, 'colSpan must be 0 (hidden) or >= 1, got $value.');
+    _colSpan = value;
+  }
+
+  /// The number of rows this cell should span.
+  ///
+  /// Must be either 0 (hidden placeholder cell) or >= 1 (normal or spanning cell).
+  /// A hidden cell must have both [colSpan] and [rowSpan] set to 0.
+  int get rowSpan => _rowSpan;
+  int _rowSpan = 1;
+  set rowSpan(int value) {
+    assert(value >= 0, 'rowSpan must be 0 (hidden) or >= 1, got $value.');
+    _rowSpan = value;
+  }
+
+  /// Whether this cell is visible (not hidden by spanning cells).
+  /// Hidden cells have both [rowSpan] and [colSpan] set to 0.
+  bool get _isVisible => _rowSpan != 0 && _colSpan != 0;
+
+  /// Whether this cell spans multiple rows or columns.
+  bool get _hasSpan => colSpan > 1 || rowSpan > 1;
+
   @override
   String toString() =>
-      '${super.toString()}; ${verticalAlignment == null ? "default vertical alignment" : "$verticalAlignment"}';
+      '${super.toString()}; '
+      '${verticalAlignment == null ? "default vertical alignment" : "$verticalAlignment"}'
+      '${colSpan <= 1 ? '' : '$colSpan cols'}'
+      '${rowSpan <= 1 ? '' : '$rowSpan rows'}';
 }
 
 /// Base class to describe how wide a column in a [RenderTable] should be.
@@ -609,6 +641,20 @@ class RenderTable extends RenderBox {
     config.role = SemanticsRole.table;
     config.isSemanticBoundary = true;
     config.explicitChildNodes = true;
+  }
+
+  @override
+  void visitChildrenForSemantics(RenderObjectVisitor visitor) {
+    // Skip hidden cells as they are not laid out and should not appear in the
+    // semantics tree.
+    for (final RenderBox? child in _children) {
+      if (child != null && child.hasSize) {
+        final cellParentData = child.parentData! as TableCellParentData;
+        if (cellParentData._isVisible) {
+          visitor(child);
+        }
+      }
+    }
   }
 
   final Map<int, _Index> _idToIndexMap = <int, _Index>{};
@@ -1240,6 +1286,50 @@ class RenderTable extends RenderBox {
   Iterable<double>? _columnLefts;
   late double _tableWidth;
 
+  // Two bitmaps of hidden cells for border painting, both in logical row-major
+  // order (bit = y * columns + x). They differ in *why* a cell is hidden:
+  //
+  //  _cachedColSpanHiddenCells – cell is covered by a horizontal (colSpan) span,
+  //    i.e. the span origin is in the same row.  Used to skip *vertical* inner
+  //    borders that fall inside a spanning cell.
+  //
+  //  _cachedRowSpanHiddenCells – cell is covered by a vertical (rowSpan) span,
+  //    i.e. the span origin is in an earlier row.  Used to skip *horizontal*
+  //    inner borders that fall inside a spanning cell.
+  //
+  //  A cell at the corner of a rectangular span (colSpan > 1 AND rowSpan > 1)
+  //  has its bit set in **both** bitmaps.
+  //
+  // Row heights are not cached; they are computed on-the-fly as
+  // _rowTops[i + 1] - _rowTops[i], which is O(1) per row.
+  Uint8List? _cachedColSpanHiddenCells;
+  Uint8List? _cachedRowSpanHiddenCells;
+
+  /// Invalidates the cached span information when the table structure changes.
+  void _invalidateSpanCache() {
+    _cachedColSpanHiddenCells = null;
+    _cachedRowSpanHiddenCells = null;
+  }
+
+  @override
+  void markNeedsLayout() {
+    _invalidateSpanCache();
+    super.markNeedsLayout();
+  }
+
+  /// Computes the visual x-position for a cell, adjusting for text direction
+  /// and column span.
+  double _computeCellX({
+    required Float64List positions,
+    required int columnIndex,
+    required int colSpan,
+  }) {
+    return switch (textDirection) {
+      TextDirection.ltr => positions[columnIndex],
+      TextDirection.rtl => positions[columnIndex + colSpan - 1],
+    };
+  }
+
   /// Returns the position and dimensions of the box that the given
   /// row covers, in this render object's coordinate space (so the
   /// left coordinate is always 0.0).
@@ -1292,6 +1382,7 @@ class RenderTable extends RenderBox {
       return constraints.constrain(Size.zero);
     }
     final List<double> widths = _computeColumnWidths(constraints);
+    final pendingRowSpanHeights = Float64List(rows);
     final double tableWidth = widths.fold(0.0, (double a, double b) => a + b);
     var rowTop = 0.0;
     for (var y = 0; y < rows; y += 1) {
@@ -1301,6 +1392,15 @@ class RenderTable extends RenderBox {
         final RenderBox? child = _children[xy];
         if (child != null) {
           final childParentData = child.parentData! as TableCellParentData;
+          final int colSpan = childParentData.colSpan;
+          final int rowSpan = childParentData.rowSpan;
+
+          // Compute the total width covered by this cell's column span.
+          var spanWidth = 0.0;
+          for (var i = 0; i < colSpan && (x + i) < columns; i++) {
+            spanWidth += widths[x + i];
+          }
+
           switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
             case TableCellVerticalAlignment.baseline:
               assert(
@@ -1314,11 +1414,38 @@ class RenderTable extends RenderBox {
             case TableCellVerticalAlignment.middle:
             case TableCellVerticalAlignment.bottom:
             case TableCellVerticalAlignment.intrinsicHeight:
-              final Size childSize = child.getDryLayout(BoxConstraints.tightFor(width: widths[x]));
-              rowHeight = math.max(rowHeight, childSize.height);
+              final Size childSize = child.getDryLayout(BoxConstraints.tightFor(width: spanWidth));
+              if (rowSpan == 1) {
+                rowHeight = math.max(rowHeight, childSize.height);
+              } else if (rowSpan > 1) {
+                final int targetY = y + rowSpan - 1;
+                if (targetY < rows) {
+                  pendingRowSpanHeights[targetY] = math.max(
+                    pendingRowSpanHeights[targetY],
+                    childSize.height,
+                  );
+                }
+              }
             case TableCellVerticalAlignment.fill:
               break;
           }
+        }
+      }
+
+      final double pendingHeightForThisRow = pendingRowSpanHeights[y];
+      rowHeight = math.max(rowHeight, pendingHeightForThisRow);
+      pendingRowSpanHeights[y] = 0.0; // Reset current row
+
+      // Update pending heights - subtract rowHeight from future rows
+      for (int futureY = y + 1; futureY < rows; futureY++) {
+        if (pendingRowSpanHeights[futureY] > 0) {
+          // For cells spanning multiple rows, reduce the pending height by the
+          // current row's height. Use math.max to ensure non-negative values,
+          // as the pending height may already be satisfied by earlier rows.
+          pendingRowSpanHeights[futureY] = math.max(
+            0.0,
+            pendingRowSpanHeights[futureY] - rowHeight,
+          );
         }
       }
       rowTop += rowHeight;
@@ -1340,113 +1467,308 @@ class RenderTable extends RenderBox {
       return;
     }
     final List<double> widths = _computeColumnWidths(constraints);
-    final positions = List<double>.filled(columns, 0.0);
+    // Two flat bitmaps for hidden-cell detection.
+    // colSpanHiddenBitmap: cells covered by a horizontal (colSpan) span;
+    //   used to skip vertical inner borders during painting.
+    // rowSpanHiddenBitmap: cells covered by a vertical (rowSpan) span;
+    //   used to skip horizontal inner borders during painting.
+    // Both are in logical row-major order: bit = y * columns + x.
+    // A cell at the corner of a rectangular span is set in both bitmaps.
+    final colSpanHiddenBitmap = Uint8List((rows * columns + 7) >> 3);
+    final rowSpanHiddenBitmap = Uint8List((rows * columns + 7) >> 3);
+    var hasCellSpans = false;
+    // Use typed lists for predictable memory layout and faster indexed access.
+    final columnStartPositions = Float64List(columns);
+    final remainingRowSpanHeights = Float64List(rows);
+    final rowHeights = Float64List(rows);
+    final beforeBaselineDistances = Float64List(rows);
+    // Flat arrays in row-major order (index: y * columns + x) instead of
+    // nested lists for better cache locality.
+    final spanWidthsInRowMajor = Float64List(rows * columns);
+    final baselinesInRowMajor = Float64List(rows * columns);
+
     switch (textDirection) {
       case TextDirection.rtl:
-        positions[columns - 1] = 0.0;
+        columnStartPositions[columns - 1] = 0.0;
         for (int x = columns - 2; x >= 0; x -= 1) {
-          positions[x] = positions[x + 1] + widths[x + 1];
+          columnStartPositions[x] = columnStartPositions[x + 1] + widths[x + 1];
         }
-        _columnLefts = positions.reversed;
-        _tableWidth = positions.first + widths.first;
+        _columnLefts = columnStartPositions.reversed;
+        _tableWidth = columnStartPositions.first + widths.first;
       case TextDirection.ltr:
-        positions[0] = 0.0;
+        columnStartPositions[0] = 0.0;
         for (var x = 1; x < columns; x += 1) {
-          positions[x] = positions[x - 1] + widths[x - 1];
+          columnStartPositions[x] = columnStartPositions[x - 1] + widths[x - 1];
         }
-        _columnLefts = positions;
-        _tableWidth = positions.last + widths.last;
+        _columnLefts = columnStartPositions;
+        _tableWidth = columnStartPositions.last + widths.last;
     }
     _rowTops.clear();
     _baselineDistance = null;
-    // then, lay out each row
+
+    // First layout pass: measure children and collect span information.
     var rowTop = 0.0;
     for (var y = 0; y < rows; y += 1) {
-      _rowTops.add(rowTop);
       var rowHeight = 0.0;
       var haveBaseline = false;
       var beforeBaselineDistance = 0.0;
       var afterBaselineDistance = 0.0;
-      final baselines = List<double>.filled(columns, 0.0);
+
       for (var x = 0; x < columns; x += 1) {
         final int xy = x + y * columns;
         final RenderBox? child = _children[xy];
-        if (child != null) {
-          final childParentData = child.parentData! as TableCellParentData;
-          childParentData.x = x;
-          childParentData.y = y;
-          switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
-            case TableCellVerticalAlignment.baseline:
-              assert(
-                textBaseline != null,
-                'An explicit textBaseline is required when using baseline alignment.',
-              );
-              child.layout(BoxConstraints.tightFor(width: widths[x]), parentUsesSize: true);
-              final double? childBaseline = child.getDistanceToBaseline(
-                textBaseline!,
-                onlyReal: true,
-              );
-              if (childBaseline != null) {
-                beforeBaselineDistance = math.max(beforeBaselineDistance, childBaseline);
-                afterBaselineDistance = math.max(
-                  afterBaselineDistance,
-                  child.size.height - childBaseline,
-                );
-                baselines[x] = childBaseline;
-                haveBaseline = true;
-              } else {
-                rowHeight = math.max(rowHeight, child.size.height);
-                childParentData.offset = Offset(positions[x], rowTop);
+        if (child == null) {
+          continue;
+        }
+        final childParentData = child.parentData! as TableCellParentData;
+        childParentData.x = x;
+        childParentData.y = y;
+
+        final int colSpan = childParentData.colSpan;
+        final int rowSpan = childParentData.rowSpan;
+
+        // Compute the total width covered by this cell's column span.
+        var spanWidth = 0.0;
+        for (var i = 0; i < colSpan && (x + i) < columns; i++) {
+          spanWidth += widths[x + i];
+        }
+        spanWidthsInRowMajor[y * columns + x] = spanWidth;
+
+        // Update span caches for hidden-cell detection and border painting.
+        if (childParentData._hasSpan) {
+          assert(() {
+            if (x + colSpan > columns) {
+              throw FlutterError.fromParts(<DiagnosticsNode>[
+                ErrorSummary('Invalid TableCell.colSpan'),
+                ErrorDescription(
+                  'In row $y, the cell at column $x has a colSpan of $colSpan, '
+                  'which extends beyond the total number of columns ($columns).',
+                ),
+                ErrorHint(
+                  'Ensure that colSpan does not exceed the remaining columns in the row.\n'
+                  'For example, if a table has $columns columns, '
+                  'and you are at column index $x, the maximum valid colSpan is '
+                  '${columns - x}.',
+                ),
+              ]);
+            }
+            if (y + rowSpan > rows) {
+              throw FlutterError.fromParts(<DiagnosticsNode>[
+                ErrorSummary('Invalid TableCell.rowSpan'),
+                ErrorDescription(
+                  'In row $y, the cell at column $x has a rowSpan of $rowSpan, '
+                  'which extends beyond the total number of rows ($rows).',
+                ),
+                ErrorHint(
+                  'Ensure that rowSpan does not exceed the remaining rows in the table.\n'
+                  'For example, if a table has $rows rows, '
+                  'and you are at row index $y, the maximum valid rowSpan is '
+                  '${rows - y}.',
+                ),
+              ]);
+            }
+            return true;
+          }());
+          final int maxColSpan = math.min(colSpan, columns - x);
+          final int maxRowSpan = math.min(rowSpan, rows - y);
+          for (var dx = 0; dx < maxColSpan; dx++) {
+            for (var dy = 0; dy < maxRowSpan; dy++) {
+              if (dx == 0 && dy == 0) {
+                continue;
               }
-            case TableCellVerticalAlignment.top:
-            case TableCellVerticalAlignment.middle:
-            case TableCellVerticalAlignment.bottom:
-            case TableCellVerticalAlignment.intrinsicHeight:
-              child.layout(BoxConstraints.tightFor(width: widths[x]), parentUsesSize: true);
-              rowHeight = math.max(rowHeight, child.size.height);
-            case TableCellVerticalAlignment.fill:
-              break;
+              hasCellSpans = true;
+              final int bit = (y + dy) * columns + (x + dx);
+              // dx > 0: covered by horizontal (colSpan) extent.
+              // dy > 0: covered by vertical (rowSpan) extent.
+              // Corner cells (dx > 0 AND dy > 0) get set in both.
+              if (dx > 0) {
+                colSpanHiddenBitmap[bit >> 3] |= 1 << (bit & 7);
+              }
+              if (dy > 0) {
+                rowSpanHiddenBitmap[bit >> 3] |= 1 << (bit & 7);
+              }
+            }
           }
         }
+
+        final int cellBit = y * columns + x;
+        final isHiddenCell =
+            (colSpanHiddenBitmap[cellBit >> 3] | rowSpanHiddenBitmap[cellBit >> 3]) &
+                (1 << (cellBit & 7)) !=
+            0;
+        if (isHiddenCell) {
+          assert(
+            !childParentData._isVisible,
+            'Cell at ($x, $y) is covered by a spanning cell but is not TableCell.none. '
+            'Cells that are covered by a colSpan or rowSpan must be declared as TableCell.none.',
+          );
+          continue;
+        }
+
+        // Layout the child according to its vertical alignment.
+        switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
+          case TableCellVerticalAlignment.baseline:
+            assert(
+              textBaseline != null,
+              'An explicit textBaseline is required when using baseline alignment.',
+            );
+            child.layout(BoxConstraints.tightFor(width: spanWidth), parentUsesSize: true);
+
+            final double? childBaseline = child.getDistanceToBaseline(
+              textBaseline!,
+              onlyReal: true,
+            );
+
+            if (childBaseline != null) {
+              beforeBaselineDistance = math.max(beforeBaselineDistance, childBaseline);
+              afterBaselineDistance = math.max(
+                afterBaselineDistance,
+                child.size.height - childBaseline,
+              );
+              baselinesInRowMajor[y * columns + x] = childBaseline;
+              haveBaseline = true;
+            } else {
+              rowHeight = math.max(rowHeight, child.size.height);
+              final double cellX = _computeCellX(
+                positions: columnStartPositions,
+                columnIndex: x,
+                colSpan: colSpan,
+              );
+              childParentData.offset = Offset(cellX, rowTop);
+            }
+          case TableCellVerticalAlignment.top:
+          case TableCellVerticalAlignment.middle:
+          case TableCellVerticalAlignment.bottom:
+          case TableCellVerticalAlignment.intrinsicHeight:
+            child.layout(BoxConstraints.tightFor(width: spanWidth), parentUsesSize: true);
+            final double childHeight = child.size.height;
+
+            if (rowSpan == 1) {
+              rowHeight = math.max(rowHeight, childHeight);
+            } else if (rowSpan > 1) {
+              final int targetY = y + rowSpan - 1;
+              if (targetY < rows) {
+                remainingRowSpanHeights[targetY] = math.max(
+                  remainingRowSpanHeights[targetY],
+                  childHeight,
+                );
+              }
+            }
+
+          case TableCellVerticalAlignment.fill:
+            break;
+        }
       }
+
+      final double pendingHeightForThisRow = remainingRowSpanHeights[y];
+      rowHeight = math.max(rowHeight, pendingHeightForThisRow);
+      remainingRowSpanHeights[y] = 0.0; // Reset after use.
+
+      // Adjust pending heights for future rows by subtracting the current height.
+      for (int futureY = y + 1; futureY < rows; futureY++) {
+        if (remainingRowSpanHeights[futureY] > 0) {
+          // For cells spanning multiple rows, reduce the pending height by the
+          // current row's height. Use math.max to ensure non-negative values,
+          // as the pending height may already be satisfied by earlier rows.
+          remainingRowSpanHeights[futureY] = math.max(
+            0.0,
+            remainingRowSpanHeights[futureY] - rowHeight,
+          );
+        }
+      }
+
       if (haveBaseline) {
         if (y == 0) {
           _baselineDistance = beforeBaselineDistance;
         }
         rowHeight = math.max(rowHeight, beforeBaselineDistance + afterBaselineDistance);
       }
+      rowHeights[y] = rowHeight;
+      beforeBaselineDistances[y] = beforeBaselineDistance;
+    }
+
+    // Second layout pass: position children using final row heights.
+    rowTop = 0.0;
+    for (var y = 0; y < rows; y += 1) {
+      _rowTops.add(rowTop);
+      final double beforeBaselineDistance = beforeBaselineDistances[y];
+      final double rowHeight = rowHeights[y];
+
       for (var x = 0; x < columns; x += 1) {
         final int xy = x + y * columns;
         final RenderBox? child = _children[xy];
-        if (child != null) {
-          final childParentData = child.parentData! as TableCellParentData;
-          switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
-            case TableCellVerticalAlignment.baseline:
-              childParentData.offset = Offset(
-                positions[x],
-                rowTop + beforeBaselineDistance - baselines[x],
-              );
-            case TableCellVerticalAlignment.top:
-              childParentData.offset = Offset(positions[x], rowTop);
-            case TableCellVerticalAlignment.middle:
-              childParentData.offset = Offset(
-                positions[x],
-                rowTop + (rowHeight - child.size.height) / 2.0,
-              );
-            case TableCellVerticalAlignment.bottom:
-              childParentData.offset = Offset(positions[x], rowTop + rowHeight - child.size.height);
-            case TableCellVerticalAlignment.fill:
-            case TableCellVerticalAlignment.intrinsicHeight:
-              child.layout(BoxConstraints.tightFor(width: widths[x], height: rowHeight));
-              childParentData.offset = Offset(positions[x], rowTop);
+        if (child == null) {
+          continue;
+        }
+
+        final childParentData = child.parentData! as TableCellParentData;
+        final int rowSpan = childParentData.rowSpan;
+        final int cellBit = y * columns + x;
+        final isHiddenCell =
+            (colSpanHiddenBitmap[cellBit >> 3] | rowSpanHiddenBitmap[cellBit >> 3]) &
+                (1 << (cellBit & 7)) !=
+            0;
+        if (isHiddenCell) {
+          assert(
+            !childParentData._isVisible,
+            'Cell at ($x, $y) is covered by a spanning cell but is not TableCell.none. '
+            'Cells that are covered by a colSpan or rowSpan must be declared as TableCell.none.',
+          );
+          continue;
+        }
+
+        // Compute the total height covered by this cell's row span.
+        var spanHeight = rowHeight;
+        if (rowSpan > 1) {
+          spanHeight = 0.0;
+          for (var dy = 0; dy < rowSpan && (y + dy) < rows; dy++) {
+            spanHeight += rowHeights[y + dy];
           }
         }
+
+        final int colSpan = childParentData.colSpan;
+        final double cellX = _computeCellX(
+          positions: columnStartPositions,
+          columnIndex: x,
+          colSpan: colSpan,
+        );
+
+        // Set the child's final offset based on vertical alignment.
+        switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
+          case TableCellVerticalAlignment.baseline:
+            childParentData.offset = Offset(
+              cellX,
+              rowTop + beforeBaselineDistance - baselinesInRowMajor[y * columns + x],
+            );
+          case TableCellVerticalAlignment.top:
+            childParentData.offset = Offset(cellX, rowTop);
+          case TableCellVerticalAlignment.middle:
+            childParentData.offset = Offset(cellX, rowTop + (spanHeight - child.size.height) / 2.0);
+          case TableCellVerticalAlignment.bottom:
+            childParentData.offset = Offset(cellX, rowTop + spanHeight - child.size.height);
+          case TableCellVerticalAlignment.fill:
+          case TableCellVerticalAlignment.intrinsicHeight:
+            final double spanWidth = spanWidthsInRowMajor[y * columns + x];
+
+            child.layout(BoxConstraints.tightFor(width: spanWidth, height: spanHeight));
+            childParentData.offset = Offset(cellX, rowTop);
+        }
       }
+
       rowTop += rowHeight;
     }
     _rowTops.add(rowTop);
     size = constraints.constrain(Size(_tableWidth, rowTop));
     assert(_rowTops.length == rows + 1);
+
+    // Publish the two hidden-cell bitmaps for use during border painting.
+    if (hasCellSpans) {
+      _cachedColSpanHiddenCells = colSpanHiddenBitmap;
+      _cachedRowSpanHiddenCells = rowSpanHiddenBitmap;
+    } else {
+      _cachedColSpanHiddenCells = null;
+      _cachedRowSpanHiddenCells = null;
+    }
   }
 
   @override
@@ -1454,7 +1776,7 @@ class RenderTable extends RenderBox {
     assert(_children.length == rows * columns);
     for (int index = _children.length - 1; index >= 0; index -= 1) {
       final RenderBox? child = _children[index];
-      if (child != null) {
+      if (child != null && child.hasSize) {
         final childParentData = child.parentData! as BoxParentData;
         final bool isHit = result.addWithPaintOffset(
           offset: childParentData.offset,
@@ -1483,6 +1805,7 @@ class RenderTable extends RenderBox {
           borderRect,
           rows: const <double>[],
           columns: const <double>[],
+          rowTops: const <double>[],
         );
       }
       return;
@@ -1507,7 +1830,7 @@ class RenderTable extends RenderBox {
     }
     for (var index = 0; index < _children.length; index += 1) {
       final RenderBox? child = _children[index];
-      if (child != null) {
+      if (child != null && child.hasSize) {
         final childParentData = child.parentData! as BoxParentData;
         context.paintChild(child, childParentData.offset + offset);
       }
@@ -1521,7 +1844,17 @@ class RenderTable extends RenderBox {
       final borderRect = Rect.fromLTWH(offset.dx, offset.dy, _tableWidth, _rowTops.last);
       final Iterable<double> rows = _rowTops.getRange(1, _rowTops.length - 1);
       final Iterable<double> columns = _columnLefts!.skip(1);
-      border!.paint(context.canvas, borderRect, rows: rows, columns: columns);
+
+      border!.paint(
+        context.canvas,
+        borderRect,
+        rows: rows,
+        columns: columns,
+        rowTops: _rowTops,
+        colSpanHiddenCells: _cachedColSpanHiddenCells,
+        rowSpanHiddenCells: _cachedRowSpanHiddenCells,
+        textDirection: textDirection,
+      );
     }
   }
 

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1459,7 +1459,7 @@ class RenderTable extends RenderBox {
     // Tracks which cells are covered by a colSpan and/or rowSpan so the inner
     // borders that fall inside a span can be skipped while painting. See
     // [TableSpannedCells].
-    final spannedCells = TableSpannedCells(rows: rows, columns: columns);
+    final spannedCells = TableSpannedCells._(rows: rows, columns: columns);
     // Use typed lists for predictable memory layout and faster indexed access.
     final columnStartPositions = Float64List(columns);
     final remainingRowSpanHeights = Float64List(rows);
@@ -1563,16 +1563,16 @@ class RenderTable extends RenderBox {
               // dy > 0: this cell is covered by the vertical (rowSpan) extent.
               // Corner cells (dx > 0 AND dy > 0) are marked as both.
               if (dx > 0) {
-                spannedCells.markColumnSpanned(x + dx, y + dy);
+                spannedCells._markColumnSpanned(x + dx, y + dy);
               }
               if (dy > 0) {
-                spannedCells.markRowSpanned(x + dx, y + dy);
+                spannedCells._markRowSpanned(x + dx, y + dy);
               }
             }
           }
         }
 
-        final bool isHiddenCell = spannedCells.isSpanned(x, y);
+        final bool isHiddenCell = spannedCells._isSpanned(x, y);
         if (isHiddenCell) {
           assert(
             !childParentData._isVisible,
@@ -1680,7 +1680,7 @@ class RenderTable extends RenderBox {
 
         final childParentData = child.parentData! as TableCellParentData;
         final int rowSpan = childParentData.rowSpan;
-        final bool isHiddenCell = spannedCells.isSpanned(x, y);
+        final bool isHiddenCell = spannedCells._isSpanned(x, y);
         if (isHiddenCell) {
           assert(
             !childParentData._isVisible,
@@ -1736,7 +1736,7 @@ class RenderTable extends RenderBox {
 
     // Publish the spanned-cell map for use during border painting, or clear it
     // when the table has no spanning cells.
-    _cachedSpannedCells = spannedCells.hasSpannedCells ? spannedCells : null;
+    _cachedSpannedCells = spannedCells._hasSpannedCells ? spannedCells : null;
   }
 
   @override
@@ -1894,4 +1894,74 @@ class _Index {
 
   @override
   int get hashCode => Object.hash(y, x);
+}
+
+/// Records which cells in a table are covered ("hidden") by a spanning cell.
+///
+/// This is typically used by [TableBorder] to decide whether to skip painting
+/// some of the cell dividers.
+///
+/// A cell can be covered in two independent ways, and both are tracked here:
+///
+///  * **column-spanned** – covered by a horizontal (colSpan) span from a
+///    preceding cell in the same row.
+///  * **row-spanned** – covered by a vertical (rowSpan) span from a cell above.
+///
+/// A cell in the interior of a rectangular span is both column- and row-spanned.
+class TableSpannedCells {
+  // Only [RenderTable] populates this map, during layout. Consumers such as
+  // [TableBorder] receive it read-only, so painting can never mutate the flags
+  // that layout derived.
+  TableSpannedCells._({required int rows, required int columns})
+    : _columns = columns,
+      // Both flags of every cell are packed into a single bitmap, 8 bits to a
+      // byte: `* 2` reserves both bits for every cell, `+ 7` rounds the total
+      // bit count up so a trailing partial byte is still allocated, and `>> 3`
+      // converts the bit count to a byte count (an integer divide by 8).
+      _bits = Uint8List((rows * columns * 2 + 7) >> 3);
+
+  final int _columns;
+
+  // The packed flags, in row-major order. See [_bitIndexFor].
+  final Uint8List _bits;
+
+  // Whether any cell has been marked as covered by a span.
+  bool _hasSpannedCells = false;
+
+  // Each cell reserves two consecutive bits in [_bits]; these are their offsets
+  // within that pair.
+  static const int _columnSpanFlag = 0;
+  static const int _rowSpanFlag = 1;
+
+  // The absolute bit index of `flag` for the cell at (x, y). Cells are stored in
+  // row-major order and each cell owns two bits, hence the `* 2`.
+  int _bitIndexFor(int x, int y, int flag) => (y * _columns + x) * 2 + flag;
+
+  void _setFlag(int x, int y, int flag) {
+    final int bit = _bitIndexFor(x, y, flag);
+    // `bit >> 3` selects the byte holding the flag (bit ~/ 8) and `bit & 7` is
+    // the position within that byte (bit % 8).
+    _bits[bit >> 3] |= 1 << (bit & 7);
+    _hasSpannedCells = true;
+  }
+
+  bool _hasFlag(int x, int y, int flag) {
+    final int bit = _bitIndexFor(x, y, flag);
+    return _bits[bit >> 3] & (1 << (bit & 7)) != 0;
+  }
+
+  // Marks the cell at (x, y) as covered by a horizontal (colSpan) span.
+  void _markColumnSpanned(int x, int y) => _setFlag(x, y, _columnSpanFlag);
+
+  // Marks the cell at (x, y) as covered by a vertical (rowSpan) span.
+  void _markRowSpanned(int x, int y) => _setFlag(x, y, _rowSpanFlag);
+
+  // Whether the cell at (x, y) is covered by any span.
+  bool _isSpanned(int x, int y) => isColumnSpanned(x, y) || isRowSpanned(x, y);
+
+  /// Whether the cell at (`x`, `y`) is covered by a horizontal (colSpan) span.
+  bool isColumnSpanned(int x, int y) => _hasFlag(x, y, _columnSpanFlag);
+
+  /// Whether the cell at (`x`, `y`) is covered by a vertical (rowSpan) span.
+  bool isRowSpanned(int x, int y) => _hasFlag(x, y, _rowSpanFlag);
 }

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -58,8 +58,8 @@ class TableCellParentData extends BoxParentData {
   String toString() =>
       '${super.toString()}; '
       '${verticalAlignment == null ? "default vertical alignment" : "$verticalAlignment"}'
-      '${colSpan <= 1 ? '' : '$colSpan cols'}'
-      '${rowSpan <= 1 ? '' : '$rowSpan rows'}';
+      '${colSpan <= 1 ? '' : '; $colSpan cols'}'
+      '${rowSpan <= 1 ? '' : '; $rowSpan rows'}';
 }
 
 /// Base class to describe how wide a column in a [RenderTable] should be.
@@ -1381,6 +1381,11 @@ class RenderTable extends RenderBox {
         final RenderBox? child = _children[xy];
         if (child != null) {
           final childParentData = child.parentData! as TableCellParentData;
+          // Placeholder cells (TableCell.none) are covered by a spanning cell
+          // and contribute no size of their own, so there is nothing to measure.
+          if (!childParentData._isVisible) {
+            continue;
+          }
           final int colSpan = childParentData.colSpan;
           final int rowSpan = childParentData.rowSpan;
 

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1474,6 +1474,11 @@ class RenderTable extends RenderBox {
     // nested lists for better cache locality.
     final spanWidthsInRowMajor = Float64List(rows * columns);
     final baselinesInRowMajor = Float64List(rows * columns);
+    // Sentinel stored in [baselinesInRowMajor] for baseline-aligned cells whose
+    // child has no real baseline. Such cells are top-aligned, so they must not
+    // be offset by the row's baseline distance in the second pass. Real baseline
+    // distances are always >= 0, so a negative value is unambiguous.
+    const noBaseline = -1.0;
 
     switch (textDirection) {
       case TextDirection.rtl:
@@ -1578,12 +1583,14 @@ class RenderTable extends RenderBox {
         }
 
         final bool isHiddenCell = spannedCells._isSpanned(x, y);
+        assert(
+          isHiddenCell == !childParentData._isVisible,
+          'Cell at ($x, $y): a cell is covered by a span if and only if it is a '
+          'TableCell.none placeholder. A cell covered by a colSpan or rowSpan must '
+          'be declared as TableCell.none, and a TableCell.none must only appear '
+          'where it is covered by a span.',
+        );
         if (isHiddenCell) {
-          assert(
-            !childParentData._isVisible,
-            'Cell at ($x, $y) is covered by a spanning cell but is not TableCell.none. '
-            'Cells that are covered by a colSpan or rowSpan must be declared as TableCell.none.',
-          );
           continue;
         }
 
@@ -1610,13 +1617,11 @@ class RenderTable extends RenderBox {
               baselinesInRowMajor[y * columns + x] = childBaseline;
               haveBaseline = true;
             } else {
+              // The child has no real baseline, so it is top-aligned within the
+              // row. Record the sentinel so the second pass places it the same
+              // way instead of offsetting it by the row's baseline distance.
               rowHeight = math.max(rowHeight, child.size.height);
-              final double cellX = _computeCellX(
-                positions: columnStartPositions,
-                columnIndex: x,
-                colSpan: colSpan,
-              );
-              childParentData.offset = Offset(cellX, rowTop);
+              baselinesInRowMajor[y * columns + x] = noBaseline;
             }
           case TableCellVerticalAlignment.top:
           case TableCellVerticalAlignment.middle:
@@ -1686,12 +1691,14 @@ class RenderTable extends RenderBox {
         final childParentData = child.parentData! as TableCellParentData;
         final int rowSpan = childParentData.rowSpan;
         final bool isHiddenCell = spannedCells._isSpanned(x, y);
+        assert(
+          isHiddenCell == !childParentData._isVisible,
+          'Cell at ($x, $y): a cell is covered by a span if and only if it is a '
+          'TableCell.none placeholder. A cell covered by a colSpan or rowSpan must '
+          'be declared as TableCell.none, and a TableCell.none must only appear '
+          'where it is covered by a span.',
+        );
         if (isHiddenCell) {
-          assert(
-            !childParentData._isVisible,
-            'Cell at ($x, $y) is covered by a spanning cell but is not TableCell.none. '
-            'Cells that are covered by a colSpan or rowSpan must be declared as TableCell.none.',
-          );
           continue;
         }
 
@@ -1714,10 +1721,13 @@ class RenderTable extends RenderBox {
         // Set the child's final offset based on vertical alignment.
         switch (childParentData.verticalAlignment ?? defaultVerticalAlignment) {
           case TableCellVerticalAlignment.baseline:
-            childParentData.offset = Offset(
-              cellX,
-              rowTop + beforeBaselineDistance - baselinesInRowMajor[y * columns + x],
-            );
+            final double childBaseline = baselinesInRowMajor[y * columns + x];
+            // A child with no real baseline was top-aligned in the first pass;
+            // keep it top-aligned here rather than offsetting it by the row's
+            // baseline distance.
+            childParentData.offset = childBaseline == noBaseline
+                ? Offset(cellX, rowTop)
+                : Offset(cellX, rowTop + beforeBaselineDistance - childBaseline);
           case TableCellVerticalAlignment.top:
             childParentData.offset = Offset(cellX, rowTop);
           case TableCellVerticalAlignment.middle:

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1778,7 +1778,6 @@ class RenderTable extends RenderBox {
           borderRect,
           rows: const <double>[],
           columns: const <double>[],
-          rowTops: const <double>[],
         );
       }
       return;
@@ -1823,7 +1822,6 @@ class RenderTable extends RenderBox {
         borderRect,
         rows: rows,
         columns: columns,
-        rowTops: _rowTops,
         spannedCells: _cachedSpannedCells,
         textDirection: textDirection,
       );

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1482,7 +1482,7 @@ class RenderTable extends RenderBox {
     // child has no real baseline. Such cells are top-aligned, so they must not
     // be offset by the row's baseline distance in the second pass. Real baseline
     // distances are always >= 0, so a negative value is unambiguous.
-    const noBaseline = -1.0;
+    const kNoBaseline = -1.0;
 
     switch (textDirection) {
       case TextDirection.rtl:
@@ -1625,7 +1625,7 @@ class RenderTable extends RenderBox {
               // row. Record the sentinel so the second pass places it the same
               // way instead of offsetting it by the row's baseline distance.
               rowHeight = math.max(rowHeight, child.size.height);
-              baselinesInRowMajor[y * columns + x] = noBaseline;
+              baselinesInRowMajor[y * columns + x] = kNoBaseline;
             }
           case TableCellVerticalAlignment.top:
           case TableCellVerticalAlignment.middle:
@@ -1729,7 +1729,7 @@ class RenderTable extends RenderBox {
             // A child with no real baseline was top-aligned in the first pass;
             // keep it top-aligned here rather than offsetting it by the row's
             // baseline distance.
-            childParentData.offset = childBaseline == noBaseline
+            childParentData.offset = childBaseline == kNoBaseline
                 ? Offset(cellX, rowTop)
                 : Offset(cellX, rowTop + beforeBaselineDistance - childBaseline);
           case TableCellVerticalAlignment.top:

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -799,6 +799,10 @@ class RenderTable extends RenderBox {
         }
         // Add wrapper transform
         if (addCellWrapper) {
+          // TODO(hm21): These wrapper bounds use a single column width and a
+          // single row height, so a cell spanning multiple columns or rows is
+          // clipped to one cell in the semantics tree. Make them span-aware
+          // (along with the RTL handling in findColumnIndex) in a follow-up.
           cell
             ..transform = Matrix4.translationValues(_columnLefts!.elementAt(x), 0, 0)
             ..rect = Rect.fromLTWH(0, 0, cellWidth, rowBox.height);

--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -1016,6 +1016,17 @@ class RenderTable extends RenderBox {
     visitChildren(redepthChild);
   }
 
+  // Cells that span several columns are measured as part of the column they
+  // start in, because [TableColumnWidth] is handed the cells of a single column
+  // at a time. A spanning cell can therefore make that one column as wide as
+  // the whole span instead of having its width shared between the columns it
+  // covers.
+  //
+  // Sharing it would mean growing only the columns whose width actually depends
+  // on their cells - a [FixedColumnWidth] column has to keep the width it asked
+  // for - and [TableColumnWidth] does not expose whether that is the case.
+  // TODO(hm21): Share the width of a column-spanning cell between the columns
+  // it covers, once TableColumnWidth can report whether it is cell-driven.
   @override
   double computeMinIntrinsicWidth(double height) {
     assert(_children.length == rows * columns);
@@ -1055,14 +1066,60 @@ class RenderTable extends RenderBox {
       return 0.0;
     }
     final List<double> widths = _computeColumnWidths(BoxConstraints.tightForFinite(width: width));
+    // A cell that spans several rows is parked on the last row it covers and is
+    // reduced by the height of every row in between, so that it only adds the
+    // height its span still needs. This mirrors the accounting in
+    // [computeDryLayout] and [performLayout], which keeps the intrinsic height
+    // in agreement with the height the table actually lays out to.
+    final pendingRowSpanHeights = Float64List(rows);
     var rowTop = 0.0;
     for (var y = 0; y < rows; y += 1) {
       var rowHeight = 0.0;
       for (var x = 0; x < columns; x += 1) {
         final int xy = x + y * columns;
         final RenderBox? child = _children[xy];
-        if (child != null) {
-          rowHeight = math.max(rowHeight, child.getMaxIntrinsicHeight(widths[x]));
+        if (child == null) {
+          continue;
+        }
+        final childParentData = child.parentData! as TableCellParentData;
+        // Placeholder cells (TableCell.none) are covered by a spanning cell and
+        // contribute no size of their own, so there is nothing to measure.
+        if (!childParentData._isVisible) {
+          continue;
+        }
+        final int colSpan = childParentData.colSpan;
+        final int rowSpan = childParentData.rowSpan;
+
+        // Compute the total width covered by this cell's column span.
+        var spanWidth = 0.0;
+        for (var i = 0; i < colSpan && (x + i) < columns; i++) {
+          spanWidth += widths[x + i];
+        }
+
+        final double childHeight = child.getMaxIntrinsicHeight(spanWidth);
+        if (rowSpan == 1) {
+          rowHeight = math.max(rowHeight, childHeight);
+        } else {
+          final int targetY = y + rowSpan - 1;
+          if (targetY < rows) {
+            pendingRowSpanHeights[targetY] = math.max(pendingRowSpanHeights[targetY], childHeight);
+          }
+        }
+      }
+
+      rowHeight = math.max(rowHeight, pendingRowSpanHeights[y]);
+      pendingRowSpanHeights[y] = 0.0; // Reset current row
+
+      // Update pending heights - subtract rowHeight from future rows.
+      for (int futureY = y + 1; futureY < rows; futureY += 1) {
+        if (pendingRowSpanHeights[futureY] > 0) {
+          // For cells spanning multiple rows, reduce the pending height by the
+          // current row's height. Use math.max to ensure non-negative values,
+          // as the pending height may already be satisfied by earlier rows.
+          pendingRowSpanHeights[futureY] = math.max(
+            0.0,
+            pendingRowSpanHeights[futureY] - rowHeight,
+          );
         }
       }
       rowTop += rowHeight;

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -8,6 +8,8 @@ library;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/painting.dart' hide Border;
 
+import 'table.dart';
+
 /// Border specification for [Table] widgets.
 ///
 /// This is like [Border], with the addition of two sides: the inner horizontal
@@ -523,75 +525,4 @@ class TableBorder {
   @override
   String toString() =>
       'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside, $borderRadius)';
-}
-
-/// Records which cells in a table are covered ("hidden") by a spanning cell, so
-/// that the inner [TableBorder] dividers that fall inside a span can be skipped
-/// while painting.
-///
-/// A cell can be covered in two independent ways, and both are tracked here:
-///
-///  * **column-spanned** – covered by a horizontal (colSpan) span. The vertical
-///    inner border on the cell's leading edge is not painted.
-///  * **row-spanned** – covered by a vertical (rowSpan) span. The horizontal
-///    inner border on the cell's top edge is not painted.
-///
-/// A cell in the interior of a rectangular span is both column- and row-spanned.
-///
-/// Both flags for every cell are packed into a single [Uint8List] in row-major
-/// order. Callers use the named accessors and never manipulate the bits
-/// directly.
-class TableSpannedCells {
-  /// Creates a map able to hold the span flags for a `rows` × `columns` table.
-  TableSpannedCells({required int rows, required int columns})
-    : _columns = columns,
-      // Two flags per cell (column-spanned and row-spanned) are packed 8 bits
-      // to a byte: `* 2` reserves both bits for every cell, `+ 7` rounds the
-      // total bit count up so a trailing partial byte is still allocated, and
-      // `>> 3` converts the bit count to a byte count (an integer divide by 8).
-      _bits = Uint8List((rows * columns * 2 + 7) >> 3);
-
-  final int _columns;
-  final Uint8List _bits;
-  bool _hasSpannedCells = false;
-
-  // Each cell reserves two consecutive bits in [_bits]; these are their offsets
-  // within that pair.
-  static const int _columnSpanFlag = 0;
-  static const int _rowSpanFlag = 1;
-
-  // The absolute bit index of `flag` for the cell at (x, y). Cells are stored in
-  // row-major order and each cell owns two bits, hence the `* 2`.
-  int _bitIndexFor(int x, int y, int flag) => (y * _columns + x) * 2 + flag;
-
-  void _setFlag(int x, int y, int flag) {
-    final int bit = _bitIndexFor(x, y, flag);
-    // `bit >> 3` selects the byte holding the flag (bit ~/ 8) and `bit & 7` is
-    // the position within that byte (bit % 8).
-    _bits[bit >> 3] |= 1 << (bit & 7);
-    _hasSpannedCells = true;
-  }
-
-  bool _hasFlag(int x, int y, int flag) {
-    final int bit = _bitIndexFor(x, y, flag);
-    return _bits[bit >> 3] & (1 << (bit & 7)) != 0;
-  }
-
-  /// Whether any cell has been marked as covered by a span.
-  bool get hasSpannedCells => _hasSpannedCells;
-
-  /// Marks the cell at (`x`, `y`) as covered by a horizontal (colSpan) span.
-  void markColumnSpanned(int x, int y) => _setFlag(x, y, _columnSpanFlag);
-
-  /// Marks the cell at (`x`, `y`) as covered by a vertical (rowSpan) span.
-  void markRowSpanned(int x, int y) => _setFlag(x, y, _rowSpanFlag);
-
-  /// Whether the cell at (`x`, `y`) is covered by a horizontal (colSpan) span.
-  bool isColumnSpanned(int x, int y) => _hasFlag(x, y, _columnSpanFlag);
-
-  /// Whether the cell at (`x`, `y`) is covered by a vertical (rowSpan) span.
-  bool isRowSpanned(int x, int y) => _hasFlag(x, y, _rowSpanFlag);
-
-  /// Whether the cell at (`x`, `y`) is covered by any span.
-  bool isSpanned(int x, int y) => isColumnSpanned(x, y) || isRowSpanned(x, y);
 }

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -307,7 +307,7 @@ class TableBorder {
     Rect rect,
     List<double> columnList,
     List<double> rowTops,
-    Uint8List colSpanHiddenCells,
+    TableSpannedCells spannedCells,
     int tableColumns,
     bool isRTL,
     Paint paint,
@@ -334,8 +334,7 @@ class TableBorder {
         // is logical col (x+1); in RTL the "right" visual cell becomes logical
         // col (cols-1-x) which is to the left visually.
         final int logicalX = isRTL ? (tableColumns - 1 - x) : (x + 1);
-        final int bit = y * tableColumns + logicalX;
-        if (colSpanHiddenCells[bit >> 3] & (1 << (bit & 7)) != 0) {
+        if (spannedCells.isColumnSpanned(logicalX, y)) {
           continue;
         }
         final double xPos = rect.left + columnList[x];
@@ -356,7 +355,7 @@ class TableBorder {
     Rect rect,
     List<double> rowList,
     List<double> columnList,
-    Uint8List rowSpanHiddenCells,
+    TableSpannedCells spannedCells,
     int tableColumns,
     bool isRTL,
     Paint paint,
@@ -392,8 +391,7 @@ class TableBorder {
         // In LTR visual segment x maps to logical col x; in RTL it maps to
         // logical col (cols-1-x).
         final int logicalX = isRTL ? (tableColumns - 1 - x) : x;
-        final int bit = (y + 1) * tableColumns + logicalX;
-        if (rowSpanHiddenCells[bit >> 3] & (1 << (bit & 7)) != 0) {
+        if (spannedCells.isRowSpanned(logicalX, y + 1)) {
           continue;
         }
         path
@@ -426,20 +424,18 @@ class TableBorder {
   /// each row (plus a final entry for the bottom of the last row). Row heights
   /// are derived from consecutive differences and never cached separately.
   ///
-  /// The optional [colSpanHiddenCells] and [rowSpanHiddenCells] are flat
-  /// bitmaps in **logical** row-major order (`bit = y * tableColumns + x`).
+  /// The optional [spannedCells] records which logical cells are covered by a
+  /// spanning cell, so that the inner borders that fall inside a span can be
+  /// skipped:
   ///
-  ///  * [colSpanHiddenCells] – a set bit means logical cell (x, y) is covered
-  ///    by a **horizontal** (colSpan) span.  Vertical inner borders that fall
-  ///    inside such a span are skipped.
-  ///  * [rowSpanHiddenCells] – a set bit means logical cell (x, y) is covered
-  ///    by a **vertical** (rowSpan) span.  Horizontal inner borders that fall
-  ///    inside such a span are skipped.
+  ///  * A cell covered by a **horizontal** (colSpan) span skips the vertical
+  ///    inner border on its leading edge.
+  ///  * A cell covered by a **vertical** (rowSpan) span skips the horizontal
+  ///    inner border on its top edge.
   ///
-  /// Cells at the corner of a rectangular span have their bit set in **both**
-  /// bitmaps.  When both parameters are null, no borders are skipped.
-  /// Pass [textDirection] so the bitmaps can be interpreted correctly for RTL
-  /// tables.
+  /// A cell at the corner of a rectangular span is covered by both. When
+  /// [spannedCells] is null, no borders are skipped. Pass [textDirection] so
+  /// the cell coordinates can be interpreted correctly for RTL tables.
   ///
   /// The [verticalInside] border is only drawn if there are at least two
   /// columns. The [horizontalInside] border is only drawn if there are at least
@@ -456,8 +452,7 @@ class TableBorder {
     required Iterable<double> rows,
     required Iterable<double> columns,
     required List<double> rowTops,
-    Uint8List? colSpanHiddenCells,
-    Uint8List? rowSpanHiddenCells,
+    TableSpannedCells? spannedCells,
     TextDirection textDirection = TextDirection.ltr,
   }) {
     // Validate row and column offsets are within the table's bounds.
@@ -468,7 +463,7 @@ class TableBorder {
     final path = Path();
     final List<double> columnList = columns.toList();
 
-    if (colSpanHiddenCells != null || rowSpanHiddenCells != null) {
+    if (spannedCells != null) {
       final int tableColumns = columnList.length + 1;
       final isRTL = textDirection == TextDirection.rtl;
       final List<double> rowList = rows.toList();
@@ -477,7 +472,7 @@ class TableBorder {
         rect,
         rowList,
         columnList,
-        rowSpanHiddenCells ?? Uint8List(0),
+        spannedCells,
         tableColumns,
         isRTL,
         paint,
@@ -488,7 +483,7 @@ class TableBorder {
         rect,
         columnList,
         rowTops,
-        colSpanHiddenCells ?? Uint8List(0),
+        spannedCells,
         tableColumns,
         isRTL,
         paint,
@@ -528,4 +523,75 @@ class TableBorder {
   @override
   String toString() =>
       'TableBorder($top, $right, $bottom, $left, $horizontalInside, $verticalInside, $borderRadius)';
+}
+
+/// Records which cells in a table are covered ("hidden") by a spanning cell, so
+/// that the inner [TableBorder] dividers that fall inside a span can be skipped
+/// while painting.
+///
+/// A cell can be covered in two independent ways, and both are tracked here:
+///
+///  * **column-spanned** – covered by a horizontal (colSpan) span. The vertical
+///    inner border on the cell's leading edge is not painted.
+///  * **row-spanned** – covered by a vertical (rowSpan) span. The horizontal
+///    inner border on the cell's top edge is not painted.
+///
+/// A cell in the interior of a rectangular span is both column- and row-spanned.
+///
+/// Both flags for every cell are packed into a single [Uint8List] in row-major
+/// order. Callers use the named accessors and never manipulate the bits
+/// directly.
+class TableSpannedCells {
+  /// Creates a map able to hold the span flags for a `rows` × `columns` table.
+  TableSpannedCells({required int rows, required int columns})
+    : _columns = columns,
+      // Two flags per cell (column-spanned and row-spanned) are packed 8 bits
+      // to a byte: `* 2` reserves both bits for every cell, `+ 7` rounds the
+      // total bit count up so a trailing partial byte is still allocated, and
+      // `>> 3` converts the bit count to a byte count (an integer divide by 8).
+      _bits = Uint8List((rows * columns * 2 + 7) >> 3);
+
+  final int _columns;
+  final Uint8List _bits;
+  bool _hasSpannedCells = false;
+
+  // Each cell reserves two consecutive bits in [_bits]; these are their offsets
+  // within that pair.
+  static const int _columnSpanFlag = 0;
+  static const int _rowSpanFlag = 1;
+
+  // The absolute bit index of `flag` for the cell at (x, y). Cells are stored in
+  // row-major order and each cell owns two bits, hence the `* 2`.
+  int _bitIndexFor(int x, int y, int flag) => (y * _columns + x) * 2 + flag;
+
+  void _setFlag(int x, int y, int flag) {
+    final int bit = _bitIndexFor(x, y, flag);
+    // `bit >> 3` selects the byte holding the flag (bit ~/ 8) and `bit & 7` is
+    // the position within that byte (bit % 8).
+    _bits[bit >> 3] |= 1 << (bit & 7);
+    _hasSpannedCells = true;
+  }
+
+  bool _hasFlag(int x, int y, int flag) {
+    final int bit = _bitIndexFor(x, y, flag);
+    return _bits[bit >> 3] & (1 << (bit & 7)) != 0;
+  }
+
+  /// Whether any cell has been marked as covered by a span.
+  bool get hasSpannedCells => _hasSpannedCells;
+
+  /// Marks the cell at (`x`, `y`) as covered by a horizontal (colSpan) span.
+  void markColumnSpanned(int x, int y) => _setFlag(x, y, _columnSpanFlag);
+
+  /// Marks the cell at (`x`, `y`) as covered by a vertical (rowSpan) span.
+  void markRowSpanned(int x, int y) => _setFlag(x, y, _rowSpanFlag);
+
+  /// Whether the cell at (`x`, `y`) is covered by a horizontal (colSpan) span.
+  bool isColumnSpanned(int x, int y) => _hasFlag(x, y, _columnSpanFlag);
+
+  /// Whether the cell at (`x`, `y`) is covered by a vertical (rowSpan) span.
+  bool isRowSpanned(int x, int y) => _hasFlag(x, y, _rowSpanFlag);
+
+  /// Whether the cell at (`x`, `y`) is covered by any span.
+  bool isSpanned(int x, int y) => isColumnSpanned(x, y) || isRowSpanned(x, y);
 }

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -251,6 +251,160 @@ class TableBorder {
     );
   }
 
+  /// Draws all vertical dividers between columns without checking for spans.
+  void _paintVerticalDividersUnspanned(
+    Canvas canvas,
+    Rect rect,
+    Iterable<double> columns,
+    Paint paint,
+    Path path,
+  ) {
+    if (columns.isEmpty || verticalInside.style == BorderStyle.none) {
+      return;
+    }
+
+    paint
+      ..color = verticalInside.color
+      ..strokeWidth = verticalInside.width
+      ..style = PaintingStyle.stroke;
+    path.reset();
+
+    for (final x in columns) {
+      path.moveTo(rect.left + x, rect.top);
+      path.lineTo(rect.left + x, rect.bottom);
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  /// Draws all horizontal dividers between rows without checking for spans.
+  void _paintHorizontalDividersUnspanned(
+    Canvas canvas,
+    Rect rect,
+    Iterable<double> rows,
+    Paint paint,
+    Path path,
+  ) {
+    if (rows.isEmpty || horizontalInside.style == BorderStyle.none) {
+      return;
+    }
+
+    paint
+      ..color = horizontalInside.color
+      ..strokeWidth = horizontalInside.width
+      ..style = PaintingStyle.stroke;
+    path.reset();
+
+    for (final y in rows) {
+      path.moveTo(rect.left, rect.top + y);
+      path.lineTo(rect.right, rect.top + y);
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  /// Draws vertical dividers between columns, skipping spanned regions.
+  void _paintVerticalDividersWithSpans(
+    Canvas canvas,
+    Rect rect,
+    List<double> columnList,
+    List<double> rowTops,
+    Uint8List colSpanHiddenCells,
+    int tableColumns,
+    bool isRTL,
+    Paint paint,
+    Path path,
+  ) {
+    if (columnList.isEmpty || verticalInside.style == BorderStyle.none) {
+      return;
+    }
+
+    paint
+      ..color = verticalInside.color
+      ..strokeWidth = verticalInside.width
+      ..style = PaintingStyle.stroke;
+    path.reset();
+
+    double yOffset = rect.top;
+
+    for (var y = 0; y < rowTops.length - 1; y++) {
+      final double nextY = yOffset + (rowTops[y + 1] - rowTops[y]);
+
+      for (var x = 0; x < columnList.length; x++) {
+        // Skip a vertical divider when a colSpan covers both the cell to its
+        // left and the cell to its right at this row.  In LTR the right cell
+        // is logical col (x+1); in RTL the "right" visual cell becomes logical
+        // col (cols-1-x) which is to the left visually.
+        final int logicalX = isRTL ? (tableColumns - 1 - x) : (x + 1);
+        final int bit = y * tableColumns + logicalX;
+        if (colSpanHiddenCells[bit >> 3] & (1 << (bit & 7)) != 0) {
+          continue;
+        }
+        final double xPos = rect.left + columnList[x];
+        path
+          ..moveTo(xPos, yOffset)
+          ..lineTo(xPos, nextY);
+      }
+
+      yOffset = nextY;
+    }
+
+    canvas.drawPath(path, paint);
+  }
+
+  /// Draws horizontal dividers between rows, skipping spanned regions.
+  void _paintHorizontalDividersWithSpans(
+    Canvas canvas,
+    Rect rect,
+    List<double> rowList,
+    List<double> columnList,
+    Uint8List rowSpanHiddenCells,
+    int tableColumns,
+    bool isRTL,
+    Paint paint,
+    Path path,
+  ) {
+    if (rowList.isEmpty || horizontalInside.style == BorderStyle.none) {
+      return;
+    }
+
+    paint
+      ..color = horizontalInside.color
+      ..strokeWidth = horizontalInside.width
+      ..style = PaintingStyle.stroke;
+    path.reset();
+
+    // Compute absolute column offsets including the left and right edges.
+    final int columnCount = columnList.length;
+    final columnOffsets = Float64List(columnCount + 2);
+    columnOffsets[0] = rect.left;
+    for (var i = 0; i < columnCount; i++) {
+      columnOffsets[i + 1] = rect.left + columnList[i];
+    }
+    columnOffsets[columnCount + 1] = rect.right;
+
+    for (var y = 0; y < rowList.length; y++) {
+      final double yPos = rect.top + rowList[y];
+
+      for (var x = 0; x < columnOffsets.length - 1; x++) {
+        // Skip a horizontal divider when a rowSpan covers both the cell above
+        // and the cell below the divider in the same column.  Only rowSpan
+        // crossings are relevant here; colSpan-hidden cells on either side do
+        // not remove a horizontal border.
+        // In LTR visual segment x maps to logical col x; in RTL it maps to
+        // logical col (cols-1-x).
+        final int logicalX = isRTL ? (tableColumns - 1 - x) : x;
+        final int bit = (y + 1) * tableColumns + logicalX;
+        if (rowSpanHiddenCells[bit >> 3] & (1 << (bit & 7)) != 0) {
+          continue;
+        }
+        path
+          ..moveTo(columnOffsets[x], yPos)
+          ..lineTo(columnOffsets[x + 1], yPos);
+      }
+    }
+
+    canvas.drawPath(path, paint);
+  }
+
   /// Paints the border around the given [Rect] on the given [Canvas], with the
   /// given rows and columns.
   ///
@@ -268,6 +422,25 @@ class TableBorder {
   /// single value, 100.0, which is the vertical position between the two
   /// columns (relative to the left edge of `rect`).
   ///
+  /// The [rowTops] list contains the absolute y-position of the top edge of
+  /// each row (plus a final entry for the bottom of the last row). Row heights
+  /// are derived from consecutive differences and never cached separately.
+  ///
+  /// The optional [colSpanHiddenCells] and [rowSpanHiddenCells] are flat
+  /// bitmaps in **logical** row-major order (`bit = y * tableColumns + x`).
+  ///
+  ///  * [colSpanHiddenCells] – a set bit means logical cell (x, y) is covered
+  ///    by a **horizontal** (colSpan) span.  Vertical inner borders that fall
+  ///    inside such a span are skipped.
+  ///  * [rowSpanHiddenCells] – a set bit means logical cell (x, y) is covered
+  ///    by a **vertical** (rowSpan) span.  Horizontal inner borders that fall
+  ///    inside such a span are skipped.
+  ///
+  /// Cells at the corner of a rectangular span have their bit set in **both**
+  /// bitmaps.  When both parameters are null, no borders are skipped.
+  /// Pass [textDirection] so the bitmaps can be interpreted correctly for RTL
+  /// tables.
+  ///
   /// The [verticalInside] border is only drawn if there are at least two
   /// columns. The [horizontalInside] border is only drawn if there are at least
   /// two rows. The horizontal borders are drawn after the vertical borders.
@@ -275,61 +448,58 @@ class TableBorder {
   /// The outer borders (in the order [top], [right], [bottom], [left], with
   /// [left] above the others) are painted after the inner borders.
   ///
-  /// The paint order is particularly notable in the case of
+  /// The paint order is particularly relevant when using
   /// partially-transparent borders.
   void paint(
     Canvas canvas,
     Rect rect, {
     required Iterable<double> rows,
     required Iterable<double> columns,
+    required List<double> rowTops,
+    Uint8List? colSpanHiddenCells,
+    Uint8List? rowSpanHiddenCells,
+    TextDirection textDirection = TextDirection.ltr,
   }) {
-    // properties can't be null
-
-    // arguments can't be null
+    // Validate row and column offsets are within the table's bounds.
     assert(rows.isEmpty || (rows.first >= 0.0 && rows.last <= rect.height));
     assert(columns.isEmpty || (columns.first >= 0.0 && columns.last <= rect.width));
 
-    if (columns.isNotEmpty || rows.isNotEmpty) {
-      final paint = Paint();
-      final path = Path();
+    final paint = Paint();
+    final path = Path();
+    final List<double> columnList = columns.toList();
 
-      if (columns.isNotEmpty) {
-        switch (verticalInside.style) {
-          case BorderStyle.solid:
-            paint
-              ..color = verticalInside.color
-              ..strokeWidth = verticalInside.width
-              ..style = PaintingStyle.stroke;
-            path.reset();
-            for (final x in columns) {
-              path.moveTo(rect.left + x, rect.top);
-              path.lineTo(rect.left + x, rect.bottom);
-            }
-            canvas.drawPath(path, paint);
-          case BorderStyle.none:
-            break;
-        }
-      }
-
-      if (rows.isNotEmpty) {
-        switch (horizontalInside.style) {
-          case BorderStyle.solid:
-            paint
-              ..color = horizontalInside.color
-              ..strokeWidth = horizontalInside.width
-              ..style = PaintingStyle.stroke;
-            path.reset();
-            for (final y in rows) {
-              path.moveTo(rect.left, rect.top + y);
-              path.lineTo(rect.right, rect.top + y);
-            }
-            canvas.drawPath(path, paint);
-          case BorderStyle.none:
-            break;
-        }
-      }
+    if (colSpanHiddenCells != null || rowSpanHiddenCells != null) {
+      final int tableColumns = columnList.length + 1;
+      final isRTL = textDirection == TextDirection.rtl;
+      final List<double> rowList = rows.toList();
+      _paintHorizontalDividersWithSpans(
+        canvas,
+        rect,
+        rowList,
+        columnList,
+        rowSpanHiddenCells ?? Uint8List(0),
+        tableColumns,
+        isRTL,
+        paint,
+        path,
+      );
+      _paintVerticalDividersWithSpans(
+        canvas,
+        rect,
+        columnList,
+        rowTops,
+        colSpanHiddenCells ?? Uint8List(0),
+        tableColumns,
+        isRTL,
+        paint,
+        path,
+      );
+    } else {
+      _paintHorizontalDividersUnspanned(canvas, rect, rows, paint, path);
+      _paintVerticalDividersUnspanned(canvas, rect, columns, paint, path);
     }
 
+    // Paint the outer border of the table.
     _paintTableBorder(canvas, rect);
   }
 

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -422,10 +422,6 @@ class TableBorder {
   /// single value, 100.0, which is the vertical position between the two
   /// columns (relative to the left edge of `rect`).
   ///
-  /// The [rowTops] list contains the absolute y-position of the top edge of
-  /// each row (plus a final entry for the bottom of the last row). Row heights
-  /// are derived from consecutive differences and never cached separately.
-  ///
   /// The optional [spannedCells] records which logical cells are covered by a
   /// spanning cell, so that the inner borders that fall inside a span can be
   /// skipped:
@@ -453,7 +449,6 @@ class TableBorder {
     Rect rect, {
     required Iterable<double> rows,
     required Iterable<double> columns,
-    required List<double> rowTops,
     TableSpannedCells? spannedCells,
     TextDirection textDirection = TextDirection.ltr,
   }) {
@@ -469,17 +464,12 @@ class TableBorder {
       final int tableColumns = columnList.length + 1;
       final isRTL = textDirection == TextDirection.rtl;
       final List<double> rowList = rows.toList();
-      _paintHorizontalDividersWithSpans(
-        canvas,
-        rect,
-        rowList,
-        columnList,
-        spannedCells,
-        tableColumns,
-        isRTL,
-        paint,
-        path,
-      );
+      // The full set of row edges: the top of the first row (0.0), the inner
+      // row boundaries ([rowList]), and the bottom of the last row
+      // ([rect.height]). Consecutive differences give each row's height.
+      final rowTops = <double>[0.0, ...rowList, rect.height];
+      // Vertical dividers are painted before the horizontal ones (see the doc
+      // comment), so that horizontal borders sit on top at the intersections.
       _paintVerticalDividersWithSpans(
         canvas,
         rect,
@@ -491,9 +481,20 @@ class TableBorder {
         paint,
         path,
       );
+      _paintHorizontalDividersWithSpans(
+        canvas,
+        rect,
+        rowList,
+        columnList,
+        spannedCells,
+        tableColumns,
+        isRTL,
+        paint,
+        path,
+      );
     } else {
-      _paintHorizontalDividersUnspanned(canvas, rect, rows, paint, path);
       _paintVerticalDividersUnspanned(canvas, rect, columns, paint, path);
+      _paintHorizontalDividersUnspanned(canvas, rect, rows, paint, path);
     }
 
     // Paint the outer border of the table.

--- a/packages/flutter/lib/src/widgets/table.dart
+++ b/packages/flutter/lib/src/widgets/table.dart
@@ -145,19 +145,44 @@ class Table extends RenderObjectWidget {
        }()),
        assert(() {
          if (children.isNotEmpty) {
-           final int cellCount = children.first.children.length;
-           if (children.any((TableRow row) => row.children.length != cellCount)) {
-             throw FlutterError(
-               'Table contains irregular row lengths.\n'
-               'Every TableRow in a Table must have the same number of children, so that every cell is filled. '
-               'Otherwise, the table will contain holes.',
-             );
+           final int expectedColumnCount = children.first.children.length;
+
+           // Check if the first row has cells before using it as a reference
+           if (expectedColumnCount == 0) {
+             throw FlutterError.fromParts(<DiagnosticsNode>[
+               ErrorSummary('Empty first TableRow.'),
+               ErrorDescription(
+                 'The first TableRow in the table has no cells. '
+                 'It must contain at least one child widget to define the '
+                 "table's column count.",
+               ),
+             ]);
            }
-           if (children.any((TableRow row) => row.children.isEmpty)) {
-             throw FlutterError(
-               'One or more TableRow have no children.\n'
-               'Every TableRow in a Table must have at least one child, so there is no empty row. ',
-             );
+
+           for (var y = 0; y < children.length; y++) {
+             final TableRow row = children[y];
+             final List<Widget> cellList = row.children;
+             final int cellCount = cellList.length;
+
+             // Check if this row has the correct number of cells
+             if (cellCount != expectedColumnCount) {
+               throw FlutterError.fromParts(<DiagnosticsNode>[
+                 ErrorSummary('Inconsistent number of table cells.'),
+                 ErrorDescription(
+                   'Row $y contains $cellCount cells, but each row in this table '
+                   'must contain exactly $expectedColumnCount, like the first row.',
+                 ),
+                 ErrorHint(
+                   'When using colSpan or rowSpan, every TableRow must still '
+                   'define the same total number of cells (including placeholder '
+                   'cells such as TableCell.none) to ensure a consistent table grid.',
+                 ),
+                 ErrorDescription(
+                   'For example, if one cell spans 3 columns, you must still include '
+                   'two TableCell.none placeholders to fill the remaining column slots in that row.',
+                 ),
+               ]);
+             }
            }
          }
          return true;
@@ -438,10 +463,54 @@ class _TableElement extends RenderObjectElement {
 /// as the [child].
 class TableCell extends StatelessWidget {
   /// Creates a widget that controls how a child of a [Table] is aligned.
-  const TableCell({super.key, this.verticalAlignment, required this.child});
+  const TableCell({
+    super.key,
+    this.colSpan = 1,
+    this.rowSpan = 1,
+    this.verticalAlignment,
+    required this.child,
+  }) : assert(colSpan >= 1, 'The colSpan of a TableCell must be at least 1.'),
+       assert(rowSpan >= 1, 'The rowSpan of a TableCell must be at least 1.');
+
+  /// Internal constructor used for [TableCell.none].
+  const TableCell._none()
+    : colSpan = 0,
+      rowSpan = 0,
+      verticalAlignment = null,
+      child = const SizedBox.shrink();
+
+  /// {@template flutter.widgets.table.none}
+  /// A table cell that acts as a structural placeholder to preserve the
+  /// table’s grid alignment.
+  ///
+  /// This cell must be used in positions covered by another cell’s [colSpan]
+  /// or [rowSpan] to make the table’s structure explicit and maintain a
+  /// consistent layout across all rows and columns.
+  /// {@endtemplate}
+  static const TableCell none = TableCell._none();
 
   /// How this cell is aligned vertically.
   final TableCellVerticalAlignment? verticalAlignment;
+
+  /// The number of columns this cell should span.
+  ///
+  /// The value represents the number of columns the cell will extend to cover,
+  /// defaults to 1.
+  ///
+  /// When a cell spans multiple columns, you must follow with
+  /// the corresponding number of [TableCell.none] in the same row to fill the
+  /// remaining covered columns and maintain the table’s grid structure.
+  final int colSpan;
+
+  /// The number of rows this cell should span.
+  ///
+  /// The value represents the number of rows the cell will extend to cover,
+  /// defaults to 1.
+  ///
+  /// When a cell spans multiple rows, you must follow with
+  /// the corresponding number of [TableCell.none] in the following [TableRow]s
+  /// to preserve consistent table alignment.
+  final int rowSpan;
 
   /// The child of this cell.
   final Widget child;
@@ -449,6 +518,8 @@ class TableCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return _TableCell(
+      colSpan: colSpan,
+      rowSpan: rowSpan,
       verticalAlignment: verticalAlignment,
       child: Semantics(role: SemanticsRole.cell, child: child),
     );
@@ -456,15 +527,36 @@ class TableCell extends StatelessWidget {
 }
 
 class _TableCell extends ParentDataWidget<TableCellParentData> {
-  const _TableCell({this.verticalAlignment, required super.child});
-
+  const _TableCell({
+    this.verticalAlignment,
+    required this.colSpan,
+    required this.rowSpan,
+    required super.child,
+  });
   final TableCellVerticalAlignment? verticalAlignment;
+
+  final int colSpan;
+  final int rowSpan;
 
   @override
   void applyParentData(RenderObject renderObject) {
     final parentData = renderObject.parentData! as TableCellParentData;
+    var needsLayout = false;
+
     if (parentData.verticalAlignment != verticalAlignment) {
       parentData.verticalAlignment = verticalAlignment;
+      needsLayout = true;
+    }
+    if (parentData.colSpan != colSpan) {
+      parentData.colSpan = colSpan;
+      needsLayout = true;
+    }
+    if (parentData.rowSpan != rowSpan) {
+      parentData.rowSpan = rowSpan;
+      needsLayout = true;
+    }
+
+    if (needsLayout) {
       renderObject.parent?.markNeedsLayout();
     }
   }
@@ -475,9 +567,10 @@ class _TableCell extends ParentDataWidget<TableCellParentData> {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(
-      EnumProperty<TableCellVerticalAlignment>('verticalAlignment', verticalAlignment),
-    );
+    properties
+      ..add(EnumProperty<TableCellVerticalAlignment>('verticalAlignment', verticalAlignment))
+      ..add(IntProperty('colSpan', colSpan))
+      ..add(IntProperty('rowSpan', rowSpan));
   }
 }
 

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -402,6 +402,377 @@ void main() {
     expect(table.defaultVerticalAlignment, TableCellVerticalAlignment.intrinsicHeight);
   });
 
+  group('RenderTable colSpan and rowSpan tests', () {
+    RenderBox constrainedBox([BoxConstraints constraints = const BoxConstraints()]) {
+      return RenderConstrainedBox(additionalConstraints: constraints);
+    }
+
+    test('TableCellParentData default colSpan and rowSpan', () {
+      final parentData = TableCellParentData();
+      expect(parentData.colSpan, equals(1));
+      expect(parentData.rowSpan, equals(1));
+    });
+
+    test('TableCellParentData custom colSpan and rowSpan', () {
+      final parentData = TableCellParentData()
+        ..colSpan = 3
+        ..rowSpan = 2;
+      expect(parentData.colSpan, equals(3));
+      expect(parentData.rowSpan, equals(2));
+    });
+
+    test('TableCellParentData toString includes colSpan and rowSpan', () {
+      final parentData = TableCellParentData()
+        ..colSpan = 2
+        ..rowSpan = 3;
+      final description = parentData.toString();
+      expect(description, contains('2 cols'));
+      expect(description, contains('3 rows'));
+
+      // Test default case (should not show cols/rows when they are 1)
+      final defaultParentData = TableCellParentData();
+      final defaultDescription = defaultParentData.toString();
+      expect(defaultDescription, isNot(contains('cols')));
+      expect(defaultDescription, isNot(contains('rows')));
+    });
+
+    test('RenderTable correctly distributes column widths when using colSpan', () {
+      final table = RenderTable(
+        textDirection: TextDirection.ltr,
+        columns: 3,
+        rows: 1,
+        columnWidths: const <int, TableColumnWidth>{
+          0: FlexColumnWidth(),
+          1: FlexColumnWidth(),
+          2: FlexColumnWidth(),
+        },
+      );
+
+      final RenderBox spanningCell = constrainedBox();
+      final RenderBox regularCell = constrainedBox();
+
+      // Set up colSpan
+      final spanningCellParentData = TableCellParentData()..colSpan = 2;
+      spanningCell.parentData = spanningCellParentData;
+
+      table.setChild(0, 0, spanningCell); // spans columns 0 and 1
+      table.setChild(2, 0, regularCell); // column 2
+
+      layout(table, constraints: const BoxConstraints.tightFor(width: 300.0));
+
+      // With 3 equal flex columns and 300.0 total width, each column should
+      // be 100.0 wide. The spanning cell spans 2 columns, so it should be
+      // 200.0 wide.
+      expect(spanningCell.size.width, equals(200.0));
+      expect(regularCell.size.width, equals(100.0));
+      expect(spanningCellParentData.colSpan, equals(2));
+    });
+
+    test('RenderTable correctly merges row heights when using rowSpan', () {
+      final table = RenderTable(textDirection: TextDirection.ltr, columns: 2, rows: 2);
+
+      final RenderBox spanningCell = constrainedBox(
+        const BoxConstraints(minHeight: 200, maxHeight: 200),
+      );
+      final RenderBox regularCell1 = constrainedBox(
+        const BoxConstraints(minHeight: 150, maxHeight: 150),
+      );
+      final RenderBox regularCell2 = constrainedBox(
+        const BoxConstraints(minHeight: 50, maxHeight: 50),
+      );
+
+      // Set up rowSpan - spanning cell should span rows 0 and 1
+      final spanningCellParentData = TableCellParentData()..rowSpan = 2;
+      spanningCell.parentData = spanningCellParentData;
+
+      table.setChild(0, 0, spanningCell); // column 0, row 0 - spans to row 1
+      table.setChild(1, 0, regularCell1); // column 1, row 0
+      table.setChild(1, 1, regularCell2); // column 1, row 1
+
+      layout(table, constraints: const BoxConstraints.tightFor(width: 300.0));
+
+      expect(spanningCellParentData.rowSpan, equals(2));
+
+      expect(regularCell1.size.height, equals(150.0));
+      expect(regularCell2.size.height, equals(50.0));
+
+      // The table height should be determined by the spanning cell that takes up both rows
+      expect(table.size.height, equals(200.0));
+    });
+
+    test('RenderTable correctly handles cells spanning multiple rows and columns', () {
+      final table = RenderTable(
+        textDirection: TextDirection.ltr,
+        columns: 3,
+        rows: 3,
+        columnWidths: const <int, TableColumnWidth>{
+          0: FlexColumnWidth(),
+          1: FlexColumnWidth(),
+          2: FlexColumnWidth(),
+        },
+      );
+
+      final RenderBox spanningCell = constrainedBox(
+        const BoxConstraints(minHeight: 200, maxHeight: 200),
+      );
+      final RenderBox regularCell1 = constrainedBox(
+        const BoxConstraints(minHeight: 80, maxHeight: 80),
+      );
+      final RenderBox regularCell2 = constrainedBox(
+        const BoxConstraints(minHeight: 120, maxHeight: 120),
+      );
+      final RenderBox regularCell3 = constrainedBox(
+        const BoxConstraints(minHeight: 60, maxHeight: 60),
+      );
+
+      // Set up colSpan and rowSpan - spanning cell spans 2 columns and 2 rows
+      final spanningCellParentData = TableCellParentData()
+        ..colSpan = 2
+        ..rowSpan = 2;
+      spanningCell.parentData = spanningCellParentData;
+
+      table.setChild(0, 0, spanningCell); // column 0-1, row 0-1 (spans 2x2)
+      table.setChild(2, 0, regularCell1); // column 2, row 0
+      table.setChild(2, 1, regularCell2); // column 2, row 1
+      table.setChild(0, 2, regularCell3); // column 0, row 2
+
+      layout(table, constraints: const BoxConstraints.tightFor(width: 300.0));
+
+      expect(spanningCellParentData.colSpan, equals(2));
+      expect(spanningCellParentData.rowSpan, equals(2));
+
+      // With 3 equal flex columns and 300.0 total width, each column should
+      // be 100.0 wide. The spanning cell spans 2 columns, so it should be
+      // 200.0 wide.
+      expect(spanningCell.size.width, equals(200.0));
+      expect(regularCell1.size.width, equals(100.0));
+      expect(regularCell2.size.width, equals(100.0));
+      expect(regularCell3.size.width, equals(100.0));
+
+      // Height checks
+      expect(regularCell1.size.height, equals(80.0));
+      expect(regularCell2.size.height, equals(120.0));
+      expect(regularCell3.size.height, equals(60.0));
+
+      // The spanning cell should have its preferred height
+      expect(spanningCell.size.height, equals(200.0));
+    });
+
+    group('TableCellVerticalAlignment works correctly with colSpan and rowSpan', () {
+      const spannedCellHeight = 50.0;
+      const regularCellHeight = 80.0;
+      const tableWidth = 300.0;
+
+      // Helper to create a fixed-size RenderBox
+      RenderBox createBox(double height) {
+        return RenderConstrainedBox(additionalConstraints: BoxConstraints.tightFor(height: height));
+      }
+
+      // Helper to setup the table structure
+      // Layout:
+      // Row 0: | RowSpan 0-1 | ColSpan 1-2         |
+      // Row 1: |             | Reg 1       | Reg 2 |
+      (RenderTable, RenderBox, RenderBox) setupTable(TableCellVerticalAlignment alignment) {
+        final table = RenderTable(textDirection: TextDirection.ltr, columns: 3, rows: 2);
+
+        final RenderBox rowSpanningCell = createBox(spannedCellHeight);
+        final RenderBox colSpanningCell = createBox(spannedCellHeight);
+        final RenderBox regularCell1 = createBox(regularCellHeight);
+        final RenderBox regularCell2 = createBox(regularCellHeight);
+
+        // Setup Row Spanning Cell (Col 0, Rows 0-1)
+        rowSpanningCell.parentData = TableCellParentData()
+          ..rowSpan = 2
+          ..verticalAlignment = alignment;
+        table.setChild(0, 0, rowSpanningCell);
+
+        // Setup Column Spanning Cell (Col 1-2, Row 0)
+        colSpanningCell.parentData = TableCellParentData()
+          ..colSpan = 2
+          ..verticalAlignment = alignment;
+        table.setChild(1, 0, colSpanningCell);
+
+        // Setup Regular Cells (Row 1)
+        table.setChild(1, 1, regularCell1);
+        table.setChild(2, 1, regularCell2);
+
+        table.layout(const BoxConstraints.tightFor(width: tableWidth));
+
+        return (table, rowSpanningCell, colSpanningCell);
+      }
+
+      test('Common constraints and dimensions', () {
+        final (RenderTable table, RenderBox rowSpanCell, RenderBox colSpanCell) = setupTable(
+          TableCellVerticalAlignment.top,
+        );
+
+        // Column width logic: 300 width / 3 columns = 100 per column
+        expect(rowSpanCell.size.width, equals(100.0), reason: 'Spans 1 column');
+        expect(colSpanCell.size.width, equals(200.0), reason: 'Spans 2 columns');
+
+        final rowData = rowSpanCell.parentData! as TableCellParentData;
+        final colData = colSpanCell.parentData! as TableCellParentData;
+
+        expect(rowData.rowSpan, equals(2));
+        expect(colData.colSpan, equals(2));
+      });
+
+      test('Alignment: Fill', () {
+        final (RenderTable table, RenderBox rowSpanCell, RenderBox colSpanCell) = setupTable(
+          TableCellVerticalAlignment.fill,
+        );
+
+        // In Fill, the cell expands to match the row(s) height.
+        // Row 1 is driven by regularCell (80.0).
+        // Row 0 matches the intrinsic height of the content or the span.
+        // Total Table Height = Row 0 Height + Row 1 Height.
+
+        expect(
+          rowSpanCell.size.height,
+          equals(table.size.height),
+          reason: 'RowSpan should fill total table height',
+        );
+
+        expect(
+          colSpanCell.size.height,
+          equals(table.size.height - regularCellHeight),
+          reason: 'ColSpan should fill Row 0 (Total - Row 1)',
+        );
+      });
+
+      test('Alignment: IntrinsicHeight', () {
+        final (RenderTable table, RenderBox rowSpanCell, RenderBox colSpanCell) = setupTable(
+          TableCellVerticalAlignment.intrinsicHeight,
+        );
+
+        expect(colSpanCell.size.height, equals(spannedCellHeight));
+        expect(rowSpanCell.size.height, equals(table.size.height));
+      });
+
+      test('Alignment: Top', () {
+        final (_, RenderBox rowSpanCell, RenderBox colSpanCell) = setupTable(
+          TableCellVerticalAlignment.top,
+        );
+
+        expect(rowSpanCell.size.height, equals(spannedCellHeight));
+        expect(colSpanCell.size.height, equals(spannedCellHeight));
+
+        final rowData = rowSpanCell.parentData! as TableCellParentData;
+        final colData = colSpanCell.parentData! as TableCellParentData;
+
+        expect(rowData.offset.dy, equals(0.0), reason: 'Should start at top of table');
+        expect(colData.offset.dy, equals(0.0), reason: 'Should start at top of Row 0');
+      });
+
+      test('Alignment: Middle', () {
+        final (RenderTable table, RenderBox rowSpanCell, RenderBox colSpanCell) = setupTable(
+          TableCellVerticalAlignment.middle,
+        );
+
+        expect(rowSpanCell.size.height, equals(spannedCellHeight));
+        expect(colSpanCell.size.height, equals(spannedCellHeight));
+
+        final rowData = rowSpanCell.parentData! as TableCellParentData;
+        final colData = colSpanCell.parentData! as TableCellParentData;
+
+        // Available space calculations
+        final double totalTableHeight = table.size.height;
+        final double row0Height = totalTableHeight - regularCellHeight;
+
+        // Math: (AvailableSpace - CellSize) / 2
+        expect(rowData.offset.dy, (totalTableHeight - spannedCellHeight) / 2);
+        expect(colData.offset.dy, (row0Height - spannedCellHeight) / 2);
+      });
+
+      test('Alignment: Bottom', () {
+        final (RenderTable table, RenderBox rowSpanCell, RenderBox colSpanCell) = setupTable(
+          TableCellVerticalAlignment.bottom,
+        );
+
+        expect(rowSpanCell.size.height, equals(spannedCellHeight));
+        expect(colSpanCell.size.height, equals(spannedCellHeight));
+
+        final rowData = rowSpanCell.parentData! as TableCellParentData;
+        final colData = colSpanCell.parentData! as TableCellParentData;
+
+        final double totalTableHeight = table.size.height;
+        final double row0Height = totalTableHeight - regularCellHeight;
+
+        // Math: AvailableSpace - CellSize
+        expect(rowData.offset.dy, totalTableHeight - spannedCellHeight);
+        expect(colData.offset.dy, row0Height - spannedCellHeight);
+      });
+
+      test('Alignment: Baseline', () {
+        final table = RenderTable(
+          textDirection: TextDirection.ltr,
+          columns: 3,
+          rows: 2,
+          defaultVerticalAlignment: TableCellVerticalAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+        );
+
+        // Create RenderParagraph cells with different font sizes
+        final rowSpanningCell = RenderParagraph(
+          const TextSpan(text: 'RowSpan', style: TextStyle(fontSize: 20)),
+          textDirection: TextDirection.ltr,
+        );
+        final colSpanningCell = RenderParagraph(
+          const TextSpan(text: 'ColSpan', style: TextStyle(fontSize: 40)),
+          textDirection: TextDirection.ltr,
+        );
+        final regularCell1 = RenderParagraph(
+          const TextSpan(text: 'Reg1', style: TextStyle(fontSize: 12)),
+          textDirection: TextDirection.ltr,
+        );
+        final regularCell2 = RenderParagraph(
+          const TextSpan(text: 'Reg2', style: TextStyle(fontSize: 12)),
+          textDirection: TextDirection.ltr,
+        );
+
+        // Setup Row Spanning Cell (Col 0, Rows 0-1)
+        rowSpanningCell.parentData = TableCellParentData()
+          ..rowSpan = 2
+          ..verticalAlignment = TableCellVerticalAlignment.baseline;
+        table.setChild(0, 0, rowSpanningCell);
+
+        // Setup Column Spanning Cell (Col 1-2, Row 0)
+        colSpanningCell.parentData = TableCellParentData()
+          ..colSpan = 2
+          ..verticalAlignment = TableCellVerticalAlignment.baseline;
+        table.setChild(1, 0, colSpanningCell);
+
+        // Setup Regular Cells (Row 1) - need baseline alignment too
+        regularCell1.parentData = TableCellParentData()
+          ..verticalAlignment = TableCellVerticalAlignment.baseline;
+        regularCell2.parentData = TableCellParentData()
+          ..verticalAlignment = TableCellVerticalAlignment.baseline;
+        table.setChild(1, 1, regularCell1);
+        table.setChild(2, 1, regularCell2);
+
+        // Use the layout helper from rendering_tester.dart
+        layout(table, constraints: const BoxConstraints.tightFor(width: tableWidth));
+
+        final rowData = rowSpanningCell.parentData! as TableCellParentData;
+        final colData = colSpanningCell.parentData! as TableCellParentData;
+        final reg1Data = regularCell1.parentData! as TableCellParentData;
+        final reg2Data = regularCell2.parentData! as TableCellParentData;
+
+        // For baseline alignment, cells in the same row should align at their baselines
+        // The larger font (ColSpan 40px) will be positioned higher, smaller font (RowSpan 20px) lower
+        // so that their baselines match
+
+        // Both cells in row 0 should have aligned baselines
+        // The cell with larger font should start higher (smaller offset.dy)
+        // so its baseline matches the cell with smaller font
+        expect(colData.offset.dy, lessThan(rowData.offset.dy));
+
+        // For row 1, cells with same font size should have same offset
+        expect(reg1Data.offset.dy, equals(reg2Data.offset.dy));
+      });
+    });
+  });
+
   test('Empty table intrinsic dimensions should not crash', () {
     // Test that empty tables (0 rows x 0 columns) don't cause division by zero
     // when intrinsic size methods are called with non-zero constraints.

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -770,6 +770,41 @@ void main() {
         // For row 1, cells with same font size should have same offset
         expect(reg1Data.offset.dy, equals(reg2Data.offset.dy));
       });
+
+      test('Baseline: a cell without a baseline is top-aligned', () {
+        // Regression test: in a baseline-aligned row, a cell whose child has no
+        // baseline must be top-aligned (matching the first layout pass), not
+        // pushed down by the row's baseline distance.
+        final table = RenderTable(
+          textDirection: TextDirection.ltr,
+          columns: 2,
+          rows: 1,
+          defaultVerticalAlignment: TableCellVerticalAlignment.baseline,
+          textBaseline: TextBaseline.alphabetic,
+        );
+
+        // A tall text cell defines a non-zero baseline distance for the row.
+        final textCell = RenderParagraph(
+          const TextSpan(text: 'Text', style: TextStyle(fontSize: 40)),
+          textDirection: TextDirection.ltr,
+        );
+        textCell.parentData = TableCellParentData()
+          ..verticalAlignment = TableCellVerticalAlignment.baseline;
+        // A plain box has no baseline.
+        final RenderBox boxCell = sizedBox(50.0, 30.0);
+        boxCell.parentData = TableCellParentData()
+          ..verticalAlignment = TableCellVerticalAlignment.baseline;
+
+        table.setChild(0, 0, textCell);
+        table.setChild(1, 0, boxCell);
+
+        layout(table, constraints: const BoxConstraints.tightFor(width: 200.0));
+
+        // Row 0 starts at y = 0, so top-aligned means offset.dy == 0. Before the
+        // fix this was rowTop + beforeBaselineDistance (> 0).
+        final boxData = boxCell.parentData! as TableCellParentData;
+        expect(boxData.offset.dy, 0.0);
+      });
     });
   });
 

--- a/packages/flutter/test/rendering/table_test.dart
+++ b/packages/flutter/test/rendering/table_test.dart
@@ -829,4 +829,111 @@ void main() {
     expect(table.getMinIntrinsicHeight(double.infinity), equals(0.0));
     expect(table.getMaxIntrinsicHeight(double.infinity), equals(0.0));
   });
+
+  group('Intrinsic dimensions with colSpan and rowSpan', () {
+    test('rowSpan does not add its height to the row it starts in', () {
+      // Row 0: | RowSpan 0-1 (300 tall) | Reg (20 tall) |
+      // Row 1: |                        | Reg (20 tall) |
+      //
+      // The spanning cell covers both rows, so the table only needs to be 300
+      // tall. Measuring it as part of row 0 alone would report 320.
+      final table = RenderTable(textDirection: TextDirection.ltr, columns: 2, rows: 2);
+
+      final RenderBox spanningCell = sizedBox(50.0, 300.0);
+      spanningCell.parentData = TableCellParentData()..rowSpan = 2;
+      table.setChild(0, 0, spanningCell);
+      table.setChild(1, 0, sizedBox(50.0, 20.0));
+      table.setChild(1, 1, sizedBox(50.0, 20.0));
+
+      expect(table.getMinIntrinsicHeight(100.0), equals(300.0));
+      expect(table.getMaxIntrinsicHeight(100.0), equals(300.0));
+
+      // The intrinsic height agrees with the height the table lays out to.
+      layout(table, constraints: const BoxConstraints(maxWidth: 100.0));
+      expect(table.size.height, equals(300.0));
+    });
+
+    test('rowSpan still grows the table when the rows it covers are shorter', () {
+      // The rows the span covers only account for 40 of its 300, so the last row
+      // of the span has to absorb the remaining 260.
+      final table = RenderTable(textDirection: TextDirection.ltr, columns: 2, rows: 2);
+
+      final RenderBox spanningCell = sizedBox(50.0, 300.0);
+      spanningCell.parentData = TableCellParentData()..rowSpan = 2;
+      table.setChild(0, 0, spanningCell);
+      table.setChild(1, 0, sizedBox(50.0, 20.0));
+      table.setChild(1, 1, sizedBox(50.0, 20.0));
+
+      // Row 0 is 20 tall, so row 1 has to be 280 tall for the span to fit.
+      expect(table.getMinIntrinsicHeight(100.0), equals(300.0));
+
+      // A taller neighbour in the second row wins over the remainder of the span.
+      table.setChild(1, 1, sizedBox(50.0, 400.0));
+      expect(table.getMinIntrinsicHeight(100.0), equals(420.0));
+    });
+
+    test('placeholder cells do not contribute to the intrinsic height', () {
+      // A placeholder (TableCell.none) sits where a spanning cell already covers
+      // the grid, so whatever it is made of must not be measured.
+      final table = RenderTable(textDirection: TextDirection.ltr, columns: 2, rows: 2);
+
+      final RenderBox spanningCell = sizedBox(50.0, 40.0);
+      spanningCell.parentData = TableCellParentData()..rowSpan = 2;
+      table.setChild(0, 0, spanningCell);
+
+      final RenderBox placeholder = sizedBox(50.0, 500.0);
+      placeholder.parentData = TableCellParentData()
+        ..colSpan = 0
+        ..rowSpan = 0;
+      table.setChild(0, 1, placeholder);
+
+      table.setChild(1, 0, sizedBox(50.0, 20.0));
+      table.setChild(1, 1, sizedBox(50.0, 20.0));
+
+      expect(table.getMinIntrinsicHeight(100.0), equals(40.0));
+    });
+
+    test('colSpan measures the cell against the width of the whole span', () {
+      // The cell is as tall as it is wide, and it covers both 50 wide columns,
+      // so it is 100 tall - not the 50 it would be in a single column.
+      final table = RenderTable(
+        textDirection: TextDirection.ltr,
+        columns: 2,
+        rows: 1,
+        columnWidths: const <int, TableColumnWidth>{
+          0: FixedColumnWidth(50.0),
+          1: FixedColumnWidth(50.0),
+        },
+      );
+
+      final square = RenderAspectRatio(aspectRatio: 1.0);
+      square.parentData = TableCellParentData()..colSpan = 2;
+      table.setChild(0, 0, square);
+
+      expect(table.getMinIntrinsicHeight(100.0), equals(100.0));
+    });
+
+    test('colSpan attributes the cell width to the column it starts in', () {
+      // Documents a known limitation: TableColumnWidth is handed the cells of a
+      // single column at a time, so an IntrinsicColumnWidth column that a
+      // spanning cell starts in is sized to the whole span. The table therefore
+      // reports 350 (300 + 50) where 300 would be enough.
+      // See the TODO on RenderTable.computeMinIntrinsicWidth.
+      final table = RenderTable(
+        textDirection: TextDirection.ltr,
+        columns: 2,
+        rows: 2,
+        defaultColumnWidth: const IntrinsicColumnWidth(),
+      );
+
+      final RenderBox spanningCell = sizedBox(300.0, 20.0);
+      spanningCell.parentData = TableCellParentData()..colSpan = 2;
+      table.setChild(0, 0, spanningCell);
+      table.setChild(1, 0, sizedBox(50.0, 20.0));
+      table.setChild(1, 1, sizedBox(50.0, 20.0));
+
+      expect(table.getMaxIntrinsicWidth(double.infinity), equals(350.0));
+      expect(table.getMinIntrinsicWidth(double.infinity), equals(350.0));
+    });
+  });
 }

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -817,7 +818,7 @@ void main() {
       error = e;
     } finally {
       expect(error, isNotNull);
-      expect(error!.toStringDeep(), contains('Table contains irregular row lengths.'));
+      expect(error!.toStringDeep(), contains('Inconsistent number of table cells.'));
     }
   });
 
@@ -915,8 +916,10 @@ void main() {
 
     expect(
       result,
-      'One or more TableRow have no children.\n'
-      'Every TableRow in a Table must have at least one child, so there is no empty row.',
+      'Empty first TableRow.\n'
+      'The first TableRow in the table has no cells. '
+      'It must contain at least one child widget to define the '
+      "table's column count.",
     );
   });
 
@@ -1094,5 +1097,1060 @@ void main() {
 
     final int? cellWrapperIdAfterUIchanges = textFieldSemanticsNodeNew.parent?.id;
     expect(cellWrapperIdAfterUIchanges, cellWrapperId);
+  });
+
+  group('TableCell colSpan and rowSpan tests', () {
+    const spannedCellHeight = 50.0;
+    const regularCellHeight = 80.0;
+    const tableWidth = 300.0;
+
+    testWidgets('TableCell with default colSpan and rowSpan', (WidgetTester tester) async {
+      const cell = TableCell(child: Text('Cell'));
+      expect(cell.colSpan, equals(1));
+      expect(cell.rowSpan, equals(1));
+    });
+
+    testWidgets('TableCell with custom colSpan', (WidgetTester tester) async {
+      const cell = TableCell(colSpan: 3, child: Text('Cell'));
+      expect(cell.colSpan, equals(3));
+      expect(cell.rowSpan, equals(1));
+    });
+
+    testWidgets('TableCell with custom rowSpan', (WidgetTester tester) async {
+      const cell = TableCell(rowSpan: 2, child: Text('Cell'));
+      expect(cell.colSpan, equals(1));
+      expect(cell.rowSpan, equals(2));
+    });
+
+    testWidgets('TableCell with both colSpan and rowSpan', (WidgetTester tester) async {
+      const cell = TableCell(colSpan: 2, rowSpan: 3, child: Text('Cell'));
+      expect(cell.colSpan, equals(2));
+      expect(cell.rowSpan, equals(3));
+    });
+
+    testWidgets('TableCell.none has zero colSpan and rowSpan', (WidgetTester tester) async {
+      expect(TableCell.none.colSpan, equals(0));
+      expect(TableCell.none.rowSpan, equals(0));
+    });
+
+    testWidgets('Table with colSpan - basic functionality', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(colSpan: 2, child: Text('Spanning Cell')),
+                  TableCell.none,
+                ],
+              ),
+              TableRow(children: <Widget>[Text('Cell 1'), Text('Cell 2')]),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Spanning Cell'), findsOneWidget);
+      expect(find.text('Cell 1'), findsOneWidget);
+      expect(find.text('Cell 2'), findsOneWidget);
+    });
+
+    testWidgets('Table with rowSpan - basic functionality', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(rowSpan: 2, child: Text('Spanning Cell')),
+                  Text('Cell 1'),
+                ],
+              ),
+              TableRow(children: <Widget>[TableCell.none, Text('Cell 2')]),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Spanning Cell'), findsOneWidget);
+      expect(find.text('Cell 1'), findsOneWidget);
+      expect(find.text('Cell 2'), findsOneWidget);
+    });
+
+    testWidgets('Table with both colSpan and rowSpan', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(colSpan: 2, rowSpan: 2, child: Text('Large Cell')),
+                  TableCell.none,
+                  Text('Right Cell'),
+                ],
+              ),
+              TableRow(children: <Widget>[TableCell.none, TableCell.none, Text('Bottom Right')]),
+              TableRow(children: <Widget>[Text('Bottom 1'), Text('Bottom 2'), Text('Bottom 3')]),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Large Cell'), findsOneWidget);
+      expect(find.text('Right Cell'), findsOneWidget);
+      expect(find.text('Bottom Right'), findsOneWidget);
+      expect(find.text('Bottom 1'), findsOneWidget);
+      expect(find.text('Bottom 2'), findsOneWidget);
+      expect(find.text('Bottom 3'), findsOneWidget);
+    });
+
+    testWidgets('TableCell colSpan exceeds table columns - throws error', (
+      WidgetTester tester,
+    ) async {
+      final errors = <FlutterErrorDetails>[];
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      FlutterError.onError = errors.add;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(colSpan: 3, child: Text('Too Wide')),
+                  TableCell.none,
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      FlutterError.onError = oldHandler;
+
+      expect(errors, isNotEmpty);
+      expect(errors.first.exception, isA<FlutterError>());
+      expect(errors.first.exception.toString(), contains('Invalid TableCell.colSpan'));
+    });
+
+    testWidgets('TableCell rowSpan exceeds table rows - throws error', (WidgetTester tester) async {
+      final errors = <FlutterErrorDetails>[];
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      FlutterError.onError = errors.add;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(rowSpan: 3, child: Text('Too Tall')),
+                  TableCell.none,
+                ],
+              ),
+              TableRow(children: <Widget>[TableCell.none, Text('Cell 2')]),
+            ],
+          ),
+        ),
+      );
+
+      FlutterError.onError = oldHandler;
+
+      expect(errors, isNotEmpty);
+      expect(errors.first.exception, isA<FlutterError>());
+      expect(errors.first.exception.toString(), contains('Invalid TableCell.rowSpan'));
+    });
+
+    testWidgets('Non-TableCell.none widget in colSpan-covered position - throws error', (
+      WidgetTester tester,
+    ) async {
+      final errors = <FlutterErrorDetails>[];
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      FlutterError.onError = errors.add;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(colSpan: 2, child: Text('Spanning')),
+                  Text('not a placeholder'), // must be TableCell.none
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      FlutterError.onError = oldHandler;
+
+      expect(errors, isNotEmpty);
+      expect(
+        errors.first.exception.toString(),
+        contains('is covered by a spanning cell but is not TableCell.none'),
+      );
+    });
+
+    testWidgets('Non-TableCell.none widget in rowSpan-covered position - throws error', (
+      WidgetTester tester,
+    ) async {
+      final errors = <FlutterErrorDetails>[];
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      FlutterError.onError = errors.add;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(rowSpan: 2, child: Text('Spanning')),
+                  Text('Cell 1'),
+                ],
+              ),
+              TableRow(
+                children: <Widget>[
+                  Text('not a placeholder'), // must be TableCell.none
+                  Text('Cell 2'),
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      FlutterError.onError = oldHandler;
+
+      expect(errors, isNotEmpty);
+      expect(
+        errors.first.exception.toString(),
+        contains('is covered by a spanning cell but is not TableCell.none'),
+      );
+    });
+
+    testWidgets('TableCell with colSpan at last column - valid edge case', (
+      WidgetTester tester,
+    ) async {
+      // This should not throw an error as colSpan is exactly at the boundary
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  Text('Cell 1'),
+                  TableCell(colSpan: 2, child: Text('Last Two')),
+                  TableCell.none,
+                ],
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Cell 1'), findsOneWidget);
+      expect(find.text('Last Two'), findsOneWidget);
+    });
+
+    testWidgets('TableCell with rowSpan at last row - valid edge case', (
+      WidgetTester tester,
+    ) async {
+      // This should not throw an error as rowSpan is exactly at the boundary
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  Text('Cell 1'),
+                  TableCell(rowSpan: 2, child: Text('Tall Cell')),
+                ],
+              ),
+              TableRow(children: <Widget>[Text('Cell 2'), TableCell.none]),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Cell 1'), findsOneWidget);
+      expect(find.text('Cell 2'), findsOneWidget);
+      expect(find.text('Tall Cell'), findsOneWidget);
+    });
+
+    testWidgets('TableCell colSpan and rowSpan assertions', (WidgetTester tester) async {
+      expect(() => TableCell(colSpan: 0, child: Container()), throwsAssertionError);
+
+      expect(() => TableCell(rowSpan: 0, child: Container()), throwsAssertionError);
+
+      expect(() => TableCell(colSpan: -1, child: Container()), throwsAssertionError);
+
+      expect(() => TableCell(rowSpan: -1, child: Container()), throwsAssertionError);
+    });
+
+    testWidgets('TableCell parent data contains colSpan and rowSpan', (WidgetTester tester) async {
+      const testKey = ValueKey<String>('TestCell');
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(key: testKey, colSpan: 2, rowSpan: 3, child: Text('Test')),
+                  TableCell.none,
+                ],
+              ),
+              TableRow(children: <Widget>[TableCell.none, TableCell.none]),
+              TableRow(children: <Widget>[TableCell.none, TableCell.none]),
+            ],
+          ),
+        ),
+      );
+
+      // Instead of trying to access parentData directly, test the widget properties
+      final TableCell cellWidget = tester.widget(find.byKey(testKey));
+      expect(cellWidget.colSpan, equals(2));
+      expect(cellWidget.rowSpan, equals(3));
+    });
+
+    testWidgets('Table with complex colSpan and rowSpan layout', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(colSpan: 2, child: Text('Header')),
+                  TableCell.none,
+                  Text('Top Right'),
+                ],
+              ),
+              TableRow(
+                children: <Widget>[
+                  TableCell(rowSpan: 2, child: Text('Left Tall')),
+                  Text('Middle'),
+                  TableCell(rowSpan: 2, child: Text('Right Tall')),
+                ],
+              ),
+              TableRow(children: <Widget>[TableCell.none, Text('Bottom Middle'), TableCell.none]),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Header'), findsOneWidget);
+      expect(find.text('Top Right'), findsOneWidget);
+      expect(find.text('Left Tall'), findsOneWidget);
+      expect(find.text('Middle'), findsOneWidget);
+      expect(find.text('Right Tall'), findsOneWidget);
+      expect(find.text('Bottom Middle'), findsOneWidget);
+    });
+
+    testWidgets('Table with all cells using TableCell.none in spanning area', (
+      WidgetTester tester,
+    ) async {
+      // Test that using TableCell.none correctly maintains table structure
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Table(
+            children: const <TableRow>[
+              TableRow(
+                children: <Widget>[
+                  TableCell(colSpan: 3, rowSpan: 2, child: Text('Big Cell')),
+                  TableCell.none,
+                  TableCell.none,
+                ],
+              ),
+              TableRow(children: <Widget>[TableCell.none, TableCell.none, TableCell.none]),
+              TableRow(children: <Widget>[Text('A'), Text('B'), Text('C')]),
+            ],
+          ),
+        ),
+      );
+
+      expect(find.text('Big Cell'), findsOneWidget);
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+      expect(find.text('C'), findsOneWidget);
+    });
+
+    group('TableCellVerticalAlignment works correctly with colSpan and rowSpan', () {
+      // Helper to setup the table structure
+      // Layout:
+      // Row 0: | RowSpan 0-1 | ColSpan 1-2         |
+      // Row 1: |             | Reg 1       | Reg 2 |
+      Widget buildTable({TableCellVerticalAlignment? alignment}) {
+        return Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox(
+              width: tableWidth,
+              child: Table(
+                defaultVerticalAlignment: alignment ?? TableCellVerticalAlignment.fill,
+                children: const <TableRow>[
+                  TableRow(
+                    children: <Widget>[
+                      TableCell(
+                        rowSpan: 2,
+                        child: SizedBox(height: spannedCellHeight, child: Text('RowSpan')),
+                      ),
+                      TableCell(
+                        colSpan: 2,
+                        child: SizedBox(height: spannedCellHeight, child: Text('ColSpan')),
+                      ),
+                      TableCell.none,
+                    ],
+                  ),
+                  TableRow(
+                    children: <Widget>[
+                      TableCell.none,
+                      TableCell(
+                        verticalAlignment: TableCellVerticalAlignment.top,
+                        child: SizedBox(height: regularCellHeight, child: Text('Reg1')),
+                      ),
+                      SizedBox(height: regularCellHeight, child: Text('Reg2')),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      }
+
+      Future<void> pumpTable(WidgetTester tester, {TableCellVerticalAlignment? alignment}) async {
+        await tester.pumpWidget(buildTable(alignment: alignment));
+      }
+
+      Rect rowSpanRect(WidgetTester tester) => tester.getRect(find.text('RowSpan'));
+
+      Rect colSpanRect(WidgetTester tester) => tester.getRect(find.text('ColSpan'));
+
+      Rect tableRect(WidgetTester tester) => tester.getRect(find.byType(Table));
+
+      double row0Height(Rect tableRect) => tableRect.height - regularCellHeight;
+
+      testWidgets('Common constraints and dimensions', (WidgetTester tester) async {
+        await pumpTable(tester);
+
+        final Rect rowSpan = rowSpanRect(tester);
+        final Rect colSpan = colSpanRect(tester);
+
+        expect(rowSpan.width, equals(100.0));
+        expect(colSpan.width, equals(200.0));
+      });
+
+      testWidgets('Alignment: Fill', (WidgetTester tester) async {
+        await pumpTable(tester, alignment: TableCellVerticalAlignment.fill);
+
+        final Rect table = tableRect(tester);
+        final Rect rowSpan = rowSpanRect(tester);
+        final Rect colSpan = colSpanRect(tester);
+
+        expect(rowSpan.height, equals(table.height));
+        expect(colSpan.height, equals(table.height - regularCellHeight));
+      });
+
+      testWidgets('Alignment: IntrinsicHeight', (WidgetTester tester) async {
+        await pumpTable(tester, alignment: TableCellVerticalAlignment.intrinsicHeight);
+
+        final Rect table = tableRect(tester);
+        final Rect rowSpan = rowSpanRect(tester);
+        final Rect colSpan = colSpanRect(tester);
+
+        expect(colSpan.height, equals(spannedCellHeight));
+        expect(rowSpan.height, equals(table.height));
+      });
+
+      testWidgets('Alignment: Top', (WidgetTester tester) async {
+        await pumpTable(tester, alignment: TableCellVerticalAlignment.top);
+
+        final Rect table = tableRect(tester);
+        final Rect rowSpan = rowSpanRect(tester);
+        final Rect colSpan = colSpanRect(tester);
+
+        expect(rowSpan.height, equals(spannedCellHeight));
+        expect(colSpan.height, equals(spannedCellHeight));
+        expect(rowSpan.top, equals(table.top));
+        expect(colSpan.top, equals(table.top));
+      });
+
+      testWidgets('Alignment: Middle', (WidgetTester tester) async {
+        await pumpTable(tester, alignment: TableCellVerticalAlignment.middle);
+
+        final Rect table = tableRect(tester);
+        final Rect rowSpan = rowSpanRect(tester);
+        final Rect colSpan = colSpanRect(tester);
+        final double rowHeight0 = row0Height(table);
+
+        final double expectedRowSpanTop = table.top + (table.height - spannedCellHeight) / 2;
+
+        final double expectedColSpanTop = table.top + (rowHeight0 - spannedCellHeight) / 2;
+
+        expect(rowSpan.top, expectedRowSpanTop);
+        expect(colSpan.top, expectedColSpanTop);
+      });
+
+      testWidgets('Alignment: Bottom', (WidgetTester tester) async {
+        await pumpTable(tester, alignment: TableCellVerticalAlignment.bottom);
+
+        final Rect table = tableRect(tester);
+        final Rect rowSpan = rowSpanRect(tester);
+        final Rect colSpan = colSpanRect(tester);
+        final double rowHeight0 = row0Height(table);
+
+        final double expectedRowSpanTop = table.top + (table.height - spannedCellHeight);
+        final double expectedColSpanTop = table.top + (rowHeight0 - spannedCellHeight);
+
+        expect(rowSpan.top, expectedRowSpanTop);
+        expect(colSpan.top, expectedColSpanTop);
+      });
+
+      testWidgets('Alignment: Baseline', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: Center(
+              child: SizedBox(
+                width: tableWidth,
+                child: Table(
+                  defaultVerticalAlignment: TableCellVerticalAlignment.baseline,
+                  textBaseline: TextBaseline.alphabetic,
+                  children: const <TableRow>[
+                    TableRow(
+                      children: <Widget>[
+                        TableCell(
+                          rowSpan: 2,
+                          child: Text('RowSpan', style: TextStyle(fontSize: 20)),
+                        ),
+                        TableCell(
+                          colSpan: 2,
+                          child: Text('ColSpan', style: TextStyle(fontSize: 40)),
+                        ),
+                        TableCell.none,
+                      ],
+                    ),
+                    TableRow(
+                      children: <Widget>[
+                        TableCell.none,
+                        Text('Reg1', style: TextStyle(fontSize: 12)),
+                        Text('Reg2', style: TextStyle(fontSize: 12)),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Get RenderParagraph to calculate baseline offset
+        final RenderParagraph rowSpanRender = tester.renderObject(find.text('RowSpan'));
+        final RenderParagraph colSpanRender = tester.renderObject(find.text('ColSpan'));
+        final RenderParagraph reg1Render = tester.renderObject(find.text('Reg1'));
+        final RenderParagraph reg2Render = tester.renderObject(find.text('Reg2'));
+
+        // Get positions of texts
+        final Rect rowSpanRect = tester.getRect(find.text('RowSpan'));
+        final Rect colSpanRect = tester.getRect(find.text('ColSpan'));
+        final Rect reg1Rect = tester.getRect(find.text('Reg1'));
+        final Rect reg2Rect = tester.getRect(find.text('Reg2'));
+
+        // Calculate baseline positions using text metrics
+        // The baseline is typically at ~80% of the font size from top for alphabetic baseline
+        final double rowSpanBaseline = rowSpanRect.top + rowSpanRender.text.style!.fontSize! * 0.8;
+        final double colSpanBaseline = colSpanRect.top + colSpanRender.text.style!.fontSize! * 0.8;
+
+        // Both cells in row 0 should have the same baseline
+        expect(rowSpanBaseline, closeTo(colSpanBaseline, 1.0));
+
+        // For row 1, cells with same font size should have same top position
+        final double reg1Baseline = reg1Rect.top + reg1Render.text.style!.fontSize! * 0.8;
+        final double reg2Baseline = reg2Rect.top + reg2Render.text.style!.fontSize! * 0.8;
+
+        // Both cells in row 1 should have the same baseline
+        expect(reg1Baseline, closeTo(reg2Baseline, 0.5));
+      });
+    });
+
+    group('Table golden tests', () {
+      testWidgets('Table with colSpan is displayed correctly', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          RepaintBoundary(
+            child: Center(
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: SizedBox(
+                  width: 300,
+                  child: Table(
+                    border: TableBorder.all(),
+                    defaultColumnWidth: const FixedColumnWidth(100),
+                    children: <TableRow>[
+                      TableRow(
+                        children: <Widget>[
+                          TableCell(
+                            colSpan: 2,
+                            child: Container(
+                              height: 40,
+                              color: const Color(0xFF2196F3),
+                              alignment: Alignment.center,
+                              child: const Text('Spanning 2 cols'),
+                            ),
+                          ),
+                          TableCell.none,
+                          Container(
+                            height: 40,
+                            color: const Color(0xFF4CAF50),
+                            alignment: Alignment.center,
+                            child: const Text('Col 3'),
+                          ),
+                        ],
+                      ),
+                      TableRow(
+                        children: <Widget>[
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFFFCDD2),
+                            alignment: Alignment.center,
+                            child: const Text('R2C1'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFEF9A9A),
+                            alignment: Alignment.center,
+                            child: const Text('R2C2'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFE57373),
+                            alignment: Alignment.center,
+                            child: const Text('R2C3'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await expectLater(find.byType(RepaintBoundary), matchesGoldenFile('table.colSpan.png'));
+      });
+
+      testWidgets('Table with rowSpan is displayed correctly', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          RepaintBoundary(
+            child: Center(
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: SizedBox(
+                  width: 300,
+                  child: Table(
+                    border: TableBorder.all(),
+                    defaultColumnWidth: const FixedColumnWidth(100),
+                    children: <TableRow>[
+                      TableRow(
+                        children: <Widget>[
+                          TableCell(
+                            rowSpan: 2,
+                            child: Container(
+                              height: 80,
+                              color: const Color(0xFF2196F3),
+                              alignment: Alignment.center,
+                              child: const Text('Spanning\n2 rows'),
+                            ),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFC8E6C9),
+                            alignment: Alignment.center,
+                            child: const Text('R1C2'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFA5D6A7),
+                            alignment: Alignment.center,
+                            child: const Text('R1C3'),
+                          ),
+                        ],
+                      ),
+                      TableRow(
+                        children: <Widget>[
+                          TableCell.none,
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFFFCDD2),
+                            alignment: Alignment.center,
+                            child: const Text('R2C2'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFEF9A9A),
+                            alignment: Alignment.center,
+                            child: const Text('R2C3'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await expectLater(find.byType(RepaintBoundary), matchesGoldenFile('table.rowSpan.png'));
+      });
+
+      testWidgets('Table with colSpan and rowSpan combined is displayed correctly', (
+        WidgetTester tester,
+      ) async {
+        await tester.pumpWidget(
+          RepaintBoundary(
+            child: Center(
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: SizedBox(
+                  width: 300,
+                  child: Table(
+                    border: TableBorder.all(),
+                    defaultColumnWidth: const FixedColumnWidth(100),
+                    children: <TableRow>[
+                      TableRow(
+                        children: <Widget>[
+                          TableCell(
+                            colSpan: 2,
+                            rowSpan: 2,
+                            child: Container(
+                              height: 80,
+                              color: const Color(0xFF2196F3),
+                              alignment: Alignment.center,
+                              child: const Text('2x2\nCell'),
+                            ),
+                          ),
+                          TableCell.none,
+                          Container(
+                            height: 40,
+                            color: const Color(0xFF4CAF50),
+                            alignment: Alignment.center,
+                            child: const Text('R1C3'),
+                          ),
+                        ],
+                      ),
+                      TableRow(
+                        children: <Widget>[
+                          TableCell.none,
+                          TableCell.none,
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFFF9800),
+                            alignment: Alignment.center,
+                            child: const Text('R2C3'),
+                          ),
+                        ],
+                      ),
+                      TableRow(
+                        children: <Widget>[
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFFFCDD2),
+                            alignment: Alignment.center,
+                            child: const Text('R3C1'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFEF9A9A),
+                            alignment: Alignment.center,
+                            child: const Text('R3C2'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFE57373),
+                            alignment: Alignment.center,
+                            child: const Text('R3C3'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await expectLater(
+          find.byType(RepaintBoundary),
+          matchesGoldenFile('table.colSpan_rowSpan_combined.png'),
+        );
+      });
+
+      testWidgets('Table with complex spanning layout is displayed correctly', (
+        WidgetTester tester,
+      ) async {
+        // A more complex table layout similar to what you might see in a real application
+        await tester.pumpWidget(
+          RepaintBoundary(
+            child: Center(
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: SizedBox(
+                  width: 400,
+                  child: Table(
+                    border: TableBorder.all(),
+                    defaultColumnWidth: const FixedColumnWidth(100),
+                    children: <TableRow>[
+                      // Header row spanning all columns
+                      TableRow(
+                        decoration: const BoxDecoration(color: Color(0xFF607D8B)),
+                        children: <Widget>[
+                          TableCell(
+                            colSpan: 4,
+                            child: Container(
+                              height: 50,
+                              alignment: Alignment.center,
+                              child: const Text(
+                                'Table Header',
+                                style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  color: Color(0xFFFFFFFF),
+                                ),
+                              ),
+                            ),
+                          ),
+                          TableCell.none,
+                          TableCell.none,
+                          TableCell.none,
+                        ],
+                      ),
+                      // Row with side label spanning multiple rows
+                      TableRow(
+                        children: <Widget>[
+                          TableCell(
+                            rowSpan: 2,
+                            child: Container(
+                              height: 80,
+                              color: const Color(0xFFFFC107),
+                              alignment: Alignment.center,
+                              child: const Text('Label'),
+                            ),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFB3E5FC),
+                            alignment: Alignment.center,
+                            child: const Text('A'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFF81D4FA),
+                            alignment: Alignment.center,
+                            child: const Text('B'),
+                          ),
+                          Container(
+                            height: 40,
+                            color: const Color(0xFF4FC3F7),
+                            alignment: Alignment.center,
+                            child: const Text('C'),
+                          ),
+                        ],
+                      ),
+                      TableRow(
+                        children: <Widget>[
+                          TableCell.none,
+                          Container(
+                            height: 40,
+                            color: const Color(0xFFDCEDC8),
+                            alignment: Alignment.center,
+                            child: const Text('D'),
+                          ),
+                          TableCell(
+                            colSpan: 2,
+                            child: Container(
+                              height: 40,
+                              color: const Color(0xFFCE93D8),
+                              alignment: Alignment.center,
+                              child: const Text('E+F'),
+                            ),
+                          ),
+                          TableCell.none,
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+        await expectLater(
+          find.byType(RepaintBoundary),
+          matchesGoldenFile('table.complex_spanning.png'),
+        );
+      });
+
+      group('Table VerticalAlignment with Spans', () {
+        Widget buildGoldenTable({required TableCellVerticalAlignment alignment}) {
+          return RepaintBoundary(
+            child: Center(
+              child: Directionality(
+                textDirection: TextDirection.ltr,
+                child: SizedBox(
+                  width: tableWidth,
+                  child: Table(
+                    border: TableBorder.all(),
+                    defaultVerticalAlignment: alignment,
+                    children: <TableRow>[
+                      TableRow(
+                        children: <Widget>[
+                          TableCell(
+                            rowSpan: 2,
+                            child: Container(
+                              height: spannedCellHeight,
+                              color: const Color(0xFF2196F3),
+                              alignment: Alignment.center,
+                              child: const Text('RowSpan'),
+                            ),
+                          ),
+                          TableCell(
+                            colSpan: 2,
+                            child: Container(
+                              height: spannedCellHeight,
+                              color: const Color(0xFF4CAF50),
+                              alignment: Alignment.center,
+                              child: const Text('ColSpan'),
+                            ),
+                          ),
+                          TableCell.none,
+                        ],
+                      ),
+                      TableRow(
+                        children: <Widget>[
+                          TableCell.none,
+                          TableCell(
+                            verticalAlignment: TableCellVerticalAlignment.top,
+                            child: Container(
+                              height: regularCellHeight,
+                              color: const Color(0xFFFF9800),
+                              alignment: Alignment.center,
+                              child: const Text('Reg1'),
+                            ),
+                          ),
+                          Container(
+                            height: regularCellHeight,
+                            color: const Color(0xFFF44336),
+                            alignment: Alignment.center,
+                            child: const Text('Reg2'),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+
+        testWidgets('Golden: Fill alignment', (WidgetTester tester) async {
+          await tester.pumpWidget(buildGoldenTable(alignment: TableCellVerticalAlignment.fill));
+          await expectLater(
+            find.byType(RepaintBoundary),
+            matchesGoldenFile('table.vertical_alignment_fill.png'),
+          );
+        });
+
+        testWidgets('Golden: Top alignment', (WidgetTester tester) async {
+          await tester.pumpWidget(buildGoldenTable(alignment: TableCellVerticalAlignment.top));
+          await expectLater(
+            find.byType(RepaintBoundary),
+            matchesGoldenFile('table.vertical_alignment_top.png'),
+          );
+        });
+
+        testWidgets('Golden: IntrinsicHeight alignment', (WidgetTester tester) async {
+          await tester.pumpWidget(
+            buildGoldenTable(alignment: TableCellVerticalAlignment.intrinsicHeight),
+          );
+          await expectLater(
+            find.byType(RepaintBoundary),
+            matchesGoldenFile('table.vertical_alignment_intrinsicHeight.png'),
+          );
+        });
+
+        testWidgets('Golden: Middle alignment', (WidgetTester tester) async {
+          await tester.pumpWidget(buildGoldenTable(alignment: TableCellVerticalAlignment.middle));
+          await expectLater(
+            find.byType(RepaintBoundary),
+            matchesGoldenFile('table.vertical_alignment_middle.png'),
+          );
+        });
+
+        testWidgets('Golden: Bottom alignment', (WidgetTester tester) async {
+          await tester.pumpWidget(buildGoldenTable(alignment: TableCellVerticalAlignment.bottom));
+          await expectLater(
+            find.byType(RepaintBoundary),
+            matchesGoldenFile('table.vertical_alignment_bottom.png'),
+          );
+        });
+
+        testWidgets('Golden: Baseline alignment', (WidgetTester tester) async {
+          await tester.pumpWidget(
+            RepaintBoundary(
+              child: Center(
+                child: Directionality(
+                  textDirection: TextDirection.ltr,
+                  child: SizedBox(
+                    width: tableWidth,
+                    child: Table(
+                      border: TableBorder.all(),
+                      defaultVerticalAlignment: TableCellVerticalAlignment.baseline,
+                      textBaseline: TextBaseline.alphabetic,
+                      children: const <TableRow>[
+                        TableRow(
+                          children: <Widget>[
+                            TableCell(
+                              rowSpan: 2,
+                              child: Text('RowSpan', style: TextStyle(fontSize: 20)),
+                            ),
+                            TableCell(
+                              colSpan: 2,
+                              child: Text('ColSpan', style: TextStyle(fontSize: 40)),
+                            ),
+                            TableCell.none,
+                          ],
+                        ),
+                        TableRow(
+                          children: <Widget>[
+                            TableCell.none,
+                            Text('Reg1', style: TextStyle(fontSize: 12)),
+                            Text('Reg2', style: TextStyle(fontSize: 12)),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await expectLater(
+            find.byType(RepaintBoundary),
+            matchesGoldenFile('table.vertical_alignment_baseline.png'),
+          );
+        });
+      });
+    });
   });
 }

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is run as part of a reduced test set in CI on Mac and Windows
+// machines.
+@Tags(<String>['reduced-test-set'])
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/table_test.dart
+++ b/packages/flutter/test/widgets/table_test.dart
@@ -1294,7 +1294,7 @@ void main() {
       expect(errors, isNotEmpty);
       expect(
         errors.first.exception.toString(),
-        contains('is covered by a spanning cell but is not TableCell.none'),
+        contains('must be declared as TableCell.none'),
       );
     });
 
@@ -1332,7 +1332,7 @@ void main() {
       expect(errors, isNotEmpty);
       expect(
         errors.first.exception.toString(),
-        contains('is covered by a spanning cell but is not TableCell.none'),
+        contains('must be declared as TableCell.none'),
       );
     });
 


### PR DESCRIPTION
## Description

This PR adds support for `colSpan` and `rowSpan` to the `TableCell` widget.  
With this change, each `TableCell` can now span multiple columns and/or rows, similar to how HTML tables work.

This allows developers to create more flexible and complex table layouts without manually merging cells or resorting to nested tables.

#### Examples

<details>
    <summary>Example 1</summary>

<img width="350" alt="image" src="https://github.com/user-attachments/assets/eaa2a0fc-2c75-41f7-829d-02f355608ecc" />


```dart
Table(
  border: TableBorder.all(color: Colors.grey),
  columnWidths: const <int, TableColumnWidth>{
    0: FixedColumnWidth(120),
    1: FlexColumnWidth(),
    2: FlexColumnWidth(),
  },
  children: <TableRow>[
    const TableRow(
      decoration: BoxDecoration(color: Color(0xFFE0E0E0)),
      children: <Widget>[
        TableCell(
          colSpan: 3,
          child: Padding(
            padding: EdgeInsets.all(8),
            child: Text(
              'Invoice Summary',
              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
              textAlign: TextAlign.center,
            ),
          ),
        ),
        TableCell.none,
        TableCell.none,
      ],
    ),
    const TableRow(
      decoration: BoxDecoration(color: Color(0xFFF5F5F5)),
      children: <Widget>[
        Padding(padding: EdgeInsets.all(8), child: Text('Customer')),
        TableCell(
          colSpan: 2,
          child: Padding(padding: EdgeInsets.all(8), child: Text('Alex Frei')),
        ),
        TableCell.none,
      ],
    ),
    const TableRow(
      children: <Widget>[
        Padding(padding: EdgeInsets.all(8), child: Text('Date')),
        Padding(padding: EdgeInsets.all(8), child: Text('16 Oct 2025')),
        Padding(padding: EdgeInsets.all(8), child: Text('Invoice #1024')),
      ],
    ),
    const TableRow(
      decoration: BoxDecoration(color: Color(0xFFE0E0E0)),
      children: <Widget>[
        TableCell(
          colSpan: 3,
          child: Padding(
            padding: EdgeInsets.all(8),
            child: Text('Items', style: TextStyle(fontWeight: FontWeight.bold)),
          ),
        ),
        TableCell.none,
        TableCell.none,
      ],
    ),
    const TableRow(
      children: <Widget>[
        Padding(padding: EdgeInsets.all(8), child: Text('Development Work')),
        Padding(padding: EdgeInsets.all(8), child: Text('10 hours')),
        Padding(padding: EdgeInsets.all(8), child: Text(r'$500')),
      ],
    ),
    const TableRow(
      children: <Widget>[
        Padding(padding: EdgeInsets.all(8), child: Text('Design Work')),
        Padding(padding: EdgeInsets.all(8), child: Text('5 hours')),
        Padding(padding: EdgeInsets.all(8), child: Text(r'$250')),
      ],
    ),
    TableRow(
      children: <Widget>[
        TableCell(
          rowSpan: 2,
          verticalAlignment: TableCellVerticalAlignment.fill,
          child: Container(
            color: const Color(0xFFF5F5F5),
            padding: const EdgeInsets.all(8),
            child: const Text('Notes'),
          ),
        ),
        const TableCell(
          colSpan: 2,
          child: Padding(
            padding: EdgeInsets.all(8),
            child: Text('Thank you for your business!'),
          ),
        ),
        TableCell.none,
      ],
    ),
    const TableRow(
      children: <Widget>[
        TableCell.none,
        TableCell(
          colSpan: 2,
          child: Padding(padding: EdgeInsets.all(8), child: Text('Payment due in 14 days.')),
        ),
        TableCell.none,
      ],
    ),
  ],
)
```
</details>

<details>
    <summary>Example 2</summary>

<img width="350" alt="image" src="https://github.com/user-attachments/assets/96d385dd-0082-46f7-aa28-e20db47abef8" />

```dart
Table(
  border: TableBorder.all(),
  children: <TableRow>[
    TableRow(
      children: <Widget>[
        TableCell(
          rowSpan: 3,
          verticalAlignment: TableCellVerticalAlignment.fill,
          child: Container(color: Colors.blue),
        ),
        TableCell(colSpan: 2, child: Container(color: Colors.pink, height: 50)),
        TableCell.none,
      ],
    ),
    TableRow(
      children: <Widget>[
        TableCell.none,
        TableCell(child: Container(color: Colors.green, height: 50)),
        TableCell(
          verticalAlignment: TableCellVerticalAlignment.bottom,
          rowSpan: 2,
          child: Container(color: Colors.orange, height: 75),
        ),
      ],
    ),
    TableRow(
      children: <Widget>[
        TableCell.none,
        TableCell(child: Container(color: Colors.purple, height: 50)),
        TableCell.none,
      ],
    ),
  ],
);
```
</details>


## Issues Fixed

Fixes #21594


## Questions for Reviewers

1. This PR introduces the static constant `TableCell.none` to represent a skipped cell (for when another cell uses `rowSpan` or `colSpan`).  I’m not sure if `none` is the best name, alternatives like `placeholder` or `skipped` might also fit. I avoided `empty` since `DataCell.empty` already exists with different semantics.
2. Should this feature also be considered for `DataTable`? I initially didn’t include it cuz the Material Design table doesn’t normally support `rowSpan` or `colSpan`.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
