### PR TITLE
[web] Move webparagraph tests to their right location

### DIFF
--- a/engine/src/flutter/lib/web_ui/test/webparagraph/font_collection_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/webparagraph/font_collection_test.dart
@@ -8,8 +8,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
-import '../../common/fake_asset_manager.dart';
-import '../../common/test_initialization.dart';
+import '../common/fake_asset_manager.dart';
+import '../common/test_initialization.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);


### PR DESCRIPTION
Many failures happening in [`Linux linux_web_engine_tests
`](https://ci.chromium.org/ui/p/flutter/builders/luci.flutter.prod/Linux%20linux_web_engine_tests) due to `ui/web_paragraph/font_collection_test.dart` being misplaced.

This PR moves the test file to the correct directory so it runs with the correct test suite.