### PR TITLE
[ Tool ] Add `Stream.transformWithCallSite` to provide more useful stack traces

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -15,6 +15,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../convert.dart';
 import '../device.dart';
@@ -1118,13 +1119,10 @@ class AdbLogReader extends DeviceLogReader {
     // We expect logcat streams to occasionally contain invalid utf-8,
     // see: https://github.com/flutter/flutter/pull/8864.
     const decoder = Utf8Decoder(reportErrors: false);
-    _adbProcess.stdout
-        .transform<String>(decoder)
-        .transform<String>(const LineSplitter())
-        .listen(_onLine);
+    _adbProcess.stdout.transform(utf8LineDecoder).listen(_onLine);
     _adbProcess.stderr
-        .transform<String>(decoder)
-        .transform<String>(const LineSplitter())
+        .transformWithCallSite(decoder)
+        .transform(const LineSplitter())
         .listen(_onLine);
     unawaited(
       _adbProcess.exitCode.whenComplete(() {

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -11,7 +11,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
-import '../convert.dart';
+import '../base/utils.dart';
 import '../device.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';
@@ -159,12 +159,10 @@ class AndroidEmulator extends Emulator {
     final stdoutList = <String>[];
     final stderrList = <String>[];
     final StreamSubscription<String> stdoutSubscription = process.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .listen(stdoutList.add);
     final StreamSubscription<String> stderrSubscription = process.stderr
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .listen(stderrList.add);
     final Future<void> stdioFuture = Future.wait<void>(<Future<void>>[
       stdoutSubscription.asFuture<void>(),

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -13,6 +13,7 @@ import 'async_guard.dart';
 import 'exit.dart';
 import 'io.dart';
 import 'logger.dart';
+import 'utils.dart';
 
 typedef StringConverter = String? Function(String string);
 
@@ -561,8 +562,7 @@ class _DefaultProcessUtils implements ProcessUtils {
       environment: environment,
     );
     final StreamSubscription<String> stdoutSubscription = process.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .where((String line) => filter == null || filter.hasMatch(line))
         .listen((String line) {
           String? mappedLine = line;
@@ -581,8 +581,7 @@ class _DefaultProcessUtils implements ProcessUtils {
           }
         });
     final StreamSubscription<String> stderrSubscription = process.stderr
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .where((String line) => filter == null || filter.hasMatch(line))
         .listen((String line) {
           String? mappedLine = line;

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -11,6 +11,7 @@ import 'package:native_stack_traces/native_stack_traces.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
+import '../base/utils.dart';
 import '../convert.dart';
 import '../runner/flutter_command.dart';
 
@@ -175,7 +176,7 @@ class SymbolizeCommand extends FlutterCommand {
       output = outputFile.openWrite();
     } else {
       final outputController = StreamController<List<int>>();
-      outputController.stream.transform(utf8.decoder).listen(_stdio.stdoutWrite);
+      outputController.stream.transformWithCallSite(utf8.decoder).listen(_stdio.stdoutWrite);
       output = IOSink(outputController);
     }
 
@@ -299,9 +300,9 @@ class DwarfSymbolizationService {
     StreamSubscription<void>? subscription;
     subscription = input
         .cast<List<int>>()
-        .transform(const Utf8Decoder())
-        .transform(const LineSplitter())
-        .transform(unitSymbolsTransformer(unitSymbols))
+        .transformWithCallSite(const Utf8Decoder())
+        .transformWithCallSite(const LineSplitter())
+        .transformWithCallSite(unitSymbolsTransformer(unitSymbols))
         .listen(
           (String line) {
             try {

--- a/packages/flutter_tools/lib/src/commands/symbolize.dart
+++ b/packages/flutter_tools/lib/src/commands/symbolize.dart
@@ -300,8 +300,7 @@ class DwarfSymbolizationService {
     StreamSubscription<void>? subscription;
     subscription = input
         .cast<List<int>>()
-        .transformWithCallSite(const Utf8Decoder())
-        .transformWithCallSite(const LineSplitter())
+        .transform(utf8LineDecoder)
         .transformWithCallSite(unitSymbolsTransformer(unitSymbols))
         .listen(
           (String line) {

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -17,6 +17,7 @@ import 'base/io.dart';
 import 'base/logger.dart';
 import 'base/platform.dart';
 import 'base/process.dart';
+import 'base/utils.dart';
 import 'build_info.dart';
 import 'convert.dart';
 
@@ -378,10 +379,7 @@ class KernelCompiler {
     final Process server = await _processManager.start(command);
 
     server.stderr.transform<String>(utf8.decoder).listen(_logger.printError);
-    server.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
-        .listen(_stdoutHandler.handler);
+    server.stdout.transform(utf8LineDecoder).listen(_stdoutHandler.handler);
     final int exitCode = await server.exitCode;
     if (exitCode == 0) {
       return _stdoutHandler.compilerOutput?.future;
@@ -893,8 +891,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     _logger.printTrace(command.join(' '));
     _server = await _processManager.start(command);
     _server?.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .listen(
           _stdoutHandler.handler,
           onDone: () {
@@ -907,10 +904,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
           },
         );
 
-    _server?.stderr
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
-        .listen(_logger.printError);
+    _server?.stderr.transform(utf8LineDecoder).listen(_logger.printError);
 
     unawaited(
       _server?.exitCode.then((int code) {

--- a/packages/flutter_tools/lib/src/dart/analysis.dart
+++ b/packages/flutter_tools/lib/src/dart/analysis.dart
@@ -75,14 +75,10 @@ class AnalysisServer {
     // This callback hookup can't throw.
     unawaited(_process!.exitCode.whenComplete(() => _process = null));
 
-    final Stream<String> errorStream = _process!.stderr
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter());
+    final Stream<String> errorStream = _process!.stderr.transform(utf8LineDecoder);
     errorStream.listen(_handleError);
 
-    final Stream<String> inStream = _process!.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter());
+    final Stream<String> inStream = _process!.stdout.transform(utf8LineDecoder);
     inStream.listen(_handleServerResponse);
 
     _sendCommand('server.setSubscriptions', <String, dynamic>{

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -10,6 +10,7 @@ import 'package:vm_service/vm_service.dart' as vm;
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/platform.dart';
+import '../base/utils.dart';
 import '../cache.dart';
 import '../convert.dart';
 import 'flutter_adapter_args.dart';
@@ -165,8 +166,8 @@ abstract class FlutterBaseDebugAdapter
         }(executable, processArgs, env: env);
     this.process = process;
 
-    process.stdout.transform(ByteToLineTransformer()).listen(handleStdout);
-    process.stderr.transform(utf8.decoder).listen(handleStderr);
+    process.stdout.transformWithCallSite(ByteToLineTransformer()).listen(handleStdout);
+    process.stderr.transformWithCallSite(utf8.decoder).listen(handleStderr);
     unawaited(process.exitCode.then(handleExitCode));
   }
 

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -13,7 +13,6 @@ import 'base/logger.dart';
 import 'base/os.dart';
 import 'base/utils.dart';
 import 'build_info.dart';
-import 'convert.dart';
 import 'devfs.dart';
 import 'device.dart';
 import 'device_port_forwarder.dart';
@@ -363,9 +362,7 @@ class DesktopLogReader extends DeviceLogReader {
 
   @override
   Stream<String> get logLines {
-    return _inputController.stream
-        .transformWithCallSite(utf8.decoder)
-        .transformWithCallSite(const LineSplitter());
+    return _inputController.stream.transform(utf8LineDecoder);
   }
 
   @override

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -11,6 +11,7 @@ import 'base/file_system.dart';
 import 'base/io.dart';
 import 'base/logger.dart';
 import 'base/os.dart';
+import 'base/utils.dart';
 import 'build_info.dart';
 import 'convert.dart';
 import 'devfs.dart';
@@ -362,7 +363,9 @@ class DesktopLogReader extends DeviceLogReader {
 
   @override
   Stream<String> get logLines {
-    return _inputController.stream.transform(utf8.decoder).transform(const LineSplitter());
+    return _inputController.stream
+        .transformWithCallSite(utf8.decoder)
+        .transformWithCallSite(const LineSplitter());
   }
 
   @override

--- a/packages/flutter_tools/lib/src/devtools_launcher.dart
+++ b/packages/flutter_tools/lib/src/devtools_launcher.dart
@@ -12,6 +12,7 @@ import 'base/bot_detector.dart';
 import 'base/common.dart';
 import 'base/io.dart' as io;
 import 'base/logger.dart';
+import 'base/utils.dart';
 import 'convert.dart';
 import 'resident_runner.dart';
 
@@ -66,23 +67,24 @@ class DevtoolsServerLauncher extends DevtoolsLauncher {
       _processStartCompleter.complete();
 
       final devToolsCompleter = Completer<Uri>();
-      _devToolsProcess!.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((
-        String line,
-      ) {
-        final Match? dtdMatch = _serveDtdPattern.firstMatch(line);
-        if (dtdMatch != null) {
-          final String uri = dtdMatch[1]!;
-          dtdUri = Uri.parse(uri);
-        }
-        final Match? devToolsMatch = _serveDevToolsPattern.firstMatch(line);
-        if (devToolsMatch != null) {
-          final String url = devToolsMatch[1]!;
-          devToolsCompleter.complete(Uri.parse(url));
-        }
-      });
+      _devToolsProcess!.stdout
+          .transformWithCallSite(utf8.decoder)
+          .transformWithCallSite(const LineSplitter())
+          .listen((String line) {
+            final Match? dtdMatch = _serveDtdPattern.firstMatch(line);
+            if (dtdMatch != null) {
+              final String uri = dtdMatch[1]!;
+              dtdUri = Uri.parse(uri);
+            }
+            final Match? devToolsMatch = _serveDevToolsPattern.firstMatch(line);
+            if (devToolsMatch != null) {
+              final String url = devToolsMatch[1]!;
+              devToolsCompleter.complete(Uri.parse(url));
+            }
+          });
       _devToolsProcess!.stderr
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
+          .transformWithCallSite(utf8.decoder)
+          .transformWithCallSite(const LineSplitter())
           .listen(_logger.printError);
 
       final bool runningOnBot = await _botDetector.isRunningOnBot;

--- a/packages/flutter_tools/lib/src/ios/core_devices.dart
+++ b/packages/flutter_tools/lib/src/ios/core_devices.dart
@@ -13,6 +13,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/template.dart';
+import '../base/utils.dart';
 import '../convert.dart';
 import '../device.dart';
 import '../macos/xcode.dart';
@@ -767,8 +768,7 @@ class IOSCoreDeviceControl {
       coreDeviceLogForwarder.launchProcess = launchProcess;
 
       final StreamSubscription<String> stdoutSubscription = launchProcess.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
+          .transform(utf8LineDecoder)
           .listen((String line) {
             if (launchCompleter.isCompleted && !_ignoreLog(line)) {
               coreDeviceLogForwarder.addLog(line);
@@ -782,8 +782,7 @@ class IOSCoreDeviceControl {
           });
 
       final StreamSubscription<String> stderrSubscription = launchProcess.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
+          .transform(utf8LineDecoder)
           .listen((String line) {
             if (launchCompleter.isCompleted && !_ignoreLog(line)) {
               coreDeviceLogForwarder.addLog(line);

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -1709,14 +1709,8 @@ class IOSDeviceLogReader extends DeviceLogReader {
       return;
     }
     _iMobileDevice.startLogger(_deviceId, _isWirelesslyConnected).then<void>((Process process) {
-      process.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_newSyslogLineHandler());
-      process.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_newSyslogLineHandler());
+      process.stdout.transform(utf8LineDecoder).listen(_newSyslogLineHandler());
+      process.stderr.transform(utf8LineDecoder).listen(_newSyslogLineHandler());
       process.exitCode.whenComplete(() {
         if (!linesController.hasListener) {
           return;

--- a/packages/flutter_tools/lib/src/ios/lldb.dart
+++ b/packages/flutter_tools/lib/src/ios/lldb.dart
@@ -10,7 +10,7 @@ import 'dart:async';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
-import '../convert.dart';
+import '../base/utils.dart';
 
 /// LLDB is the default debugger in Xcode on macOS. Once the application has
 /// launched on a physical iOS device, you can attach to it using LLDB.
@@ -148,8 +148,7 @@ return False
       );
 
       final StreamSubscription<String> stdoutSubscription = _lldbProcess!.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
+          .transform(utf8LineDecoder)
           .listen((String line) {
             if (_isAttached && !_ignoreLog(line)) {
               // Only forwards logs after LLDB is attached. All logs before then are part of the
@@ -163,8 +162,7 @@ return False
           });
 
       final StreamSubscription<String> stderrSubscription = _lldbProcess!.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
+          .transform(utf8LineDecoder)
           .listen((String line) {
             _monitorError(line);
             if (_isAttached && !_ignoreLog(line)) {

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -834,40 +834,22 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
     // Unified logging iOS 11 and greater (introduced in iOS 10).
     if (await device.sdkMajorVersion >= 11) {
       _deviceProcess = await launchDeviceUnifiedLogging(device, _appName);
-      _deviceProcess?.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_onUnifiedLoggingLine);
-      _deviceProcess?.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_onUnifiedLoggingLine);
+      _deviceProcess?.stdout.transform(utf8LineDecoder).listen(_onUnifiedLoggingLine);
+      _deviceProcess?.stderr.transform(utf8LineDecoder).listen(_onUnifiedLoggingLine);
     } else {
       // Fall back to syslog parsing.
       await device.ensureLogsExists();
       _deviceProcess = await launchDeviceSystemLogTool(device);
-      _deviceProcess?.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_onSysLogDeviceLine);
-      _deviceProcess?.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_onSysLogDeviceLine);
+      _deviceProcess?.stdout.transform(utf8LineDecoder).listen(_onSysLogDeviceLine);
+      _deviceProcess?.stderr.transform(utf8LineDecoder).listen(_onSysLogDeviceLine);
     }
 
     // Track system.log crashes.
     // ReportCrash[37965]: Saved crash report for FlutterRunner[37941]...
     _systemProcess = await launchSystemLogTool(device);
     if (_systemProcess != null) {
-      _systemProcess?.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_onSystemLine);
-      _systemProcess?.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen(_onSystemLine);
+      _systemProcess?.stdout.transform(utf8LineDecoder).listen(_onSystemLine);
+      _systemProcess?.stderr.transform(utf8LineDecoder).listen(_onSystemLine);
     }
 
     // We don't want to wait for the process or its callback. Best effort

--- a/packages/flutter_tools/lib/src/ios/xcode_debug.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_debug.dart
@@ -16,6 +16,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 import '../base/template.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../convert.dart';
 import '../macos/xcode.dart';
@@ -106,36 +107,34 @@ class XcodeDebug {
       ]);
 
       final stdoutBuffer = StringBuffer();
-      stdoutSubscription = startDebugActionProcess!.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen((String line) {
-            _logger.printTrace(line);
-            stdoutBuffer.write(line);
-          });
+      stdoutSubscription = startDebugActionProcess!.stdout.transform(utf8LineDecoder).listen((
+        String line,
+      ) {
+        _logger.printTrace(line);
+        stdoutBuffer.write(line);
+      });
 
       final stderrBuffer = StringBuffer();
       var permissionWarningPrinted = false;
       // console.log from the script are found in the stderr
-      stderrSubscription = startDebugActionProcess!.stderr
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
-          .listen((String line) {
-            _logger.printTrace('stderr: $line');
-            stderrBuffer.write(line);
+      stderrSubscription = startDebugActionProcess!.stderr.transform(utf8LineDecoder).listen((
+        String line,
+      ) {
+        _logger.printTrace('stderr: $line');
+        stderrBuffer.write(line);
 
-            // This error may occur if Xcode automation has not been allowed.
-            // Example: Failed to get workspace: Error: An error occurred.
-            if (!permissionWarningPrinted &&
-                line.contains('Failed to get workspace') &&
-                line.contains('An error occurred')) {
-              _logger.printError(
-                'There was an error finding the project in Xcode. Ensure permission '
-                'has been given to control Xcode in Settings > Privacy & Security > Automation.',
-              );
-              permissionWarningPrinted = true;
-            }
-          });
+        // This error may occur if Xcode automation has not been allowed.
+        // Example: Failed to get workspace: Error: An error occurred.
+        if (!permissionWarningPrinted &&
+            line.contains('Failed to get workspace') &&
+            line.contains('An error occurred')) {
+          _logger.printError(
+            'There was an error finding the project in Xcode. Ensure permission '
+            'has been given to control Xcode in Settings > Privacy & Security > Automation.',
+          );
+          permissionWarningPrinted = true;
+        }
+      });
 
       final int exitCode = await startDebugActionProcess!.exitCode.whenComplete(() async {
         await stdoutSubscription?.cancel();

--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -14,6 +14,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
+import '../base/utils.dart';
 import '../base/version.dart';
 import '../build_info.dart';
 import '../cache.dart';
@@ -287,8 +288,7 @@ class XCDevice {
     final Process process = await _processUtils.start(cmd);
 
     final StreamSubscription<String> stdoutSubscription = process.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .listen((String line) {
           String? mappedLine = line;
           if (mapFunction != null) {
@@ -300,8 +300,7 @@ class XCDevice {
           }
         });
     final StreamSubscription<String> stderrSubscription = process.stderr
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
+        .transform(utf8LineDecoder)
         .listen((String line) {
           String? mappedLine = line;
           if (mapFunction != null) {

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'base/io.dart';
 import 'base/logger.dart';
+import 'base/utils.dart';
 import 'device.dart';
 import 'device_port_forwarder.dart';
 import 'globals.dart' as globals;
@@ -85,7 +86,7 @@ class ProtocolDiscovery {
   /// Port forwarding is only attempted when this is invoked,
   /// for each VM Service URL in the stream.
   Stream<Uri> get uris {
-    final Stream<Uri> uriStream = _uriStreamController.stream.transform(
+    final Stream<Uri> uriStream = _uriStreamController.stream.transformWithCallSite(
       _throttle<Uri>(waitDuration: throttleDuration),
     );
     return uriStream.asyncMap<Uri>(_forwardPort);

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -14,7 +14,7 @@ import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
-import '../convert.dart';
+import '../base/utils.dart';
 import '../device.dart';
 import '../globals.dart' as globals;
 import '../native_assets.dart';
@@ -297,8 +297,7 @@ class FlutterTesterTestDevice extends TestDevice {
   }) {
     for (final stream in <Stream<List<int>>>[process.stderr, process.stdout]) {
       stream
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
+          .transform(utf8LineDecoder)
           .listen(
             (String line) async {
               logger.printTrace('test $id: Shell: $line');

--- a/packages/flutter_tools/lib/src/test/test_golden_comparator.dart
+++ b/packages/flutter_tools/lib/src/test/test_golden_comparator.dart
@@ -11,6 +11,7 @@ import 'package:process/process.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/utils.dart';
 import '../convert.dart';
 import 'test_compiler.dart';
 import 'test_config.dart';
@@ -273,8 +274,7 @@ class TestGoldenComparatorProcess {
     // Also parse stdout as a stream of JSON objects.
     streamIterator = StreamIterator<Map<String, dynamic>>(
       process.stdout
-          .transform<String>(utf8.decoder)
-          .transform<String>(const LineSplitter())
+          .transform(utf8LineDecoder)
           .where((String line) {
             logger.printTrace('<<< $line');
             return line.isNotEmpty && line[0] == '{';
@@ -283,9 +283,7 @@ class TestGoldenComparatorProcess {
           .cast<Map<String, dynamic>>(),
     );
 
-    process.stderr.transform<String>(utf8.decoder).transform<String>(const LineSplitter()).forEach((
-      String line,
-    ) {
+    process.stderr.transform(utf8LineDecoder).forEach((String line) {
       logger.printError('<<< $line');
     });
   }

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -16,6 +16,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/platform.dart';
+import '../base/utils.dart';
 import '../convert.dart';
 
 /// An environment variable used to override the location of Google Chrome.
@@ -303,9 +304,12 @@ class ChromiumLauncher {
     while (true) {
       final Process process = await _processManager.start(args);
 
-      process.stdout.transform(utf8.decoder).transform(const LineSplitter()).listen((String line) {
-        _logger.printTrace('[CHROME]: $line');
-      });
+      process.stdout
+          .transformWithCallSite(utf8.decoder)
+          .transformWithCallSite(const LineSplitter())
+          .listen((String line) {
+            _logger.printTrace('[CHROME]: $line');
+          });
 
       // Wait until the DevTools are listening before trying to connect. This is
       // only required for flutter_test --platform=chrome and not flutter run.
@@ -313,8 +317,8 @@ class ChromiumLauncher {
       var shouldRetry = false;
       final errors = <String>[];
       await process.stderr
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
+          .transformWithCallSite(utf8.decoder)
+          .transformWithCallSite(const LineSplitter())
           .map((String line) {
             _logger.printTrace('[CHROME]: $line');
             errors.add('[CHROME]:$line');

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -17,7 +17,6 @@ import '../base/logger.dart';
 import '../base/os.dart';
 import '../base/platform.dart';
 import '../base/utils.dart';
-import '../convert.dart';
 
 /// An environment variable used to override the location of Google Chrome.
 const kChromeEnvironment = 'CHROME_EXECUTABLE';
@@ -304,12 +303,9 @@ class ChromiumLauncher {
     while (true) {
       final Process process = await _processManager.start(args);
 
-      process.stdout
-          .transformWithCallSite(utf8.decoder)
-          .transformWithCallSite(const LineSplitter())
-          .listen((String line) {
-            _logger.printTrace('[CHROME]: $line');
-          });
+      process.stdout.transform(utf8LineDecoder).listen((String line) {
+        _logger.printTrace('[CHROME]: $line');
+      });
 
       // Wait until the DevTools are listening before trying to connect. This is
       // only required for flutter_test --platform=chrome and not flutter run.
@@ -317,8 +313,7 @@ class ChromiumLauncher {
       var shouldRetry = false;
       final errors = <String>[];
       await process.stderr
-          .transformWithCallSite(utf8.decoder)
-          .transformWithCallSite(const LineSplitter())
+          .transform(utf8LineDecoder)
           .map((String line) {
             _logger.printTrace('[CHROME]: $line');
             errors.add('[CHROME]:$line');

--- a/packages/flutter_tools/lib/src/widget_preview/dtd_services.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/dtd_services.dart
@@ -17,6 +17,7 @@ import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/platform.dart';
 import '../base/process.dart';
+import '../base/utils.dart';
 import '../convert.dart';
 import '../dart/package_map.dart';
 import '../project.dart';
@@ -175,7 +176,7 @@ class DtdLauncher {
     // Wait for the DTD connection information.
     final dtdUri = Completer<Uri>();
     late final StreamSubscription<String> sub;
-    sub = _dtdProcess!.stdout.transform(const Utf8Decoder()).listen((String data) async {
+    sub = _dtdProcess!.stdout.transformWithCallSite(utf8.decoder).listen((String data) async {
       await sub.cancel();
       final jsonData = json.decode(data) as Map<String, Object?>;
       if (jsonData case {'tooling_daemon_details': {'uri': final String dtdUriString}}) {


### PR DESCRIPTION
Exceptions thrown within a stream transformer don't provide any context as to where the call to `transform(...)` occurred within the program, often resulting in stack traces consisting of only Dart SDK sources.

This change adds a new extension method on `Stream` called `transformWithCallSite`, which captures the current `StackTrace` upon invocation. This stack trace is reported in the case of an error in order to provide context for better error reporting.

Example issue: https://github.com/flutter/flutter/issues/81666