### PR TITLE
Mark deprecated ios application lifecycle methods as such

### DIFF
--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -44,6 +44,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (void)applicationDidBecomeActive:(UIApplication*)application
     API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/sceneDidBecomeActive:`` instead.",
@@ -51,6 +54,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (void)applicationWillResignActive:(UIApplication*)application
     API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/willResignActive:`` instead.",
@@ -58,6 +64,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (void)applicationDidEnterBackground:(UIApplication*)application
     API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/didEnterBackground:`` instead.",
@@ -77,6 +86,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (void)application:(UIApplication*)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
@@ -118,6 +130,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
@@ -129,6 +144,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (BOOL)application:(UIApplication*)application
       handleOpenURL:(NSURL*)url
@@ -139,6 +157,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (BOOL)application:(UIApplication*)application
               openURL:(NSURL*)url
@@ -151,6 +172,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (BOOL)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
@@ -164,6 +188,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
@@ -181,6 +208,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
+ *
+ * This method is deprecated and will not be called when this plugin conforms to
+ * `FlutterSceneLifeCycleDelegate`.
  */
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -45,22 +45,30 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  */
-- (void)applicationDidBecomeActive:(UIApplication*)application;
+- (void)applicationDidBecomeActive:(UIApplication*)application
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/sceneDidBecomeActive:`` instead.",
+                   ios(2.0, 26.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  */
-- (void)applicationWillResignActive:(UIApplication*)application;
+- (void)applicationWillResignActive:(UIApplication*)application
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/willResignActive:`` instead.",
+                   ios(2.0, 26.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  */
-- (void)applicationDidEnterBackground:(UIApplication*)application;
+- (void)applicationDidEnterBackground:(UIApplication*)application
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/didEnterBackground:`` instead.",
+                   ios(4.0, 26.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  */
-- (void)applicationWillEnterForeground:(UIApplication*)application;
+- (void)applicationWillEnterForeground:(UIApplication*)application
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/willEnterForeground:`` instead.",
+                   ios(4.0, 26.0));
 
 /**
  Called if this has been registered for `UIApplicationDelegate` callbacks.
@@ -113,14 +121,19 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options;
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/scene:openURLContexts:`` instead.",
+                   ios(9.0, 26.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
  */
-- (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url;
+- (BOOL)application:(UIApplication*)application
+      handleOpenURL:(NSURL*)url
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/scene:openURLContexts:`` instead.",
+                   ios(2.0, 9.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
@@ -130,7 +143,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)application:(UIApplication*)application
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
-           annotation:(id)annotation;
+           annotation:(id)annotation
+    API_DEPRECATED("Implement ``FlutterSceneLifeCycleDelegate/scene:openURLContexts:`` instead.",
+                   ios(4.2, 9.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
@@ -140,7 +155,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler
-    API_AVAILABLE(ios(9.0));
+    API_DEPRECATED("Implement "
+                   "``FlutterSceneLifeCycleDelegate/"
+                   "windowScene:performActionForShortcutItem:completionHandler:`` instead.",
+                   ios(9.0, 26.0));
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
@@ -166,7 +184,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void (^)(NSArray*))restorationHandler;
+      restorationHandler:(void (^)(NSArray*))restorationHandler
+    API_DEPRECATED(
+        "Implement ``FlutterSceneLifeCycleDelegate/scene:continueUserActivity:`` instead.",
+        ios(8.0, 26.0));
 @end
 
 #pragma mark -

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -84,7 +84,9 @@ FLUTTER_DARWIN_EXPORT
  */
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options;
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
+    API_DEPRECATED("Use ``FlutterPluginSceneLifeCycleDelegate/scene:openURLContexts:`` instead.",
+                   ios(9.0, 26.0));
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks in order of registration until
@@ -92,7 +94,10 @@ FLUTTER_DARWIN_EXPORT
  *
  * @return `YES` if any plugin handles the request.
  */
-- (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url;
+- (BOOL)application:(UIApplication*)application
+      handleOpenURL:(NSURL*)url
+    API_DEPRECATED("Use ``FlutterPluginSceneLifeCycleDelegate/scene:openURLContexts:`` instead.",
+                   ios(2.0, 9.0));
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks in order of registration until
@@ -103,7 +108,9 @@ FLUTTER_DARWIN_EXPORT
 - (BOOL)application:(UIApplication*)application
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
-           annotation:(id)annotation;
+           annotation:(id)annotation
+    API_DEPRECATED("Use ``FlutterPluginSceneLifeCycleDelegate/scene:openURLContexts:`` instead.",
+                   ios(4.2, 9.0));
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
@@ -111,7 +118,10 @@ FLUTTER_DARWIN_EXPORT
 - (void)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler
-    API_AVAILABLE(ios(9.0));
+    API_DEPRECATED("Use "
+                   "``FlutterPluginSceneLifeCycleDelegate/"
+                   "windowScene:performActionForShortcutItem:completionHandler:`` instead.",
+                   ios(9.0, 26.0));
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks in order of registration until
@@ -140,7 +150,10 @@ FLUTTER_DARWIN_EXPORT
  */
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void (^)(NSArray*))restorationHandler;
+      restorationHandler:(void (^)(NSArray*))restorationHandler
+    API_DEPRECATED(
+        "Use ``FlutterPluginSceneLifeCycleDelegate/scene:continueUserActivity:`` instead.",
+        ios(8.0, 26.0));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -81,6 +81,8 @@ FLUTTER_DARWIN_EXPORT
  * some plugin handles the request.
  *
  *  @return `YES` if any plugin handles the request.
+ *
+ * This method is deprecated and must not be called when this app is using UIScenes.
  */
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
@@ -93,6 +95,8 @@ FLUTTER_DARWIN_EXPORT
  * some plugin handles the request.
  *
  * @return `YES` if any plugin handles the request.
+ *
+ * This method is deprecated and must not be called when this app is using UIScenes.
  */
 - (BOOL)application:(UIApplication*)application
       handleOpenURL:(NSURL*)url
@@ -104,6 +108,8 @@ FLUTTER_DARWIN_EXPORT
  * some plugin handles the request.
  *
  * @return `YES` if any plugin handles the request.
+ *
+ * This method is deprecated and must not be called when this app is using UIScenes.
  */
 - (BOOL)application:(UIApplication*)application
               openURL:(NSURL*)url
@@ -114,6 +120,8 @@ FLUTTER_DARWIN_EXPORT
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
+ *
+ * This method is deprecated and must not be called when this app is using UIScenes.
  */
 - (void)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
@@ -147,6 +155,8 @@ FLUTTER_DARWIN_EXPORT
  * some plugin handles the request.
  *
  * @return `YES` if any plugin handles the request.
+ *
+ * This method is deprecated and must not be called when this app is using UIScenes.
  */
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity


### PR DESCRIPTION
This adds deprecation annotation to `FlutterPluginAppLifeCycleDelegate` (the concrete class the app developers is supposed to send app lifecycle events to, in a multi-scene add-to-app) and `FlutterApplicationLifeCycleDelegate` (the protocol implemented by plugins).

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
