### PR TITLE
Remove the x64 version of build_ios_framework_module_test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3695,28 +3695,6 @@ targets:
     properties:
       task_name: basic_material_app_macos__compile
 
-  - name: Mac_x64 build_ios_framework_module_test
-    recipe: devicelab/devicelab_drone
-    bringup: true
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      dependencies: >-
-        [
-          {"dependency": "ruby", "version": "ruby_3.1-pod_1.13"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
-      task_name: build_ios_framework_module_test
-      test_timeout_secs: "2700"
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-      - engine/**
-      - DEPS
-
   - name: Mac_arm64 build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
The test is running on arm64 and does not need to run on x64.

See https://github.com/flutter/flutter/pull/176811