### PR TITLE
Add headers to proxy rules #173434

### DIFF
--- a/packages/flutter_tools/lib/src/web/devfs_proxy.dart
+++ b/packages/flutter_tools/lib/src/web/devfs_proxy.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:yaml/yaml.dart';
+import 'package:meta/meta.dart';
 import '../base/logger.dart';
 
 /// Represents a rule for proxying requests based on a specific pattern.
@@ -72,11 +73,11 @@ sealed class ProxyRule {
       final Object? name = item[_kName];
       final Object? value = item[_kValue];
       if (name is! String || name.isEmpty) {
-        logger.printError('$_kLogEntryPrefix Header "$_kName" must be a non-null String. Found ${name.runtimeType}');
+        logger.printError('$_kLogEntryPrefix Header "$_kName" must be a non-empty String. Found ${name.runtimeType}');
         continue;
       }
       if (value is! String) {
-        logger.printError('$_kLogEntryPrefix Header "$_kValue" must be a non-null String. Found ${value.runtimeType}');
+        logger.printError('$_kLogEntryPrefix Header "$_kValue" must be a String. Found ${value.runtimeType}');
         continue;
       }
       result[name] = value;
@@ -110,6 +111,15 @@ class RegexProxyRule implements ProxyRule {
   final String? _replacement;
   final Map<String, String> _headers;
 
+  @protected
+  String buildToString(String typeKey) {
+    final base = '{$typeKey: ${_pattern.pattern}, ${ProxyRule._kTarget}: $_target, ${ProxyRule._kReplace}: ${_replacement ?? 'null'}';
+    if (_headers.isEmpty) {
+      return '$base}';
+    }
+    return '$base, ${ProxyRule._kHeaders}: $_headers}';
+  }
+
   @override
   bool matches(String path) {
     return _pattern.hasMatch(path);
@@ -140,11 +150,7 @@ class RegexProxyRule implements ProxyRule {
 
   @override
   String toString() {
-    final base = '{${ProxyRule._kRegex}: ${_pattern.pattern}, ${ProxyRule._kTarget}: $_target, ${ProxyRule._kReplace}: ${_replacement ?? 'null'}';
-    if (_headers.isEmpty) {
-      return '$base}';
-    }
-    return '$base, ${ProxyRule._kHeaders}: $_headers}';
+    return buildToString(ProxyRule._kRegex);
   }
 
   /// Checks if the given [yaml] can be handled by this rule.
@@ -207,11 +213,7 @@ class PrefixProxyRule extends RegexProxyRule {
 
   @override
   String toString() {
-    final base = '{${ProxyRule._kPrefix}: ${_pattern.pattern}, ${ProxyRule._kTarget}: $_target, ${ProxyRule._kReplace}: ${_replacement ?? 'null'}';
-    if (headers.isEmpty) {
-      return '$base}';
-    }
-    return '$base, ${ProxyRule._kHeaders}: $headers}';
+    return buildToString(ProxyRule._kPrefix);
   }
 
   /// Checks if the given [yaml] can be handled by this rule.

--- a/packages/flutter_tools/lib/src/web/devfs_proxy.dart
+++ b/packages/flutter_tools/lib/src/web/devfs_proxy.dart
@@ -72,12 +72,13 @@ sealed class ProxyRule {
       final Object? name = item[_kName];
       final Object? value = item[_kValue];
       if (name is! String || name.isEmpty) {
-        logger.printError('$_kLogEntryPrefix Header "$_kName" must be a non-null String. Found ${name.runtimeType}');
+        logger.printError('$_kLogEntryPrefix Header "$_kName" must be a non-empty String. Found ${name.runtimeType}');
         continue;
       }
       if (value is! String) {
-        logger.printError('$_kLogEntryPrefix Header "$_kValue" must be a non-null String. Found ${value.runtimeType}');
+        logger.printError('$_kLogEntryPrefix Header "$_kValue" must be a String. Found ${value.runtimeType}');
         continue;
+      }
       }
       result[name] = value;
     }


### PR DESCRIPTION
Add headers to proxy rules for Flutter web dev server

This PR adds support for injecting custom HTTP request headers per proxy rule in the Flutter Web development server, configured via web_dev_config.yaml. This enables local development with APIs that require headers (e.g., Authorization) without browser flags or ad‑hoc CORS workarounds.

What’s changing
- Configuration
  - New optional headers field under server.proxy rules in web_dev_config.yaml.
  - Same format as server.headers: a list of { name, value } pairs.
- Implementation
  - Parse proxy rule headers from YAML and attach them to ProxyRule.
  - Extend RegexProxyRule and PrefixProxyRule to carry headers.
  - proxyRequest merges injected headers into outgoing proxied requests without overwriting existing headers (case-insensitive).
- No changes to server.headers behavior (these remain default response headers set by the dev server).

Sample configuration
```yaml
server:
  headers:
    - name: Access-Control-Allow-Origin
      value: "*"
  proxy:
    - prefix: /api
      target: http://localhost:3000
      headers:
        - name: Authorization
          value: "Bearer dev-token"
        - name: X-Env
          value: Local
```

Files touched (high-level)
- packages/flutter_tools/lib/src/web/devfs_proxy.dart
  - Add ProxyRule.headers and YAML parsing.
  - Extend RegexProxyRule/PrefixProxyRule to accept and expose headers.
- packages/flutter_tools/lib/src/isolated/proxy_middleware.dart
  - Add injectedHeaders to proxyRequest and merge headers case-insensitively.
- packages/flutter_tools/test/general.shard/web/proxy_test.dart
  - Add tests for YAML parsing and header merge semantics.

Rationale
- Use case: Injecting Authorization or environment markers during local dev for APIs that enforce auth headers.
- Avoids requiring --disable-web-security or custom browser setups, improving team workflows.

Tests
- Added unit tests:
  - ProxyRule.fromYaml parses headers correctly (including validation).
  - proxyRequest merges injected headers without overwriting existing values (case-insensitive).
- All existing and new tests pass locally.

Breaking change
- None.

Issue
- Fixes #173434
- Related: #173570

Docs
- Tooling changelog updated.
- If desirable, I can also add a short section to the Web tooling docs describing the new proxy headers field in web_dev_config.yaml.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments and a short tooling changelog note).
- [x] I added new tests to check the change I am making.
- [x] I followed the [breaking change policy] (not applicable here; no breaking changes).
- [x] All existing and new tests are passing.

Notes to reviewers
- Header merging is intentionally non-overwriting to avoid clobbering client-set headers like Authorization. If overwriting should be supported in the future, we could add a rule-level flag.