### PR TITLE
Use inert attribute for platform view accessibility on web

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -161,11 +161,6 @@ class PlatformViewManager {
       _ensureContentCorrectlySized(content, viewType);
       wrapper.append(content);
 
-      // By default, hide platform views from screen readers and keyboard navigation.
-      // The semantic layer will remove this when a semantic node is created.
-      // This ensures ExcludeSemantics works correctly on web.
-      // We use 'inert' attribute which prevents focus and hides from accessibility tree.
-      // See: https://github.com/flutter/flutter/issues/171948
       wrapper.setAttribute('inert', '');
 
       return wrapper;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -124,13 +124,16 @@ class PlatformViewManager {
   /// </flt-platform-view-slot>
   /// ```
   ///
+  /// The `arbitrary-html-elements` are the result of the call to the user-supplied
+  /// `factory` function for this Platform View (see [registerFactory]).
+  ///
   /// The outer `flt-platform-view` tag is a simple wrapper that we add to have
   /// a place where to attach the `slot` property, that will tell the browser
   /// what `slot` tag will reveal this `contents`, **without modifying the returned
   /// html from the `factory` function**.
   ///
-  /// By default, platform views are made inert. The semantics layer will
-  /// remove this when a semantic node is created.
+  /// By default, platform views are made inert. The semantics layer will remove
+  /// this when a semantic node is created.
   DomElement renderContent(String viewType, int viewId, Object? params) {
     assert(
       knowsViewType(viewType),

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -121,7 +121,7 @@ class PlatformViewManager {
   /// The resulting DOM for the `contents` of a Platform View looks like this:
   ///
   /// ```html
-  /// <flt-platform-view id="flt-pv-VIEW_ID" slot="..." aria-hidden="true">
+  /// <flt-platform-view id="flt-pv-VIEW_ID" slot="..." inert>
   ///   <arbitrary-html-elements />
   /// </flt-platform-view-slot>
   /// ```
@@ -131,8 +131,8 @@ class PlatformViewManager {
   /// what `slot` tag will reveal this `contents`, **without modifying the returned
   /// html from the `factory` function**.
   ///
-  /// By default, platform views are hidden from screen readers (aria-hidden="true").
-  /// The semantics layer will remove this when a semantic node is created.
+  /// By default, platform views are made inert. The semantics layer will
+  /// remove this when a semantic node is created.
   DomElement renderContent(String viewType, int viewId, Object? params) {
     assert(
       knowsViewType(viewType),

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:js_interop';
-
 import 'package:ui/ui_web/src/ui_web.dart' as ui_web;
 
 import '../dom.dart';

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../dom.dart';
+import '../platform_views/content_manager.dart';
 import '../platform_views/slots.dart';
 import 'label_and_value.dart';
 import 'semantics.dart';
@@ -40,9 +42,14 @@ class SemanticPlatformView extends SemanticRole {
     super.update();
 
     if (semanticsObject.isPlatformView) {
+      final int platformViewId = semanticsObject.platformViewId;
+
       if (semanticsObject.isPlatformViewIdDirty) {
-        setAttribute('aria-owns', getPlatformViewDomId(semanticsObject.platformViewId));
+        setAttribute('aria-owns', getPlatformViewDomId(platformViewId));
       }
+
+      final bool isHidden = semanticsObject.flags.isHidden;
+      PlatformViewManager.instance.updatePlatformViewAccessibility(platformViewId, isHidden);
     } else {
       removeAttribute('aria-owns');
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -47,8 +47,10 @@ class SemanticPlatformView extends SemanticRole {
         setAttribute('aria-owns', getPlatformViewDomId(platformViewId));
       }
 
-      final bool isHidden = semanticsObject.flags.isHidden;
-      PlatformViewManager.instance.updatePlatformViewAccessibility(platformViewId, isHidden);
+      PlatformViewManager.instance.updatePlatformViewAccessibility(
+        platformViewId,
+        semanticsObject.flags.isHidden,
+      );
     } else {
       removeAttribute('aria-owns');
     }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/platform_view.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/semantics/platform_view.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../dom.dart';
 import '../platform_views/content_manager.dart';
 import '../platform_views/slots.dart';
 import 'label_and_value.dart';

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -261,11 +261,9 @@ void testMain() {
       test('hides platform view from accessibility when isHidden is true', () {
         final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
 
-        // Remove inert to simulate semantic node making it accessible
         wrapper.removeAttribute('inert');
         expect(wrapper.hasAttribute('inert'), isFalse);
 
-        // Now hide it again
         contentManager.updatePlatformViewAccessibility(viewId, true);
 
         expect(
@@ -284,7 +282,6 @@ void testMain() {
           reason: 'Platform view should start as inert',
         );
 
-        // Make it accessible
         contentManager.updatePlatformViewAccessibility(viewId, false);
 
         expect(
@@ -297,21 +294,17 @@ void testMain() {
       test('handles toggle between hidden and accessible states', () {
         final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
 
-        // Make accessible
         contentManager.updatePlatformViewAccessibility(viewId, false);
         expect(wrapper.hasAttribute('inert'), isFalse);
 
-        // Hide again
         contentManager.updatePlatformViewAccessibility(viewId, true);
         expect(wrapper.hasAttribute('inert'), isTrue);
 
-        // Make accessible again
         contentManager.updatePlatformViewAccessibility(viewId, false);
         expect(wrapper.hasAttribute('inert'), isFalse);
       });
 
       test('does nothing when viewId does not exist', () {
-        // Should not throw
         expect(() => contentManager.updatePlatformViewAccessibility(999, true), returnsNormally);
         expect(() => contentManager.updatePlatformViewAccessibility(999, false), returnsNormally);
       });

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -242,5 +242,79 @@ void testMain() {
       expect(contentManager.isVisible(viewId + 2), isTrue);
       expect(contentManager.isInvisible(viewId + 2), isFalse);
     });
+
+    group('updatePlatformViewAccessibility', () {
+      setUp(() {
+        contentManager.registerFactory(viewType, (int id) => createDomHTMLDivElement());
+      });
+
+      test('sets inert attribute by default when rendering', () {
+        final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
+
+        expect(
+          wrapper.hasAttribute('inert'),
+          isTrue,
+          reason: 'Platform views should be inert by default for ExcludeSemantics support',
+        );
+      });
+
+      test('hides platform view from accessibility when isHidden is true', () {
+        final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
+
+        // Remove inert to simulate semantic node making it accessible
+        wrapper.removeAttribute('inert');
+        expect(wrapper.hasAttribute('inert'), isFalse);
+
+        // Now hide it again
+        contentManager.updatePlatformViewAccessibility(viewId, true);
+
+        expect(
+          wrapper.hasAttribute('inert'),
+          isTrue,
+          reason: 'inert should be set when isHidden is true',
+        );
+      });
+
+      test('makes platform view accessible when isHidden is false', () {
+        final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
+
+        expect(
+          wrapper.hasAttribute('inert'),
+          isTrue,
+          reason: 'Platform view should start as inert',
+        );
+
+        // Make it accessible
+        contentManager.updatePlatformViewAccessibility(viewId, false);
+
+        expect(
+          wrapper.hasAttribute('inert'),
+          isFalse,
+          reason: 'inert should be removed when isHidden is false',
+        );
+      });
+
+      test('handles toggle between hidden and accessible states', () {
+        final DomElement wrapper = contentManager.renderContent(viewType, viewId, null);
+
+        // Make accessible
+        contentManager.updatePlatformViewAccessibility(viewId, false);
+        expect(wrapper.hasAttribute('inert'), isFalse);
+
+        // Hide again
+        contentManager.updatePlatformViewAccessibility(viewId, true);
+        expect(wrapper.hasAttribute('inert'), isTrue);
+
+        // Make accessible again
+        contentManager.updatePlatformViewAccessibility(viewId, false);
+        expect(wrapper.hasAttribute('inert'), isFalse);
+      });
+
+      test('does nothing when viewId does not exist', () {
+        // Should not throw
+        expect(() => contentManager.updatePlatformViewAccessibility(999, true), returnsNormally);
+        expect(() => contentManager.updatePlatformViewAccessibility(999, false), returnsNormally);
+      });
+    });
   });
 }


### PR DESCRIPTION
Use inert attribute for platform view accessibility on web

Before change:
https://map-1023-before.web.app/

After change:
https://map-1023-after.web.app/

