### PR TITLE
Enable deprecated_member_use_from_same_package for all packages containing tests of Dart fixes defined within the package

### DIFF
--- a/packages/flutter_driver/test_fixes/analysis_options.yaml
+++ b/packages/flutter_driver/test_fixes/analysis_options.yaml
@@ -1,1 +1,10 @@
 # This ensures that parent analysis options do not accidentally break the fix tests.
+
+linter:
+  rules:
+    # Since these test cases live inside the `flutter_driver` package, the
+    # lint `deprecated_member_use_from_same_package` is required in
+    # order to trigger them. Customer code (which lives outside of the
+    # `flutter` package) will be triggered by the analyzer warning
+    # `deprecated_member_use`, which is enabled by default.
+    - deprecated_member_use_from_same_package

--- a/packages/flutter_driver/test_fixes/analysis_options.yaml
+++ b/packages/flutter_driver/test_fixes/analysis_options.yaml
@@ -5,6 +5,6 @@ linter:
     # Since these test cases live inside the `flutter_driver` package, the
     # lint `deprecated_member_use_from_same_package` is required in
     # order to trigger them. Customer code (which lives outside of the
-    # `flutter` package) will be triggered by the analyzer warning
+    # `flutter_driver` package) will be triggered by the analyzer warning
     # `deprecated_member_use`, which is enabled by default.
     - deprecated_member_use_from_same_package

--- a/packages/flutter_test/test_fixes/analysis_options.yaml
+++ b/packages/flutter_test/test_fixes/analysis_options.yaml
@@ -1,1 +1,10 @@
 # This ensures that parent analysis options do not accidentally break the fix tests.
+
+linter:
+  rules:
+    # Since these test cases live inside the `flutter_test` package, the
+    # lint `deprecated_member_use_from_same_package` is required in
+    # order to trigger them. Customer code (which lives outside of the
+    # `flutter` package) will be triggered by the analyzer warning
+    # `deprecated_member_use`, which is enabled by default.
+    - deprecated_member_use_from_same_package

--- a/packages/flutter_test/test_fixes/analysis_options.yaml
+++ b/packages/flutter_test/test_fixes/analysis_options.yaml
@@ -5,6 +5,6 @@ linter:
     # Since these test cases live inside the `flutter_test` package, the
     # lint `deprecated_member_use_from_same_package` is required in
     # order to trigger them. Customer code (which lives outside of the
-    # `flutter` package) will be triggered by the analyzer warning
+    # `flutter_test` package) will be triggered by the analyzer warning
     # `deprecated_member_use`, which is enabled by default.
     - deprecated_member_use_from_same_package

--- a/packages/integration_test/test_fixes/analysis_options.yaml
+++ b/packages/integration_test/test_fixes/analysis_options.yaml
@@ -1,1 +1,10 @@
 # This ensures that parent analysis options do not accidentally break the fix tests.
+
+linter:
+  rules:
+    # Since these test cases live inside the `integration_test` package, the
+    # lint `deprecated_member_use_from_same_package` is required in
+    # order to trigger them. Customer code (which lives outside of the
+    # `flutter` package) will be triggered by the analyzer warning
+    # `deprecated_member_use`, which is enabled by default.
+    - deprecated_member_use_from_same_package

--- a/packages/integration_test/test_fixes/analysis_options.yaml
+++ b/packages/integration_test/test_fixes/analysis_options.yaml
@@ -5,6 +5,6 @@ linter:
     # Since these test cases live inside the `integration_test` package, the
     # lint `deprecated_member_use_from_same_package` is required in
     # order to trigger them. Customer code (which lives outside of the
-    # `flutter` package) will be triggered by the analyzer warning
+    # `integration_test` package) will be triggered by the analyzer warning
     # `deprecated_member_use`, which is enabled by default.
     - deprecated_member_use_from_same_package


### PR DESCRIPTION
See https://github.com/flutter/flutter/pull/177183