### PR TITLE
Add framework-side hitTestBehavior support for Semantics widget and apply to ModalRoute

### DIFF
--- a/packages/flutter/lib/src/rendering/custom_paint.dart
+++ b/packages/flutter/lib/src/rendering/custom_paint.dart
@@ -1046,6 +1046,9 @@ class RenderCustomPaint extends RenderProxyBox {
     if (config.validationResult != properties.validationResult) {
       config.validationResult = properties.validationResult;
     }
+    if (properties.hitTestBehavior != null) {
+      config.hitTestBehavior = properties.hitTestBehavior!;
+    }
     if (properties.inputType != null) {
       config.inputType = properties.inputType!;
     }

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4940,6 +4940,10 @@ mixin SemanticsAnnotationsMixin on RenderObject {
       config.validationResult = _properties.validationResult;
     }
 
+    if (_properties.hitTestBehavior != null) {
+      config.hitTestBehavior = _properties.hitTestBehavior!;
+    }
+
     if (_properties.inputType != null) {
       config.inputType = _properties.inputType!;
     }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -12,6 +12,7 @@ library;
 import 'dart:core';
 import 'dart:math' as math;
 import 'dart:ui'
+    as ui
     show
         CheckedState,
         Locale,
@@ -20,6 +21,7 @@ import 'dart:ui'
         SemanticsAction,
         SemanticsFlag,
         SemanticsFlags,
+        SemanticsHitTestBehavior,
         SemanticsInputType,
         SemanticsRole,
         SemanticsUpdate,
@@ -1020,6 +1022,7 @@ class SemanticsData with Diagnosticable {
     required this.role,
     required this.controlsNodes,
     required this.validationResult,
+    required this.hitTestBehavior,
     required this.inputType,
     required this.locale,
     this.tags,
@@ -1287,6 +1290,9 @@ class SemanticsData with Diagnosticable {
 
   /// {@macro flutter.semantics.SemanticsProperties.validationResult}
   final SemanticsValidationResult validationResult;
+
+  /// {@macro flutter.semantics.SemanticsProperties.hitTestBehavior}
+  final ui.SemanticsHitTestBehavior hitTestBehavior;
 
   /// {@macro flutter.semantics.SemanticsNode.inputType}
   final SemanticsInputType inputType;
@@ -1611,6 +1617,7 @@ class SemanticsProperties extends DiagnosticableTree {
     this.controlsNodes,
     this.inputType,
     this.validationResult = SemanticsValidationResult.none,
+    this.hitTestBehavior,
     this.onTap,
     this.onLongPress,
     this.onScrollLeft,
@@ -2555,6 +2562,13 @@ class SemanticsProperties extends DiagnosticableTree {
   /// {@endtemplate}
   final SemanticsValidationResult validationResult;
 
+  /// {@template flutter.semantics.SemanticsProperties.hitTestBehavior}
+  /// Describes how the semantic node should behave during hit testing.
+  ///
+  /// See [ui.SemanticsHitTestBehavior] for more details.
+  /// {@endtemplate}
+  final ui.SemanticsHitTestBehavior? hitTestBehavior;
+
   /// {@template flutter.semantics.SemanticsProperties.inputType}
   /// The input type for of a editable widget.
   ///
@@ -3227,7 +3241,8 @@ class SemanticsNode with DiagnosticableTreeMixin {
         _headingLevel != config._headingLevel ||
         _linkUrl != config._linkUrl ||
         _role != config.role ||
-        _validationResult != config.validationResult;
+        _validationResult != config.validationResult ||
+        _hitTestBehavior != config.hitTestBehavior;
   }
 
   // TAGS, LABELS, ACTIONS
@@ -3521,6 +3536,10 @@ class SemanticsNode with DiagnosticableTreeMixin {
   SemanticsValidationResult get validationResult => _validationResult;
   SemanticsValidationResult _validationResult = _kEmptyConfig.validationResult;
 
+  /// {@macro flutter.semantics.SemanticsProperties.hitTestBehavior}
+  ui.SemanticsHitTestBehavior get hitTestBehavior => _hitTestBehavior;
+  ui.SemanticsHitTestBehavior _hitTestBehavior = ui.SemanticsHitTestBehavior.defer;
+
   /// {@template flutter.semantics.SemanticsNode.inputType}
   /// The input type for of a editable node.
   ///
@@ -3601,6 +3620,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     _role = config._role;
     _controlsNodes = config._controlsNodes;
     _validationResult = config._validationResult;
+    _hitTestBehavior = config._hitTestBehavior;
     _inputType = config._inputType;
     _locale = config.locale;
 
@@ -3655,6 +3675,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
     SemanticsRole role = _role;
     Set<String>? controlsNodes = _controlsNodes;
     SemanticsValidationResult validationResult = _validationResult;
+    ui.SemanticsHitTestBehavior hitTestBehavior = _hitTestBehavior;
     SemanticsInputType inputType = _inputType;
     final Locale? locale = _locale;
     final Set<int> customSemanticsActionIds = <int>{};
@@ -3810,6 +3831,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       role: role,
       controlsNodes: controlsNodes,
       validationResult: validationResult,
+      hitTestBehavior: hitTestBehavior,
       inputType: inputType,
       locale: locale,
     );
@@ -4001,6 +4023,7 @@ class SemanticsNode with DiagnosticableTreeMixin {
       role: data.role,
       controlsNodes: data.controlsNodes?.toList(),
       validationResult: data.validationResult,
+      hitTestBehavior: data.hitTestBehavior,
       inputType: data.inputType,
       locale: data.locale,
     );
@@ -6423,6 +6446,14 @@ class SemanticsConfiguration {
   SemanticsValidationResult _validationResult = SemanticsValidationResult.none;
   set validationResult(SemanticsValidationResult value) {
     _validationResult = value;
+    _hasBeenAnnotated = true;
+  }
+
+  /// {@macro flutter.semantics.SemanticsProperties.hitTestBehavior}
+  ui.SemanticsHitTestBehavior get hitTestBehavior => _hitTestBehavior;
+  ui.SemanticsHitTestBehavior _hitTestBehavior = ui.SemanticsHitTestBehavior.defer;
+  set hitTestBehavior(ui.SemanticsHitTestBehavior value) {
+    _hitTestBehavior = value;
     _hasBeenAnnotated = true;
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1457,8 +1457,6 @@ class SemanticsData with Diagnosticable {
       validationResult,
       controlsNodes == null ? null : Object.hashAll(controlsNodes!),
       inputType,
-      traversalParentIdentifier,
-      traversalChildIdentifier,
       hitTestBehavior,
     ),
   );

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -6679,7 +6679,7 @@ class SemanticsConfiguration {
       child._accessiblityFocusBlockType,
     );
 
-    if (_hitTestBehavior == ui.SemanticsHitTestBehavior.defer && 
+    if (_hitTestBehavior == ui.SemanticsHitTestBehavior.defer &&
         child._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
       _hitTestBehavior = child._hitTestBehavior;
     }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -12,7 +12,6 @@ library;
 import 'dart:core';
 import 'dart:math' as math;
 import 'dart:ui'
-    as ui
     show
         CheckedState,
         Locale,
@@ -21,7 +20,6 @@ import 'dart:ui'
         SemanticsAction,
         SemanticsFlag,
         SemanticsFlags,
-        SemanticsHitTestBehavior,
         SemanticsInputType,
         SemanticsRole,
         SemanticsUpdate,
@@ -30,6 +28,7 @@ import 'dart:ui'
         StringAttribute,
         TextDirection,
         Tristate;
+import 'dart:ui' as ui show SemanticsHitTestBehavior;
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
@@ -6720,7 +6719,8 @@ class SemanticsConfiguration {
       .._role = _role
       .._controlsNodes = _controlsNodes
       .._validationResult = _validationResult
-      .._inputType = _inputType;
+      .._inputType = _inputType
+      .._hitTestBehavior = _hitTestBehavior;
   }
 }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -6569,6 +6569,10 @@ class SemanticsConfiguration {
     if (_hasExplicitRole && other._hasExplicitRole) {
       return false;
     }
+    if (_hitTestBehavior != ui.SemanticsHitTestBehavior.defer ||
+        other._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+      return false;
+    }
     return true;
   }
 
@@ -6679,8 +6683,7 @@ class SemanticsConfiguration {
       child._accessiblityFocusBlockType,
     );
 
-    if (_hitTestBehavior == ui.SemanticsHitTestBehavior.defer &&
-        child._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+    if (_hitTestBehavior == ui.SemanticsHitTestBehavior.defer) {
       _hitTestBehavior = child._hitTestBehavior;
     }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3741,7 +3741,8 @@ class SemanticsNode with DiagnosticableTreeMixin {
         if (inputType == SemanticsInputType.none) {
           inputType = node._inputType;
         }
-        if (node._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+        if (hitTestBehavior == ui.SemanticsHitTestBehavior.defer &&
+            node._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
           hitTestBehavior = node._hitTestBehavior;
         }
         if (tooltip == '') {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -1420,6 +1420,7 @@ class SemanticsData with Diagnosticable {
         other.role == role &&
         other.validationResult == validationResult &&
         other.inputType == inputType &&
+        other.hitTestBehavior == hitTestBehavior &&
         _sortedListsEqual(other.customSemanticsActionIds, customSemanticsActionIds) &&
         setEquals<String>(controlsNodes, other.controlsNodes);
   }
@@ -1458,6 +1459,7 @@ class SemanticsData with Diagnosticable {
       inputType,
       traversalParentIdentifier,
       traversalChildIdentifier,
+      hitTestBehavior,
     ),
   );
 
@@ -3738,6 +3740,9 @@ class SemanticsNode with DiagnosticableTreeMixin {
         }
         if (inputType == SemanticsInputType.none) {
           inputType = node._inputType;
+        }
+        if (node._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+          hitTestBehavior = node._hitTestBehavior;
         }
         if (tooltip == '') {
           tooltip = node._tooltip;
@@ -6673,6 +6678,11 @@ class SemanticsConfiguration {
     _accessiblityFocusBlockType = _accessiblityFocusBlockType._merge(
       child._accessiblityFocusBlockType,
     );
+
+    if (_hitTestBehavior == ui.SemanticsHitTestBehavior.defer && 
+        child._hitTestBehavior != ui.SemanticsHitTestBehavior.defer) {
+      _hitTestBehavior = child._hitTestBehavior;
+    }
 
     _hasBeenAnnotated = hasBeenAnnotated || child.hasBeenAnnotated;
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -9,7 +9,9 @@
 library;
 
 import 'dart:math' as math;
-import 'dart:ui' as ui show Image, ImageFilter, SemanticsInputType, TextHeightBehavior;
+import 'dart:ui'
+    as ui
+    show Image, ImageFilter, SemanticsHitTestBehavior, SemanticsInputType, TextHeightBehavior;
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -4048,6 +4050,7 @@ sealed class _SemanticsBase extends SingleChildRenderObjectWidget {
     required SemanticsRole? role,
     required Set<String>? controlsNodes,
     required SemanticsValidationResult validationResult,
+    required ui.SemanticsHitTestBehavior? hitTestBehavior,
     required ui.SemanticsInputType? inputType,
     required Locale? localeForSubtree,
   }) : this.fromProperties(
@@ -4133,6 +4136,7 @@ sealed class _SemanticsBase extends SingleChildRenderObjectWidget {
            role: role,
            controlsNodes: controlsNodes,
            validationResult: validationResult,
+           hitTestBehavior: hitTestBehavior,
            inputType: inputType,
          ),
        );
@@ -7964,6 +7968,7 @@ class Semantics extends _SemanticsBase {
     super.role,
     super.controlsNodes,
     super.validationResult = SemanticsValidationResult.none,
+    super.hitTestBehavior,
     super.inputType,
     super.localeForSubtree,
   });

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4386,6 +4386,7 @@ class SliverSemantics extends _SemanticsBase {
     super.role,
     super.controlsNodes,
     super.validationResult = SemanticsValidationResult.none,
+    super.hitTestBehavior,
     super.inputType,
     super.localeForSubtree,
   }) : super(child: sliver);

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2313,6 +2313,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
     // To be sorted before the _modalBarrier.
     return _modalScopeCache ??= Semantics(
       sortKey: const OrdinalSortKey(0.0),
+      hitTestBehavior: ui.SemanticsHitTestBehavior.opaque,
       child: _ModalScope<T>(
         key: _scopeKey,
         route: this,

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2617,6 +2617,7 @@ class RawDialogRoute<T> extends PopupRoute<T> {
     return Semantics(
       scopesRoute: true,
       explicitChildNodes: true,
+      hitTestBehavior: ui.SemanticsHitTestBehavior.opaque,
       child: DisplayFeatureSubScreen(
         anchorPoint: anchorPoint,
         child: _pageBuilder(context, animation, secondaryAnimation),

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2617,7 +2617,6 @@ class RawDialogRoute<T> extends PopupRoute<T> {
     return Semantics(
       scopesRoute: true,
       explicitChildNodes: true,
-      hitTestBehavior: ui.SemanticsHitTestBehavior.opaque,
       child: DisplayFeatureSubScreen(
         anchorPoint: anchorPoint,
         child: _pageBuilder(context, animation, secondaryAnimation),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1486,7 +1486,9 @@ void main() {
                                     SemanticsFlag.isFocused,
                                     SemanticsFlag.isFocusable,
                                   ],
-                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  tags: <SemanticsTag>[
+                                    const SemanticsTag('RenderViewport.twoPane'),
+                                  ],
                                   actions: <SemanticsAction>[
                                     SemanticsAction.tap,
                                     SemanticsAction.focus,
@@ -1500,7 +1502,9 @@ void main() {
                                     SemanticsFlag.isButton,
                                     SemanticsFlag.isFocusable,
                                   ],
-                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  tags: <SemanticsTag>[
+                                    const SemanticsTag('RenderViewport.twoPane'),
+                                  ],
                                   actions: <SemanticsAction>[
                                     SemanticsAction.tap,
                                     SemanticsAction.focus,
@@ -1514,7 +1518,9 @@ void main() {
                                     SemanticsFlag.isButton,
                                     SemanticsFlag.isFocusable,
                                   ],
-                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  tags: <SemanticsTag>[
+                                    const SemanticsTag('RenderViewport.twoPane'),
+                                  ],
                                   actions: <SemanticsAction>[
                                     SemanticsAction.tap,
                                     SemanticsAction.focus,
@@ -1528,7 +1534,9 @@ void main() {
                                     SemanticsFlag.isButton,
                                     SemanticsFlag.isFocusable,
                                   ],
-                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  tags: <SemanticsTag>[
+                                    const SemanticsTag('RenderViewport.twoPane'),
+                                  ],
                                   actions: <SemanticsAction>[
                                     SemanticsAction.tap,
                                     SemanticsAction.focus,

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -1462,75 +1462,78 @@ void main() {
         TestSemantics.root(
           children: <TestSemantics>[
             TestSemantics.rootChild(
-              actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.dismiss],
-              label: 'Dismiss',
               textDirection: TextDirection.ltr,
               children: <TestSemantics>[
                 TestSemantics(
-                  role: SemanticsRole.menu,
-                  flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
-                  label: 'Popup menu',
                   children: <TestSemantics>[
                     TestSemantics(
+                      role: SemanticsRole.menu,
+                      flags: <SemanticsFlag>[SemanticsFlag.scopesRoute, SemanticsFlag.namesRoute],
+                      label: 'Popup menu',
+                      textDirection: TextDirection.ltr,
                       children: <TestSemantics>[
                         TestSemantics(
-                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
                           children: <TestSemantics>[
                             TestSemantics(
-                              role: SemanticsRole.menuItem,
-                              label: 'one',
-                              textDirection: TextDirection.ltr,
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isButton,
-                                SemanticsFlag.isFocused,
-                                SemanticsFlag.isFocusable,
-                              ],
-                              tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
-                              actions: <SemanticsAction>[
-                                SemanticsAction.tap,
-                                SemanticsAction.focus,
-                              ],
-                            ),
-                            TestSemantics(
-                              role: SemanticsRole.menuItem,
-                              label: 'two',
-                              textDirection: TextDirection.ltr,
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isButton,
-                                SemanticsFlag.isFocusable,
-                              ],
-                              tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
-                              actions: <SemanticsAction>[
-                                SemanticsAction.tap,
-                                SemanticsAction.focus,
-                              ],
-                            ),
-                            TestSemantics(
-                              role: SemanticsRole.menuItem,
-                              label: 'three',
-                              textDirection: TextDirection.ltr,
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isButton,
-                                SemanticsFlag.isFocusable,
-                              ],
-                              tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
-                              actions: <SemanticsAction>[
-                                SemanticsAction.tap,
-                                SemanticsAction.focus,
-                              ],
-                            ),
-                            TestSemantics(
-                              role: SemanticsRole.menuItem,
-                              label: 'four',
-                              textDirection: TextDirection.ltr,
-                              flags: <SemanticsFlag>[
-                                SemanticsFlag.isButton,
-                                SemanticsFlag.isFocusable,
-                              ],
-                              tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
-                              actions: <SemanticsAction>[
-                                SemanticsAction.tap,
-                                SemanticsAction.focus,
+                              flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                              children: <TestSemantics>[
+                                TestSemantics(
+                                  role: SemanticsRole.menuItem,
+                                  label: 'one',
+                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isFocused,
+                                    SemanticsFlag.isFocusable,
+                                  ],
+                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
+                                ),
+                                TestSemantics(
+                                  role: SemanticsRole.menuItem,
+                                  label: 'two',
+                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isFocusable,
+                                  ],
+                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
+                                ),
+                                TestSemantics(
+                                  role: SemanticsRole.menuItem,
+                                  label: 'three',
+                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isFocusable,
+                                  ],
+                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
+                                ),
+                                TestSemantics(
+                                  role: SemanticsRole.menuItem,
+                                  label: 'four',
+                                  textDirection: TextDirection.ltr,
+                                  flags: <SemanticsFlag>[
+                                    SemanticsFlag.isButton,
+                                    SemanticsFlag.isFocusable,
+                                  ],
+                                  tags: <SemanticsTag>[const SemanticsTag('RenderViewport.twoPane')],
+                                  actions: <SemanticsAction>[
+                                    SemanticsAction.tap,
+                                    SemanticsAction.focus,
+                                  ],
+                                ),
                               ],
                             ),
                           ],
@@ -1538,6 +1541,11 @@ void main() {
                       ],
                     ),
                   ],
+                ),
+                TestSemantics(
+                  actions: <SemanticsAction>[SemanticsAction.tap, SemanticsAction.dismiss],
+                  label: 'Dismiss',
+                  textDirection: TextDirection.ltr,
                 ),
               ],
             ),

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -1040,6 +1040,34 @@ void main() {
     expect(config.customSemanticsActions[customAction], same(onCustomAction));
   });
 
+  test('SemanticsConfiguration.copy() preserves hitTestBehavior', () {
+    final SemanticsConfiguration config = SemanticsConfiguration()
+      ..isSemanticBoundary = true
+      ..label = 'test'
+      ..hitTestBehavior = SemanticsHitTestBehavior.opaque;
+
+    expect(config.hitTestBehavior, SemanticsHitTestBehavior.opaque);
+
+    final SemanticsConfiguration copy = config.copy();
+
+    expect(copy.hitTestBehavior, SemanticsHitTestBehavior.opaque);
+    expect(copy.isSemanticBoundary, isTrue);
+    expect(copy.label, 'test');
+  });
+
+  test('SemanticsConfiguration.copy() preserves all hitTestBehavior values', () {
+    final SemanticsConfiguration deferConfig = SemanticsConfiguration();
+    expect(deferConfig.copy().hitTestBehavior, SemanticsHitTestBehavior.defer);
+
+    final SemanticsConfiguration opaqueConfig = SemanticsConfiguration()
+      ..hitTestBehavior = SemanticsHitTestBehavior.opaque;
+    expect(opaqueConfig.copy().hitTestBehavior, SemanticsHitTestBehavior.opaque);
+
+    final SemanticsConfiguration transparentConfig = SemanticsConfiguration()
+      ..hitTestBehavior = SemanticsHitTestBehavior.transparent;
+    expect(transparentConfig.copy().hitTestBehavior, SemanticsHitTestBehavior.transparent);
+  });
+
   test('SemanticsOwner dispatches memory events', () async {
     await expectLater(
       await memoryEvents(

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2701,6 +2701,42 @@ void main() {
     expect(parentRoute, isA<MaterialPageRoute<void>>());
   });
 
+  testWidgets('ModalRoute sets hitTestBehavior.opaque on modal scope', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            return ElevatedButton(
+              onPressed: () {
+                showDialog<void>(
+                  context: context,
+                  builder: (BuildContext context) => const AlertDialog(
+                    title: Text('Test Dialog'),
+                  ),
+                );
+              },
+              child: const Text('Show Dialog'),
+            );
+          },
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Show Dialog'));
+    await tester.pumpAndSettle();
+
+    final Iterable<Semantics> semanticsWidgets = tester.widgetList<Semantics>(find.byType(Semantics));
+    
+    final Semantics modalScopeSemantics = semanticsWidgets.firstWhere(
+      (Semantics widget) => 
+        widget.properties.scopesRoute == true &&
+        widget.properties.hitTestBehavior != null,
+    );
+    
+    expect(modalScopeSemantics.properties.scopesRoute, isTrue);
+    expect(modalScopeSemantics.properties.hitTestBehavior, SemanticsHitTestBehavior.opaque);
+  });
+
   testWidgets('RawDialogRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
       const MaterialApp(restorationScopeId: 'app', home: _RestorableDialogTestWidget()),

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2702,6 +2702,8 @@ void main() {
   });
 
   testWidgets('ModalRoute sets hitTestBehavior.opaque on modal scope', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    
     await tester.pumpWidget(
       MaterialApp(
         home: Builder(
@@ -2727,14 +2729,18 @@ void main() {
 
     final Iterable<Semantics> semanticsWidgets = tester.widgetList<Semantics>(find.byType(Semantics));
     
-    final Semantics modalScopeSemantics = semanticsWidgets.firstWhere(
-      (Semantics widget) => 
-        (widget.properties.scopesRoute ?? false) &&
-        widget.properties.hitTestBehavior != null,
-    );
+    bool found = false;
+    for (final Semantics widget in semanticsWidgets) {
+      if (widget.properties.hitTestBehavior == SemanticsHitTestBehavior.opaque) {
+        expect(widget.properties.hitTestBehavior, SemanticsHitTestBehavior.opaque);
+        found = true;
+        break;
+      }
+    }
     
-    expect(modalScopeSemantics.properties.scopesRoute, isTrue);
-    expect(modalScopeSemantics.properties.hitTestBehavior, SemanticsHitTestBehavior.opaque);
+    expect(found, isTrue, reason: 'No Semantics widget with hitTestBehavior.opaque found');
+    
+    semantics.dispose();
   });
 
   testWidgets('RawDialogRoute is state restorable', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2729,7 +2729,7 @@ void main() {
     
     final Semantics modalScopeSemantics = semanticsWidgets.firstWhere(
       (Semantics widget) => 
-        widget.properties.scopesRoute == true &&
+        (widget.properties.scopesRoute ?? false) &&
         widget.properties.hitTestBehavior != null,
     );
     

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2703,7 +2703,7 @@ void main() {
 
   testWidgets('ModalRoute sets hitTestBehavior.opaque on modal scope', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
-    
+
     await tester.pumpWidget(
       MaterialApp(
         home: Builder(
@@ -2712,9 +2712,7 @@ void main() {
               onPressed: () {
                 showDialog<void>(
                   context: context,
-                  builder: (BuildContext context) => const AlertDialog(
-                    title: Text('Test Dialog'),
-                  ),
+                  builder: (BuildContext context) => const AlertDialog(title: Text('Test Dialog')),
                 );
               },
               child: const Text('Show Dialog'),
@@ -2727,8 +2725,10 @@ void main() {
     await tester.tap(find.text('Show Dialog'));
     await tester.pumpAndSettle();
 
-    final Iterable<Semantics> semanticsWidgets = tester.widgetList<Semantics>(find.byType(Semantics));
-    
+    final Iterable<Semantics> semanticsWidgets = tester.widgetList<Semantics>(
+      find.byType(Semantics),
+    );
+
     bool found = false;
     for (final Semantics widget in semanticsWidgets) {
       if (widget.properties.hitTestBehavior == SemanticsHitTestBehavior.opaque) {
@@ -2737,9 +2737,9 @@ void main() {
         break;
       }
     }
-    
+
     expect(found, isTrue, reason: 'No Semantics widget with hitTestBehavior.opaque found');
-    
+
     semantics.dispose();
   });
 

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -755,6 +755,7 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        hitTestBehavior: ui.SemanticsHitTestBehavior.defer,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1057,6 +1058,7 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        hitTestBehavior: ui.SemanticsHitTestBehavior.defer,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1159,6 +1161,7 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        hitTestBehavior: ui.SemanticsHitTestBehavior.defer,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
@@ -1266,6 +1269,7 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        hitTestBehavior: ui.SemanticsHitTestBehavior.defer,
       );
       final _FakeSemanticsNode emptyNode = _FakeSemanticsNode(emptyData);
 
@@ -1301,6 +1305,7 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        hitTestBehavior: ui.SemanticsHitTestBehavior.defer,
       );
       final _FakeSemanticsNode fullNode = _FakeSemanticsNode(fullData);
 
@@ -1435,6 +1440,7 @@ void main() {
         validationResult: SemanticsValidationResult.none,
         inputType: ui.SemanticsInputType.none,
         locale: null,
+        hitTestBehavior: ui.SemanticsHitTestBehavior.defer,
       );
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 


### PR DESCRIPTION
Fix premature dialog dismissal on Flutter Web when semantics are enabled by correctly propagating hitTestBehavior through the semantics pipeline and declaring modal routes as opaque to pointer events.

Before change
https://dialog-dismiss-before.web.app/

Click on the "Show Dialog" button.
Click anywhere inside the dialog that is not a form field.
Observe the dialog being dismissed.

After change
https://dialog-dimiss-after.web.app/

Click on the "Show Dialog" button.
Click anywhere inside the dialog that is not a form field.
Observe the dialog not dismissed.

Fixes: #149001
Engine work: #176974