### PR TITLE
Revert "[Android 16] Update `android_engine_vulkan_tests` to Test Against SDK 36 Emulator"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1690,6 +1690,7 @@ targets:
 
   - name: Linux_android_emu_vulkan_stable android_engine_vulkan_tests
     recipe: flutter/flutter_drone
+    bringup: true
     timeout: 60
     properties:
       shard: android_engine_vulkan_tests

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -73,7 +73,28 @@ platform_properties:
         [
           {"dependency": "android_sdk", "version": "version:36v3"},
           {"dependency": "android_virtual_device", "version": "android_36_google_apis_x64.textpb"},
-          {"dependency": "avd_cipd_version", "version": "build_id:8701084295319811169"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8719362231152674241"},
+          {"dependency": "open_jdk", "version": "version:21"}
+        ]
+      os: Ubuntu
+      cores: "8"
+      device_type: none
+      kvm: "1"
+
+  # linux_android_emu_vulkan_stable temporarily depends on an API 35 AVD while all
+  # other linux_android_emu test targets depend on an API 36 AVD due to a potential issue with
+  # virtual display on API 36: https://github.com/flutter/flutter/issues/170024.
+  linux_android_emu_vulkan_stable:
+    properties:
+      contexts: >-
+        [
+          "android_virtual_device"
+        ]
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:36v3"},
+          {"dependency": "android_virtual_device", "version": "android_35_google_apis_x64.textpb"},
+          {"dependency": "avd_cipd_version", "version": "build_id:8733065022087935185"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
       os: Ubuntu
@@ -1667,9 +1688,8 @@ targets:
       - engine/**
       - DEPS
 
-  - name: Linux_android_emu_unstable android_engine_vulkan_tests
+  - name: Linux_android_emu_vulkan_stable android_engine_vulkan_tests
     recipe: flutter/flutter_drone
-    bringup: true
     timeout: 60
     properties:
       shard: android_engine_vulkan_tests


### PR DESCRIPTION
Reverts flutter/flutter#176985
Issue https://github.com/flutter/flutter/issues/170024

`android_engine_vulkan_tests` is very flaky https://flutter-dashboard.appspot.com/#/build?repo=flutter&branch=master&showMac=false&showWindows=false&showiOS=false&showAndroid=false&showBringup=true.

We were waiting on android for a 36 system image that passed android testing. I believe the 36 image I am using is up to date, but it's possible an incompatible avd version was used (I chose the latest at the time). Before filing a ticket against android, check if the avd version is compatible.