### PR TITLE
Speculative fix for android_verified_input_test

### DIFF
--- a/dev/devicelab/bin/tasks/android_verified_input_test.dart
+++ b/dev/devicelab/bin/tasks/android_verified_input_test.dart
@@ -6,5 +6,6 @@ import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';
 
 Future<void> main() async {
+  
   await task(androidVerifiedInputTest());
 }

--- a/dev/devicelab/bin/tasks/android_verified_input_test.dart
+++ b/dev/devicelab/bin/tasks/android_verified_input_test.dart
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/integration_tests.dart';
 
 Future<void> main() async {
-  
+  deviceOperatingSystem = DeviceOperatingSystem.android;
   await task(androidVerifiedInputTest());
 }


### PR DESCRIPTION
This test passes when run locally as instructed in the README for the devicelab
```
../../bin/cache/dart-sdk/bin/dart bin/test_runner.dart test -t android_verified_input_test
```

but fails on CI:
https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_pixel_7pro%20android_verified_input_test/106/overview
```
[2025-11-03 11:08:04.090018] [STDOUT] stdout: [        ]   Original error: ext.flutter.driver: (-32000) Service connection disposed
[2025-11-03 11:08:04.090156] [STDOUT] stdout: [        ]   Original stack trace:
[2025-11-03 11:08:04.090199] [STDOUT] stdout: [        ]   #0      new _OutstandingRequest (package:vm_service/src/vm_service.dart:268:34)
[2025-11-03 11:08:04.091572] [STDOUT] stdout: [        ]   #1      VmService._call.<anonymous closure> (package:vm_service/src/vm_service.dart:1950:25)
[2025-11-03 11:08:04.091647] [STDOUT] stdout: [        ]   #2      VmService._call (package:vm_service/src/vm_service.dart:1962:8)
[2025-11-03 11:08:04.091674] [STDOUT] stdout: [        ]   #3      VmService.callServiceExtension (package:vm_service/src/vm_service.dart:1901:14)
[2025-11-03 11:08:04.091693] [STDOUT] stdout: [        ]   #4      VMServiceFlutterDriver.sendCommand (package:flutter_driver/src/driver/vmservice_driver.dart:327:12)
[2025-11-03 11:08:04.091713] [STDOUT] stdout: [        ]   #5      FlutterDriver.requestData (package:flutter_driver/src/driver/driver.dart:573:13)
[2025-11-03 11:08:04.091733] [STDOUT] stdout: [        ]   #6      main.<anonymous closure> (file:///opt/s/w/ir/x/w/rc/tmpv6pcbna2/flutter%20sdk/dev/integration_tests/android_verified_input/test_driver/main_test.dart:28:57)
[2025-11-03 11:08:04.091750] [STDOUT] stdout: [        ]   <asynchronous suspension>
[2025-11-03 11:08:04.091767] [STDOUT] stdout: [        ]   #7      Declarer.test.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:242:9)
[2025-11-03 11:08:04.091784] [STDOUT] stdout: [        ]   <asynchronous suspension>
[2025-11-03 11:08:04.092408] [STDOUT] stdout: [        ]   #8      Declarer.test.<anonymous closure> (package:test_api/src/backend/declarer.dart:240:7)
[2025-11-03 11:08:04.092472] [STDOUT] stdout: [        ]   <asynchronous suspension>
[2025-11-03 11:08:04.092502] [STDOUT] stdout: [        ]   #9      Invoker._waitForOutstandingCallbacks.<anonymous closure> (package:test_api/src/backend/invoker.dart:282:9)
```

Try copying this configuration used by other tests as a speculative fix. I can't get this test to kick off in presubmit, so I suppose we will just try this. The test is marked bringup anyways so it won't block the tree if this doesn't help.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
