### PR TITLE
Fix DropdownMenu escape key does not close the menu

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1326,6 +1326,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
         _ArrowUpIntent: CallbackAction<_ArrowUpIntent>(onInvoke: handleUpKeyInvoke),
         _ArrowDownIntent: CallbackAction<_ArrowDownIntent>(onInvoke: handleDownKeyInvoke),
         _EnterIntent: CallbackAction<_EnterIntent>(onInvoke: (_) => _handleEditingComplete()),
+        DismissIntent: DismissMenuAction(controller: _controller),
       },
       child: Stack(
         children: <Widget>[
@@ -1335,6 +1336,7 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
               SingleActivator(LogicalKeyboardKey.arrowUp): _ArrowUpIntent(),
               SingleActivator(LogicalKeyboardKey.arrowDown): _ArrowDownIntent(),
               SingleActivator(LogicalKeyboardKey.enter): _EnterIntent(),
+              SingleActivator(LogicalKeyboardKey.escape): DismissIntent(),
             },
             child: Focus(
               focusNode: _internalFocudeNode,

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -2050,15 +2050,13 @@ void main() {
     expect(isItemHighlighted(tester, themeData, 'Menu 1'), true);
 
     // Press up to the upper item (Item 0).
-    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
-    await simulateKeyUpEvent(LogicalKeyboardKey.arrowUp);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(find.widgetWithText(TextField, 'Item 0'), findsOneWidget);
     expect(isItemHighlighted(tester, themeData, 'Item 0'), true);
 
     // Continue to move up to the last item (Item 5).
-    await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
-    await simulateKeyUpEvent(LogicalKeyboardKey.arrowUp);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
     await tester.pumpAndSettle();
     expect(find.widgetWithText(TextField, 'Item 5'), findsOneWidget);
     expect(isItemHighlighted(tester, themeData, 'Item 5'), true);
@@ -2273,9 +2271,9 @@ void main() {
     final ThemeData themeData = ThemeData();
     final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
       const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
-      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 1', enabled: false),
-      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 2'),
-      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 3'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu1, label: 'Item 1', enabled: false),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu2, label: 'Item 2'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu3, label: 'Item 3'),
     ];
     final TextEditingController controller = TextEditingController();
     addTearDown(controller.dispose);
@@ -2311,7 +2309,7 @@ void main() {
     int expectedCount = 1;
 
     // Test onSelected on key press
-    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
     await tester.pumpAndSettle();
 
     // On mobile platforms, the TextField cannot gain focus by default; the focus is
@@ -4059,6 +4057,101 @@ void main() {
       await tester.pump();
 
       expect(selectedMenu, TestMenu.mainMenu0);
+    },
+    variant: TargetPlatformVariant.all(),
+  );
+
+  // Regression test for https://github.com/flutter/flutter/issues/177993.
+  testWidgets(
+    'Pressing ESC key closes the menu when requestFocusOnTap is false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: DropdownMenu<TestMenu>(
+                dropdownMenuEntries: menuChildren,
+                requestFocusOnTap: false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move focus to the TextField and open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(findMenuPanel(), findsOne);
+
+      // Press ESC to close the menu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      expect(findMenuPanel(), findsNothing);
+    },
+    variant: TargetPlatformVariant.all(),
+  );
+
+  testWidgets(
+    'Pressing ESC key closes the menu when requestFocusOnTap is true',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: Center(
+              child: DropdownMenu<TestMenu>(
+                dropdownMenuEntries: menuChildren,
+                requestFocusOnTap: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move focus to the TextField and open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(findMenuPanel(), findsOne);
+
+      // Press ESC to close the menu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      expect(findMenuPanel(), findsNothing);
+    },
+    variant: TargetPlatformVariant.all(),
+  );
+
+  testWidgets(
+    'Pressing ESC key after changing the selected item closes the menu',
+    (WidgetTester tester) async {
+      final ThemeData themeData = ThemeData();
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: themeData,
+          home: Material(
+            child: Center(
+              child: DropdownMenu<TestMenu>(
+                dropdownMenuEntries: menuChildren,
+                initialSelection: menuChildren[2].value,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Move focus to the TextField and open the menu.
+      await tester.tap(find.byType(TextField));
+      await tester.pump();
+      expect(findMenuPanel(), findsOne);
+
+      // Move the selection.
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(isItemHighlighted(tester, themeData, menuChildren[3].label), isTrue);
+
+      // Press ESC to close the menu.
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      expect(findMenuPanel(), findsNothing);
     },
     variant: TargetPlatformVariant.all(),
   );

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4062,63 +4062,59 @@ void main() {
   );
 
   // Regression test for https://github.com/flutter/flutter/issues/177993.
-  testWidgets(
-    'Pressing ESC key closes the menu when requestFocusOnTap is false',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: DropdownMenu<TestMenu>(
-                dropdownMenuEntries: menuChildren,
-                requestFocusOnTap: false,
-              ),
+  testWidgets('Pressing ESC key closes the menu when requestFocusOnTap is false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+              requestFocusOnTap: false,
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      // Move focus to the TextField and open the menu.
-      await tester.tap(find.byType(TextField));
-      await tester.pump();
-      expect(findMenuPanel(), findsOne);
+    // Move focus to the TextField and open the menu.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    expect(findMenuPanel(), findsOne);
 
-      // Press ESC to close the menu.
-      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
-      await tester.pump();
-      expect(findMenuPanel(), findsNothing);
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // Press ESC to close the menu.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(findMenuPanel(), findsNothing);
+  });
 
-  testWidgets(
-    'Pressing ESC key closes the menu when requestFocusOnTap is true',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: Center(
-              child: DropdownMenu<TestMenu>(
-                dropdownMenuEntries: menuChildren,
-                requestFocusOnTap: true,
-              ),
+  testWidgets('Pressing ESC key closes the menu when requestFocusOnTap is true', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: Center(
+            child: DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+              requestFocusOnTap: true,
             ),
           ),
         ),
-      );
+      ),
+    );
 
-      // Move focus to the TextField and open the menu.
-      await tester.tap(find.byType(TextField));
-      await tester.pump();
-      expect(findMenuPanel(), findsOne);
+    // Move focus to the TextField and open the menu.
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    expect(findMenuPanel(), findsOne);
 
-      // Press ESC to close the menu.
-      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
-      await tester.pump();
-      expect(findMenuPanel(), findsNothing);
-    },
-    variant: TargetPlatformVariant.all(),
-  );
+    // Press ESC to close the menu.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(findMenuPanel(), findsNothing);
+  });
 
   testWidgets(
     'Pressing ESC key after changing the selected item closes the menu',


### PR DESCRIPTION
## Description

This PR fixes escape key not closing the menu when `DropdownMenu.requestFocusOnTap` is false.

## Related Issue

Fixes [DropdownMenu menu panel does not close when pressing ESC and requestFocusOnTap is false](https://github.com/flutter/flutter/issues/177993) 
Part of https://github.com/flutter/flutter/issues/123797
 
## Tests

- Adds 3 tests.
- Updates 2 non-related tests where I spotted some nits.

