### PR TITLE
[web] Set `pointer-events: none` for img-element-backed images

### DIFF
--- a/packages/flutter/lib/src/web.dart
+++ b/packages/flutter/lib/src/web.dart
@@ -42,6 +42,8 @@ extension type CSSStyleDeclaration._(JSObject _) implements JSObject {
   external String get height;
   external set width(String value);
   external String get width;
+  external set pointerEvents(String value);
+  external String get pointerEvents;
 }
 
 extension type CSSStyleSheet._(JSObject _) implements JSObject {

--- a/packages/flutter/lib/src/widgets/_web_image_web.dart
+++ b/packages/flutter/lib/src/widgets/_web_image_web.dart
@@ -42,7 +42,8 @@ class ImgElementPlatformView extends StatelessWidget {
       // Set `width` and `height`, otherwise the engine will issue a warning.
       img.style
         ..width = '100%'
-        ..height = '100%';
+        ..height = '100%'
+        ..pointerEvents = 'none';
       return img;
     });
   }

--- a/packages/flutter/test/painting/_network_image_test_web.dart
+++ b/packages/flutter/test/painting/_network_image_test_web.dart
@@ -471,6 +471,25 @@ void runTests() {
     expect(imgElement.style.height, '100%');
   });
 
+  testWidgets('Creates an <img> with pointer-events: none', (WidgetTester tester) async {
+    final TestImgElement testImg = TestImgElement();
+    testImg.src = _uniqueUrl(tester.testDescription);
+
+    final _TestImageStreamCompleter streamCompleter = _TestImageStreamCompleter();
+    final _TestImageProvider imageProvider = _TestImageProvider(streamCompleter: streamCompleter);
+
+    await tester.pumpWidget(Image(image: imageProvider));
+    streamCompleter.setData(
+      imageInfo: WebImageInfo(testImg.getMock() as web_shim.HTMLImageElement),
+    );
+    await tester.pumpAndSettle();
+    final FakePlatformView imgElementPlatformView = fakePlatformViewRegistry.views.single;
+    expect(imgElementPlatformView.htmlElement, isA<web.HTMLImageElement>());
+    final web.HTMLImageElement imgElement =
+        imgElementPlatformView.htmlElement as web.HTMLImageElement;
+    expect(imgElement.style.pointerEvents, 'none');
+  });
+
   group('RenderWebImage', () {
     testWidgets('BoxFit.contain centers and sizes the image correctly', (
       WidgetTester tester,


### PR DESCRIPTION
This stops the context menu from showing up when you right click on an image that is backed by an <img> element.

Fixes internal issue

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
