### PR TITLE
Fix ElevatedButton.icon breaks focus traversal and VoiceOver when toggling icon

### DIFF
--- a/dev/integration_tests/flutter_gallery/test/demo/material/buttons_demo_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/demo/material/buttons_demo_test.dart
@@ -13,9 +13,9 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(theme: ThemeData(useMaterial3: false), home: const ButtonsDemo()),
       );
-      expect(find.byType(ElevatedButton).evaluate().length, 2);
+      expect(find.byType(ElevatedButton).evaluate().length, 4);
       final Offset topLeft1 = tester.getTopLeft(find.byType(ElevatedButton).first);
-      final Offset topLeft2 = tester.getTopLeft(find.byType(ElevatedButton).last);
+      final Offset topLeft2 = tester.getTopLeft(find.byType(ElevatedButton).at(1));
       expect(topLeft1.dx, 203);
       expect(topLeft2.dx, 453);
       expect(topLeft1.dy, topLeft2.dy);

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -2608,4 +2608,86 @@ void main() {
     expect(textColor(tester, buttonText), hoveredColor);
     expect(iconStyle(tester, buttonIcon).color, hoveredColor);
   });
+
+  testWidgets('When an ElevatedButton gains an icon, preserves the same SemanticsNode id', (
+    WidgetTester tester,
+  ) async {
+    bool toggled = false;
+    const Key key = Key('button');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Row(
+                children: <Widget>[
+                  ElevatedButton.icon(
+                    key: key,
+                    onPressed: () {
+                      setState(() {
+                        toggled = true;
+                      });
+                    },
+                    icon: toggled ? const Icon(Icons.favorite) : null,
+                    label: const Text('Button'),
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    // Initially, no icons are present.
+    expect(find.byIcon(Icons.favorite), findsNothing);
+
+    // Find the original ElevatedButton with no icon and get its SemanticsNode.
+    final Finder elevatedButton = find.bySemanticsLabel('Button');
+    expect(elevatedButton, findsOneWidget);
+
+    final SemanticsNode origSemanticsNode = tester.getSemantics(elevatedButton);
+
+    // Tap the button. It should receive an icon now.
+    await tester.tap(elevatedButton);
+    await tester.pump();
+
+    // Now one icon should be present.
+    expect(find.byIcon(Icons.favorite), findsOneWidget);
+
+    // Check if the semantics has change.
+    final SemanticsNode semanticsNodeWithIcon = tester.getSemantics(elevatedButton);
+
+    expect(semanticsNodeWithIcon, origSemanticsNode);
+  });
+
+  testWidgets('ElevatedButton.icon does not lose focus when icon is nullified', (
+    WidgetTester tester,
+  ) async {
+    Widget buildButton({required Widget? icon}) {
+      return MaterialApp(
+        home: Center(
+          child: ElevatedButton.icon(onPressed: () {}, icon: icon, label: const Text('button')),
+        ),
+      );
+    }
+
+    // Build once with an icon.
+    await tester.pumpWidget(buildButton(icon: const Icon(Icons.abc)));
+
+    FocusNode getButtonFocusNode() {
+      return Focus.of(tester.element(find.text('button')));
+    }
+
+    getButtonFocusNode().requestFocus();
+    await tester.pumpAndSettle();
+    expect(getButtonFocusNode().hasFocus, true);
+
+    // Rebuild without icon.
+    await tester.pumpWidget(buildButton(icon: null));
+
+    // The button should still be focused.
+    expect(getButtonFocusNode().hasFocus, true);
+  });
 }


### PR DESCRIPTION
## Description

This PR changes `ElevatedButton.icon` to avoid building a different widget. When a different widget is created the whole subtree is recreated which leads to various issues (Focus and A11y issues for instance).
The change is similar to https://github.com/flutter/flutter/pull/175810 which fixed the exact same problem for `OutlinedButton.icon`.

## Related Issue

[TextButton.icon breaks focus traversal and ink effect when toggling icon](https://github.com/flutter/flutter/issues/173944)
[Voiceover focus traversal breaks if a button's state changes to include an icon](https://github.com/flutter/flutter/pull/175810) 

## Tests

- Adds 2 tests
