### PR TITLE
Adds a new CI build for Linux host DDM-enabled artifacts

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -234,13 +234,13 @@ targets:
   - name: Linux linux_host_engine_ddm
     recipe: engine_v2/engine_v2
     bringup: true
+    backfill: false
     timeout: 120
     enabled_branches:
       # Don't run this on release branches
       - master
     properties:
       add_recipes_cq: "true"
-      release_build: "true"
       config_name: linux_host_engine_ddm
     # Do not remove(https://github.com/flutter/flutter/issues/144644)
     # Scheduler will fail to get the platform

--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -231,6 +231,28 @@ targets:
       # at https://github.com/flutter/flutter/issues/152186.
       cores: "8"
 
+  - name: Linux linux_host_engine_ddm
+    recipe: engine_v2/engine_v2
+    bringup: true
+    timeout: 120
+    enabled_branches:
+      # Don't run this on release branches
+      - master
+    properties:
+      add_recipes_cq: "true"
+      release_build: "true"
+      config_name: linux_host_engine_ddm
+    # Do not remove(https://github.com/flutter/flutter/issues/144644)
+    # Scheduler will fail to get the platform
+    drone_dimensions:
+      - os=Linux
+    dimensions:
+      # This is needed so that orchestrators that only spawn subbuilds are not
+      # assigned to the large 32 core workers when doing release builds.
+      # For more details see the issue
+      # at https://github.com/flutter/flutter/issues/152186.
+      cores: "8"
+
   - name: Linux linux_host_engine_test
     recipe: engine_v2/engine_v2
     timeout: 120

--- a/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
@@ -18,7 +18,7 @@
                     "base_path": "out/ci/host_debug_ddm/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/ci/host_debug_ddm/zip_archives/linux-x64/artifacts.zip"
+                        "out/ci/host_debug_ddm/zip_archives/linux-x64-ddm/artifacts.zip"
                     ],
                     "realm": "production"
                 }

--- a/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
@@ -18,7 +18,7 @@
                     "base_path": "out/ci/host_debug_ddm/zip_archives/",
                     "type": "gcs",
                     "include_paths": [
-                        "out/ci/host_debug_ddm/zip_archives/linux-x64/artifacts.zip",
+                        "out/ci/host_debug_ddm/zip_archives/linux-x64/artifacts.zip"
                     ],
                     "realm": "production"
                 }
@@ -47,7 +47,7 @@
             "ninja": {
                 "config": "ci/host_debug_ddm",
                 "targets": [
-                    "flutter/build/archives:artifacts",
+                    "flutter/build/archives:artifacts"
                 ]
             }
         },

--- a/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
@@ -50,6 +50,6 @@
                     "flutter/build/archives:artifacts"
                 ]
             }
-        },
-    ],
+        }
+    ]
 }

--- a/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
+++ b/engine/src/flutter/ci/builders/linux_host_engine_ddm.json
@@ -1,0 +1,55 @@
+{
+    "_comment": [
+        "The builds defined in this file should not contain tests, ",
+        "and the file should not contain builds that are essentially tests. ",
+        "The only builds in this file should be the builds necessary to produce ",
+        "release artifacts. ",
+        "Tests to run on linux hosts should go in one of the other linux_ build ",
+        "definition files."
+    ],
+    "luci_flags": {
+      "upload_content_hash": true
+    },
+    "builds": [
+        {
+            "archives": [
+                {
+                    "name": "ci/host_debug_ddm",
+                    "base_path": "out/ci/host_debug_ddm/zip_archives/",
+                    "type": "gcs",
+                    "include_paths": [
+                        "out/ci/host_debug_ddm/zip_archives/linux-x64/artifacts.zip",
+                    ],
+                    "realm": "production"
+                }
+            ],
+            "drone_dimensions": [
+                "device_type=none",
+                "os=Linux"
+            ],
+            "gclient_variables": {
+                "download_android_deps": false,
+                "download_jdk": false,
+                "use_rbe": true
+            },
+            "gn": [
+                "--target-dir",
+                "ci/host_debug_ddm",
+                "--runtime-mode",
+                "debug",
+                "--prebuilt-dart-sdk",
+                "--rbe",
+                "--no-goma",
+                "--gn-args=dart_dynamic_modules=true"
+            ],
+            "name": "ci/host_debug_ddm",
+            "description": "Produces debug mode Linux host-side tooling with dynamic modules enabled.",
+            "ninja": {
+                "config": "ci/host_debug_ddm",
+                "targets": [
+                    "flutter/build/archives:artifacts",
+                ]
+            }
+        },
+    ],
+}


### PR DESCRIPTION
Work towards [b/452833651](b/452833651).

This adds a new flavor of linux_host_engine, which enables the DDM build flag with the goal of building a flutter_tester binary that supports loading DDMs in tests.

Tested locally via `et build --config ci/host_debug_ddm`.

This roughly follows https://github.com/flutter/flutter/pull/168717, which added a similar DDM-enabled build for iOS.

I've branched this off the `linux_host_engine.json`, added the build flag for DDM support, and removed things we don't need.