### PR TITLE
[Impeller] Commands that don't specify their own viewports get the viewport of the render pass.

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/gles/pipeline_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/pipeline_gles.h
@@ -15,6 +15,10 @@ namespace impeller {
 
 class PipelineLibraryGLES;
 
+namespace testing {
+class RenderPassGLESViewportTest;
+}  // namespace testing
+
 class PipelineGLES final
     : public Pipeline<PipelineDescriptor>,
       public BackendCast<PipelineGLES, Pipeline<PipelineDescriptor>> {
@@ -37,6 +41,7 @@ class PipelineGLES final
 
  private:
   friend PipelineLibraryGLES;
+  friend class testing::RenderPassGLESViewportTest;
 
   std::shared_ptr<ReactorGLES> reactor_;
   std::shared_ptr<UniqueHandleGLES> handle_;

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles.cc
@@ -189,6 +189,38 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
   gl.StencilMaskSeparate(GL_BACK, 0xFFFFFFFF);
 }
 
+static void EncodeViewport(const ProcTableGLES& gl,
+                           const RenderPassData& pass_data,
+                           const std::optional<Viewport>& command_viewport,
+                           const ISize& target_size,
+                           std::optional<Viewport>& current_viewport) {
+  auto new_viewport = command_viewport.value_or(pass_data.viewport);
+
+  if (current_viewport.has_value() &&
+      current_viewport.value() == new_viewport) {
+    // The viewport is the same as the last command. Skip an unnecessary call.
+    return;
+  }
+
+  current_viewport = new_viewport;
+
+  gl.Viewport(new_viewport.rect.GetX(),  // x
+              target_size.height - new_viewport.rect.GetY() -
+                  new_viewport.rect.GetHeight(),  // y
+              new_viewport.rect.GetWidth(),       // width
+              new_viewport.rect.GetHeight()       // height
+  );
+  if (pass_data.depth_attachment) {
+    if (gl.DepthRangef.IsAvailable()) {
+      gl.DepthRangef(new_viewport.depth_range.z_near,
+                     new_viewport.depth_range.z_far);
+    } else {
+      gl.DepthRange(new_viewport.depth_range.z_near,
+                    new_viewport.depth_range.z_far);
+    }
+  }
+}
+
 [[nodiscard]] bool EncodeCommandsInReactor(
     const RenderPassData& pass_data,
     const ReactorGLES& reactor,
@@ -304,24 +336,7 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
   // is bottom left origin, so we convert the coordinates here.
   ISize target_size = pass_data.color_attachment->GetSize();
 
-  //--------------------------------------------------------------------------
-  /// Setup the viewport.
-  ///
-  const auto& viewport = pass_data.viewport;
-  gl.Viewport(viewport.rect.GetX(),  // x
-              target_size.height - viewport.rect.GetY() -
-                  viewport.rect.GetHeight(),  // y
-              viewport.rect.GetWidth(),       // width
-              viewport.rect.GetHeight()       // height
-  );
-  if (pass_data.depth_attachment) {
-    if (gl.DepthRangef.IsAvailable()) {
-      gl.DepthRangef(viewport.depth_range.z_near, viewport.depth_range.z_far);
-    } else {
-      gl.DepthRange(viewport.depth_range.z_near, viewport.depth_range.z_far);
-    }
-  }
-
+  std::optional<Viewport> current_viewport;
   CullMode current_cull_mode = CullMode::kNone;
   WindingOrder current_winding_order = WindingOrder::kClockwise;
   gl.FrontFace(GL_CW);
@@ -373,23 +388,12 @@ void RenderPassGLES::ResetGLState(const ProcTableGLES& gl) {
     //--------------------------------------------------------------------------
     /// Setup the viewport.
     ///
-    if (command.viewport.has_value()) {
-      gl.Viewport(viewport.rect.GetX(),  // x
-                  target_size.height - viewport.rect.GetY() -
-                      viewport.rect.GetHeight(),  // y
-                  viewport.rect.GetWidth(),       // width
-                  viewport.rect.GetHeight()       // height
-      );
-      if (pass_data.depth_attachment) {
-        if (gl.DepthRangef.IsAvailable()) {
-          gl.DepthRangef(viewport.depth_range.z_near,
-                         viewport.depth_range.z_far);
-        } else {
-          gl.DepthRange(viewport.depth_range.z_near,
-                        viewport.depth_range.z_far);
-        }
-      }
-    }
+    EncodeViewport(gl,                //
+                   pass_data,         //
+                   command.viewport,  //
+                   target_size,       //
+                   current_viewport   //
+    );
 
     //--------------------------------------------------------------------------
     /// Setup the scissor rect.

--- a/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/render_pass_gles_unittests.cc
@@ -9,10 +9,12 @@
 #include "impeller/core/formats.h"
 #include "impeller/renderer/backend/gles/command_buffer_gles.h"
 #include "impeller/renderer/backend/gles/context_gles.h"
+#include "impeller/renderer/backend/gles/pipeline_gles.h"
 #include "impeller/renderer/backend/gles/proc_table_gles.h"
 #include "impeller/renderer/backend/gles/reactor_gles.h"
 #include "impeller/renderer/backend/gles/test/mock_gles.h"
 #include "impeller/renderer/backend/gles/texture_gles.h"
+#include "impeller/renderer/backend/gles/unique_handle_gles.h"
 #include "impeller/renderer/context.h"
 #include "impeller/renderer/render_pass.h"
 #include "impeller/renderer/render_target.h"
@@ -214,6 +216,138 @@ TEST(RenderPassGLESTest, ResolvingMultisampleTextureCachesResolveFBO) {
     ASSERT_TRUE(render_pass2->EncodeCommands());
     ASSERT_TRUE(reactor->React());
   }
+}
+
+class RenderPassGLESViewportTest : public ::testing::Test {
+ protected:
+  struct RenderPassGLESContext {
+    std::shared_ptr<MockGLES> mock_gl;
+    testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref;
+    std::shared_ptr<ContextGLES> context;
+    std::shared_ptr<MockWorker> dummy_worker;
+    std::shared_ptr<ReactorGLES> reactor;
+    std::shared_ptr<CommandBuffer> command_buffer;
+    std::shared_ptr<RenderPass> render_pass;
+    std::shared_ptr<PipelineGLES> pipeline;
+  };
+
+  RenderPassGLESContext CreateRenderPassGLESContext() {
+    std::unique_ptr<NiceMock<MockGLESImpl>> mock_gl_impl =
+        std::make_unique<NiceMock<MockGLESImpl>>();
+    testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = *mock_gl_impl;
+    std::shared_ptr<MockGLES> mock_gl = MockGLES::Init(std::move(mock_gl_impl));
+
+    std::shared_ptr<ContextGLES> context = CreateFakeGLESContext();
+    std::shared_ptr<MockWorker> dummy_worker = std::make_shared<MockWorker>();
+    context->AddReactorWorker(dummy_worker);
+    std::shared_ptr<ReactorGLES> reactor = context->GetReactor();
+
+    TextureDescriptor tex_desc;
+    tex_desc.size = {100, 100};
+    tex_desc.format = PixelFormat::kR8G8B8A8UNormInt;
+    auto texture = std::make_shared<TextureGLES>(reactor, tex_desc, false);
+
+    RenderTarget target;
+    ColorAttachment color0;
+    color0.texture = texture;
+    color0.store_action = StoreAction::kDontCare;
+    color0.load_action = LoadAction::kClear;
+    target.SetColorAttachment(color0, 0);
+
+    std::shared_ptr<CommandBuffer> command_buffer =
+        std::static_pointer_cast<Context>(context)->CreateCommandBuffer();
+    std::shared_ptr<RenderPass> render_pass =
+        command_buffer->CreateRenderPass(target);
+
+    EXPECT_CALL(mock_gl_impl_ref, CheckFramebufferStatus(_))
+        .WillRepeatedly(Return(GL_FRAMEBUFFER_COMPLETE));
+
+    PipelineDescriptor desc;
+    ColorAttachmentDescriptor color0_desc;
+    color0_desc.format = PixelFormat::kR8G8B8A8UNormInt;
+    desc.SetColorAttachmentDescriptor(0, color0_desc);
+
+    HandleGLES pipeline_handle = reactor->CreateHandle(HandleType::kProgram);
+    std::shared_ptr<PipelineGLES> pipeline =
+        std::shared_ptr<PipelineGLES>(new PipelineGLES(
+            reactor, std::weak_ptr<PipelineLibrary>(), desc,
+            std::make_shared<UniqueHandleGLES>(reactor, pipeline_handle)));
+    pipeline->buffer_bindings_ = std::make_unique<BufferBindingsGLES>();
+
+    return {std::move(mock_gl),     mock_gl_impl_ref,
+            std::move(context),     std::move(dummy_worker),
+            std::move(reactor),     std::move(command_buffer),
+            std::move(render_pass), std::move(pipeline)};
+  }
+};
+
+TEST_F(RenderPassGLESViewportTest, ViewportCachedAcrossCommands) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetViewport(
+      Viewport{Rect::MakeXYWH(0, 0, 50, 50), DepthRange{0.0f, 1.0f}});
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetViewport(
+      Viewport{Rect::MakeXYWH(0, 0, 50, 50), DepthRange{0.0f, 1.0f}});
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  // Viewport should only be called twice. Once for the fallback, once for the
+  // first override. We set a catch-all to 0 to ensure no other calls occur.
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(0, 0, 100, 100)).Times(1);
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(0, 50, 50, 50)).Times(1);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
+}
+
+TEST_F(RenderPassGLESViewportTest,
+       CommandsWithoutViewportGetRenderPassViewport) {
+  auto ctx = CreateRenderPassGLESContext();
+  testing::NiceMock<MockGLESImpl>& mock_gl_impl_ref = ctx.mock_gl_impl_ref;
+  std::shared_ptr<RenderPass>& render_pass = ctx.render_pass;
+  std::shared_ptr<PipelineGLES>& pipeline = ctx.pipeline;
+  std::shared_ptr<ReactorGLES>& reactor = ctx.reactor;
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  render_pass->SetViewport(
+      Viewport{Rect::MakeXYWH(0, 0, 50, 50), DepthRange{0.0f, 1.0f}});
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  render_pass->SetPipeline(PipelineRef(pipeline));
+  render_pass->SetElementCount(1);
+  render_pass->SetIndexBuffer({}, IndexType::kNone);
+  EXPECT_TRUE(render_pass->Draw().ok());
+
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(_, _, _, _)).Times(0);
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(0, 0, 100, 100)).Times(2);
+  EXPECT_CALL(mock_gl_impl_ref, Viewport(0, 50, 50, 50)).Times(1);
+
+  EXPECT_TRUE(render_pass->EncodeCommands());
+  EXPECT_TRUE(reactor->React());
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.cc
@@ -318,6 +318,10 @@ void mockDiscardFramebufferEXT(GLenum target,
                         numAttachments, attachments);
 }
 
+void mockViewport(GLint x, GLint y, GLsizei width, GLsizei height) {
+  return CallMockMethod(&IMockGLESImpl::Viewport, x, y, width, height);
+}
+
 static_assert(CheckSameSignature<decltype(mockDiscardFramebufferEXT),  //
                                  decltype(glDiscardFramebufferEXT)>::value);
 
@@ -437,6 +441,8 @@ const ProcTableGLES::Resolver kMockResolverGLES = [](const char* name) {
     return reinterpret_cast<void*>(mockDiscardFramebufferEXT);
   } else if (strcmp(name, "glInvalidateFramebuffer") == 0) {
     return reinterpret_cast<void*>(mockInvalidateFramebuffer);
+  } else if (strcmp(name, "glViewport") == 0) {
+    return reinterpret_cast<void*>(mockViewport);
   } else {
     return reinterpret_cast<void*>(&doNothing);
   }

--- a/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/test/mock_gles.h
@@ -100,6 +100,7 @@ class IMockGLESImpl {
                                      GLsizei numAttachments,
                                      const GLenum* attachments) {};
   virtual void GetIntegerv(GLenum name, GLint* attachments) {};
+  virtual void Viewport(GLint x, GLint y, GLsizei width, GLsizei height) {}
 };
 
 class MockGLESImpl : public IMockGLESImpl {
@@ -241,6 +242,10 @@ class MockGLESImpl : public IMockGLESImpl {
                const GLenum* attachments),
               (override));
   MOCK_METHOD(void, GetIntegerv, (GLenum name, GLint* value), (override));
+  MOCK_METHOD(void,
+              Viewport,
+              (GLint x, GLint y, GLsizei width, GLsizei height),
+              (override));
 };
 
 /// @brief      Provides a mocked version of the |ProcTableGLES| class.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/176945
