### PR TITLE
Replace deprecated withOpacity in `radio.1.dart` example

### DIFF
--- a/examples/api/lib/material/radio/radio.1.dart
+++ b/examples/api/lib/material/radio/radio.1.dart
@@ -64,9 +64,9 @@ class _RadioExampleState extends State<RadioExample> {
               value: RadioType.backgroundColor,
               backgroundColor: WidgetStateColor.resolveWith((Set<WidgetState> states) {
                 if (states.contains(WidgetState.selected)) {
-                  return Colors.greenAccent.withOpacity(0.5);
+                  return Colors.greenAccent.withValues(alpha: 0.5);
                 } else {
-                  return Colors.grey.shade300.withOpacity(0.3);
+                  return Colors.grey.shade300.withValues(alpha: 0.3);
                 }
               }),
             ),

--- a/examples/api/test/material/radio/radio.1_test.dart
+++ b/examples/api/test/material/radio/radio.1_test.dart
@@ -30,11 +30,11 @@ void main() {
     );
     expect(
       radioBackgroundColor.backgroundColor!.resolve(const <WidgetState>{WidgetState.selected}),
-      Colors.greenAccent.withOpacity(0.5),
+      Colors.greenAccent.withValues(alpha: 0.5),
     );
     expect(
       radioBackgroundColor.backgroundColor!.resolve(const <WidgetState>{}),
-      Colors.grey.shade300.withOpacity(0.3),
+      Colors.grey.shade300.withValues(alpha: 0.3),
     );
 
     final Radio<example.RadioType> radioSide = tester.widget<Radio<example.RadioType>>(


### PR DESCRIPTION
Original PR that was intended to fix all examples:  
- #177205  

It was later split into smaller PRs due to a major misunderstanding and  test failures caused by color values not matching exactly.  

Similar PRs:  
- #177374  
- #177490  
- #177540  
- #177541  
- #177542

<img width="859" height="148" alt="Screenshot 2025-10-27 at 20 09 35" src="https://github.com/user-attachments/assets/daf13a7b-a157-410a-9feb-dc466128c5a1" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
