### PR TITLE
[beta] CP: Fixes hot reload/restart crashes after closing browser tab on web-server device

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -968,18 +968,6 @@ class ResidentWebRunner extends ResidentRunner {
       _registeredMethodsForService.remove(serviceName);
     }
   }
-
-  /// Checks if the given JSON response indicates no clients are available.
-  /// Returns an [OperationResult] if no clients are available, otherwise returns null.
-  OperationResult? _checkNoClientsAvailable(Map<String, dynamic>? json, Status status) {
-    if (json != null && json['noClientsAvailable'] == true) {
-      _logger.printTrace('No browser clients currently connected');
-      status.stop();
-      _logger.printStatus(kNoClientConnectedMessage);
-      return OperationResult.ok;
-    }
-    return null;
-  }
 }
 
 Uri _httpUriFromWebsocketUri(Uri websocketUri) {

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -88,6 +88,8 @@ const kExitMessage =
     'instance in Chrome.\nThis can happen if the websocket connection used by the '
     'web tooling is unable to correctly establish a connection, for example due to a firewall.';
 
+const kNoClientConnectedMessage = 'Recompile complete. No client connected.';
+
 class ResidentWebRunner extends ResidentRunner {
   ResidentWebRunner(
     FlutterDevice device, {
@@ -964,6 +966,18 @@ class ResidentWebRunner extends ResidentRunner {
       final String serviceName = e.service!;
       _registeredMethodsForService.remove(serviceName);
     }
+  }
+
+  /// Checks if the given JSON response indicates no clients are available.
+  /// Returns an [OperationResult] if no clients are available, otherwise returns null.
+  OperationResult? _checkNoClientsAvailable(Map<String, dynamic>? json, Status status) {
+    if (json != null && json['noClientsAvailable'] == true) {
+      _logger.printTrace('No browser clients currently connected');
+      status.stop();
+      _logger.printStatus(kNoClientConnectedMessage);
+      return OperationResult.ok;
+    }
+    return null;
   }
 }
 

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -518,7 +518,8 @@ class ResidentWebRunner extends ResidentRunner {
             // DWDS throws an RPC error with kServerError code when there are no
             // browser clients currently connected during a hot restart operation.
             if (e.callingMethod == hotRestartMethod &&
-                e.code == vmservice.RPCErrorKind.kServerError.code) {
+                (e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code ||
+                    e.code == vmservice.RPCErrorKind.kServerError.code)) {
               return _handleNoClientsAvailable(status);
             }
             // Re-throw other RPC errors

--- a/packages/flutter_tools/lib/src/isolated/web_expression_compiler.dart
+++ b/packages/flutter_tools/lib/src/isolated/web_expression_compiler.dart
@@ -25,6 +25,7 @@ class WebExpressionCompiler implements ExpressionCompiler {
   Future<ExpressionCompilationResult> compileExpressionToJs(
     String isolateId,
     String libraryUri,
+    String scriptUri,
     int line,
     int column,
     Map<String, String> jsModules,
@@ -34,6 +35,7 @@ class WebExpressionCompiler implements ExpressionCompiler {
   ) async {
     final CompilerOutput? compilerOutput = await _generator.compileExpressionToJs(
       libraryUri,
+      scriptUri,
       line,
       column,
       jsModules,

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.0.3
-  dwds: 26.1.0
+  dwds: 26.2.0
   code_builder: 4.11.0
   collection: 1.19.1
   completion: 1.0.2
@@ -28,7 +28,7 @@ dependencies:
   intl: 0.20.2
   meta: 1.17.0
   multicast_dns: 0.3.3
-  mustache_template: 2.0.1
+  mustache_template: 2.0.2
   package_config: 2.2.0
   process: 5.0.5
   fake_async: 1.3.3
@@ -61,7 +61,7 @@ dependencies:
   hooks_runner: 0.23.0
   hooks: 0.20.1
   code_assets: 0.19.7
-  data_assets: 0.19.3
+  data_assets: 0.19.4
 
   # We depend on very specific internal implementation details of the
   # 'test' package, which change between versions, so when upgrading
@@ -127,4 +127,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: 848sij
+# PUBSPEC CHECKSUM: c6mcub

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.0.3
-  dwds: 25.1.0
+  dwds: 26.1.0
   code_builder: 4.11.0
   collection: 1.19.1
   completion: 1.0.2

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -127,4 +127,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: ho7nke
+# PUBSPEC CHECKSUM: 848sij

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -963,7 +963,7 @@ name: my_app
       expect(debugConnectionInfo, isNotNull);
 
       final OperationResult result = await residentWebRunner.restart();
-      expect(logger.statusText, contains('Recompile complete. No client connected.'));
+      expect(logger.statusText, contains(kNoClientConnectedMessage));
       expect(result.code, 0);
     },
     overrides: <Type, Generator>{
@@ -1166,7 +1166,7 @@ name: my_app
 
       expect(result.code, 0);
       expect(result.isOk, isTrue);
-      expect(logger.statusText, contains('Recompile complete. No client connected.'));
+      expect(logger.statusText, contains(kNoClientConnectedMessage));
     },
     overrides: <Type, Generator>{
       Analytics: () => fakeAnalytics,

--- a/packages/flutter_tools/test/general.shard/web/web_expression_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/web_expression_compiler_test.dart
@@ -31,6 +31,7 @@ void main() {
     final ExpressionCompilationResult result = await expressionCompiler.compileExpressionToJs(
       '',
       '',
+      '',
       1,
       1,
       <String, String>{},
@@ -55,6 +56,7 @@ void main() {
     final ExpressionCompilationResult result = await expressionCompiler.compileExpressionToJs(
       '',
       '',
+      '',
       1,
       1,
       <String, String>{},
@@ -74,6 +76,7 @@ void main() {
     );
 
     final ExpressionCompilationResult result = await expressionCompiler.compileExpressionToJs(
+      '',
       '',
       '',
       1,
@@ -105,6 +108,7 @@ class FakeResidentCompiler extends Fake implements ResidentCompiler {
   @override
   Future<CompilerOutput?> compileExpressionToJs(
     String libraryUri,
+    String scriptUri,
     int line,
     int column,
     Map<String, String> jsModules,

--- a/packages/flutter_tools/test/integration.shard/test_data/websocket_dwds_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/websocket_dwds_test_common.dart
@@ -51,7 +51,7 @@ class WebSocketDwdsTestUtils {
     required List<String> additionalCommandArgs,
     WebSocketDwdsTestConfig config = const WebSocketDwdsTestConfig(),
   }) async {
-    debugPrint('Step 1: Starting WebSocket DWDS connection setup...');
+    debugPrint('Starting WebSocket DWDS connection setup...');
 
     // Set up listening for app output before starting
     final stdout = StringBuffer();
@@ -72,15 +72,15 @@ class WebSocketDwdsTestUtils {
 
     io.Process? chromeProcess;
     try {
-      // Step 1: Start Flutter app with web-server device (will wait for debug connection)
-      debugPrint('Step 2: Starting Flutter app with web-server device...');
+      // Start Flutter app with web-server device (will wait for debug connection)
+      debugPrint('Starting Flutter app with web-server device...');
       final Future<void> appStartFuture = runFlutterWithWebServerDevice(
         flutter,
         additionalCommandArgs: [...additionalCommandArgs, '--no-web-resources-cdn'],
       );
 
-      // Step 2: Wait for DWDS debug URL to be available
-      debugPrint('Step 3: Waiting for DWDS debug service URL...');
+      // Wait for DWDS debug URL to be available
+      debugPrint('Waiting for DWDS debug service URL...');
       final String debugUrl = await sawDebugUrl.future.timeout(
         config.debugUrlTimeout,
         onTimeout: () {
@@ -89,13 +89,13 @@ class WebSocketDwdsTestUtils {
       );
       debugPrint('✓ DWDS debug service available at: $debugUrl');
 
-      // Step 3: Launch headless Chrome to connect to DWDS
-      debugPrint('Step 4: Launching headless Chrome to connect to DWDS...');
+      // Launch headless Chrome to connect to DWDS
+      debugPrint('Launching headless Chrome to connect to DWDS...');
       chromeProcess = await launchHeadlessChrome(debugUrl);
       debugPrint('✓ Headless Chrome launched and connecting to DWDS');
 
-      // Step 4: Wait for app to start (Chrome connection established)
-      debugPrint('Step 5: Waiting for Flutter app to start after Chrome connection...');
+      // Wait for app to start (Chrome connection established)
+      debugPrint('Waiting for Flutter app to start after Chrome connection...');
       await appStartFuture.timeout(
         config.appStartTimeout,
         onTimeout: () {

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/pubspec.yaml
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/pubspec.yaml
@@ -46,10 +46,10 @@ dependencies:
   test_api: 0.7.7
   typed_data: 1.4.0
   unified_analytics: 8.0.5
-  url_launcher_android: 6.3.23
-  url_launcher_ios: 6.3.4
+  url_launcher_android: 6.3.24
+  url_launcher_ios: 6.3.5
   url_launcher_linux: 3.2.1
-  url_launcher_macos: 3.2.3
+  url_launcher_macos: 3.2.4
   url_launcher_platform_interface: 2.3.2
   url_launcher_web: 2.4.1
   url_launcher_windows: 3.1.4
@@ -66,4 +66,4 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
-# PUBSPEC CHECKSUM: 130obr
+# PUBSPEC CHECKSUM: v8f3kv

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: animations
-      sha256: d3d6dcfb218225bbe68e87ccf6378bbb2e32a94900722c5f81611dad089911cb
+      sha256: a8031b276f0a7986ac907195f10ca7cd04ecf2a8a566bd6dbe03018a9b02b427
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.11"
+    version: "2.1.0"
   archive:
     dependency: "direct main"
     description:
@@ -558,18 +558,18 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider_android
-      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
+      sha256: e122c5ea805bb6773bb12ce667611265980940145be920cd09a4b0ec0285cb16
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.18"
+    version: "2.2.20"
   path_provider_foundation:
     dependency: "direct main"
     description:
       name: path_provider_foundation
-      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      sha256: efaec349ddfc181528345c56f8eda9d6cccd71c177511b132c6a0ddaefaa2738
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.3"
   path_provider_linux:
     dependency: "direct main"
     description:
@@ -646,10 +646,10 @@ packages:
     dependency: "direct main"
     description:
       name: process_runner
-      sha256: "4763f660895a1aea3c097bba3204794094b828cb9a279a65a2506a9b93d47d12"
+      sha256: "98b68d1764e49e8ab2cdb982c8d75a9658a0f9ada5565ec6185014a7141a034d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.3"
   provider:
     dependency: "direct main"
     description:
@@ -867,18 +867,18 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher_android
-      sha256: c0fb544b9ac7efa10254efaf00a951615c362d1ea1877472f8f6c0fa00fcf15b
+      sha256: "5c8b6c2d89a78f5a1cca70a73d9d5f86c701b36b42f9c9dac7bad592113c28e9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.23"
+    version: "6.3.24"
   url_launcher_ios:
     dependency: "direct main"
     description:
       name: url_launcher_ios
-      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      sha256: "6b63f1441e4f653ae799166a72b50b1767321ecc263a57aadf825a7a2a5477d9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "6.3.5"
   url_launcher_linux:
     dependency: "direct main"
     description:
@@ -891,10 +891,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher_macos
-      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      sha256: "8262208506252a3ed4ff5c0dc1e973d2c0e0ef337d0a074d35634da5d44397c9"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.4"
   url_launcher_platform_interface:
     dependency: "direct main"
     description:
@@ -939,26 +939,26 @@ packages:
     dependency: "direct main"
     description:
       name: video_player_android
-      sha256: "6cfe0b1e102522eda1e139b82bf00602181c5844fd2885340f595fb213d74842"
+      sha256: cf768d02924b91e333e2bc1ff928528f57d686445874f383bafab12d0bdfc340
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.14"
+    version: "2.8.17"
   video_player_avfoundation:
     dependency: "direct main"
     description:
       name: video_player_avfoundation
-      sha256: f9a780aac57802b2892f93787e5ea53b5f43cc57dc107bee9436458365be71cd
+      sha256: "19ed1162a7a5520e7d7791e0b7b73ba03161b6a69428b82e4689e435b325432d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.4"
+    version: "2.8.5"
   video_player_platform_interface:
     dependency: "direct main"
     description:
       name: video_player_platform_interface
-      sha256: cf2a1d29a284db648fd66cbd18aacc157f9862d77d2cc790f6f9678a46c1db5a
+      sha256: "9e372520573311055cb353b9a0da1c9d72b094b7ba01b8ecc66f28473553793b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.0"
+    version: "6.5.0"
   video_player_web:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,7 @@ dependencies:
   _fe_analyzer_shared: 89.0.0
   adaptive_breakpoints: 0.1.7
   analyzer: 8.2.0
-  animations: 2.0.11
+  animations: 2.1.0
   archive: 3.6.1
   args: 2.7.0
   async: 2.13.0
@@ -139,8 +139,8 @@ dependencies:
   package_config: 2.2.0
   path: 1.9.1
   path_provider: 2.1.5
-  path_provider_android: 2.2.18
-  path_provider_foundation: 2.4.2
+  path_provider_android: 2.2.20
+  path_provider_foundation: 2.4.3
   path_provider_linux: 2.2.1
   path_provider_platform_interface: 2.1.2
   path_provider_windows: 2.3.0
@@ -149,7 +149,7 @@ dependencies:
   plugin_platform_interface: 2.1.8
   pool: 1.5.2
   process: 5.0.5
-  process_runner: 4.2.0
+  process_runner: 4.2.3
   provider: 6.1.5+1
   pub_semver: 2.2.0
   pubspec_parse: 1.5.0
@@ -175,18 +175,18 @@ dependencies:
   test_core: 0.6.12
   typed_data: 1.4.0
   url_launcher: 6.3.2
-  url_launcher_android: 6.3.23
-  url_launcher_ios: 6.3.4
+  url_launcher_android: 6.3.24
+  url_launcher_ios: 6.3.5
   url_launcher_linux: 3.2.1
-  url_launcher_macos: 3.2.3
+  url_launcher_macos: 3.2.4
   url_launcher_platform_interface: 2.3.2
   url_launcher_web: 2.4.1
   url_launcher_windows: 3.1.4
   vector_math: 2.2.0
   video_player: 2.10.0
-  video_player_android: 2.8.14
-  video_player_avfoundation: 2.8.4
-  video_player_platform_interface: 6.4.0
+  video_player_android: 2.8.17
+  video_player_avfoundation: 2.8.5
+  video_player_platform_interface: 6.5.0
   video_player_web: 2.4.0
   vm_service: 15.0.2
   vm_snapshot_analysis: 0.7.6
@@ -212,4 +212,4 @@ dependencies:
   pedantic: 1.11.1
   quiver: 3.2.2
   yaml_edit: 2.2.2
-# PUBSPEC CHECKSUM: 5h4lnl
+# PUBSPEC CHECKSUM: pqh0jk


### PR DESCRIPTION
**Impacted Users:**
Flutter web developers using the `web-server` device for hot reload/restart.

**Impact Description:**
Hot reload/restart crashes when the browser tab is closed, causing “Bad state: No element” errors and breaking the DWDS connection.

**Workaround:**
Rerun the app.

**Risk:**
Low — changes only affect hot reload/restart handling when no clients are connected.

**Test Coverage:**
Yes — covered by automated integration tests and verified with manual testing across reload/restart scenarios.

**Validation Steps:**

1. run the app on webserver `flutter run -d web-server`
2. open the url
3. do hot reload
4. close the browser
5. do hot reload 

You should see a warning `WebSocketProxyService: No clients available.` along with `Recompile complete. No client connected.` printed in the console. The app should no longer crash.


**Merged PR:** https://github.com/flutter/flutter/pull/177026
**Changes in DWDS (Parent PR):** [https://github.com/dart-lang/webdev/pull/2699](https://github.com/dart-lang/webdev/pull/2699)

Fixes https://github.com/flutter/flutter/issues/174791
