### PR TITLE
Make sure that a SnackBarAction doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -4390,6 +4390,19 @@ void main() {
     // The snackbar auto dismisses after the timeout.
     expect(find.text(snackbarContent), findsNothing);
   });
+
+  testWidgets('SnackBarAction does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: SnackBarAction(label: 'X', onPressed: () {}),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(SnackBarAction)), Size.zero);
+  });
 }
 
 /// Start test for "SnackBar dismiss test".


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the SnackBarAction widget.