### PR TITLE
Print reason for adb command failure in verified input test (attempt 3)

### DIFF
--- a/dev/integration_tests/android_verified_input/test_driver/main_test.dart
+++ b/dev/integration_tests/android_verified_input/test_driver/main_test.dart
@@ -45,7 +45,11 @@ Future<void> main() async {
         '${offset.dx}',
         '${offset.dy}',
       ]);
-      expect(result.exitCode, equals(0), reason: 'Stdout: ${result.stdout}\nStderr: ${result.stderr}');
+      expect(
+        result.exitCode,
+        equals(0),
+        reason: 'Stdout: ${result.stdout}\nStderr: ${result.stderr}',
+      );
     }
     // Input
     expect(await inputEventWasVerified, equals('true'));

--- a/dev/integration_tests/android_verified_input/test_driver/main_test.dart
+++ b/dev/integration_tests/android_verified_input/test_driver/main_test.dart
@@ -45,7 +45,7 @@ Future<void> main() async {
         '${offset.dx}',
         '${offset.dy}',
       ]);
-      expect(result.exitCode, equals(0));
+      expect(result.exitCode, equals(0), reason: 'Stdout: ${result.stdout}\nStderr: ${result.stderr}');
     }
     // Input
     expect(await inputEventWasVerified, equals('true'));


### PR DESCRIPTION
Print the logs, so we can see why the command is failing in ci. Seems [the last pr](https://github.com/flutter/flutter/pull/177961) was wrong about the reason, should have just done this in the first place 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
