### PR TITLE
Fix default value for DateRangePickerDialog currentDate

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1339,7 +1339,7 @@ class DateRangePickerDialog extends StatefulWidget {
     this.initialDateRange,
     required this.firstDate,
     required this.lastDate,
-    this.currentDate,
+    DateTime? currentDate,
     this.initialEntryMode = DatePickerEntryMode.calendar,
     this.helpText,
     this.cancelText,
@@ -1358,7 +1358,7 @@ class DateRangePickerDialog extends StatefulWidget {
     this.switchToCalendarEntryModeIcon,
     this.selectableDayPredicate,
     this.calendarDelegate = const GregorianCalendarDelegate(),
-  });
+  }) : _currentDate = currentDate;
 
   /// The date range that the date range picker starts with when it opens.
   ///
@@ -1382,8 +1382,12 @@ class DateRangePickerDialog extends StatefulWidget {
   ///
   /// This date will be highlighted in the day grid.
   ///
-  /// If `null`, the date of `DateTime.now()` will be used.
-  final DateTime? currentDate;
+  /// If `null`, the date of `calendarDelegate.now()` will be used.
+  DateTime get currentDate {
+    return calendarDelegate.dateOnly(_currentDate ?? calendarDelegate.now());
+  }
+
+  final DateTime? _currentDate;
 
   /// The initial date range picker entry mode.
   ///

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -2005,6 +2005,26 @@ void main() {
 
     expect(startDateDecoration.filled, isTrue);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/177441.
+  testWidgets('DateRangePickerDialog.currentDate is optional', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: InputDecorationTheme(
+            data: const InputDecorationThemeData(filled: true),
+            child: DateRangePickerDialog(
+              firstDate: firstDate,
+              lastDate: lastDate,
+              initialEntryMode: DatePickerEntryMode.inputOnly,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), null);
+  });
 }
 
 class _RestorableDateRangePickerDialogTestWidget extends StatefulWidget {


### PR DESCRIPTION
## Description

This PR fixes the default value for `DateRangePickerDialog.currentDate`.
Before this PR, the comment mentions that `currentDate` defaults to `DateTime.now()` but this is not the case (the value is not initialised).
After this PR, `currentDate` defaults to `calendarDelegate.now()`.

## Related Issue

Fixes  [DateRangePickerDialog crashes when currentDate is omitted](https://github.com/flutter/flutter/issues/177441)

## Tests

- Adds 1 test
