### PR TITLE
Fix the platform name of the windowing_test target for macOS in ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7005,7 +7005,7 @@ targets:
         ["devicelab", "hostonly", "linux"]
       task_name: windowing_test_linux
 
-  - name: MacOS windowing_test
+  - name: Mac windowing_test
     recipe: devicelab/devicelab_drone
     presubmit: true
     bringup: true

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -7012,7 +7012,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "hostonly", "macos"]
+        ["devicelab", "hostonly", "mac"]
       task_name: windowing_test_macos
 
 


### PR DESCRIPTION
The name of platform within the target name must exactly match one of the platforms declared in the platform_properties section.

Fixes https://github.com/flutter/flutter/issues/177465