### PR TITLE
[DDM] enable host builds in the merge queue

### DIFF
--- a/engine/src/flutter/.ci.yaml
+++ b/engine/src/flutter/.ci.yaml
@@ -233,13 +233,12 @@ targets:
 
   - name: Linux linux_host_engine_ddm
     recipe: engine_v2/engine_v2
-    bringup: true
-    backfill: false
     timeout: 120
     enabled_branches:
       # Don't run this on release branches
       - master
     properties:
+      release_build: "true"
       add_recipes_cq: "true"
       config_name: linux_host_engine_ddm
     # Do not remove(https://github.com/flutter/flutter/issues/144644)


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/177252.
Towards b/452833651.
Similar to https://github.com/flutter/flutter/pull/168233.

This changes the ddm host build to be part of the merge queue so they are available on every commit because we want to use them for internal testing and use them on CI internally.

