### PR TITLE
Roll dartdoc to 9.0.0

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -121,7 +121,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 8.3.3
+    "$DART" pub global activate dartdoc 9.0.0
 
     # Build and install the snippets tool, which resides in
     # the dev/docs/snippets directory.


### PR DESCRIPTION
Required for compatibility with the latest Dart SDK and analyzer package