### PR TITLE
Fixed `RuntimeEffect` with `ImageFilter.compose`

### DIFF
--- a/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -400,7 +400,6 @@ TEST_P(AiksTest, ComposePaintBlurOuter) {
       DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal);
   paint.setImageFilter(DlImageFilter::MakeCompose(blur, color_filter));
   builder.DrawCircle(DlPoint(400, 400), 200, paint);
-  builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -426,7 +425,6 @@ TEST_P(AiksTest, ComposePaintBlurInner) {
       DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal);
   paint.setImageFilter(DlImageFilter::MakeCompose(color_filter, blur));
   builder.DrawCircle(DlPoint(400, 400), 200, paint);
-  builder.Restore();
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -381,6 +381,11 @@ TEST_P(AiksTest, CanRenderClippedBlur) {
 
 TEST_P(AiksTest, ComposePaintBlurOuter) {
   DisplayListBuilder builder;
+
+  DlPaint background;
+  background.setColor(DlColor(1.0, 0.1, 0.1, 0.1, DlColorSpace::kSRGB));
+  builder.DrawPaint(background);
+
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
   float matrix[] = {
@@ -402,6 +407,11 @@ TEST_P(AiksTest, ComposePaintBlurOuter) {
 
 TEST_P(AiksTest, ComposePaintBlurInner) {
   DisplayListBuilder builder;
+
+  DlPaint background;
+  background.setColor(DlColor(1.0, 0.1, 0.1, 0.1, DlColorSpace::kSRGB));
+  builder.DrawPaint(background);
+
   DlPaint paint;
   paint.setColor(DlColor::kGreen());
   float matrix[] = {

--- a/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_blur_unittests.cc
@@ -379,6 +379,48 @@ TEST_P(AiksTest, CanRenderClippedBlur) {
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
 
+TEST_P(AiksTest, ComposePaintBlurOuter) {
+  DisplayListBuilder builder;
+  DlPaint paint;
+  paint.setColor(DlColor::kGreen());
+  float matrix[] = {
+      0, 1, 0, 0, 0,  //
+      1, 0, 0, 0, 0,  //
+      0, 0, 1, 0, 0,  //
+      0, 0, 0, 1, 0   //
+  };
+  std::shared_ptr<DlImageFilter> color_filter =
+      DlImageFilter::MakeColorFilter(DlColorFilter::MakeMatrix(matrix));
+  std::shared_ptr<DlImageFilter> blur =
+      DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal);
+  paint.setImageFilter(DlImageFilter::MakeCompose(blur, color_filter));
+  builder.DrawCircle(DlPoint(400, 400), 200, paint);
+  builder.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
+TEST_P(AiksTest, ComposePaintBlurInner) {
+  DisplayListBuilder builder;
+  DlPaint paint;
+  paint.setColor(DlColor::kGreen());
+  float matrix[] = {
+      0, 1, 0, 0, 0,  //
+      1, 0, 0, 0, 0,  //
+      0, 0, 1, 0, 0,  //
+      0, 0, 0, 1, 0   //
+  };
+  std::shared_ptr<DlImageFilter> color_filter =
+      DlImageFilter::MakeColorFilter(DlColorFilter::MakeMatrix(matrix));
+  std::shared_ptr<DlImageFilter> blur =
+      DlImageFilter::MakeBlur(20, 20, DlTileMode::kDecal);
+  paint.setImageFilter(DlImageFilter::MakeCompose(color_filter, blur));
+  builder.DrawCircle(DlPoint(400, 400), 200, paint);
+  builder.Restore();
+
+  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+}
+
 TEST_P(AiksTest, ClippedBlurFilterRendersCorrectlyInteractive) {
   auto callback = [&]() -> sk_sp<DisplayList> {
     static PlaygroundPoint playground_point(Point(400, 400), 20,

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -169,7 +169,7 @@ TEST_P(AiksTest, ComposePaintRuntimeOuter) {
   auto uniform_data = std::make_shared<std::vector<uint8_t>>();
   uniform_data->resize(sizeof(Vector2));
 
-  [[maybe_unused]] auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
+  auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
       DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
       uniform_data);
 

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -188,22 +188,6 @@ TEST_P(AiksTest, ComposePaintRuntimeOuter) {
 }
 
 TEST_P(AiksTest, ComposePaintRuntimeInner) {
-  DisplayListBuilder builder;
-  DlPaint background;
-  background.setColor(DlColor(1.0, 0.1, 0.1, 0.1, DlColorSpace::kSRGB));
-  builder.DrawPaint(background);
-
-  DlPaint paint;
-  paint.setColor(DlColor::kGreen());
-  float matrix[] = {
-      0, 1, 0, 0, 0,  //
-      1, 0, 0, 0, 0,  //
-      0, 0, 1, 0, 0,  //
-      0, 0, 0, 1, 0   //
-  };
-  [[maybe_unused]] std::shared_ptr<DlImageFilter> color_filter =
-      DlImageFilter::MakeColorFilter(DlColorFilter::MakeMatrix(matrix));
-
   auto runtime_stages =
       OpenAssetAsRuntimeStage("runtime_stage_filter_warp.frag.iplr");
 
@@ -211,29 +195,77 @@ TEST_P(AiksTest, ComposePaintRuntimeInner) {
       runtime_stages[PlaygroundBackendToRuntimeStageBackend(GetBackend())];
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
+  Scalar xoffset = 0;
+  Scalar yoffset = 0;
+  Scalar xscale = 1;
+  Scalar yscale = 1;
+  bool compare = false;
 
-  std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {
-      nullptr,
+  auto callback = [&]() -> sk_sp<DisplayList> {
+    if (AiksTest::ImGuiBegin("Controls", nullptr,
+                             ImGuiWindowFlags_AlwaysAutoResize)) {
+      ImGui::SliderFloat("xoffset", &xoffset, -50, 50);
+      ImGui::SliderFloat("yoffset", &yoffset, -50, 50);
+      ImGui::SliderFloat("xscale", &xscale, 0, 1);
+      ImGui::SliderFloat("yscale", &yscale, 0, 1);
+      ImGui::Checkbox("compare", &compare);
+      ImGui::End();
+    }
+    DisplayListBuilder builder;
+    DlPaint background;
+    background.setColor(DlColor(1.0, 0.1, 0.1, 0.1, DlColorSpace::kSRGB));
+    builder.DrawPaint(background);
+
+    DlPaint paint;
+    paint.setColor(DlColor::kGreen());
+    float matrix[] = {
+        0, 1, 0, 0, 0,  //
+        1, 0, 0, 0, 0,  //
+        0, 0, 1, 0, 0,  //
+        0, 0, 0, 1, 0   //
+    };
+    [[maybe_unused]] std::shared_ptr<DlImageFilter> color_filter =
+        DlImageFilter::MakeColorFilter(DlColorFilter::MakeMatrix(matrix));
+
+    std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {
+        nullptr,
+    };
+    auto uniform_data = std::make_shared<std::vector<uint8_t>>();
+    uniform_data->resize(sizeof(Vector2));
+
+    auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
+        DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
+        uniform_data);
+
+    builder.Translate(xoffset, yoffset);
+    builder.Scale(xscale, yscale);
+
+    paint.setImageFilter(
+        DlImageFilter::MakeCompose(color_filter, runtime_filter));
+    auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));
+    builder.DrawImage(image, DlPoint(100.0, 100.0),
+                      DlImageSampling::kNearestNeighbor, &paint);
+
+    if (compare) {
+      paint.setImageFilter(
+          DlImageFilter::MakeCompose(runtime_filter, color_filter));
+      builder.DrawImage(image, DlPoint(800.0, 100.0),
+                        DlImageSampling::kNearestNeighbor, &paint);
+
+      paint.setImageFilter(runtime_filter);
+      builder.DrawImage(image, DlPoint(100.0, 800.0),
+                        DlImageSampling::kNearestNeighbor, &paint);
+    }
+
+    DlPaint green;
+    green.setColor(DlColor::kGreen());
+    builder.DrawLine({100, 100}, {200, 100}, green);
+    builder.DrawLine({100, 100}, {100, 200}, green);
+
+    return builder.Build();
   };
-  auto uniform_data = std::make_shared<std::vector<uint8_t>>();
-  uniform_data->resize(sizeof(Vector2));
 
-  [[maybe_unused]] auto runtime_filter = DlImageFilter::MakeRuntimeEffect(
-      DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
-      uniform_data);
-
-  paint.setImageFilter(
-      DlImageFilter::MakeCompose(color_filter, runtime_filter));
-  auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));
-  builder.DrawImage(image, DlPoint(100.0, 100.0),
-                    DlImageSampling::kNearestNeighbor, &paint);
-
-  DlPaint green;
-  green.setColor(DlColor::kGreen());
-  builder.DrawLine({100, 100}, {200, 100}, green);
-  builder.DrawLine({100, 100}, {100, 200}, green);
-
-  ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
+  ASSERT_TRUE(OpenPlaygroundHere(callback));
 }
 
 }  // namespace testing

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -261,6 +261,12 @@ TEST_P(AiksTest, ComposePaintRuntimeInner) {
     green.setColor(DlColor::kGreen());
     builder.DrawLine({100, 100}, {200, 100}, green);
     builder.DrawLine({100, 100}, {100, 200}, green);
+    if (compare) {
+      builder.DrawLine({800, 100}, {900, 100}, green);
+      builder.DrawLine({800, 100}, {800, 200}, green);
+      builder.DrawLine({100, 800}, {200, 800}, green);
+      builder.DrawLine({100, 800}, {100, 900}, green);
+    }
 
     return builder.Build();
   };

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -173,6 +173,9 @@ TEST_P(AiksTest, ComposePaintRuntimeOuter) {
       DlRuntimeEffectImpeller::Make(runtime_stage), sampler_inputs,
       uniform_data);
 
+  builder.Translate(50, 50);
+  builder.Scale(0.7, 0.7);
+
   paint.setImageFilter(
       DlImageFilter::MakeCompose(runtime_filter, color_filter));
   auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));
@@ -195,10 +198,10 @@ TEST_P(AiksTest, ComposePaintRuntimeInner) {
       runtime_stages[PlaygroundBackendToRuntimeStageBackend(GetBackend())];
   ASSERT_TRUE(runtime_stage);
   ASSERT_TRUE(runtime_stage->IsDirty());
-  Scalar xoffset = 0;
-  Scalar yoffset = 0;
-  Scalar xscale = 1;
-  Scalar yscale = 1;
+  Scalar xoffset = 50;
+  Scalar yoffset = 50;
+  Scalar xscale = 0.7;
+  Scalar yscale = 0.7;
   bool compare = false;
 
   auto callback = [&]() -> sk_sp<DisplayList> {

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -178,7 +178,11 @@ TEST_P(AiksTest, ComposePaintRuntimeOuter) {
   auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));
   builder.DrawImage(image, DlPoint(100.0, 100.0),
                     DlImageSampling::kNearestNeighbor, &paint);
-  builder.Restore();
+
+  DlPaint green;
+  green.setColor(DlColor::kGreen());
+  builder.DrawLine({100, 100}, {200, 100}, green);
+  builder.DrawLine({100, 100}, {100, 200}, green);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }
@@ -223,7 +227,11 @@ TEST_P(AiksTest, ComposePaintRuntimeInner) {
   auto image = DlImageImpeller::Make(CreateTextureForFixture("kalimba.jpg"));
   builder.DrawImage(image, DlPoint(100.0, 100.0),
                     DlImageSampling::kNearestNeighbor, &paint);
-  builder.Restore();
+
+  DlPaint green;
+  green.setColor(DlColor::kGreen());
+  builder.DrawLine({100, 100}, {200, 100}, green);
+  builder.DrawLine({100, 100}, {100, 200}, green);
 
   ASSERT_TRUE(OpenPlaygroundHere(builder.Build()));
 }

--- a/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
+++ b/engine/src/flutter/impeller/display_list/aiks_dl_runtime_effect_unittests.cc
@@ -152,7 +152,7 @@ TEST_P(AiksTest, ComposePaintRuntimeOuter) {
       0, 0, 1, 0, 0,  //
       0, 0, 0, 1, 0   //
   };
-  [[maybe_unused]] std::shared_ptr<DlImageFilter> color_filter =
+  std::shared_ptr<DlImageFilter> color_filter =
       DlImageFilter::MakeColorFilter(DlColorFilter::MakeMatrix(matrix));
 
   auto runtime_stages =
@@ -227,7 +227,7 @@ TEST_P(AiksTest, ComposePaintRuntimeInner) {
         0, 0, 1, 0, 0,  //
         0, 0, 0, 1, 0   //
     };
-    [[maybe_unused]] std::shared_ptr<DlImageFilter> color_filter =
+    std::shared_ptr<DlImageFilter> color_filter =
         DlImageFilter::MakeColorFilter(DlColorFilter::MakeMatrix(matrix));
 
     std::vector<std::shared_ptr<DlColorSource>> sampler_inputs = {

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -86,8 +86,8 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
     contents.SetTextureInputs(texture_inputs);
     contents.SetGeometry(&geom);
     Entity offset_entity = entity.Clone();
-    offset_entity.SetTransform(
-        entity.GetTransform().Translate(snapshot_origin));
+    offset_entity.SetTransform(entity.GetTransform() *
+                               Matrix::MakeTranslation(snapshot_origin));
     return contents.Render(renderer, offset_entity, pass);
   };
 
@@ -101,9 +101,9 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetBlendMode(entity.GetBlendMode());
-  sub_entity.SetTransform(entity.GetTransform() *
-                          Matrix::MakeTranslation(-1.0f * snapshot_origin) *
+  sub_entity.SetTransform(Matrix::MakeTranslation(-1.0f * snapshot_origin) *
                           input_snapshot->transform);
+
   return sub_entity;
 }
 

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -101,8 +101,8 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
   Entity sub_entity;
   sub_entity.SetContents(std::move(contents));
   sub_entity.SetBlendMode(entity.GetBlendMode());
-  sub_entity.SetTransform(Matrix::MakeTranslation(-1.0f * snapshot_origin) *
-                          input_snapshot->transform);
+  sub_entity.SetTransform(input_snapshot->transform *
+                          Matrix::MakeTranslation(-1.0f * snapshot_origin));
 
   return sub_entity;
 }

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -93,7 +93,7 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
 
   CoverageProc coverage_proc =
       [coverage](const Entity& entity) -> std::optional<Rect> {
-    return coverage.TransformBounds(entity.GetTransform());
+    return coverage;
   };
 
   auto contents = AnonymousContents::Make(render_proc, coverage_proc);

--- a/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
+++ b/engine/src/flutter/impeller/entity/contents/filters/runtime_effect_filter_contents.cc
@@ -76,11 +76,11 @@ std::optional<Entity> RuntimeEffectFilterContents::RenderFilter(
   ///
   RenderProc render_proc =
       [snapshot_origin, input_snapshot, runtime_stage = runtime_stage_,
-       uniforms = uniforms_, texture_inputs = texture_input_copy,
-       input_coverage](const ContentContext& renderer, const Entity& entity,
-                       RenderPass& pass) -> bool {
+       uniforms = uniforms_, texture_inputs = texture_input_copy](
+          const ContentContext& renderer, const Entity& entity,
+          RenderPass& pass) -> bool {
     RuntimeEffectContents contents;
-    FillRectGeometry geom(Rect::MakeSize(input_coverage.GetSize()));
+    FillRectGeometry geom(Rect::MakeSize(input_snapshot->texture->GetSize()));
     contents.SetRuntimeStage(runtime_stage);
     contents.SetUniformData(uniforms);
     contents.SetTextureInputs(texture_inputs);

--- a/engine/src/flutter/impeller/fixtures/BUILD.gn
+++ b/engine/src/flutter/impeller/fixtures/BUILD.gn
@@ -91,6 +91,7 @@ impellerc("runtime_stages") {
     "interop_runtime_stage_cs.frag",
     "runtime_stage_simple.frag",
     "runtime_stage_position.frag",
+    "runtime_stage_filter_warp.frag",
     "gradient.frag",
     "uniforms_and_sampler_1.frag",
     "uniforms_and_sampler_2.frag",

--- a/engine/src/flutter/impeller/fixtures/runtime_stage_filter_warp.frag
+++ b/engine/src/flutter/impeller/fixtures/runtime_stage_filter_warp.frag
@@ -10,6 +10,8 @@ uniform sampler2D u_texture;
 out vec4 frag_color;
 
 void main() {
-  frag_color = texture(u_texture, (FlutterFragCoord().xy / u_size) +
-    vec2(0.0, 0.1 * sin(FlutterFragCoord().x / u_size.x * 3.14 * 5.0)));
+  frag_color = texture(
+      u_texture,
+      (FlutterFragCoord().xy / u_size) +
+          vec2(0.0, 0.1 * sin(FlutterFragCoord().x / u_size.x * 3.14 * 5.0)));
 }

--- a/engine/src/flutter/impeller/fixtures/runtime_stage_filter_warp.frag
+++ b/engine/src/flutter/impeller/fixtures/runtime_stage_filter_warp.frag
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <flutter/runtime_effect.glsl>
+
+uniform vec2 u_size;
+uniform sampler2D u_texture;
+
+out vec4 frag_color;
+
+void main() {
+  frag_color = texture(u_texture, (FlutterFragCoord().xy / u_size) +
+    vec2(0.0, 0.1 * sin(FlutterFragCoord().x / u_size.x * 3.14 * 5.0)));
+}


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/170973

This changes the math for drawing RuntimeEffect's so that it works with `ImageFilter.compose`.  Without this patch the `ComposePaintRuntimeInner` would draw a cropped image.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
