### PR TITLE
[VPAT][A11y][a11y-app] Add a text label to slider. 

### DIFF
--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -40,19 +40,25 @@ class MainWidgetState extends State<MainWidget> {
         title: Semantics(headingLevel: 1, child: Text('$pageTitle demo')),
       ),
       body: Center(
-        child: Semantics(
-          label: accessibilityLabel,
-          child: Slider(
-            value: currentSliderValue,
-            max: 100,
-            divisions: 5,
-            label: currentSliderValue.round().toString(),
-            onChanged: (double value) {
-              setState(() {
-                currentSliderValue = value;
-              });
-            },
-          ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text('My Slider'),
+            Semantics(
+              label: accessibilityLabel,
+              child: Slider(
+                value: currentSliderValue,
+                max: 100,
+                divisions: 5,
+                label: currentSliderValue.round().toString(),
+                onChanged: (double value) {
+                  setState(() {
+                    currentSliderValue = value;
+                  });
+                },
+              ),
+            ),
+          ],
         ),
       ),
     );

--- a/dev/a11y_assessments/lib/use_cases/slider.dart
+++ b/dev/a11y_assessments/lib/use_cases/slider.dart
@@ -28,7 +28,6 @@ class MainWidget extends StatefulWidget {
 
 class MainWidgetState extends State<MainWidget> {
   double currentSliderValue = 20;
-  static const String accessibilityLabel = 'Accessibility Test Slider';
 
   String pageTitle = getUseCaseName(SliderUseCase());
 
@@ -44,19 +43,16 @@ class MainWidgetState extends State<MainWidget> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             const Text('My Slider'),
-            Semantics(
-              label: accessibilityLabel,
-              child: Slider(
-                value: currentSliderValue,
-                max: 100,
-                divisions: 5,
-                label: currentSliderValue.round().toString(),
-                onChanged: (double value) {
-                  setState(() {
-                    currentSliderValue = value;
-                  });
-                },
-              ),
+            Slider(
+              value: currentSliderValue,
+              max: 100,
+              divisions: 5,
+              label: currentSliderValue.round().toString(),
+              onChanged: (double value) {
+                setState(() {
+                  currentSliderValue = value;
+                });
+              },
             ),
           ],
         ),

--- a/dev/a11y_assessments/test/slider_test.dart
+++ b/dev/a11y_assessments/test/slider_test.dart
@@ -26,12 +26,6 @@ void main() {
     expect(labelWidget, findsOneWidget);
   });
 
-  testWidgets('slider semantics wrapper exists', (WidgetTester tester) async {
-    await pumpsUseCase(tester, SliderUseCase());
-    final Finder semanticsWidget = find.bySemanticsLabel('Accessibility Test Slider');
-    expect(semanticsWidget, findsOneWidget);
-  });
-
   testWidgets('slider demo page has one h1 tag', (WidgetTester tester) async {
     await pumpsUseCase(tester, SliderUseCase());
     final Finder findHeadingLevelOnes = find.bySemanticsLabel('Slider demo');

--- a/dev/a11y_assessments/test/slider_test.dart
+++ b/dev/a11y_assessments/test/slider_test.dart
@@ -19,6 +19,13 @@ void main() {
     final MainWidgetState state = tester.state<MainWidgetState>(find.byType(MainWidget));
     expect(state.currentSliderValue, 60);
   });
+
+  testWidgets('slider semantics text label exists', (WidgetTester tester) async {
+    await pumpsUseCase(tester, SliderUseCase());
+    final Finder labelWidget = find.text('My Slider');
+    expect(labelWidget, findsOneWidget);
+  });
+
   testWidgets('slider semantics wrapper exists', (WidgetTester tester) async {
     await pumpsUseCase(tester, SliderUseCase());
     final Finder semanticsWidget = find.bySemanticsLabel('Accessibility Test Slider');

--- a/dev/a11y_assessments/test/slider_test.dart
+++ b/dev/a11y_assessments/test/slider_test.dart
@@ -20,7 +20,7 @@ void main() {
     expect(state.currentSliderValue, 60);
   });
 
-  testWidgets('slider semantics text label exists', (WidgetTester tester) async {
+  testWidgets('slider text label exists', (WidgetTester tester) async {
     await pumpsUseCase(tester, SliderUseCase());
     final Finder labelWidget = find.text('My Slider');
     expect(labelWidget, findsOneWidget);


### PR DESCRIPTION


Fix #173008 

Added a visible text label and remove the redundant semantics label.




## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
