### PR TITLE
Replace deprecated `withOpacity` in `switch.1.dart` example

### DIFF
--- a/examples/api/lib/material/switch/switch.1.dart
+++ b/examples/api/lib/material/switch/switch.1.dart
@@ -41,12 +41,11 @@ class _SwitchExampleState extends State<SwitchExample> {
     );
     // This object sets the track color based on two WidgetState attributes.
     // If neither state applies, it resolves to null.
-    final WidgetStateProperty<Color?> overlayColor = WidgetStateProperty<Color?>.fromMap(
-      <WidgetState, Color>{
-        WidgetState.selected: Colors.amber.withValues(alpha: 0.54),
-        WidgetState.disabled: Colors.grey.shade400,
-      },
-    );
+    final WidgetStateProperty<Color?> overlayColor =
+        WidgetStateProperty<Color?>.fromMap(<WidgetState, Color>{
+          WidgetState.selected: Colors.amber.withValues(alpha: 0.54),
+          WidgetState.disabled: Colors.grey.shade400,
+        });
 
     return Switch(
       // This bool value toggles the switch.

--- a/examples/api/lib/material/switch/switch.1.dart
+++ b/examples/api/lib/material/switch/switch.1.dart
@@ -43,7 +43,7 @@ class _SwitchExampleState extends State<SwitchExample> {
     // If neither state applies, it resolves to null.
     final WidgetStateProperty<Color?> overlayColor = WidgetStateProperty<Color?>.fromMap(
       <WidgetState, Color>{
-        WidgetState.selected: Colors.amber.withOpacity(0.54),
+        WidgetState.selected: Colors.amber.withValues(alpha: 0.54),
         WidgetState.disabled: Colors.grey.shade400,
       },
     );


### PR DESCRIPTION
<img width="859" height="148" alt="Screenshot 2025-10-27 at 20 09 35" src="https://github.com/user-attachments/assets/daf13a7b-a157-410a-9feb-dc466128c5a1" />
Similar PRs:

- #177374  
- #177490  
- #177540  
- #177541  
- #177542



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
