### PR TITLE
Remove minimize API for dialogs

### DIFF
--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -1105,7 +1105,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
     final BaseWindowController controller = _of(context, _WindowControllerAspect.minimized);
     return switch (controller) {
       RegularWindowController() => controller.isMinimized,
-      DialogWindowController() => controller.isMinimized,
+      DialogWindowController() => false,
     };
   }
 
@@ -1127,7 +1127,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
 
     return switch (controller) {
       RegularWindowController() => controller.isMinimized,
-      DialogWindowController() => controller.isMinimized,
+      DialogWindowController() => false,
     };
   }
 
@@ -1298,8 +1298,7 @@ class WindowScope extends InheritedModel<_WindowControllerAspect> {
               final RegularWindowController regular =>
                 regular.isMinimized !=
                     (oldWidget.controller as RegularWindowController).isMinimized,
-              final DialogWindowController dialog =>
-                dialog.isMinimized != (oldWidget.controller as DialogWindowController).isMinimized,
+              DialogWindowController => false,
             },
             _WindowControllerAspect.fullscreen => switch (controller) {
               final RegularWindowController regular =>

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -427,8 +427,8 @@ mixin class DialogWindowControllerDelegate {
 ///  * Modal dialogs: created with a non-null parent. These dialogs are modal
 ///    to the parent, do not have a system menu, and are not selectable from the
 ///    window switcher.
-///  * Modeless dialogs: created with a null parent. These dialogs can be
-///    minimized (but not maximized), and have a disabled close button.
+///  * Modeless dialogs: created with a null parent. These dialogs canot be
+///    minimized or maximized and have a disabled close button.
 ///
 /// This class does not interact with the widget tree. Instead, it is typically
 /// provided to the [DialogWindow] widget, which renders the content inside the
@@ -495,7 +495,7 @@ abstract class DialogWindowController extends BaseWindowController {
   /// The [parent] argument specifies the parent window of this dialog.
   ///
   /// If the [parent] is null, then the dialog is modeless. Such dialogs can
-  /// be minimized but not maximized. They also have a disabled close button.
+  /// not be minimized or maximized. They also have a disabled close button.
   ///
   /// If the [parent] is non-null, then the dialog is modal to the parent.
   /// Such dialogs do not have a system menu. They are also not selectable
@@ -598,10 +598,6 @@ abstract class DialogWindowController extends BaseWindowController {
   ///
   /// The platform may also give the window input focus and bring it to the
   /// top of the window stack. However, this behavior is platform-dependent.
-  ///
-  /// If the window is minimized, the window returns to the size and position
-  /// that it had before that state was applied. The window will also be
-  /// brought to the top of the window stack.
   ///
   /// {@macro flutter.widgets.windowing.experimental}
   @internal

--- a/packages/flutter/lib/src/widgets/_window.dart
+++ b/packages/flutter/lib/src/widgets/_window.dart
@@ -564,12 +564,6 @@ abstract class DialogWindowController extends BaseWindowController {
   @internal
   bool get isActivated;
 
-  /// Whether or not window is currently minimized.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  @internal
-  bool get isMinimized;
-
   /// Request change to the content size of the window.
   ///
   /// The [size] describes the new requested window size. If the size disagrees
@@ -612,12 +606,6 @@ abstract class DialogWindowController extends BaseWindowController {
   /// {@macro flutter.widgets.windowing.experimental}
   @internal
   void activate();
-
-  /// Requests window to be minimized.
-  ///
-  /// {@macro flutter.widgets.windowing.experimental}
-  @internal
-  void setMinimized(bool minimized);
 }
 
 /// [WindowingOwner] is responsible for creating and managing window controllers.

--- a/packages/flutter/lib/src/widgets/_window_win32.dart
+++ b/packages/flutter/lib/src/widgets/_window_win32.dart
@@ -565,13 +565,6 @@ class DialogWindowControllerWin32 extends DialogWindowController {
 
   @override
   @internal
-  bool get isMinimized {
-    _ensureNotDestroyed();
-    return _Win32PlatformInterface.isIconic(getWindowHandle()) != 0;
-  }
-
-  @override
-  @internal
   void setSize(Size? size) {
     _ensureNotDestroyed();
     _Win32PlatformInterface.setWindowContentSize(_owner.allocator, getWindowHandle(), size);
@@ -601,21 +594,6 @@ class DialogWindowControllerWin32 extends DialogWindowController {
   void activate() {
     _ensureNotDestroyed();
     _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
-  }
-
-  @override
-  @internal
-  void setMinimized(bool minimized) {
-    if (parent != null) {
-      return;
-    }
-
-    _ensureNotDestroyed();
-    if (minimized) {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_MINIMIZE);
-    } else {
-      _Win32PlatformInterface.showWindow(getWindowHandle(), _SW_RESTORE);
-    }
   }
 
   @override

--- a/packages/flutter/test/widgets/windowing_test.dart
+++ b/packages/flutter/test/widgets/windowing_test.dart
@@ -87,9 +87,6 @@ class _StubDialogWindowController extends DialogWindowController {
   bool get isActivated => true;
 
   @override
-  bool get isMinimized => false;
-
-  @override
   void setSize(Size size) {}
 
   @override
@@ -100,9 +97,6 @@ class _StubDialogWindowController extends DialogWindowController {
 
   @override
   void activate() {}
-
-  @override
-  void setMinimized(bool minimized) {}
 
   @override
   void destroy() {}


### PR DESCRIPTION
According to the [spec](https://docs.google.com/document/d/1eQG-IS7r4_S9_h50MY_hSGwUVtgSTRSLzu7MLzPNd2Y/edit?tab=t.0) dialogs should not be minimizable.

The table in the spec:
  | Regular | Dialog | Popup | Tip | Satellite
-- | -- | -- | -- | -- | --
Has parent | No | Yes | Yes | Yes | Yes
Can have input focus | Yes | Yes | Yes | No | Yes
Can be the active window 1 | Yes | Yes | No | No | Yes
When window or ancestor is not active window | Stays open | Stays open | Closes | Stays open | Hides
User-moveable | Yes | Yes | No | No | Yes
User-resizeable | Yes | Yes | No | No | Yes
Maximizable | Yes | No | No | No | No
Minimizeable | Yes | **No** | No | No | No
Fullscreen-able | Yes | No | No | No | No
Title Bar | Yes | Same as Parent | No | No | Yes
Close button | Yes | No | No | No | Yes
