### PR TITLE
Trigger engine build, and clean up trigger file

### DIFF
--- a/engine/TRIGGER.md
+++ b/engine/TRIGGER.md
@@ -1,2 +1,0 @@
-<!-- TODO(camsim99): Delete this file. -->
-This file is purely to trigger an engine release build and will be deleted in a future commit pre-release.


### PR DESCRIPTION
My PR updating engine.version (https://github.com/flutter/flutter/pull/177178) for the 3.38.0 beta release isn't passing the analyzer because the engine artifacts don't exist. This PR will trigger another engine build, and then I'll use its merge SHA in engine.version. And it conveniently deletes the file used for this same purpose in https://github.com/flutter/flutter/pull/176842.