### PR TITLE
Move the Fuchsia SDK to //third_party/fuchsia-sdk

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -529,7 +529,7 @@ deps = {
   Var('chromium_git') + '/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator' + '@' + 'c788c52156f3ef7bc7ab769cb03c110a53ac8fcb',
 
   'engine/src/flutter/third_party/abseil-cpp':
-  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + '3ff870f957d511627690f4d3601987ce40d0d97c',
+  Var('flutter_git') + '/third_party/abseil-cpp.git' + '@' + '4cfd6e189be5108a2904c170fea64aa6eba6e9ff',
 
    # Dart packages
   'engine/src/flutter/third_party/pkg/archive':
@@ -804,7 +804,7 @@ deps = {
 
   # Get the SDK from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core at the 'latest' tag
   # Get the toolchain from https://chrome-infra-packages.appspot.com/p/fuchsia/clang at the 'goma' tag
-  'engine/src/fuchsia/sdk/linux': {
+  'engine/src/third_party/fuchsia-sdk/sdk': {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',

--- a/engine/src/build/fuchsia/sdk.gni
+++ b/engine/src/build/fuchsia/sdk.gni
@@ -27,7 +27,7 @@ declare_args() {
   skia_using_fuchsia_sdk = using_fuchsia_sdk
 }
 
-_fuchsia_sdk_path = "//third_party/fuchsia-sdk/sdk"
+_fuchsia_sdk_path = fuchsia_sdk_path
 _fuchsia_tools_path = "${_fuchsia_sdk_path}/tools/${host_cpu}"
 
 template("_fuchsia_sysroot") {

--- a/engine/src/build/fuchsia/sdk.gni
+++ b/engine/src/build/fuchsia/sdk.gni
@@ -17,7 +17,7 @@ declare_args() {
   using_fuchsia_gn_sdk = false
 
   # The following variables are Flutter buildroot specific.
-  fuchsia_sdk_path = "//fuchsia/sdk/$host_os"
+  fuchsia_sdk_path = "//third_party/fuchsia-sdk/sdk"
   fuchsia_toolchain_path = "$buildtools_path/${host_os}-${host_cpu}/clang"
 }
 
@@ -27,7 +27,7 @@ declare_args() {
   skia_using_fuchsia_sdk = using_fuchsia_sdk
 }
 
-_fuchsia_sdk_path = "//fuchsia/sdk/$host_os"
+_fuchsia_sdk_path = "//third_party/fuchsia-sdk/sdk"
 _fuchsia_tools_path = "${_fuchsia_sdk_path}/tools/${host_cpu}"
 
 template("_fuchsia_sysroot") {

--- a/engine/src/build/toolchain/fuchsia/BUILD.gn
+++ b/engine/src/build/toolchain/fuchsia/BUILD.gn
@@ -27,7 +27,7 @@ toolchain("fuchsia") {
   toolchain_bin =
       rebase_path("$buildtools_path/${host_os}-${host_cpu}/clang/bin",
                   root_out_dir)
-  fuchsia_sdk = rebase_path("//fuchsia/sdk/$host_os", root_out_dir)
+  fuchsia_sdk = rebase_path("//third_party/fuchsia-sdk/sdk", root_out_dir)
 
   # We can't do string interpolation ($ in strings) on things with dots in
   # them. To allow us to use $cc below, for example, we create copies of

--- a/engine/src/flutter/build/config/fuchsia/gn_configs.gni
+++ b/engine/src/flutter/build/config/fuchsia/gn_configs.gni
@@ -8,7 +8,7 @@
 
 # Path to the fuchsia SDK. This is intended for use in other templates &
 # rules to reference the contents of the fuchsia SDK.
-fuchsia_sdk = "//fuchsia/sdk/$host_os"
+fuchsia_sdk = "//third_party/fuchsia-sdk/sdk"
 
 declare_args() {
   # Specify a readelf_exec path to use. If not specified, the host's system

--- a/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/engine/src/flutter/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -60,7 +60,7 @@ template("make_utils") {
 action("generate_build_info_cc_file") {
   inputs = [
     "build_info_in.cc",
-    "//fuchsia/sdk/$host_os/meta/manifest.json",
+    "//third_party/fuchsia-sdk/sdk/meta/manifest.json",
     "$dart_src/.git/logs/HEAD",
   ]
   outputs = [ "$target_gen_dir/build_info.cc" ]

--- a/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/engine/src/flutter/tools/fuchsia/build_fuchsia_artifacts.py
@@ -50,17 +50,7 @@ def IsMac():
 
 
 def GetFuchsiaSDKPath():
-  # host_os references the gn host_os
-  # https://gn.googlesource.com/gn/+/main/docs/reference.md#var_host_os
-  host_os = ''
-  if IsLinux():
-    host_os = 'linux'
-  elif IsMac():
-    host_os = 'mac'
-  else:
-    host_os = 'windows'
-
-  return os.path.join(_src_root_dir, 'fuchsia', 'sdk', host_os)
+  return os.path.join(_src_root_dir, 'third_party', 'fuchsia-sdk', 'sdk')
 
 
 def RemoveDirectoryIfExists(path):

--- a/engine/src/flutter/tools/fuchsia/fuchsia_libs.gni
+++ b/engine/src/flutter/tools/fuchsia/fuchsia_libs.gni
@@ -85,7 +85,7 @@ if (is_asan) {
   ]
 }
 
-vulkan_dist = "//fuchsia/sdk/$host_os/arch/$target_cpu/dist"
+vulkan_dist = "//third_party/fuchsia-sdk/sdk/arch/$target_cpu/dist"
 
 # Note that the other validation libraries in the Fuchsia SDK seem to have a bug right
 # now causing crashes, so it is only recommended that we use
@@ -97,8 +97,7 @@ vulkan_validation_libs = [
   },
 ]
 
-vulkan_data_dir =
-    "//fuchsia/sdk/$host_os/pkg/vulkan_layers/data/vulkan/explicit_layer.d"
+vulkan_data_dir = "//third_party/fuchsia-sdk/sdk/pkg/vulkan_layers/data/vulkan/explicit_layer.d"
 
 vulkan_icds = [
   {

--- a/engine/src/flutter/tools/fuchsia/fuchsia_libs.gni
+++ b/engine/src/flutter/tools/fuchsia/fuchsia_libs.gni
@@ -5,6 +5,7 @@
 import("//flutter/tools/fuchsia/clang.gni")
 import("//flutter/tools/fuchsia/gn-sdk/src/gn_configs.gni")
 
+fuchsia_sdk_path = "//third_party/fuchsia-sdk/sdk"
 fuchsia_sdk_dist = "$fuchsia_arch_root/dist"
 sysroot_lib = "$fuchsia_arch_root/sysroot/lib"
 sysroot_dist_lib = "$fuchsia_arch_root/sysroot/dist/lib"
@@ -85,7 +86,7 @@ if (is_asan) {
   ]
 }
 
-vulkan_dist = "//third_party/fuchsia-sdk/sdk/arch/$target_cpu/dist"
+vulkan_dist = "$fuchsia_sdk_path/arch/$target_cpu/dist"
 
 # Note that the other validation libraries in the Fuchsia SDK seem to have a bug right
 # now causing crashes, so it is only recommended that we use
@@ -97,7 +98,8 @@ vulkan_validation_libs = [
   },
 ]
 
-vulkan_data_dir = "//third_party/fuchsia-sdk/sdk/pkg/vulkan_layers/data/vulkan/explicit_layer.d"
+vulkan_data_dir =
+    "$fuchsia_sdk_path/pkg/vulkan_layers/data/vulkan/explicit_layer.d"
 
 vulkan_icds = [
   {

--- a/engine/src/flutter/tools/fuchsia/make_build_info.py
+++ b/engine/src/flutter/tools/fuchsia/make_build_info.py
@@ -38,9 +38,8 @@ def GetFlutterEngineGitRevision(buildroot):
 
 
 def GetFuchsiaSdkVersion(buildroot):
-  with open(path.join(buildroot, 'fuchsia', 'sdk',
-                      'linux' if sys.platform.startswith('linux') else 'mac', 'meta',
-                      'manifest.json'), 'r') as fuchsia_sdk_manifest:
+  with open(path.join(buildroot, 'third_party', 'fuchsia-sdk', 'sdk', 'meta', 'manifest.json'),
+            'r') as fuchsia_sdk_manifest:
     return json.load(fuchsia_sdk_manifest)['id']
 
 

--- a/engine/src/flutter/tools/fuchsia/with_envs.py
+++ b/engine/src/flutter/tools/fuchsia/with_envs.py
@@ -28,7 +28,9 @@ def Main():
   os.environ['FUCHSIA_IMAGES_ROOT'] = os.path.join(os.environ['SRC_ROOT'], 'fuchsia/images/')
 
   assert platform.system() == 'Linux', 'Unsupported OS ' + platform.system()
-  os.environ['FUCHSIA_SDK_ROOT'] = os.path.join(os.environ['SRC_ROOT'], 'fuchsia/sdk/linux/')
+  os.environ['FUCHSIA_SDK_ROOT'] = os.path.join(
+      os.environ['SRC_ROOT'], 'third_party/fuchsia-sdk/sdk/'
+  )
   os.environ['FUCHSIA_GN_SDK_ROOT'] = os.path.join(
       os.environ['SRC_ROOT'], 'flutter/tools/fuchsia/gn-sdk/src'
   )


### PR DESCRIPTION
The //third_party/fuchsia-sdk path is expected by the build scripts for other packages in the Chromium tree such as Abseil.