### PR TITLE
[ Widget Preview ] Add analytic event that's reported when the previewer is opened

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -250,6 +250,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   );
 
   late var _dtdService = WidgetPreviewDtdServices(
+    previewAnalytics: previewAnalytics,
     fs: fs,
     logger: logger,
     shutdownHooks: shutdownHooks,

--- a/packages/flutter_tools/lib/src/widget_preview/analytics.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/analytics.dart
@@ -26,6 +26,9 @@ class WidgetPreviewAnalytics {
   /// The analytics event tracking widget preview reload times.
   static const kPreviewReloadTime = 'preview-reload-time';
 
+  /// The analytics event tracking actual launches of the widget preview environment.
+  static const kPreviewerConnected = 'previewer-connected';
+
   /// Provided as the label to [kLaunchTime] events if the widget preview scaffold project was
   /// generated as part of the widget previewer starting up.
   static const kScaffoldGeneratedLabel = 'scaffold-generated';
@@ -51,6 +54,14 @@ class WidgetPreviewAnalytics {
         elapsedMilliseconds: _launchTimer.elapsedMilliseconds,
         label: _launchIncludedProjectGeneration ? kScaffoldGeneratedLabel : null,
       ),
+    );
+  }
+
+  void reportPreviewerConnected() {
+    analytics.send(
+      // TODO(bkonyi): we should add a dedicated event type in unified_analytics, but this
+      // works as a temporary solution.
+      Event.timing(workflow: kWorkflow, variableName: kPreviewerConnected, elapsedMilliseconds: 0),
     );
   }
 

--- a/packages/flutter_tools/lib/src/widget_preview/analytics.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/analytics.dart
@@ -57,6 +57,7 @@ class WidgetPreviewAnalytics {
     );
   }
 
+  /// Send an analytics event reporting that the widget preview environment has loaded successfully.
   void reportPreviewerConnected() {
     analytics.send(
       // TODO(bkonyi): we should add a dedicated event type in unified_analytics, but this

--- a/packages/flutter_tools/lib/src/widget_preview/dtd_services.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/dtd_services.dart
@@ -21,6 +21,7 @@ import '../base/utils.dart';
 import '../convert.dart';
 import '../dart/package_map.dart';
 import '../project.dart';
+import 'analytics.dart';
 import 'persistent_preferences.dart';
 
 typedef DtdService = (String, DTDServiceCallback);
@@ -28,6 +29,7 @@ typedef DtdService = (String, DTDServiceCallback);
 /// Provides services, streams, and RPC invocations to interact with the Widget Preview Scaffold.
 class WidgetPreviewDtdServices {
   WidgetPreviewDtdServices({
+    required this.previewAnalytics,
     required this.fs,
     required this.logger,
     required this.shutdownHooks,
@@ -53,6 +55,9 @@ class WidgetPreviewDtdServices {
   static const kSetPreference = 'setPreference';
   static const kGetPreference = 'getPreference';
 
+  static const kWidgetPreviewScaffoldStream = 'WidgetPreviewScaffold';
+  static const kWidgetPreviewConnectedEvent = 'Connected';
+
   /// Error code for RpcException thrown when attempting to load a key from
   /// persistent preferences that doesn't have an entry.
   static const kNoValueForKey = 200;
@@ -71,6 +76,7 @@ class WidgetPreviewDtdServices {
   @visibleForTesting
   late final preferences = PersistentPreferences(fs: fs);
 
+  final WidgetPreviewAnalytics previewAnalytics;
   final FileSystem fs;
   final Logger logger;
   final ShutdownHooks shutdownHooks;
@@ -110,7 +116,16 @@ class WidgetPreviewDtdServices {
 
   Future<void> _registerServices() async {
     final DartToolingDaemon dtd = _dtd!;
+    dtd.onEvent(kWidgetPreviewScaffoldStream).listen((DTDEvent event) {
+      if (event case DTDEvent(
+        stream: kWidgetPreviewScaffoldStream,
+        kind: kWidgetPreviewConnectedEvent,
+      )) {
+        previewAnalytics.reportPreviewerConnected();
+      }
+    });
     await Future.wait(<Future<void>>[
+      dtd.streamListen(kWidgetPreviewScaffoldStream),
       for (final (String method, DTDServiceCallback callback) in services)
         dtd
             .registerService(kWidgetPreviewService, method, callback)

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
@@ -26,9 +26,6 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
   static const kSetPreference = 'setPreference';
   static const kGetPreference = 'getPreference';
 
-  static const kWidgetPreviewScaffoldStream = 'WidgetPreviewScaffold';
-  static const kWidgetPreviewConnectedEvent = 'Connected';
-
   /// Error code for RpcException thrown when attempting to load a key from
   /// persistent preferences that doesn't have an entry.
   static const kNoValueForKey = 200;
@@ -46,8 +43,8 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
     dtd = await DartToolingDaemon.connect(dtdWsUri);
     unawaited(
       dtd.postEvent(
-        kWidgetPreviewScaffoldStream,
-        kWidgetPreviewConnectedEvent,
+        'WidgetPreviewScaffold',
+        'Connected',
         const <String, Object?>{},
       ),
     );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/lib/src/dtd/dtd_services.dart
@@ -26,6 +26,9 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
   static const kSetPreference = 'setPreference';
   static const kGetPreference = 'getPreference';
 
+  static const kWidgetPreviewScaffoldStream = 'WidgetPreviewScaffold';
+  static const kWidgetPreviewConnectedEvent = 'Connected';
+
   /// Error code for RpcException thrown when attempting to load a key from
   /// persistent preferences that doesn't have an entry.
   static const kNoValueForKey = 200;
@@ -43,8 +46,8 @@ class WidgetPreviewScaffoldDtdServices with DtdEditorService {
     dtd = await DartToolingDaemon.connect(dtdWsUri);
     unawaited(
       dtd.postEvent(
-        'WidgetPreviewScaffold',
-        'Connected',
+        kWidgetPreviewScaffoldStream,
+        kWidgetPreviewConnectedEvent,
         const <String, Object?>{},
       ),
     );

--- a/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/dtd_services_test.dart
+++ b/packages/flutter_tools/test/widget_preview_scaffold.shard/widget_preview_scaffold/test/dtd_services_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/dtd_services.dart';
 import 'package:flutter_tools/src/widget_preview/persistent_preferences.dart';
 import 'package:test/fake.dart';
@@ -18,7 +19,7 @@ import 'package:widget_preview_scaffold/src/dtd/dtd_services.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
-import '../../../src/test_flutter_command_runner.dart';
+import '../../../src/fakes.dart';
 import '../../../commands.shard/permeable/utils/project_testing_utils.dart';
 
 class FakeFlutterProject extends Fake implements FlutterProject {
@@ -47,6 +48,14 @@ void main() {
         // restart requests.
         final hotRestartRequestCompleter = Completer<void>();
         dtdServer = WidgetPreviewDtdServices(
+          previewAnalytics: WidgetPreviewAnalytics(
+            analytics: getInitializedFakeAnalyticsInstance(
+              // We don't care about anything written to the file system by analytics, so we're safe
+              // to use a different file system here.
+              fs: MemoryFileSystem.test(),
+              fakeFlutterVersion: FakeFlutterVersion(),
+            ),
+          ),
           fs: MemoryFileSystem.test(),
           logger: logger,
           shutdownHooks: ShutdownHooks(),
@@ -76,6 +85,14 @@ void main() {
       'can set and retreive values from $PersistentPreferences',
       () async {
         dtdServer = WidgetPreviewDtdServices(
+          previewAnalytics: WidgetPreviewAnalytics(
+            analytics: getInitializedFakeAnalyticsInstance(
+              // We don't care about anything written to the file system by analytics, so we're safe
+              // to use a different file system here.
+              fs: MemoryFileSystem.test(),
+              fakeFlutterVersion: FakeFlutterVersion(),
+            ),
+          ),
           fs: MemoryFileSystem.test(),
           logger: logger,
           shutdownHooks: ShutdownHooks(),


### PR DESCRIPTION
With the addition of IDE support, the widget previewer is often started by default by IDE plugins, even if users don't open the previewer. This change adds an additional analytics event which is reported once the widget preview application is loaded and connects to the DTD instance.

Fixes https://github.com/flutter/flutter/issues/177948