### PR TITLE
Make sure that a SelectionArea doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -695,4 +695,15 @@ void main() {
       SystemMouseCursors.grab,
     );
   }, skip: kIsWeb); // There's a Web version in html_element_view_test.dart
+
+  testWidgets('SelectionArea does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(child: SelectionArea(child: Text('X'))),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(SelectionArea)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the SelectionArea widget.