### PR TITLE
Fixing WindowManagerTest::DialogCanNeverBeFullscreen possibly hanging

### DIFF
--- a/engine/src/flutter/shell/platform/windows/window_manager_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/window_manager_unittests.cc
@@ -368,13 +368,12 @@ TEST_F(WindowManagerTest, DialogCanNeverBeFullscreen) {
   IsolateScope isolate_scope(isolate());
 
   DialogWindowCreationRequest creation_request{
-      .preferred_size =
-          {
-              .has_preferred_view_size = true,
-              .preferred_view_width = 800,
-              .preferred_view_height = 600,
-          },
-  };
+      .preferred_size = {.has_preferred_view_size = true,
+                         .preferred_view_width = 800,
+                         .preferred_view_height = 600},
+      .preferred_constraints = {.has_view_constraints = false},
+      .title = L"Hello World",
+      .parent_or_null = nullptr};
 
   const int64_t view_id =
       InternalFlutterWindows_WindowManager_CreateDialogWindow(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/177172

I believe the issue is that the struct was not fully initialized (which is usually not a problem, but can sometimes get garbage values and start hanging). The solution is probably to initialize the struct. Let's see if it fixes CI :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
