### PR TITLE
Clean before building when framework headers change

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -272,12 +272,9 @@ Future<XcodeBuildResult> buildXcodeProject({
       'file version field before submitting to the App Store.',
     );
   }
-  final XcodeSdk sdk;
-  if (environmentType == EnvironmentType.physical) {
-    sdk = XcodeSdk.IPhoneOS;
-  } else {
-    sdk = XcodeSdk.IPhoneSimulator;
-  }
+  final XcodeSdk sdk = environmentType == EnvironmentType.physical
+      ? XcodeSdk.IPhoneOS
+      : XcodeSdk.IPhoneSimulator;
   final String buildDirectoryPath = getIosBuildDirectory();
   final Directory buildDirectory = globals.fs.directory(buildDirectoryPath);
   final bool incrementalBuild =
@@ -659,8 +656,8 @@ Future<XcodeBuildResult> buildXcodeProject({
 
 /// Check if the Flutter framework's public headers have changed since last built.
 bool publicHeadersChanged({
-  BuildMode? mode,
-  EnvironmentType? environmentType,
+  required BuildMode mode,
+  required EnvironmentType environmentType,
   required String buildDirectory,
   required Artifacts? artifacts,
   required FileSystem fileSystem,

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -337,17 +337,18 @@ Future<XcodeBuildResult> buildXcodeProject({
     configuration,
   ];
 
-  final Version? xcodeVersion = globals.xcode?.currentVersion;
   // Check the public headers before checking Xcode version so headers fingerprinter is created
   // regardless of Xcode version.
-  if (publicHeadersChanged(
-        environmentType: environmentType,
-        mode: buildInfo.mode,
-        buildDirectory: buildDirectoryPath,
-        artifacts: globals.artifacts,
-        fileSystem: globals.fs,
-        logger: globals.logger,
-      ) &&
+  final bool headersChanged = publicHeadersChanged(
+    environmentType: environmentType,
+    mode: buildInfo.mode,
+    buildDirectory: buildDirectoryPath,
+    artifacts: globals.artifacts,
+    fileSystem: globals.fs,
+    logger: globals.logger,
+  );
+  final Version? xcodeVersion = globals.xcode?.currentVersion;
+  if (headersChanged &&
       incrementalBuild &&
       (xcodeVersion != null && xcodeVersion >= Version(26, 0, 0))) {
     // Xcode 26 changed the way headers are pre-compiled and will throw an error if the headers

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_sdk.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
@@ -314,6 +315,7 @@ void main() {
       ]),
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -350,6 +352,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -387,6 +390,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -423,6 +427,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -470,6 +475,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -508,6 +514,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -545,6 +552,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -580,6 +588,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -642,6 +651,7 @@ void main() {
       FileSystemUtils: () => FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
       Analytics: () => fakeAnalytics,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -703,6 +713,7 @@ void main() {
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
         Pub: ThrowingPub.new,
         Analytics: () => fakeAnalytics,
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -766,6 +777,7 @@ void main() {
         ),
         Pub: ThrowingPub.new,
         Analytics: () => fakeAnalytics,
+        Artifacts: () => Artifacts.test(),
       },
     );
   });
@@ -809,6 +821,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -857,6 +870,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -910,6 +924,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -948,6 +963,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1004,6 +1020,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1051,6 +1068,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1092,6 +1110,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1150,6 +1169,7 @@ void main() {
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1194,6 +1214,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1236,6 +1257,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () =>
             FakeXcodeProjectInterpreterWithBuildSettings(developmentTeam: null),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1279,6 +1301,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         EnvironmentType: () => EnvironmentType.physical,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1320,6 +1343,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () =>
             FakeXcodeProjectInterpreterWithBuildSettings(developmentTeam: null),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1363,6 +1387,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () =>
             FakeXcodeProjectInterpreterWithBuildSettings(developmentTeam: null),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1413,6 +1438,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () =>
             FakeXcodeProjectInterpreterWithBuildSettings(developmentTeam: null),
+        Artifacts: () => Artifacts.test(),
       },
     );
   });
@@ -1459,6 +1485,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1507,6 +1534,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1564,6 +1592,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
 
@@ -1605,6 +1634,7 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
         Pub: ThrowingPub.new,
         Platform: () => macosPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+        Artifacts: () => Artifacts.test(),
       },
     );
   });

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 
 import 'package:args/command_runner.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -428,6 +429,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -483,6 +485,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () =>
           FakeXcodeProjectInterpreterWithBuildSettings(version: Version(15, 4, null)),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -538,6 +541,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () =>
           FakeXcodeProjectInterpreterWithBuildSettings(version: Version(15, 4, null)),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -593,6 +597,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () =>
           FakeXcodeProjectInterpreterWithBuildSettings(version: Version(15, 4, null)),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -625,6 +630,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () =>
           FakeXcodeProjectInterpreterWithBuildSettings(version: Version(15, 3, null)),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -680,6 +686,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () =>
           FakeXcodeProjectInterpreterWithBuildSettings(version: Version(15, 4, null)),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -712,6 +719,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () =>
           FakeXcodeProjectInterpreterWithBuildSettings(version: Version(15, 3, null)),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -753,6 +761,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       PlistParser: () => plistUtils,
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -811,6 +820,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -846,6 +856,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -904,6 +915,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -964,6 +976,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1024,6 +1037,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1054,6 +1068,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1085,6 +1100,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1145,6 +1161,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1174,6 +1191,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1235,6 +1253,7 @@ void main() {
       FileSystemUtils: () => FileSystemUtils(fileSystem: fileSystem, platform: macosPlatform),
       Analytics: () => fakeAnalytics,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1281,6 +1300,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1321,6 +1341,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1365,6 +1386,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1417,6 +1439,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1454,6 +1477,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1509,6 +1533,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1567,6 +1592,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       PlistParser: () => plistUtils,
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1630,6 +1656,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       PlistParser: () => plistUtils,
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1692,6 +1719,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       PlistParser: () => plistUtils,
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1740,6 +1768,7 @@ void main() {
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       PlistParser: () => plistUtils,
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1790,6 +1819,7 @@ void main() {
       Pub: ThrowingPub.new,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
       PlistParser: () => plistUtils,
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1882,6 +1912,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -1974,6 +2005,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2048,6 +2080,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2122,6 +2155,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2196,6 +2230,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2272,6 +2307,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2392,6 +2428,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2482,6 +2519,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 
@@ -2574,6 +2612,7 @@ void main() {
       Pub: ThrowingPub.new,
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
+      Artifacts: () => Artifacts.test(),
     },
   );
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -175,6 +175,7 @@ void main() {
         ),
         Xcode: () => xcode,
         Analytics: () => fakeAnalytics,
+        Artifacts: () => artifacts,
       },
     );
 
@@ -213,6 +214,7 @@ void main() {
         Platform: () => macPlatform,
         XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter(),
         Xcode: () => xcode,
+        Artifacts: () => artifacts,
       },
     );
 
@@ -298,6 +300,7 @@ void main() {
         Platform: () => macPlatform,
         XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
         Xcode: () => xcode,
+        Artifacts: () => artifacts,
       },
     );
 
@@ -413,8 +416,226 @@ void main() {
         Platform: () => macPlatform,
         XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
         Xcode: () => xcode,
+        Artifacts: () => artifacts,
       },
     );
+
+    group('with Xcode 26', () {
+      late Xcode xcode;
+      late FakeXcodeProjectInterpreter fakeXcodeProjectInterpreter;
+      late FakeArtifacts fakeArtifacts;
+
+      setUp(() {
+        fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(
+          projectInfo: projectInfo,
+          xcodeVersion: Version(26, 0, 0),
+        );
+        xcode = Xcode.test(
+          processManager: FakeProcessManager.any(),
+          xcodeProjectInterpreter: fakeXcodeProjectInterpreter,
+        );
+        fakeArtifacts = FakeArtifacts(
+          frameworkPath: fileSystem.systemTempDirectory.childDirectory('Flutter.framework').path,
+        );
+      });
+
+      testUsingContext(
+        'cleans before build when headers change when incremental build',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: processManager,
+            logger: logger,
+            artifacts: artifacts,
+          );
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+          fileSystem
+              .directory('build/ios/Release-iphoneos/My Super Awesome App.app')
+              .createSync(recursive: true);
+          fileSystem.systemTempDirectory
+              .childDirectory('Flutter.framework')
+              .childDirectory('Headers')
+              .childFile('FlutterPlugin.h')
+              .createSync(recursive: true);
+          // fileSystem
+          //     .file('build/ios/framework_public_headers.fingerprint')
+          //     .createSync(recursive: true);
+
+          processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-configuration',
+                'Release',
+                'clean',
+                'build',
+                '-quiet',
+                '-allowProvisioningUpdates',
+                '-allowProvisioningDeviceRegistration',
+                '-workspace',
+                'Runner.xcworkspace',
+                '-scheme',
+                'Runner',
+                'BUILD_DIR=/build/ios',
+                '-sdk',
+                'iphoneos',
+                '-destination',
+                'id=123',
+                'ONLY_ACTIVE_ARCH=NO',
+                'ARCHS=arm64',
+                '-resultBundlePath',
+                '/.tmp_rand0/flutter_ios_build_temp_dirrand0/temporary_xcresult_bundle',
+                '-resultBundleVersion',
+                '3',
+                'FLUTTER_SUPPRESS_ANALYTICS=true',
+                'COMPILER_INDEX_STORE_ENABLE=NO',
+              ],
+            ),
+          );
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'rsync',
+                '-8',
+                '-av',
+                '--delete',
+                'build/ios/Release-iphoneos/My Super Awesome App.app',
+                'build/ios/iphoneos',
+              ],
+            ),
+          );
+          processManager.addCommand(
+            FakeCommand(
+              command: <String>[
+                iosDeployPath,
+                '--id',
+                '123',
+                '--bundle',
+                'build/ios/iphoneos/My Super Awesome App.app',
+                '--app_deltas',
+                'build/ios/app-delta',
+                '--no-wifi',
+                '--justlaunch',
+                '--args',
+                const <String>['--enable-dart-profiling'].join(' '),
+              ],
+            ),
+          );
+
+          final LaunchResult launchResult = await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+            platformArgs: <String, Object>{},
+          );
+
+          expect(fileSystem.directory('build/ios/iphoneos'), exists);
+          expect(launchResult.started, true);
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => processManager,
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () =>
+              FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+          Pub: () => const ThrowingPub(),
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+          Artifacts: () => fakeArtifacts,
+        },
+      );
+
+      testUsingContext(
+        'cleans before build when headers change when fresh build',
+        () async {
+          final IOSDevice iosDevice = setUpIOSDevice(
+            fileSystem: fileSystem,
+            processManager: processManager,
+            logger: logger,
+            artifacts: artifacts,
+          );
+          setUpIOSProject(fileSystem);
+          final FlutterProject flutterProject = FlutterProject.fromDirectory(
+            fileSystem.currentDirectory,
+          );
+          final buildableIOSApp = BuildableIOSApp(
+            flutterProject.ios,
+            'flutter',
+            'My Super Awesome App',
+          );
+
+          fileSystem.directory('build/ios/iphoneos').deleteSync(recursive: true);
+          fileSystem.systemTempDirectory
+              .childDirectory('Flutter.framework')
+              .childDirectory('Headers')
+              .childFile('FlutterPlugin.h')
+              .createSync(recursive: true);
+
+          processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
+          processManager.addCommand(
+            const FakeCommand(
+              command: <String>[
+                'xcrun',
+                'xcodebuild',
+                '-configuration',
+                'Release',
+                '-quiet',
+                '-allowProvisioningUpdates',
+                '-allowProvisioningDeviceRegistration',
+                '-workspace',
+                'Runner.xcworkspace',
+                '-scheme',
+                'Runner',
+                'BUILD_DIR=/build/ios',
+                '-sdk',
+                'iphoneos',
+                '-destination',
+                'id=123',
+                'ONLY_ACTIVE_ARCH=NO',
+                'ARCHS=arm64',
+                '-resultBundlePath',
+                '/.tmp_rand0/flutter_ios_build_temp_dirrand0/temporary_xcresult_bundle',
+                '-resultBundleVersion',
+                '3',
+                'FLUTTER_SUPPRESS_ANALYTICS=true',
+                'COMPILER_INDEX_STORE_ENABLE=NO',
+              ],
+            ),
+          );
+
+          await iosDevice.startApp(
+            buildableIOSApp,
+            debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
+            platformArgs: <String, Object>{},
+          );
+
+          expect(processManager, hasNoRemainingExpectations);
+        },
+        overrides: <Type, Generator>{
+          ProcessManager: () => processManager,
+          FileSystem: () => fileSystem,
+          Logger: () => logger,
+          OperatingSystemUtils: () =>
+              FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_x64),
+          Pub: () => const ThrowingPub(),
+          Platform: () => macPlatform,
+          XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
+          Xcode: () => xcode,
+          Artifacts: () => fakeArtifacts,
+        },
+      );
+    });
 
     testUsingContext(
       'with concurrent build failures',
@@ -510,6 +731,7 @@ void main() {
         Pub: () => const ThrowingPub(),
         XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
         Xcode: () => xcode,
+        Artifacts: () => artifacts,
       },
     );
   });
@@ -592,6 +814,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -648,6 +871,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -694,6 +918,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -752,6 +977,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
     });
@@ -832,6 +1058,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -843,7 +1070,10 @@ void main() {
             <String>['Runner', 'free'],
             logger,
           );
-          fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(projectInfo: projectInfo);
+          fakeXcodeProjectInterpreter = FakeXcodeProjectInterpreter(
+            projectInfo: projectInfo,
+            xcodeVersion: Version(15, 0, 0),
+          );
           xcode = Xcode.test(
             processManager: FakeProcessManager.any(),
             xcodeProjectInterpreter: fakeXcodeProjectInterpreter,
@@ -928,6 +1158,7 @@ void main() {
             Platform: () => macPlatform,
             XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
             Xcode: () => xcode,
+            Artifacts: () => artifacts,
           },
         );
       });
@@ -1024,6 +1255,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -1078,6 +1310,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => FakeXcodeProjectInterpreter(),
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -1133,6 +1366,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
 
@@ -1196,6 +1430,7 @@ void main() {
           Platform: () => macPlatform,
           XcodeProjectInterpreter: () => fakeXcodeProjectInterpreter,
           Xcode: () => xcode,
+          Artifacts: () => artifacts,
         },
       );
     });
@@ -1498,4 +1733,22 @@ class FakeExactAnalytics extends Fake implements Analytics {
   void send(Event event) {
     sentEvents.add(event);
   }
+}
+
+class FakeArtifacts extends Fake implements Artifacts {
+  FakeArtifacts({required this.frameworkPath});
+
+  final String frameworkPath;
+  @override
+  String getArtifactPath(
+    Artifact artifact, {
+    TargetPlatform? platform,
+    BuildMode? mode,
+    EnvironmentType? environmentType,
+  }) {
+    return frameworkPath;
+  }
+
+  @override
+  LocalEngineInfo? get localEngineInfo => null;
 }

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -465,9 +465,8 @@ void main() {
               .childDirectory('Headers')
               .childFile('FlutterPlugin.h')
               .createSync(recursive: true);
-
-          processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
-          processManager.addCommand(
+          processManager.addCommands([
+            FakeCommand(command: _xattrArgs(flutterProject)),
             const FakeCommand(
               command: <String>[
                 'xcrun',
@@ -498,8 +497,6 @@ void main() {
                 'COMPILER_INDEX_STORE_ENABLE=NO',
               ],
             ),
-          );
-          processManager.addCommand(
             const FakeCommand(
               command: <String>[
                 'rsync',
@@ -510,8 +507,6 @@ void main() {
                 'build/ios/iphoneos',
               ],
             ),
-          );
-          processManager.addCommand(
             FakeCommand(
               command: <String>[
                 iosDeployPath,
@@ -527,8 +522,7 @@ void main() {
                 const <String>['--enable-dart-profiling'].join(' '),
               ],
             ),
-          );
-
+          ]);
           final LaunchResult launchResult = await iosDevice.startApp(
             buildableIOSApp,
             debuggingOptions: DebuggingOptions.disabled(BuildInfo.release),
@@ -578,9 +572,8 @@ void main() {
               .childDirectory('Headers')
               .childFile('FlutterPlugin.h')
               .createSync(recursive: true);
-
-          processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
-          processManager.addCommand(
+          processManager.addCommands([
+            FakeCommand(command: _xattrArgs(flutterProject)),
             const FakeCommand(
               command: <String>[
                 'xcrun',
@@ -609,7 +602,7 @@ void main() {
                 'COMPILER_INDEX_STORE_ENABLE=NO',
               ],
             ),
-          );
+          ]);
 
           await iosDevice.startApp(
             buildableIOSApp,

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_nonprebuilt_test.dart
@@ -465,9 +465,6 @@ void main() {
               .childDirectory('Headers')
               .childFile('FlutterPlugin.h')
               .createSync(recursive: true);
-          // fileSystem
-          //     .file('build/ios/framework_public_headers.fingerprint')
-          //     .createSync(recursive: true);
 
           processManager.addCommand(FakeCommand(command: _xattrArgs(flutterProject)));
           processManager.addCommand(

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -750,6 +750,93 @@ duplicate symbol '_$s29plugin_1_name23PluginNamePluginC9setDouble3key5valueySS_S
       expect(processManager, hasNoRemainingExpectations);
     });
   });
+
+  group('publicHeadersChanged', () {
+    const correctHeaderFingerprint =
+        '{"files":{"/.tmp_rand0/Flutter.framework/Headers/FlutterPlugin.h":"d41d8cd98f00b204e9800998ecf8427e"}}';
+
+    testWithoutContext('returns true when headers change', () async {
+      final fs = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final Directory mockFlutterFramework = fs.systemTempDirectory.childDirectory(
+        'Flutter.framework',
+      );
+      mockFlutterFramework
+          .childDirectory('Headers')
+          .childFile('FlutterPlugin.h')
+          .createSync(recursive: true);
+      final Directory mockBuildDirectory = fs.systemTempDirectory.childDirectory('build')
+        ..createSync(recursive: true);
+      final File fingerprintFile =
+          mockBuildDirectory.childFile('framework_public_headers.fingerprint')..writeAsStringSync(
+            '{"files":{"/.tmp_rand0/Flutter.framework/Headers/FlutterPlugin.h":"incorrect_hash"}}',
+          );
+      final bool headersChanged = publicHeadersChanged(
+        environmentType: EnvironmentType.physical,
+        mode: BuildMode.debug,
+        buildDirectory: mockBuildDirectory.path,
+        artifacts: FakeArtifacts(frameworkPath: mockFlutterFramework.path),
+        fileSystem: fs,
+        logger: logger,
+      );
+      expect(headersChanged, isTrue);
+      expect(fingerprintFile.readAsStringSync(), correctHeaderFingerprint);
+    });
+
+    testWithoutContext('returns true when fingerprint does not exist yet', () async {
+      final fs = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final Directory mockFlutterFramework = fs.systemTempDirectory.childDirectory(
+        'Flutter.framework',
+      );
+      mockFlutterFramework
+          .childDirectory('Headers')
+          .childFile('FlutterPlugin.h')
+          .createSync(recursive: true);
+      final Directory mockBuildDirectory = fs.systemTempDirectory.childDirectory('build')
+        ..createSync(recursive: true);
+      final File fingerprintFile = mockBuildDirectory.childFile(
+        'framework_public_headers.fingerprint',
+      );
+      final bool headersChanged = publicHeadersChanged(
+        environmentType: EnvironmentType.physical,
+        mode: BuildMode.debug,
+        buildDirectory: mockBuildDirectory.path,
+        artifacts: FakeArtifacts(frameworkPath: mockFlutterFramework.path),
+        fileSystem: fs,
+        logger: logger,
+      );
+      expect(headersChanged, isTrue);
+      expect(fingerprintFile.readAsStringSync(), correctHeaderFingerprint);
+    });
+
+    testWithoutContext('returns false when fingerprint has not changed', () async {
+      final fs = MemoryFileSystem.test();
+      final logger = BufferLogger.test();
+      final Directory mockFlutterFramework = fs.systemTempDirectory.childDirectory(
+        'Flutter.framework',
+      );
+      mockFlutterFramework
+          .childDirectory('Headers')
+          .childFile('FlutterPlugin.h')
+          .createSync(recursive: true);
+      final Directory mockBuildDirectory = fs.systemTempDirectory.childDirectory('build')
+        ..createSync(recursive: true);
+      final File fingerprintFile = mockBuildDirectory.childFile(
+        'framework_public_headers.fingerprint',
+      )..writeAsStringSync(correctHeaderFingerprint);
+      final bool headersChanged = publicHeadersChanged(
+        environmentType: EnvironmentType.physical,
+        mode: BuildMode.debug,
+        buildDirectory: mockBuildDirectory.path,
+        artifacts: FakeArtifacts(frameworkPath: mockFlutterFramework.path),
+        fileSystem: fs,
+        logger: logger,
+      );
+      expect(headersChanged, isFalse);
+      expect(fingerprintFile.readAsStringSync(), correctHeaderFingerprint);
+    });
+  });
 }
 
 void createFakePlugins(
@@ -847,4 +934,19 @@ class FakeFlutterManifest extends Fake implements FlutterManifest {
 
   @override
   YamlMap toYaml() => YamlMap.wrap(<String, String>{});
+}
+
+class FakeArtifacts extends Fake implements Artifacts {
+  FakeArtifacts({required this.frameworkPath});
+
+  final String frameworkPath;
+  @override
+  String getArtifactPath(
+    Artifact artifact, {
+    TargetPlatform? platform,
+    BuildMode? mode,
+    EnvironmentType? environmentType,
+  }) {
+    return frameworkPath;
+  }
 }


### PR DESCRIPTION
Starting with Xcode 26, when a precompiled file changes (like a header file in the Flutter framework), it throws an error. This PR adds a fingerprinter to track changes to the headers. If the fingerprinting detects a change, it cleans before building. This only applies to Xcode 26 and incremental builds. Fresh builds should not clean.

Fixes https://github.com/flutter/flutter/issues/176462.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
