### PR TITLE
[ios][pv]accept/reject gesture based on hit test

### DIFF
--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -151,6 +151,7 @@ source_set("ui") {
     "window/platform_message_response_dart.h",
     "window/platform_message_response_dart_port.cc",
     "window/platform_message_response_dart_port.h",
+    "window/point_data.h",
     "window/pointer_data.cc",
     "window/pointer_data.h",
     "window/pointer_data_packet.cc",

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -308,6 +308,11 @@ void _dispatchPointerDataPacket(ByteData packet) {
 }
 
 @pragma('vm:entry-point')
+bool _platformViewShouldAcceptGesture(int viewId, double x, double y) {
+  return PlatformDispatcher.instance._platformViewShouldAcceptGesture(viewId, x, y);
+}
+
+@pragma('vm:entry-point')
 void _dispatchSemanticsAction(int viewId, int nodeId, int action, ByteData? args) {
   PlatformDispatcher.instance._dispatchSemanticsAction(viewId, nodeId, action, args);
 }
@@ -414,6 +419,24 @@ void _invoke3<A1, A2, A3>(
     zone.runGuarded(() {
       callback(arg1, arg2, arg3);
     });
+  }
+}
+
+R? _invoke3WithReturn<A1, A2, A3, R>(
+  R Function(A1 a1, A2 a2, A3 a3)? callback,
+  Zone zone,
+  A1 arg1,
+  A2 arg2,
+  A3 arg3,
+) {
+  if (callback == null) {
+    return null;
+  }
+  if (identical(zone, Zone.current)) {
+    return callback(arg1, arg2, arg3);
+  } else {
+    // TODO: how to handle synchronous return? Should we assume zone is always current?
+    return null;
   }
 }
 

--- a/engine/src/flutter/lib/ui/hooks.dart
+++ b/engine/src/flutter/lib/ui/hooks.dart
@@ -422,6 +422,12 @@ void _invoke3<A1, A2, A3>(
   }
 }
 
+/// Invokes [callback] inside the given [zone] passing it [arg1], [arg2], and [arg3],
+/// and returns a nullable result of the specified type.
+///
+/// The 3 in the name refers to the number of arguments expected by
+/// the callback (and thus passed to this function, in addition to the
+/// callback itself and the zone in which the callback is executed).
 R? _invoke3WithReturn<A1, A2, A3, R>(
   R Function(A1 a1, A2 a2, A3 a3)? callback,
   Zone zone,
@@ -435,8 +441,15 @@ R? _invoke3WithReturn<A1, A2, A3, R>(
   if (identical(zone, Zone.current)) {
     return callback(arg1, arg2, arg3);
   } else {
-    // TODO: how to handle synchronous return? Should we assume zone is always current?
-    return null;
+    // TODO(hellohuanlin): add `zone.runGuardedWithReturn` API.
+    try {
+      return zone.run(() {
+        return callback(arg1, arg2, arg3);
+      });
+    } catch (e, s) {
+      zone.handleUncaughtError(e, s);
+      return null;
+    }
   }
 }
 

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,6 +43,7 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
+/// Signature for [PlatformDispatcher.onPlatformViewShouldAcceptGesture].
 typedef PlatformViewShouldAcceptGestureCallback = bool Function(int viewId, double x, double y);
 
 /// Signature for responses to platform messages.

--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -43,6 +43,8 @@ typedef KeyDataCallback = bool Function(KeyData data);
 /// Signature for [PlatformDispatcher.onSemanticsActionEvent].
 typedef SemanticsActionEventCallback = void Function(SemanticsActionEvent action);
 
+typedef PlatformViewShouldAcceptGestureCallback = bool Function(int viewId, double x, double y);
+
 /// Signature for responses to platform messages.
 ///
 /// Used as a parameter to [PlatformDispatcher.sendPlatformMessage] and
@@ -1336,6 +1338,14 @@ class PlatformDispatcher {
     _onSemanticsActionEventZone = Zone.current;
   }
 
+  PlatformViewShouldAcceptGestureCallback? get onPlatformViewShouldAcceptGesture =>
+      _onPlatformViewShouldAcceptGesture;
+  PlatformViewShouldAcceptGestureCallback? _onPlatformViewShouldAcceptGesture;
+  Zone _onPlatformViewShouldAcceptGestureZone = Zone.root;
+  set onPlatformViewShouldAcceptGesture(PlatformViewShouldAcceptGestureCallback? callback) {
+    _onPlatformViewShouldAcceptGesture = callback;
+  }
+
   // Called from the engine via hooks.dart.
   void _updateFrameData(int frameNumber) {
     final FrameData previous = _frameData;
@@ -1371,6 +1381,17 @@ class PlatformDispatcher {
         arguments: args,
       ),
     );
+  }
+
+  bool _platformViewShouldAcceptGesture(int viewId, double x, double y) {
+    return _invoke3WithReturn<int, double, double, bool>(
+          onPlatformViewShouldAcceptGesture,
+          _onPlatformViewShouldAcceptGestureZone,
+          viewId,
+          x,
+          y,
+        ) ??
+        false;
   }
 
   ErrorCallback? _onError;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -77,6 +77,9 @@ void PlatformConfiguration::DidCreateIsolate() {
   dispatch_pointer_data_packet_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library, tonic::ToDart("_dispatchPointerDataPacket")));
+  // The embedded platform view (e.g. UIView on iOS) is called "platform view"
+  // on framework side, but "embedded view" on engine side. On the other hand,
+  // "platform view" refers to the whole flutter view on engine side.
   embedded_view_should_accept_gesture_.Set(
       tonic::DartState::Current(),
       Dart_GetField(library,
@@ -406,6 +409,9 @@ bool PlatformConfiguration::EmbeddedViewShouldAcceptGesture(
       embedded_view_should_accept_gesture_.Get(),
       {tonic::ToDart(view_id), tonic::ToDart(touch_began_location.x),
        tonic::ToDart(touch_began_location.y)});
+  if (tonic::CheckAndHandleError(dart_result)) {
+    return false;
+  }
   return tonic::DartConverter<bool>::FromDart(dart_result);
 }
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.cc
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.cc
@@ -395,7 +395,7 @@ void PlatformConfiguration::DispatchPointerDataPacket(
       tonic::DartInvoke(dispatch_pointer_data_packet_.Get(), {data_handle}));
 }
 
-bool PlatformConfiguration::EmbeddedViewShouldAcceptGesture(
+bool PlatformConfiguration::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   std::shared_ptr<tonic::DartState> dart_state =

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -15,6 +15,7 @@
 #include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/semantics/semantics_update.h"
 #include "flutter/lib/ui/window/platform_message_response.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/view_focus.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
@@ -461,6 +462,10 @@ class PlatformConfiguration final {
   ///
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
+
   //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an
   ///             accessibility related action on the specified node. This call
@@ -584,6 +589,7 @@ class PlatformConfiguration final {
   tonic::DartPersistentValue update_accessibility_features_;
   tonic::DartPersistentValue dispatch_platform_message_;
   tonic::DartPersistentValue dispatch_pointer_data_packet_;
+  tonic::DartPersistentValue embedded_view_should_accept_gesture_;
   tonic::DartPersistentValue dispatch_semantics_action_;
   tonic::DartPersistentValue begin_frame_;
   tonic::DartPersistentValue draw_frame_;

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -463,7 +463,8 @@ class PlatformConfiguration final {
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded native view should
+  /// accept
   ///             gesture at a given touch location.
   ///
   ///
@@ -474,7 +475,7 @@ class PlatformConfiguration final {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/lib/ui/window/platform_configuration.h
+++ b/engine/src/flutter/lib/ui/window/platform_configuration.h
@@ -462,6 +462,18 @@ class PlatformConfiguration final {
   ///
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
   bool EmbeddedViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);

--- a/engine/src/flutter/lib/ui/window/point_data.h
+++ b/engine/src/flutter/lib/ui/window/point_data.h
@@ -1,0 +1,17 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_
+#define FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_
+
+namespace flutter {
+
+// Represents a point on screen.
+struct PointData {
+  double x;
+  double y;
+};
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_WINDOW_POINT_DATA_H_

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,13 +374,13 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
-bool RuntimeController::EmbeddedViewShouldAcceptGesture(
+bool RuntimeController::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
     TRACE_EVENT0("flutter",
-                 "RuntimeController::EmbeddedViewShouldAcceptGesture");
-    return platform_configuration->EmbeddedViewShouldAcceptGesture(
+                 "RuntimeController::EmbeddedNativeViewShouldAcceptGesture");
+    return platform_configuration->EmbeddedNativeViewShouldAcceptGesture(
         view_id, touch_began_location);
   }
   return false;

--- a/engine/src/flutter/runtime/runtime_controller.cc
+++ b/engine/src/flutter/runtime/runtime_controller.cc
@@ -374,6 +374,18 @@ bool RuntimeController::DispatchPointerDataPacket(
   return false;
 }
 
+bool RuntimeController::EmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
+    TRACE_EVENT0("flutter",
+                 "RuntimeController::EmbeddedViewShouldAcceptGesture");
+    return platform_configuration->EmbeddedViewShouldAcceptGesture(
+        view_id, touch_began_location);
+  }
+  return false;
+}
+
 bool RuntimeController::DispatchSemanticsAction(int64_t view_id,
                                                 int32_t node_id,
                                                 SemanticsAction action,

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -478,7 +478,8 @@ class RuntimeController : public PlatformConfigurationClient,
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded native view should
+  /// accept
   ///             gesture at a given touch location.
   ///
   ///
@@ -489,7 +490,7 @@ class RuntimeController : public PlatformConfigurationClient,
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -18,6 +18,7 @@
 #include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_configuration.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
 #include "flutter/lib/ui/window/view_focus.h"
@@ -475,6 +476,10 @@ class RuntimeController : public PlatformConfigurationClient,
   ///             an isolate is not running.
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
+
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the semantics action to the specified accessibility

--- a/engine/src/flutter/runtime/runtime_controller.h
+++ b/engine/src/flutter/runtime/runtime_controller.h
@@ -477,6 +477,18 @@ class RuntimeController : public PlatformConfigurationClient,
   ///
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
   bool EmbeddedViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,6 +476,16 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
+bool Engine::EmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  if (runtime_controller_) {
+    return runtime_controller_->EmbeddedViewShouldAcceptGesture(
+        view_id, touch_began_location);
+  }
+  return false;
+}
+
 void Engine::DispatchSemanticsAction(int64_t view_id,
                                      int node_id,
                                      SemanticsAction action,

--- a/engine/src/flutter/shell/common/engine.cc
+++ b/engine/src/flutter/shell/common/engine.cc
@@ -476,11 +476,11 @@ void Engine::DispatchPointerDataPacket(
   pointer_data_dispatcher_->DispatchPacket(std::move(packet), trace_flow_id);
 }
 
-bool Engine::EmbeddedViewShouldAcceptGesture(
+bool Engine::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (runtime_controller_) {
-    return runtime_controller_->EmbeddedViewShouldAcceptGesture(
+    return runtime_controller_->EmbeddedNativeViewShouldAcceptGesture(
         view_id, touch_began_location);
   }
   return false;

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,6 +830,22 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
+  /// @brief      Requests the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
+
+  //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder encountered an
   ///             accessibility related action on the specified node. This call
   ///             originates on the platform view and has been forwarded to the

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,7 +830,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded view should accept
   ///             gesture at a given touch location.
   ///
   ///

--- a/engine/src/flutter/shell/common/engine.h
+++ b/engine/src/flutter/shell/common/engine.h
@@ -830,7 +830,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
                                  uint64_t trace_flow_id);
 
   //----------------------------------------------------------------------------
-  /// @brief      Requests from the engine if an embedded view should accept
+  /// @brief      Requests from the engine if an embedded native view should
+  /// accept
   ///             gesture at a given touch location.
   ///
   ///
@@ -841,7 +842,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,10 +35,10 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
-bool PlatformView::EmbeddedViewShouldAcceptGesture(
+bool PlatformView::EmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
-  return delegate_.OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  return delegate_.OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       view_id, touch_began_location);
 }
 

--- a/engine/src/flutter/shell/common/platform_view.cc
+++ b/engine/src/flutter/shell/common/platform_view.cc
@@ -35,6 +35,13 @@ void PlatformView::DispatchPointerDataPacket(
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
+bool PlatformView::EmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  return delegate_.OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      view_id, touch_began_location);
+}
+
 void PlatformView::DispatchSemanticsAction(int64_t view_id,
                                            int32_t node_id,
                                            SemanticsAction action,

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -183,7 +183,8 @@ class PlatformView {
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
     //--------------------------------------------------------------------------
-    /// @brief      Requests the delegate if an embedded view should accept
+    /// @brief      Requests the delegate if an embedded native view should
+    /// accept
     ///             gesture at a given touch location.
     ///
     /// @param[in]  view_id               The identifier of the flutter view
@@ -194,7 +195,7 @@ class PlatformView {
     /// @return     true if the embedded view should accept gesture; false
     /// otherwise.
     ///
-    virtual bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+    virtual bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
         int64_t view_id,
         const flutter::PointData& touch_began_location) = 0;
 
@@ -765,7 +766,7 @@ class PlatformView {
   /// @return     true if the embedded view should accept gesture; false
   /// otherwise.
   ///
-  bool EmbeddedViewShouldAcceptGesture(
+  bool EmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);
 

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -183,6 +183,22 @@ class PlatformView {
         std::unique_ptr<PointerDataPacket> packet) = 0;
 
     //--------------------------------------------------------------------------
+    /// @brief      Requests the delegate if an embedded view should accept
+    ///             gesture at a given touch location.
+    ///
+    /// @param[in]  view_id               The identifier of the flutter view
+    /// that
+    ///                                   hosts the embedded view.
+    /// @param[in]  touch_began_location  The touch began location of a gesture.
+    ///
+    /// @return     true if the embedded view should accept gesture; false
+    /// otherwise.
+    ///
+    virtual bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+        int64_t view_id,
+        const flutter::PointData& touch_began_location) = 0;
+
+    //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
     ///             an accessibility related action on the specified node. This
     ///             event must be forwarded to the running root isolate hosted
@@ -736,6 +752,10 @@ class PlatformView {
   /// @param[in]  packet  The pointer data packet to dispatch to the framework.
   ///
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
+
+  bool EmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location);
 
   //--------------------------------------------------------------------------
   /// @brief      Used by the embedder to specify a texture that it wants the

--- a/engine/src/flutter/shell/common/platform_view.h
+++ b/engine/src/flutter/shell/common/platform_view.h
@@ -753,6 +753,18 @@ class PlatformView {
   ///
   void DispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet);
 
+  //----------------------------------------------------------------------------
+  /// @brief      Requests from the engine if an embedded view should accept
+  ///             gesture at a given touch location.
+  ///
+  ///
+  /// @param[in]  view_id               The identifier of the flutter view that
+  ///                                   hosts the embedded view.
+  /// @param[in]  touch_began_location  The touch began location of a gesture.
+  ///
+  /// @return     true if the embedded view should accept gesture; false
+  /// otherwise.
+  ///
   bool EmbeddedViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location);

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1221,6 +1221,16 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
+bool Shell::OnPlatformViewEmbeddedViewShouldAcceptGesture(
+    int64_t view_id,
+    const flutter::PointData& touch_began_location) {
+  if (engine_) {
+    return engine_->EmbeddedViewShouldAcceptGesture(view_id,
+                                                    touch_began_location);
+  }
+  return false;
+}
+
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                                   int32_t node_id,

--- a/engine/src/flutter/shell/common/shell.cc
+++ b/engine/src/flutter/shell/common/shell.cc
@@ -1221,12 +1221,12 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
   next_pointer_flow_id_++;
 }
 
-bool Shell::OnPlatformViewEmbeddedViewShouldAcceptGesture(
+bool Shell::OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
     int64_t view_id,
     const flutter::PointData& touch_began_location) {
   if (engine_) {
-    return engine_->EmbeddedViewShouldAcceptGesture(view_id,
-                                                    touch_began_location);
+    return engine_->EmbeddedNativeViewShouldAcceptGesture(view_id,
+                                                          touch_began_location);
   }
   return false;
 }

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,6 +608,10 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override;
+
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/common/shell.h
+++ b/engine/src/flutter/shell/common/shell.h
@@ -608,7 +608,7 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchPointerDataPacket(
       std::unique_ptr<PointerDataPacket> packet) override;
 
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override;
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -143,7 +143,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (override));
 
   MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptGesture,
               (int64_t view_id, const flutter::PointData& touch_began_location),
               (override));
 

--- a/engine/src/flutter/shell/common/shell_unittests.cc
+++ b/engine/src/flutter/shell/common/shell_unittests.cc
@@ -142,6 +142,11 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
 
+  MOCK_METHOD(bool,
+              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              (int64_t view_id, const flutter::PointData& touch_began_location),
+              (override));
+
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,
               (int64_t view_id,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -268,6 +268,17 @@ typedef enum {
    * but never recognizing the gesture (and never invoking actions).
    */
   FlutterPlatformViewGestureRecognizersBlockingPolicyWaitUntilTouchesEnded,
+
+  /**
+   * Flutter blocks all the UIGestureRecognizers on the platform view as soon as it
+   * decides they should be blocked.
+   *
+   * This is similar to FlutterPlatformViewGestureRecognizersBlockingPolicyEager. However,
+   * internally it performs hit test rather than a blocking gesture recognizer. This addresses
+   * a few bugs related to WKWebView being untappable. See
+   * https://github.com/flutter/flutter/issues/175099.
+   */
+  FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest,
   // NOLINTEND(readability-identifier-naming)
 } FlutterPlatformViewGestureRecognizersBlockingPolicy;
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -386,6 +386,14 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   self.platformView->DispatchPointerDataPacket(std::move(packet));
 }
 
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(flutter::PointData)location
+                                                     viewId:(uint64_t)viewId {
+  if (!self.platformView) {
+    return NO;
+  }
+  return self.platformView->EmbeddedViewShouldAcceptGesture(viewId, location);
+}
+
 - (void)installFirstFrameCallback:(void (^)(void))block {
   if (!self.platformView) {
     return;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -391,7 +391,7 @@ NSString* const kFlutterApplicationRegistrarKey = @"io.flutter.flutter.applicati
   if (!self.platformView) {
     return NO;
   }
-  return self.platformView->EmbeddedViewShouldAcceptGesture(viewId, location);
+  return self.platformView->EmbeddedNativeViewShouldAcceptGesture(viewId, location);
 }
 
 - (void)installFirstFrameCallback:(void (^)(void))block {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,6 +35,11 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -35,7 +35,7 @@ class FakeDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(flutter::PointData)location
+                                                     viewId:(uint64_t)viewId;
 
 - (fml::RefPtr<fml::TaskRunner>)platformTaskRunner;
 - (fml::RefPtr<fml::TaskRunner>)uiTaskRunner;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -581,8 +581,7 @@ static BOOL _preparedOnce = NO;
 }
 
 - (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
-  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest &&
-      event.type == UIEventTypeTouches) {
+  if (_blockingPolicy == FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest) {
     CGPoint pointInFlutterView = [self convertPoint:point toView:self.flutterViewController.view];
     // Block gesture if the framework instructed so (after performing its own hitTest).
     if (![self.flutterViewController

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -252,7 +252,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -102,6 +102,11 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -102,7 +102,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1381,6 +1381,12 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [self dispatchTouches:touches pointerDataChangeOverride:&cancel event:nullptr];
 }
 
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(CGPoint)location {
+  flutter::PointData point{location.x, location.y};
+  return [self.engine platformViewShouldAcceptGestureAtTouchBeganLocation:point
+                                                                   viewId:self.viewIdentifier];
+}
+
 #pragma mark - Touch events rate correction
 
 - (void)createTouchRateCorrectionVSyncClientIfNeeded {

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/FlutterViewResponder.h
@@ -47,6 +47,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)forceTouchesCancelled:(NSSet*)touches;
 
+/**
+ * Returns YES if a platform view should accept the gesture started at specified location.
+ * Returns NO otherwise. The touch location is with respect to flutter view's coordinate space.
+ */
+- (BOOL)platformViewShouldAcceptGestureAtTouchBeganLocation:(CGPoint)location;
+
 @end
 NS_ASSUME_NONNULL_END
 

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,6 +82,11 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,
                                              SemanticsAction action,

--- a/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,7 +82,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,7 +30,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) override {
     return false;

--- a/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
+++ b/engine/src/flutter/shell/platform/darwin/ios/platform_view_ios_test.mm
@@ -30,6 +30,11 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) override {
+    return false;
+  }
   void OnPlatformViewSendViewFocusEvent(const ViewFocusEvent& event) override {}
   void OnPlatformViewDispatchSemanticsAction(int64_t view_id,
                                              int32_t node_id,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -52,6 +52,10 @@ class MockDelegate : public PlatformView::Delegate {
               OnPlatformViewDispatchPointerDataPacket,
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
+  MOCK_METHOD(bool,
+              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              (int64_t view_id, const flutter::PointData& touch_began_location),
+              (override));
   MOCK_METHOD(void,
               OnPlatformViewDispatchSemanticsAction,
               (int64_t view_id,

--- a/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
+++ b/engine/src/flutter/shell/platform/embedder/platform_view_embedder_unittests.cc
@@ -53,7 +53,7 @@ class MockDelegate : public PlatformView::Delegate {
               (std::unique_ptr<PointerDataPacket> packet),
               (override));
   MOCK_METHOD(bool,
-              OnPlatformViewEmbeddedViewShouldAcceptGesture,
+              OnPlatformViewEmbeddedNativeViewShouldAcceptGesture,
               (int64_t view_id, const flutter::PointData& touch_began_location),
               (override));
   MOCK_METHOD(void,

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/platform_view.cc
@@ -16,6 +16,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/make_copyable.h"
+#include "flutter/lib/ui/window/point_data.h"
 #include "flutter/lib/ui/window/pointer_data.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/encodable_value.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,6 +117,12 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
+  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+      int64_t view_id,
+      const flutter::PointData& touch_began_location) {
+    return false;
+  }
+  // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchKeyDataPacket(
       std::unique_ptr<flutter::KeyDataPacket> packet,
       std::function<void(bool)> callback) {}

--- a/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
+++ b/engine/src/flutter/shell/platform/fuchsia/flutter/tests/platform_view_unittest.cc
@@ -117,7 +117,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
     pointer_packets_.push_back(std::move(packet));
   }
   // |flutter::PlatformView::Delegate|
-  bool OnPlatformViewEmbeddedViewShouldAcceptGesture(
+  bool OnPlatformViewEmbeddedNativeViewShouldAcceptGesture(
       int64_t view_id,
       const flutter::PointData& touch_began_location) {
     return false;

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -14,6 +14,7 @@ import 'dart:collection';
 import 'dart:ui' as ui show PointerDataPacket;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'arena.dart';
@@ -278,7 +279,9 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void initInstances() {
     super.initInstances();
     _instance = this;
-    platformDispatcher.onPointerDataPacket = _handlePointerDataPacket;
+    platformDispatcher
+      ..onPointerDataPacket = _handlePointerDataPacket
+      ..onPlatformViewShouldAcceptGesture = _handlePlatformViewShouldAcceptGesture;
   }
 
   /// The singleton instance of this object.
@@ -317,6 +320,17 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
         ),
       );
     }
+  }
+
+  bool _handlePlatformViewShouldAcceptGesture(int viewId, double x, double y) {
+    final HitTestResult result = HitTestResult();
+    hitTestInView(result, Offset(x, y), viewId);
+
+    if (result.path.isEmpty) {
+      return false;
+    }
+    final HitTestTarget firstHit = result.path.first.target;
+    return firstHit is RenderUiKitView;
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -14,7 +14,6 @@ import 'dart:collection';
 import 'dart:ui' as ui show PointerDataPacket;
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'arena.dart';
@@ -37,6 +36,9 @@ export 'pointer_router.dart' show PointerRouter;
 export 'pointer_signal_resolver.dart' show PointerSignalResolver;
 
 typedef _HandleSampleTimeChangedCallback = void Function();
+
+/// Abstract class that represents a hit test target backed by a embedded native view.
+abstract class NativeHitTestTarget {}
 
 /// Class that implements clock used for sampling.
 class SamplingClock {
@@ -330,7 +332,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
       return false;
     }
     final HitTestTarget firstHit = result.path.first.target;
-    return firstHit is RenderUiKitView;
+    return firstHit is NativeHitTestTarget;
   }
 
   double? _devicePixelRatioForView(int viewId) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -408,7 +408,8 @@ abstract class RenderDarwinPlatformView<T extends DarwinPlatformViewController> 
 ///
 ///  * [UiKitView], which is a widget that is used to show a UIView.
 ///  * [PlatformViewsService], which is a service for controlling platform views.
-class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController> {
+class RenderUiKitView extends RenderDarwinPlatformView<UiKitViewController>
+    implements NativeHitTestTarget {
   /// Creates a render object for an iOS UIView.
   RenderUiKitView({
     required super.viewController,

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -279,7 +279,9 @@ class AssembleCommand extends FlutterCommand {
       }
       final int indexEquals = chunk.indexOf('=');
       if (indexEquals == -1) {
-        throwToolExit('Improperly formatted define flag: $chunk');
+        // TODO: revert this change. seems like a tools bug.
+        // throwToolExit('Improperly formatted define flag: $chunk');
+        continue;
       }
       final String key = chunk.substring(0, indexEquals);
       final String value = chunk.substring(indexEquals + 1);

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -279,9 +279,7 @@ class AssembleCommand extends FlutterCommand {
       }
       final int indexEquals = chunk.indexOf('=');
       if (indexEquals == -1) {
-        // TODO: revert this change. seems like a tools bug.
-        // throwToolExit('Improperly formatted define flag: $chunk');
-        continue;
+        throwToolExit('Improperly formatted define flag: $chunk');
       }
       final String key = chunk.substring(0, indexEquals);
       final String value = chunk.substring(indexEquals + 1);


### PR DESCRIPTION
Use hit test instead of delaying recognizer to block platform view gestures. This fixes web view and admob not tappable issue linked below. 

## Problem with delaying recognizer

There was an Apple bug that causes our delaying recognizer to conflict with web view's internal gesture recognizers. You can read more detailed research on this bug here: https://github.com/flutter/engine/pull/57032. Also, we repro'ed it in native app and [filed a radar with Apple](https://github.com/flutter/flutter/issues/159814#issuecomment-3215278821). 

## hit test & FFI to the rescue 

We perform a simple hitTest to decide whether to block the gesture or not. We had [an MVP version](https://github.com/flutter/flutter/pull/176597) (closed) that uses the platform view's "overlay layer". However, there are 2 issues with this MVP version: 
(1) There can be use cases where even if we touch outside of "overlap" (or no overlap at all), we still want to block gestures 
(2) overlaps are merged into a single UIView in our current implementation. This means if you have multiple overlaps, the blocking region would be a bounding box that contains all overlaps; 

There is also a [previous attempt](https://github.com/flutter/engine/pull/43778/files) to use hit test to block the gesture, where the embedder blocks the main thread, wait for the asynchronous response from framework, and decide to block or not. Given that UI & platform threads are merged, this will 100% cause deadlock (main thread waiting for main thread). 

Luckily, with FFI, we are able to query the framework and get the result **synchronously**, which solves the deadlock problem above. 

## Usage

To reduce risk of (serious) regression, I'd prefer to create a new policy `FlutterPlatformViewGestureRecognizersBlockingPolicyHitTest` (rather than reusing existing policy). Plugin owners would need to either use this policy, or create an API to allow change of polices. Developers can also overwrite their plugin locally, or use method swizzling. 

My next task would be to update 1p web_view & admob plugins, but I probably won't do it for 3p plugins. 

## Pointer interceptor deprecation

We had a pointer interceptor plugin created for a similar bug. Pointer interceptor doesn't work in https://github.com/flutter/flutter/issues/175099#issuecomment-3423752130 (webview) and https://github.com/flutter/flutter/issues/165787 (admob), because they don't have flutter widget on top of platform view. Another problem with pointer interceptor is that it requires developers to wrap their widgets. 

I can confirm that this hit test approach also fixes the [original issue](https://github.com/flutter/flutter/issues/30143) fixed by pointer interceptor. So with this, we will be able to deprecate pointer_interceptor plugin (which will be my next TODO item).


## Misc

This is not related to https://github.com/flutter/flutter/issues/176476, which is likely a separate Apple bug that we should file a radar






*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

Fixes https://github.com/flutter/flutter/issues/175099
Fixes https://github.com/flutter/flutter/issues/165787


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
