### PR TITLE
Replace deprecated `withOpacity` in `interactive_viewer.constrained.0.dart`

### DIFF
--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.constrained.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.constrained.0.dart
@@ -46,7 +46,7 @@ class ConstrainedExample extends StatelessWidget {
                 for (int column = 0; column < columnCount; column += 1)
                   Container(
                     height: 26,
-                    color: row % 2 + column % 2 == 1 ? Colors.white : Colors.grey.withOpacity(0.1),
+                    color: row % 2 + column % 2 == 1 ? Colors.white : Colors.grey.withValues(alpha: 0.1),
                     child: Align(alignment: Alignment.centerLeft, child: Text('$row x $column')),
                   ),
               ],

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.constrained.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.constrained.0.dart
@@ -46,7 +46,9 @@ class ConstrainedExample extends StatelessWidget {
                 for (int column = 0; column < columnCount; column += 1)
                   Container(
                     height: 26,
-                    color: row % 2 + column % 2 == 1 ? Colors.white : Colors.grey.withValues(alpha: 0.1),
+                    color: row % 2 + column % 2 == 1
+                        ? Colors.white
+                        : Colors.grey.withValues(alpha: 0.1),
                     child: Align(alignment: Alignment.centerLeft, child: Text('$row x $column')),
                   ),
               ],


### PR DESCRIPTION
Original PR that was intended to fix all examples:  
- #177205  

It was later split into smaller PRs due to a major misunderstanding and  test failures caused by color values not matching exactly.  

Similar PRs:  
- #177374  
- #177490  
- #177540  
- #177541  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
