### PR TITLE
Roll reclient to version 185

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -45,7 +45,7 @@ vars = {
   # See https://github.com/flutter/flutter/wiki/Engine-pre‐submits-and-post‐submits#post-submit
   'clang_version': 'git_revision:8c7a2ce01a77c96028fe2c8566f65c45ad9408d3',
 
-  'reclient_version': 'git_revision:29a9d3cb597b6a7d67fa3e9aa8a7cab1c81232ee',
+  'reclient_version': 're_client_version:0.185.0.db415f21-gomaip',
 
   'gcloud_version': 'version:2@444.0.0.chromium.3',
 

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -523,9 +523,7 @@ final class BuildRunner extends Runner {
         pid: result.pid, // pid,
       );
     }
-    if (okMessage == null) {
-      okMessage = bootstrapResult.stdout.trim();
-    }
+    okMessage ??= bootstrapResult.stdout.trim();
     eventHandler(
       RunnerResult(
         '${build.name}: RBE ${shutdown ? 'shutdown' : 'startup'}',

--- a/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/lib/src/build_config_runner.dart
@@ -486,7 +486,8 @@ final class BuildRunner extends Runner {
       bootstrapPath,
       '--re_proxy=$reproxyPath',
       '--use_application_default_credentials',
-      if (shutdown) '--shutdown' else ...<String>['--cfg=$reclientConfigPath'],
+      '--cfg=$reclientConfigPath',
+      if (shutdown) '--shutdown',
     ];
     if (!processRunner.processManager.canRun(bootstrapPath)) {
       eventHandler(
@@ -502,6 +503,10 @@ final class BuildRunner extends Runner {
         rbeConfig.environment,
       ),
     );
+    String? okMessage;
+    if (shutdown) {
+      okMessage = await _reproxystatus();
+    }
     final ProcessRunnerResult bootstrapResult;
     if (dryRun) {
       bootstrapResult = _dryRunResult;
@@ -518,9 +523,8 @@ final class BuildRunner extends Runner {
         pid: result.pid, // pid,
       );
     }
-    String okMessage = bootstrapResult.stdout.trim();
-    if (shutdown) {
-      okMessage = await _reproxystatus() ?? okMessage;
+    if (okMessage == null) {
+      okMessage = bootstrapResult.stdout.trim();
     }
     eventHandler(
       RunnerResult(

--- a/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -810,6 +810,36 @@ void main() {
       emptyDir.deleteSync(recursive: true);
     }
   });
+
+  test('Bootstrap collects reproxy status before shutting down reproxy', () async {
+    final Build targetBuild = buildConfig.builds[0];
+    final commandLog = <FakeCommandLogEntry>[];
+    final BuildRunner buildRunner = BuildRunner(
+      platform: FakePlatform(operatingSystem: Platform.linux, numberOfProcessors: 32),
+      processRunner: ProcessRunner(
+        processManager: _fakeProcessManager(commandLog: commandLog, failUnknown: false),
+      ),
+      abi: ffi.Abi.linuxX64,
+      engineSrcDir: engine.srcDir,
+      build: targetBuild,
+      extraGnArgs: <String>['--rbe'],
+    );
+    void handler(RunnerEvent event) {}
+    final bool runResult = await buildRunner.run(handler);
+
+    int? reproxyStatusIndex;
+    int? bootstrapShutdownIndex;
+    for (int i = 0; i < commandLog.length; i++) {
+      final FakeCommandLogEntry entry = commandLog[i];
+      if (entry.command[0].endsWith('reproxystatus')) {
+        reproxyStatusIndex = i;
+      }
+      if (entry.command[0].endsWith('bootstrap') && entry.command.contains('--shutdown')) {
+        bootstrapShutdownIndex = i;
+      }
+    }
+    expect(reproxyStatusIndex!, lessThan(bootstrapShutdownIndex!));
+  });
 }
 
 FakeProcessManager _fakeProcessManager({
@@ -818,6 +848,7 @@ FakeProcessManager _fakeProcessManager({
   io.ProcessResult? ninjaResult,
   bool Function(Object?, {String? workingDirectory})? canRun,
   bool failUnknown = true,
+  List<FakeCommandLogEntry>? commandLog,
 }) {
   final io.ProcessResult success = io.ProcessResult(1, 0, '', '');
   FakeProcess fakeProcess(io.ProcessResult? result) => FakeProcess(
@@ -827,14 +858,20 @@ FakeProcessManager _fakeProcessManager({
   );
   return FakeProcessManager(
     canRun: canRun ?? (Object? exe, {String? workingDirectory}) => true,
-    onRun: (FakeCommandLogEntry entry) => switch (entry.command) {
-      _ => failUnknown ? io.ProcessResult(1, 1, '', '') : success,
+    onRun: (FakeCommandLogEntry entry) {
+      commandLog?.add(entry);
+      return switch (entry.command) {
+        _ => failUnknown ? io.ProcessResult(1, 1, '', '') : success,
+      };
     },
-    onStart: (FakeCommandLogEntry entry) => switch (entry.command) {
-      [final String exe, ...] when exe.endsWith('gn') => fakeProcess(gnResult),
-      [final String exe, ...] when exe.endsWith('bootstrap') => fakeProcess(bootstrapResult),
-      [final String exe, ...] when exe.endsWith('ninja') => fakeProcess(ninjaResult),
-      _ => failUnknown ? FakeProcess(exitCode: 1) : FakeProcess(),
+    onStart: (FakeCommandLogEntry entry) {
+      commandLog?.add(entry);
+      return switch (entry.command) {
+        [final String exe, ...] when exe.endsWith('gn') => fakeProcess(gnResult),
+        [final String exe, ...] when exe.endsWith('bootstrap') => fakeProcess(bootstrapResult),
+        [final String exe, ...] when exe.endsWith('ninja') => fakeProcess(ninjaResult),
+        _ => failUnknown ? FakeProcess(exitCode: 1) : FakeProcess(),
+      };
     },
   );
 }

--- a/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
+++ b/engine/src/flutter/tools/pkg/engine_build_configs/test/build_config_runner_test.dart
@@ -826,6 +826,7 @@ void main() {
     );
     void handler(RunnerEvent event) {}
     final bool runResult = await buildRunner.run(handler);
+    expect(runResult, isTrue);
 
     int? reproxyStatusIndex;
     int? bootstrapShutdownIndex;
@@ -838,7 +839,7 @@ void main() {
         bootstrapShutdownIndex = i;
       }
     }
-    expect(reproxyStatusIndex!, lessThan(bootstrapShutdownIndex!));
+    expect(reproxyStatusIndex, lessThan(bootstrapShutdownIndex!));
   });
 }
 


### PR DESCRIPTION
* The reclient bootstrap shutdown command now requires the config file flag.
* The reproxystatus command must be run before stopping the reproxy in order to access RBE metrics.