### PR TITLE
Make sure that a Scaffold doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -3676,6 +3676,19 @@ void main() {
 
     expect(find.byType(BottomAppBar), findsOneWidget);
   });
+
+  testWidgets('Scaffold does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: Scaffold(appBar: AppBar(), body: const SizedBox.shrink()),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(Scaffold)), Size.zero);
+  });
 }
 
 class _GeometryListener extends StatefulWidget {


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the Scaffold widget.