### PR TITLE
Add support for Visual Studio 2026

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -182,6 +182,7 @@ class VisualStudio {
   String? get cmakeGenerator {
     // From https://cmake.org/cmake/help/v3.22/manual/cmake-generators.7.html#visual-studio-generators
     return switch (_majorVersion) {
+      18 => 'Visual Studio 18 2026',
       17 => 'Visual Studio 17 2022',
       _ => 'Visual Studio 16 2019',
     };

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -53,6 +53,18 @@ const _vs2022Response = <String, dynamic>{
   'catalog': <String, dynamic>{'productDisplayVersion': '17.0.0'},
 };
 
+// A minimum version of a response where a VS 2026 installation was found.
+const _vs2026Response = <String, dynamic>{
+  'installationPath': visualStudioPath,
+  'displayName': 'Visual Studio Community 2026',
+  'installationVersion': '18.0.11116.177',
+  'isRebootRequired': false,
+  'isComplete': true,
+  'isLaunchable': true,
+  'isPrerelease': false,
+  'catalog': <String, dynamic>{'productDisplayVersion': 'Insiders [11116.177]'},
+};
+
 // A minimum version of a response where a Build Tools installation was found.
 const _defaultBuildToolsResponse = <String, dynamic>{
   'installationPath': visualStudioPath,
@@ -823,6 +835,27 @@ void main() {
       expect(visualStudio.hasNecessaryComponents, true);
       expect(visualStudio.cmakePath, equals(cmakePath));
       expect(visualStudio.cmakeGenerator, equals('Visual Studio 17 2022'));
+      expect(visualStudio.clPath, equals(clPath));
+      expect(visualStudio.libPath, equals(libPath));
+      expect(visualStudio.linkPath, equals(linkPath));
+      expect(visualStudio.vcvarsPath, equals(vcvarsPath));
+    });
+
+    testWithoutContext('properties return the right value for Visual Studio 2026', () {
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      setMockCompatibleVisualStudioInstallation(
+        _vs2026Response,
+        fixture.fileSystem,
+        fixture.processManager,
+      );
+
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, true);
+      expect(visualStudio.hasNecessaryComponents, true);
+      expect(visualStudio.cmakePath, equals(cmakePath));
+      expect(visualStudio.cmakeGenerator, equals('Visual Studio 18 2026'));
       expect(visualStudio.clPath, equals(clPath));
       expect(visualStudio.libPath, equals(libPath));
       expect(visualStudio.linkPath, equals(linkPath));


### PR DESCRIPTION
Adds a mapping for Visual Studio 2026 to the `cmakeGenerator` property used to drive Windows builds, enabling Flutter to be used for development on a system with Visual Studio 2026 installed and not Visual Studio 2022 or Visual Studio 2019.

Closes: #176399
Related-To: #93426

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
