### PR TITLE
Revert "Resolve resolve native Flutter dependencies in Android Studio…

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -19,9 +19,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
-import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.file.Directory
-import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar

--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.file.Directory
 import org.gradle.api.plugins.PluginContainer
 import org.gradle.api.tasks.Copy
-import org.gradle.api.tasks.TaskInstantiationException
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.os.OperatingSystem
@@ -101,7 +100,6 @@ class FlutterPlugin : Plugin<Project> {
             repositories.maven {
                 url = uri(repository!!)
             }
-            maybeAddAndroidStudioNativeConfiguration(plugins, dependencies)
         }
 
         project.apply {
@@ -329,23 +327,19 @@ class FlutterPlugin : Plugin<Project> {
     }
 
     private fun addTaskForLockfileGeneration(rootProject: Project) {
-        try {
-            rootProject.tasks.register("generateLockfiles") {
-                doLast {
-                    rootProject.subprojects.forEach { subproject ->
-                        val gradlew: String =
-                            getExecutableNameForPlatform("${rootProject.projectDir}/gradlew")
-                        val execOps = rootProject.serviceOf<ExecOperations>()
-                        execOps.exec {
-                            workingDir(rootProject.projectDir)
-                            executable(gradlew)
-                            args(":${subproject.name}:dependencies", "--write-locks")
-                        }
+        rootProject.tasks.register("generateLockfiles") {
+            doLast {
+                rootProject.subprojects.forEach { subproject ->
+                    val gradlew: String =
+                        getExecutableNameForPlatform("${rootProject.projectDir}/gradlew")
+                    val execOps = rootProject.serviceOf<ExecOperations>()
+                    execOps.exec {
+                        workingDir(rootProject.projectDir)
+                        executable(gradlew)
+                        args(":${subproject.name}:dependencies", "--write-locks")
                     }
                 }
             }
-        } catch (e: TaskInstantiationException) {
-            // ignored
         }
     }
 
@@ -821,19 +815,4 @@ class FlutterPlugin : Plugin<Project> {
      * This property is set by Android Studio when it invokes a Gradle task.
      */
     private fun isInvokedFromAndroidStudio(): Boolean = project?.hasProperty("android.injected.invoked.from.ide") == true
-
-    private fun shouldAddAndroidStudioNativeConfiguration(plugins: PluginContainer): Boolean =
-        plugins.hasPlugin("com.android.application") && isInvokedFromAndroidStudio()
-
-    private fun maybeAddAndroidStudioNativeConfiguration(
-        plugins: PluginContainer,
-        dependencies: DependencyHandler
-    ) {
-        if (shouldAddAndroidStudioNativeConfiguration(plugins)) {
-            dependencies.add("compileOnly", "io.flutter:flutter_embedding_debug:$engineVersion")
-            dependencies.add("compileOnly", "io.flutter:armeabi_v7a_debug:$engineVersion")
-            dependencies.add("compileOnly", "io.flutter:arm64_v8a_debug:$engineVersion")
-            dependencies.add("compileOnly", "io.flutter:x86_64_debug:$engineVersion")
-        }
-    }
 }


### PR DESCRIPTION
Fixes #177037 on 3.38 branch. 

This reverts commit 0c0406a6158eb07d28a70350a22801ee8f6870c9.
Leaves `isInvokedFromAndroidStudio`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

