### PR TITLE
[Impeller] Fall back to OpenGL ES on older Adreno GPUs

### DIFF
--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -358,6 +358,16 @@ bool DriverInfoVK::IsEmulator() const {
 }
 
 bool DriverInfoVK::IsKnownBadDriver() const {
+  // Fall back to OpenGL ES on older Adreno devices that require additional
+  // workarounds in the Impeller Vulkan back end such as disabling framebuffer
+  // fetch.
+  if (adreno_gpu_.has_value()) {
+    AdrenoGPU adreno = adreno_gpu_.value();
+    if (adreno <= AdrenoGPU::kAdreno630) {
+      return true;
+    }
+  }
+
   // Disable Maleoon series GPUs, see:
   // https://github.com/flutter/flutter/issues/156623
   if (vendor_ == VendorVK::kHuawei) {

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk.cc
@@ -361,11 +361,8 @@ bool DriverInfoVK::IsKnownBadDriver() const {
   // Fall back to OpenGL ES on older Adreno devices that require additional
   // workarounds in the Impeller Vulkan back end such as disabling framebuffer
   // fetch.
-  if (adreno_gpu_.has_value()) {
-    AdrenoGPU adreno = adreno_gpu_.value();
-    if (adreno <= AdrenoGPU::kAdreno630) {
-      return true;
-    }
+  if (adreno_gpu_ && *adreno_gpu_ <= AdrenoGPU::kAdreno630) {
+    return true;
   }
 
   // Disable Maleoon series GPUs, see:

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/driver_info_vk_unittests.cc
@@ -164,16 +164,16 @@ TEST(DriverInfoVKTest, DriverParsingAdreno) {
 }
 
 TEST(DriverInfoVKTest, DisabledDevices) {
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 620"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 610"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 530"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 512"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 509"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 508"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 506"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 505"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 504"));
-  EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 630"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 620"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 610"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 530"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 512"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 509"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 508"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 506"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 505"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 504"));
+  EXPECT_TRUE(IsBadVersionTest("Adreno (TM) 630"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 640"));
   EXPECT_FALSE(IsBadVersionTest("Adreno (TM) 650"));
 }


### PR DESCRIPTION
These GPUs require additional flags in WorkaroundsVK that affect key features used by the Vulkan back end such as framebuffer fetch.  The OpenGL ES back end will likely be more reliable on these devices.

Fixes https://github.com/flutter/flutter/issues/177380