### PR TITLE
Adds cache extent type to two_dimentional_viewport

### DIFF
--- a/packages/flutter/lib/src/widgets/two_dimensional_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_scroll_view.dart
@@ -62,6 +62,7 @@ abstract class TwoDimensionalScrollView extends StatelessWidget {
     this.horizontalDetails = const ScrollableDetails.horizontal(),
     required this.delegate,
     this.cacheExtent,
+    this.cacheExtentStyle,
     this.diagonalDragBehavior = DiagonalDragBehavior.none,
     this.dragStartBehavior = DragStartBehavior.start,
     this.keyboardDismissBehavior,
@@ -74,6 +75,9 @@ abstract class TwoDimensionalScrollView extends StatelessWidget {
 
   /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
   final double? cacheExtent;
+
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtentStyle}
+  final CacheExtentStyle? cacheExtentStyle;
 
   /// Whether scrolling gestures should lock to one axes, allow free movement
   /// in both axes, or be evaluated on a weighted scale.

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -148,6 +148,7 @@ abstract class TwoDimensionalViewport extends RenderObjectWidget {
     required this.delegate,
     required this.mainAxis,
     this.cacheExtent,
+    this.cacheExtentStyle,
     this.clipBehavior = Clip.hardEdge,
   }) : assert(
          verticalAxisDirection == AxisDirection.down || verticalAxisDirection == AxisDirection.up,
@@ -213,6 +214,9 @@ abstract class TwoDimensionalViewport extends RenderObjectWidget {
 
   /// {@macro flutter.rendering.RenderViewportBase.cacheExtent}
   final double? cacheExtent;
+
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtentStyle}
+  final CacheExtentStyle? cacheExtentStyle;
 
   /// {@macro flutter.material.Material.clipBehavior}
   final Clip clipBehavior;
@@ -519,6 +523,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
     required Axis mainAxis,
     required TwoDimensionalChildManager childManager,
     double? cacheExtent,
+    CacheExtentStyle? cacheExtentStyle,
     Clip clipBehavior = Clip.hardEdge,
   }) : assert(
          verticalAxisDirection == AxisDirection.down || verticalAxisDirection == AxisDirection.up,
@@ -537,6 +542,7 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
        _delegate = delegate,
        _mainAxis = mainAxis,
        _cacheExtent = cacheExtent ?? RenderAbstractViewport.defaultCacheExtent,
+       _cacheExtentStyle = cacheExtentStyle ?? CacheExtentStyle.pixel,
        _clipBehavior = clipBehavior {
     assert(() {
       _debugDanglingKeepAlives = <RenderBox>[];
@@ -673,6 +679,17 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
       return;
     }
     _cacheExtent = value;
+    markNeedsLayout();
+  }
+
+  /// {@macro flutter.rendering.RenderViewportBase.cacheExtentStyle}
+  CacheExtentStyle get cacheExtentStyle => _cacheExtentStyle;
+  CacheExtentStyle _cacheExtentStyle;
+  set cacheExtentStyle(CacheExtentStyle value) {
+    if (value == _cacheExtentStyle) {
+      return;
+    }
+    _cacheExtentStyle = value;
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -33,6 +33,7 @@ export 'package:flutter/rendering.dart' show AxisDirection;
 //     required super.mainAxis,
 //     required super.childManager,
 //     super.cacheExtent,
+//     super.cacheExtentStyle,
 //     super.clipBehavior = Clip.hardEdge,
 //   });
 //   @override

--- a/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
+++ b/packages/flutter/lib/src/widgets/two_dimensional_viewport.dart
@@ -95,6 +95,7 @@ typedef TwoDimensionalIndexedWidgetBuilder =
 ///     required super.delegate,
 ///     required super.mainAxis,
 ///     super.cacheExtent,
+///     super.cacheExtentStyle,
 ///     super.clipBehavior = Clip.hardEdge,
 ///   });
 ///
@@ -109,6 +110,7 @@ typedef TwoDimensionalIndexedWidgetBuilder =
 ///       delegate: delegate,
 ///       childManager: context as TwoDimensionalChildManager,
 ///       cacheExtent: cacheExtent,
+///       cacheExtentStyle: cacheExtentStyle,
 ///       clipBehavior: clipBehavior,
 ///     );
 ///   }
@@ -123,6 +125,7 @@ typedef TwoDimensionalIndexedWidgetBuilder =
 ///       ..mainAxis = mainAxis
 ///       ..delegate = delegate
 ///       ..cacheExtent = cacheExtent
+///       ..cacheExtentStyle = cacheExtentStyle
 ///       ..clipBehavior = clipBehavior;
 ///   }
 /// }
@@ -683,9 +686,9 @@ abstract class RenderTwoDimensionalViewport extends RenderBox implements RenderA
   }
 
   /// {@macro flutter.rendering.RenderViewportBase.cacheExtentStyle}
-  CacheExtentStyle get cacheExtentStyle => _cacheExtentStyle;
-  CacheExtentStyle _cacheExtentStyle;
-  set cacheExtentStyle(CacheExtentStyle value) {
+  CacheExtentStyle get cacheExtentStyle => _cacheExtentStyle ?? CacheExtentStyle.viewport;
+  CacheExtentStyle? _cacheExtentStyle;
+  set cacheExtentStyle(CacheExtentStyle? value) {
     if (value == _cacheExtentStyle) {
       return;
     }

--- a/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_scroll_view_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/src/gestures/monodrag.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -989,6 +990,31 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(tester.testTextInput.isVisible, isFalse);
+    });
+
+    testWidgets('cacheExtentStyle is passed to viewport', (WidgetTester tester) async {
+      late final TwoDimensionalChildBuilderDelegate delegate;
+      addTearDown(() => delegate.dispose());
+      await tester.pumpWidget(
+        MaterialApp(
+          home: SimpleBuilderTableView(
+            cacheExtent: 1.0,
+            cacheExtentStyle: CacheExtentStyle.viewport,
+            delegate: delegate = TwoDimensionalChildBuilderDelegate(
+              builder: _testChildBuilder,
+              maxXIndex: 5,
+              maxYIndex: 5,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final SimpleBuilderTableViewport viewport = tester.widget(
+        find.byType(SimpleBuilderTableViewport),
+      );
+      expect(viewport.cacheExtent, 1.0);
+      expect(viewport.cacheExtentStyle, CacheExtentStyle.viewport);
     });
   });
 }

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -7,7 +7,7 @@ import 'dart:math' as math;
 import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart' show ViewportOffset;
+import 'package:flutter/rendering.dart' show CacheExtentStyle, ViewportOffset;
 
 // BUILDER DELEGATE ---
 
@@ -35,6 +35,7 @@ Widget simpleBuilderTest({
   ScrollableDetails? horizontalDetails,
   TwoDimensionalChildBuilderDelegate? delegate,
   double? cacheExtent,
+  CacheExtentStyle? cacheExtentStyle,
   DiagonalDragBehavior? diagonalDrag,
   Clip? clipBehavior,
   String? restorationID,
@@ -52,6 +53,7 @@ Widget simpleBuilderTest({
         verticalDetails: verticalDetails ?? const ScrollableDetails.vertical(),
         horizontalDetails: horizontalDetails ?? const ScrollableDetails.horizontal(),
         cacheExtent: cacheExtent,
+        cacheExtentStyle: cacheExtentStyle,
         useCacheExtent: useCacheExtent,
         diagonalDragBehavior: diagonalDrag ?? DiagonalDragBehavior.none,
         clipBehavior: clipBehavior ?? Clip.hardEdge,
@@ -73,6 +75,7 @@ class SimpleBuilderTableView extends TwoDimensionalScrollView {
     super.horizontalDetails = const ScrollableDetails.horizontal(),
     required TwoDimensionalChildBuilderDelegate delegate,
     super.cacheExtent,
+    super.cacheExtentStyle,
     super.diagonalDragBehavior = DiagonalDragBehavior.none,
     super.dragStartBehavior = DragStartBehavior.start,
     super.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
@@ -104,6 +107,7 @@ class SimpleBuilderTableView extends TwoDimensionalScrollView {
       mainAxis: mainAxis,
       delegate: delegate as TwoDimensionalChildBuilderDelegate,
       cacheExtent: cacheExtent,
+      cacheExtentStyle: cacheExtentStyle,
       clipBehavior: clipBehavior,
       useCacheExtent: useCacheExtent,
       applyDimensions: applyDimensions,
@@ -123,6 +127,7 @@ class SimpleBuilderTableViewport extends TwoDimensionalViewport {
     required TwoDimensionalChildBuilderDelegate delegate,
     required super.mainAxis,
     super.cacheExtent,
+    super.cacheExtentStyle,
     super.clipBehavior = Clip.hardEdge,
     this.useCacheExtent = false,
     this.applyDimensions = true,
@@ -147,6 +152,7 @@ class SimpleBuilderTableViewport extends TwoDimensionalViewport {
       delegate: delegate as TwoDimensionalChildBuilderDelegate,
       childManager: context as TwoDimensionalChildManager,
       cacheExtent: cacheExtent,
+      cacheExtentStyle: cacheExtentStyle,
       clipBehavior: clipBehavior,
       useCacheExtent: useCacheExtent,
       applyDimensions: applyDimensions,
@@ -165,6 +171,7 @@ class SimpleBuilderTableViewport extends TwoDimensionalViewport {
       ..mainAxis = mainAxis
       ..delegate = delegate
       ..cacheExtent = cacheExtent
+      ..cacheExtentStyle = cacheExtentStyle
       ..clipBehavior = clipBehavior;
   }
 }
@@ -179,6 +186,7 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
     required super.mainAxis,
     required super.childManager,
     super.cacheExtent,
+    super.cacheExtentStyle,
     super.clipBehavior = Clip.hardEdge,
     this.applyDimensions = true,
     this.setLayoutOffset = true,
@@ -213,8 +221,21 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
     // Every child is 200x200 square
     final double horizontalPixels = horizontalOffset.pixels;
     final double verticalPixels = verticalOffset.pixels;
-    final double viewportWidth = viewportDimension.width + (useCacheExtent ? cacheExtent : 0.0);
-    final double viewportHeight = viewportDimension.height + (useCacheExtent ? cacheExtent : 0.0);
+    final double cacheExtentValue = useCacheExtent ? cacheExtent : 0.0;
+    final double horizontalCacheExtent;
+    final double verticalCacheExtent;
+
+    switch (cacheExtentStyle) {
+      case CacheExtentStyle.pixel:
+        horizontalCacheExtent = cacheExtentValue;
+        verticalCacheExtent = cacheExtentValue;
+      case CacheExtentStyle.viewport:
+        horizontalCacheExtent = viewportDimension.width * cacheExtentValue;
+        verticalCacheExtent = viewportDimension.height * cacheExtentValue;
+    }
+
+    final double viewportWidth = viewportDimension.width;
+    final double viewportHeight = viewportDimension.height;
     final TwoDimensionalChildBuilderDelegate builderDelegate =
         delegate as TwoDimensionalChildBuilderDelegate;
 
@@ -223,13 +244,13 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
     maxRowIndex = builderDelegate.maxYIndex ?? 5;
     maxColumnIndex = builderDelegate.maxXIndex ?? 5;
 
-    final int leadingColumn = math.max((horizontalPixels / 200).floor(), 0);
-    final int leadingRow = math.max((verticalPixels / 200).floor(), 0);
+    final int leadingColumn = math.max(((horizontalPixels - horizontalCacheExtent) / 200).floor(), 0);
+    final int leadingRow = math.max(((verticalPixels - verticalCacheExtent) / 200).floor(), 0);
     final int trailingColumn = math.min(
-      ((horizontalPixels + viewportWidth) / 200).ceil(),
+      ((horizontalPixels + viewportWidth + horizontalCacheExtent) / 200).ceil(),
       maxColumnIndex,
     );
-    final int trailingRow = math.min(((verticalPixels + viewportHeight) / 200).ceil(), maxRowIndex);
+    final int trailingRow = math.min(((verticalPixels + viewportHeight + verticalCacheExtent) / 200).ceil(), maxRowIndex);
 
     double xLayoutOffset = (leadingColumn * 200) - horizontalOffset.pixels;
     for (int column = leadingColumn; column <= trailingColumn; column++) {
@@ -285,6 +306,7 @@ Widget simpleListTest({
   ScrollableDetails? horizontalDetails,
   TwoDimensionalChildListDelegate? delegate,
   double? cacheExtent,
+  CacheExtentStyle? cacheExtentStyle,
   DiagonalDragBehavior? diagonalDrag,
   Clip? clipBehavior,
 }) {
@@ -295,6 +317,7 @@ Widget simpleListTest({
         verticalDetails: verticalDetails ?? const ScrollableDetails.vertical(),
         horizontalDetails: horizontalDetails ?? const ScrollableDetails.horizontal(),
         cacheExtent: cacheExtent,
+        cacheExtentStyle: cacheExtentStyle,
         diagonalDragBehavior: diagonalDrag ?? DiagonalDragBehavior.none,
         clipBehavior: clipBehavior ?? Clip.hardEdge,
         delegate: delegate ?? TwoDimensionalChildListDelegate(children: children),
@@ -312,6 +335,7 @@ class SimpleListTableView extends TwoDimensionalScrollView {
     super.horizontalDetails = const ScrollableDetails.horizontal(),
     required TwoDimensionalChildListDelegate delegate,
     super.cacheExtent,
+    super.cacheExtentStyle,
     super.diagonalDragBehavior = DiagonalDragBehavior.none,
     super.dragStartBehavior = DragStartBehavior.start,
     super.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
@@ -332,6 +356,7 @@ class SimpleListTableView extends TwoDimensionalScrollView {
       mainAxis: mainAxis,
       delegate: delegate as TwoDimensionalChildListDelegate,
       cacheExtent: cacheExtent,
+      cacheExtentStyle: cacheExtentStyle,
       clipBehavior: clipBehavior,
     );
   }
@@ -347,6 +372,7 @@ class SimpleListTableViewport extends TwoDimensionalViewport {
     required TwoDimensionalChildListDelegate delegate,
     required super.mainAxis,
     super.cacheExtent,
+    super.cacheExtentStyle,
     super.clipBehavior = Clip.hardEdge,
   }) : super(delegate: delegate);
 
@@ -361,6 +387,7 @@ class SimpleListTableViewport extends TwoDimensionalViewport {
       delegate: delegate as TwoDimensionalChildListDelegate,
       childManager: context as TwoDimensionalChildManager,
       cacheExtent: cacheExtent,
+      cacheExtentStyle: cacheExtentStyle,
       clipBehavior: clipBehavior,
     );
   }
@@ -375,6 +402,7 @@ class SimpleListTableViewport extends TwoDimensionalViewport {
       ..mainAxis = mainAxis
       ..delegate = delegate
       ..cacheExtent = cacheExtent
+      ..cacheExtentStyle = cacheExtentStyle
       ..clipBehavior = clipBehavior;
   }
 }
@@ -389,6 +417,7 @@ class RenderSimpleListTableViewport extends RenderTwoDimensionalViewport {
     required super.mainAxis,
     required super.childManager,
     super.cacheExtent,
+    super.cacheExtentStyle,
     super.clipBehavior = Clip.hardEdge,
   }) : super(delegate: delegate);
 

--- a/packages/flutter/test/widgets/two_dimensional_utils.dart
+++ b/packages/flutter/test/widgets/two_dimensional_utils.dart
@@ -244,13 +244,19 @@ class RenderSimpleBuilderTableViewport extends RenderTwoDimensionalViewport {
     maxRowIndex = builderDelegate.maxYIndex ?? 5;
     maxColumnIndex = builderDelegate.maxXIndex ?? 5;
 
-    final int leadingColumn = math.max(((horizontalPixels - horizontalCacheExtent) / 200).floor(), 0);
+    final int leadingColumn = math.max(
+      ((horizontalPixels - horizontalCacheExtent) / 200).floor(),
+      0,
+    );
     final int leadingRow = math.max(((verticalPixels - verticalCacheExtent) / 200).floor(), 0);
     final int trailingColumn = math.min(
       ((horizontalPixels + viewportWidth + horizontalCacheExtent) / 200).ceil(),
       maxColumnIndex,
     );
-    final int trailingRow = math.min(((verticalPixels + viewportHeight + verticalCacheExtent) / 200).ceil(), maxRowIndex);
+    final int trailingRow = math.min(
+      ((verticalPixels + viewportHeight + verticalCacheExtent) / 200).ceil(),
+      maxRowIndex,
+    );
 
     double xLayoutOffset = (leadingColumn * 200) - horizontalOffset.pixels;
     for (int column = leadingColumn; column <= trailingColumn; column++) {

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -2012,12 +2012,14 @@ void main() {
       );
       addTearDown(delegate.dispose);
 
-      await tester.pumpWidget(simpleBuilderTest(
-        delegate: delegate,
-        cacheExtent: 1.0,
-        cacheExtentStyle: CacheExtentStyle.viewport,
-        useCacheExtent: true,
-      ));
+      await tester.pumpWidget(
+        simpleBuilderTest(
+          delegate: delegate,
+          cacheExtent: 1.0,
+          cacheExtentStyle: CacheExtentStyle.viewport,
+          useCacheExtent: true,
+        ),
+      );
       await tester.pumpAndSettle();
 
       final RenderTwoDimensionalViewport viewport = getViewport(tester, childKeys.values.first);

--- a/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
+++ b/packages/flutter/test/widgets/two_dimensional_viewport_test.dart
@@ -1998,10 +1998,38 @@ void main() {
         result.first.toString(),
         equalsIgnoringHashCodes('(xIndex: 0, yIndex: 0): RenderRepaintBoundary#00000'),
       );
-      expect(
-        result.last.toString(),
-        equalsIgnoringHashCodes('(xIndex: 4, yIndex: 3): RenderRepaintBoundary#00000 NEEDS-PAINT'),
+    });
+
+    testWidgets('use cacheExtentStyle', (WidgetTester tester) async {
+      final Map<ChildVicinity, UniqueKey> childKeys = <ChildVicinity, UniqueKey>{};
+      final TwoDimensionalChildBuilderDelegate delegate = TwoDimensionalChildBuilderDelegate(
+        maxXIndex: 5,
+        maxYIndex: 5,
+        builder: (BuildContext context, ChildVicinity vicinity) {
+          childKeys[vicinity] = childKeys[vicinity] ?? UniqueKey();
+          return SizedBox.square(key: childKeys[vicinity], dimension: 200);
+        },
       );
+      addTearDown(delegate.dispose);
+
+      await tester.pumpWidget(simpleBuilderTest(
+        delegate: delegate,
+        cacheExtent: 1.0,
+        cacheExtentStyle: CacheExtentStyle.viewport,
+        useCacheExtent: true,
+      ));
+      await tester.pumpAndSettle();
+
+      final RenderTwoDimensionalViewport viewport = getViewport(tester, childKeys.values.first);
+      // The viewport is 800x600. The children are 200x200.
+      // Without cache extent, it should show 4x3 = 12 children, but with the
+      // trailing edge calculation it is 5x4 = 20.
+      // With cacheExtent: 1.0 and cacheExtentStyle: CacheExtentStyle.viewport,
+      // The visible area will be from -800 to 800 + 800 = 1600 horizontally,
+      // and -600 to 600 + 600 = 1200 vertically.
+      // So, it should lay out children from (0,0) to (5,5).
+      // This is a total of 6 * 6 = 36 children.
+      expect(viewport.debugDescribeChildren().length, 36);
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('asserts that both axes are bounded', (WidgetTester tester) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

as title. this is needed if we want to change cache extent default to use viewport % instead of pixels

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
