### PR TITLE
Only remove what is necessary from abiFilters

### DIFF
--- a/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
+++ b/packages/flutter_tools/gradle/src/main/kotlin/FlutterPlugin.kt
@@ -163,16 +163,20 @@ class FlutterPlugin : Plugin<Project> {
             // abiFilters cannot be added to templates because it would break builds when
             // --splits-per-abi is used due to conflicting configuration. This approach
             // adds them programmatically only when splits are not configured.
-            //
-            // If the user has specified abiFilters in their build.gradle file, those
-            // settings will take precedence over these defaults.
             FlutterPluginUtils.getAndroidExtension(project).buildTypes.forEach { buildType ->
-                buildType.ndk.abiFilters.clear()
-                FlutterPluginConstants.DEFAULT_PLATFORMS.forEach { platform ->
-                    val abiValue: String =
-                        FlutterPluginConstants.PLATFORM_ARCH_MAP[platform]
-                            ?: throw GradleException("Invalid platform: $platform")
-                    buildType.ndk.abiFilters.add(abiValue)
+                if (buildType.ndk.abiFilters.contains("x86")) {
+                    project.logger.warn(
+                        "Warning: Flutter does not support x86 architectures.  Removing from abiFilters."
+                    )
+                    buildType.ndk.abiFilters.remove("x86")
+                }
+            }
+            FlutterPluginUtils.getAndroidExtension(project).productFlavors.forEach { flavor ->
+                if (flavor.ndk.abiFilters.contains("x86")) {
+                    project.logger.warn(
+                        "Warning: Flutter does not support x86 architectures.  Removing from abiFilters."
+                    )
+                    flavor.ndk.abiFilters.remove("x86")
                 }
             }
         }


### PR DESCRIPTION
Instead of clearing abiFilters, just remove what is necessary (x86 - which is not supported). 

Fixes: #175845

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

