### PR TITLE
[test_fixes] Enable `deprecated_member_use_from_same_package`.

### DIFF
--- a/packages/flutter/test_fixes/analysis_options.yaml
+++ b/packages/flutter/test_fixes/analysis_options.yaml
@@ -1,1 +1,10 @@
 # This ensures that parent analysis options do not accidentally break the fix tests.
+
+linter:
+  rules:
+    # Since these test cases live inside the `flutter` package, the
+    # lint `deprecated_member_use_from_same_package` is required in
+    # order to trigger them. Customer code (which lives outside of the
+    # `flutter` package) will be triggered by the analyzer warning
+    # `deprecated_member_use`, which is enabled by default.
+    - deprecated_member_use_from_same_package


### PR DESCRIPTION
I will shortly be landing a change to the dart analyzer that removes the `deprecated_member_use_from_same_package` hint (see https://dart-review.googlesource.com/c/sdk/+/455541). This hint has been deprecated for a long time in favor of the lint of the same name, with the rationale being that most users probably don't want to see a warning if they refer to their own deprecated APIs; they only want to see a warning if they refer to other packages' deprecated APIs.

The tests in `packages/flutter/test_fixes` are an exception, though. They exist inside the `flutter` package, and their purpose is to verify that `dart fix` will properly apply fixes based on deprecated APIs in the `flutter` package. So when the hint is removed, the tests will need the `deprecated_member_use_from_same_package` lint enabled in order to keep functioning.

Users of flutter will not need to enable this lint in order for receive fixes for deprecations in the `flutter` package, because their code is not inside the `flutter` package. So there should be no user-visible impact.

<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
