### PR TITLE
Add `enableSound` flag to `CupertinoPicker`

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -94,6 +94,7 @@ class CupertinoPicker extends StatefulWidget {
     required this.onSelectedItemChanged,
     required List<Widget> children,
     this.selectionOverlay = const CupertinoPickerDefaultSelectionOverlay(),
+    this.soundEnabled = true,
     bool looping = false,
   }) : assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(magnification > 0),
@@ -135,6 +136,7 @@ class CupertinoPicker extends StatefulWidget {
     required NullableIndexedWidgetBuilder itemBuilder,
     int? childCount,
     this.selectionOverlay = const CupertinoPickerDefaultSelectionOverlay(),
+    this.soundEnabled = true,
   }) : assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(magnification > 0),
        assert(itemExtent > 0),
@@ -218,6 +220,11 @@ class CupertinoPicker extends StatefulWidget {
   /// This property can be set to null to remove the overlay.
   final Widget? selectionOverlay;
 
+  /// Whether the ticking sound is enabled when scrolling the picker.
+  ///
+  /// The sound is only played on iOS devices.
+  final bool soundEnabled;
+
   @override
   State<StatefulWidget> createState() => _CupertinoPickerState();
 }
@@ -274,7 +281,9 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
         if (index != _lastHapticIndex) {
           _lastHapticIndex = index;
           HapticFeedback.selectionClick();
-          SystemSound.play(SystemSoundType.tick);
+          if (widget.soundEnabled) {
+            SystemSound.play(SystemSoundType.tick);
+          }
         }
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:

--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -94,7 +94,7 @@ class CupertinoPicker extends StatefulWidget {
     required this.onSelectedItemChanged,
     required List<Widget> children,
     this.selectionOverlay = const CupertinoPickerDefaultSelectionOverlay(),
-    this.soundEnabled = true,
+    this.enableSound = true,
     bool looping = false,
   }) : assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(magnification > 0),
@@ -136,7 +136,7 @@ class CupertinoPicker extends StatefulWidget {
     required NullableIndexedWidgetBuilder itemBuilder,
     int? childCount,
     this.selectionOverlay = const CupertinoPickerDefaultSelectionOverlay(),
-    this.soundEnabled = true,
+    this.enableSound = true,
   }) : assert(diameterRatio > 0.0, RenderListWheelViewport.diameterRatioZeroMessage),
        assert(magnification > 0),
        assert(itemExtent > 0),
@@ -223,7 +223,7 @@ class CupertinoPicker extends StatefulWidget {
   /// Whether the ticking sound is enabled when scrolling the picker.
   ///
   /// The sound is only played on iOS devices.
-  final bool soundEnabled;
+  final bool enableSound;
 
   @override
   State<StatefulWidget> createState() => _CupertinoPickerState();
@@ -281,7 +281,7 @@ class _CupertinoPickerState extends State<CupertinoPicker> {
         if (index != _lastHapticIndex) {
           _lastHapticIndex = index;
           HapticFeedback.selectionClick();
-          if (widget.soundEnabled) {
+          if (widget.enableSound) {
             SystemSound.play(SystemSoundType.tick);
           }
         }

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -378,7 +378,7 @@ void main() {
         // Let the scroll settle and end up in the middle of the item.
         await tester.pumpAndSettle();
         expect(systemCalls, hasLength(1));
-        // Check that the haptic feedback and ticking sound were triggered.
+        // Check that only the haptic feedback was triggered.
         expect(
           systemCalls.single,
           isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.selectionClick'),

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -355,7 +355,7 @@ void main() {
           Directionality(
             textDirection: TextDirection.ltr,
             child: CupertinoPicker(
-              soundEnabled: false,
+              enableSound: false,
               itemExtent: 100.0,
               onSelectedItemChanged: (int index) {
                 selectedItems.add(index);


### PR DESCRIPTION
I am not sure how to replicate the native iOS behaviour regarding the ticking sounds yet. For now here is a flag to opt-out of the ticking altogether.

Towards https://github.com/flutter/flutter/issues/174691

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
