### PR TITLE
fix: onChanged not called when IME composing text is committed

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1390,7 +1390,8 @@ class EditableText extends StatefulWidget {
 
   /// {@template flutter.widgets.editableText.onChanged}
   /// Called when the user initiates a change to the TextField's
-  /// value: when they have inserted or deleted text.
+  /// value: when they have inserted or deleted text, or when they have
+  /// committed text that was being composed.
   ///
   /// This callback doesn't run when the TextField's text is changed
   /// programmatically, via the TextField's [controller]. Typically it
@@ -4530,7 +4531,7 @@ class EditableTextState extends State<EditableText>
       _bringIntoViewBySelectionState(oldTextSelection, value.selection, cause);
     }
     final String currentText = _value.text;
-    if (oldValue.text != currentText) {
+    if (oldValue.text != currentText || textCommitted) {
       try {
         widget.onChanged?.call(currentText);
       } catch (exception, stack) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

fix #174159
fix #128565

In iOS IME, `unmarkText` is called when composing is confirmed. However, `setMarkedText` is also called immediately beforehand with the same text.
Since this behavior depends on the IME, I fixed the Flutter code to support the IME.

https://developer.apple.com/documentation/uikit/uitextinput/unmarktext()
https://developer.apple.com/documentation/uikit/uitextinput/setmarkedtext(_:selectedrange:)

https://github.com/user-attachments/assets/3fedd4ef-bd8e-4690-b516-046f173b8f2f

This fix also resolves issues in environments like macOS + Web + Japanese IME ("ことえり").

https://github.com/user-attachments/assets/00eae8ef-7a0b-4057-a425-16038d36bd88

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
