### PR TITLE
[beta] CP: Fixes hot reload/restart crashes after closing browser tab on web-server device

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -548,14 +548,8 @@ class ResidentWebRunner extends ResidentRunner {
           } on vmservice.RPCError catch (e) {
             // DWDS throws an RPC error with kIsolateCannotReload code when there are no
             // browser clients currently connected during a hot reload operation.
-            // TODO(yjessy): Remove this temporary workaround once vm_service is fixed.
-            // There's a bug in vm_service where it re-encodes RPCErrors as kServerError
-            // instead of preserving the original error code. Until that's fixed, we need
-            // to check for both kIsolateCannotReload and kServerError for this method.
-            // See https://github.com/dart-lang/sdk/issues/61757
             if (e.callingMethod == hotReloadMethod &&
-                (e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code ||
-                    e.code == vmservice.RPCErrorKind.kServerError.code)) {
+                e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code) {
               return _handleNoClientsAvailable(status);
             }
             // Re-throw other RPC errors

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -517,8 +517,14 @@ class ResidentWebRunner extends ResidentRunner {
           } on vmservice.RPCError catch (e) {
             // DWDS throws an RPC error with kIsolateCannotReload code when there are no
             // browser clients currently connected during a hot restart operation.
+
+            // TODO(61757): Remove this temporary workaround once vm_service is fixed.
+            // There's a bug in vm_service where it re-encodes RPCErrors as kServerError
+            // instead of preserving the original error code. Until that's fixed, we need
+            // to check for both kIsolateCannotReload and kServerError for this method.
             if (e.callingMethod == hotRestartMethod &&
-                e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code) {
+                (e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code ||
+                    e.code == vmservice.RPCErrorKind.kServerError.code)) {
               return _handleNoClientsAvailable(status);
             }
             // Re-throw other RPC errors
@@ -542,8 +548,14 @@ class ResidentWebRunner extends ResidentRunner {
           } on vmservice.RPCError catch (e) {
             // DWDS throws an RPC error with kIsolateCannotReload code when there are no
             // browser clients currently connected during a hot reload operation.
+            // TODO(yjessy): Remove this temporary workaround once vm_service is fixed.
+            // There's a bug in vm_service where it re-encodes RPCErrors as kServerError
+            // instead of preserving the original error code. Until that's fixed, we need
+            // to check for both kIsolateCannotReload and kServerError for this method.
+            // See https://github.com/dart-lang/sdk/issues/61757
             if (e.callingMethod == hotReloadMethod &&
-                e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code) {
+                (e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code ||
+                    e.code == vmservice.RPCErrorKind.kServerError.code)) {
               return _handleNoClientsAvailable(status);
             }
             // Re-throw other RPC errors

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -515,10 +515,10 @@ class ResidentWebRunner extends ResidentRunner {
           try {
             await _vmService.service.callMethod(hotRestartMethod);
           } on vmservice.RPCError catch (e) {
-            // DWDS throws an RPC error with kServerError code when there are no
+            // DWDS throws an RPC error with kIsolateCannotReload code when there are no
             // browser clients currently connected during a hot restart operation.
             if (e.callingMethod == hotRestartMethod &&
-                e.code == vmservice.RPCErrorKind.kServerError.code) {
+                e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code) {
               return _handleNoClientsAvailable(status);
             }
             // Re-throw other RPC errors
@@ -540,10 +540,10 @@ class ResidentWebRunner extends ResidentRunner {
           try {
             report = await _vmService.service.reloadSources(vm.isolates!.first.id!);
           } on vmservice.RPCError catch (e) {
-            // DWDS throws an RPC error with kServerError code when there are no
+            // DWDS throws an RPC error with kIsolateCannotReload code when there are no
             // browser clients currently connected during a hot reload operation.
             if (e.callingMethod == hotReloadMethod &&
-                e.code == vmservice.RPCErrorKind.kServerError.code) {
+                e.code == vmservice.RPCErrorKind.kIsolateCannotReload.code) {
               return _handleNoClientsAvailable(status);
             }
             // Re-throw other RPC errors

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -549,8 +549,8 @@ class ResidentWebRunner extends ResidentRunner {
             // Re-throw other RPC errors
             rethrow;
           }
-          reloadDuration = _systemClock.now().difference(reloadStart);
 
+          reloadDuration = _systemClock.now().difference(reloadStart);
           final contents = ReloadReportContents.fromReloadReport(report);
           final bool success = contents.success ?? false;
           if (!success) {

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   archive: 3.6.1
   args: 2.7.0
   dds: 5.0.3
-  dwds: 25.1.0
+  dwds: 25.1.0+2
   code_builder: 4.11.0
   collection: 1.19.1
   completion: 1.0.2
@@ -127,4 +127,4 @@ dev_dependencies:
 dartdoc:
   # Exclude this package from the hosted API docs.
   nodoc: true
-# PUBSPEC CHECKSUM: ho7nke
+# PUBSPEC CHECKSUM: s8p858

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -963,7 +963,7 @@ name: my_app
       expect(debugConnectionInfo, isNotNull);
 
       final OperationResult result = await residentWebRunner.restart();
-      expect(logger.statusText, contains('Recompile complete. No client connected.'));
+      expect(logger.statusText, contains(kNoClientConnectedMessage));
       expect(result.code, 0);
     },
     overrides: <Type, Generator>{
@@ -1166,7 +1166,7 @@ name: my_app
 
       expect(result.code, 0);
       expect(result.isOk, isTrue);
-      expect(logger.statusText, contains('Recompile complete. No client connected.'));
+      expect(logger.statusText, contains(kNoClientConnectedMessage));
     },
     overrides: <Type, Generator>{
       Analytics: () => fakeAnalytics,

--- a/packages/flutter_tools/test/integration.shard/test_data/websocket_dwds_test_common.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/websocket_dwds_test_common.dart
@@ -51,7 +51,7 @@ class WebSocketDwdsTestUtils {
     required List<String> additionalCommandArgs,
     WebSocketDwdsTestConfig config = const WebSocketDwdsTestConfig(),
   }) async {
-    debugPrint('Step 1: Starting WebSocket DWDS connection setup...');
+    debugPrint('Starting WebSocket DWDS connection setup...');
 
     // Set up listening for app output before starting
     final stdout = StringBuffer();
@@ -72,15 +72,15 @@ class WebSocketDwdsTestUtils {
 
     io.Process? chromeProcess;
     try {
-      // Step 1: Start Flutter app with web-server device (will wait for debug connection)
-      debugPrint('Step 2: Starting Flutter app with web-server device...');
+      // Start Flutter app with web-server device (will wait for debug connection)
+      debugPrint('Starting Flutter app with web-server device...');
       final Future<void> appStartFuture = runFlutterWithWebServerDevice(
         flutter,
         additionalCommandArgs: [...additionalCommandArgs, '--no-web-resources-cdn'],
       );
 
-      // Step 2: Wait for DWDS debug URL to be available
-      debugPrint('Step 3: Waiting for DWDS debug service URL...');
+      // Wait for DWDS debug URL to be available
+      debugPrint('Waiting for DWDS debug service URL...');
       final String debugUrl = await sawDebugUrl.future.timeout(
         config.debugUrlTimeout,
         onTimeout: () {
@@ -89,13 +89,13 @@ class WebSocketDwdsTestUtils {
       );
       debugPrint('✓ DWDS debug service available at: $debugUrl');
 
-      // Step 3: Launch headless Chrome to connect to DWDS
-      debugPrint('Step 4: Launching headless Chrome to connect to DWDS...');
+      // Launch headless Chrome to connect to DWDS
+      debugPrint('Launching headless Chrome to connect to DWDS...');
       chromeProcess = await launchHeadlessChrome(debugUrl);
       debugPrint('✓ Headless Chrome launched and connecting to DWDS');
 
-      // Step 4: Wait for app to start (Chrome connection established)
-      debugPrint('Step 5: Waiting for Flutter app to start after Chrome connection...');
+      // Wait for app to start (Chrome connection established)
+      debugPrint('Waiting for Flutter app to start after Chrome connection...');
       await appStartFuture.timeout(
         config.appStartTimeout,
         onTimeout: () {


### PR DESCRIPTION
**Impacted Users:**
Flutter web developers using the `web-server` device for hot reload/restart.

**Impact Description:**
Hot reload/restart crashes when the browser tab is closed, causing “Bad state: No element” errors and breaking the DWDS connection.

**Workaround:**
Rerun the app.

**Risk:**
Low — changes only affect hot reload/restart handling when no clients are connected.

**Test Coverage:**
Yes — covered by automated integration tests and verified with manual testing across reload/restart scenarios.

**Validation Steps:**

1. run the app on webserver `flutter run -d web-server`
2. open the url
3. do hot reload
4. close the browser
5. do hot reload 

You should see a warning `WebSocketProxyService: No clients available.` along with `Recompile complete. No client connected.` printed in the console. The app should no longer crash.


**Merged PR:** https://github.com/flutter/flutter/pull/177026
**Changes in DWDS (Parent PR):** [https://github.com/dart-lang/webdev/pull/2699](https://github.com/dart-lang/webdev/pull/2699)

Fixes https://github.com/flutter/flutter/issues/174791
