### PR TITLE
Make sure that a SearchBar doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/search_anchor_test.dart
+++ b/packages/flutter/test/material/search_anchor_test.dart
@@ -4280,6 +4280,22 @@ void main() {
     expect(viewTextField.smartDashesType, SmartDashesType.disabled);
     expect(viewTextField.smartQuotesType, SmartQuotesType.disabled);
   });
+
+  testWidgets('SearchBar does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    final TextEditingController controller = TextEditingController(text: 'X');
+    addTearDown(controller.dispose);
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(child: SearchBar(controller: controller)),
+      ),
+    );
+    expect(tester.getSize(find.byType(SearchBar)), Size.zero);
+    controller.selection = const TextSelection.collapsed(offset: 0);
+    await tester.pump();
+    expect(find.text('X'), findsOne);
+  });
 }
 
 Future<void> checkSearchBarDefaults(


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the SearchBar widget.