### PR TITLE
[web] Don't add webparagraph suite to CI

### DIFF
--- a/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
+++ b/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
@@ -28,10 +28,15 @@ class GenerateBuilderJsonCommand extends Command<bool> {
     final FeltConfig config = FeltConfig.fromFile(
       path.join(environment.webUiTestDir.path, 'felt_config.yaml'),
     );
+    final List<TestSuite> testSuites = config.testSuites.where((suite) => suite.enableCi).toList();
+    final List<TestBundle> testBundles = testSuites
+        .map((suite) => suite.testBundle)
+        .toSet()
+        .toList();
     _writeBuilderJson(
       _generateBuilderJson(
-        config.testBundles.map((TestBundle bundle) => _getBundleBuildStep(bundle)).toList(),
-        _getAllTestSteps(config.testSuites, packageLock),
+        testBundles.map((TestBundle bundle) => _getBundleBuildStep(bundle)).toList(),
+        _getAllTestSteps(testSuites, packageLock),
       ),
       'linux_web_engine_test.json',
     );
@@ -114,9 +119,7 @@ class GenerateBuilderJsonCommand extends Command<bool> {
     String? specificOS,
     String? cpu,
   }) {
-    final filteredSuites = suites.where(
-      (suite) => suite.enableCi && suite.runConfig.browser == browser,
-    );
+    final filteredSuites = suites.where((suite) => suite.runConfig.browser == browser);
     final bundles = filteredSuites.map((suite) => suite.testBundle).toSet();
     return <String, dynamic>{
       'name': '$platform run ${browser.name} suites',

--- a/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
+++ b/engine/src/flutter/lib/web_ui/dev/generate_builder_json.dart
@@ -29,10 +29,7 @@ class GenerateBuilderJsonCommand extends Command<bool> {
       path.join(environment.webUiTestDir.path, 'felt_config.yaml'),
     );
     final List<TestSuite> testSuites = config.testSuites.where((suite) => suite.enableCi).toList();
-    final List<TestBundle> testBundles = testSuites
-        .map((suite) => suite.testBundle)
-        .toSet()
-        .toList();
+    final Iterable<TestBundle> testBundles = testSuites.map((suite) => suite.testBundle).toSet();
     _writeBuilderJson(
       _generateBuilderJson(
         testBundles.map((TestBundle bundle) => _getBundleBuildStep(bundle)).toList(),


### PR DESCRIPTION
Fix `generate-builder-json` to only include test bundles that are needed by enabled test suites.

## Before this PR
The script was unconditionally including all test bundles in CI. The result is that the `dart2js-canvaskit-experimental-webparagraph` bundle was being generated, even though it was only required by the `chrome-dart2js-experimental-webparagraph-ui` suite, which had `enable-ci: false`.

## After this PR
The script starts by finding all test suites with `enable-ci: true`, then only adds the bundles required by those suites.