### PR TITLE
Expose text spacing preferences on the web

### DIFF
--- a/engine/src/flutter/lib/ui/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/ui/platform_dispatcher.dart
@@ -1121,6 +1121,59 @@ class PlatformDispatcher {
   /// This option is used by [showTimePicker].
   bool get alwaysUse24HourFormat => _configuration.alwaysUse24HourFormat;
 
+  /// The system-reported height of the text, as a multiple of the font size.
+  ///
+  /// This value takes precedence over any text height specified at the
+  /// application level. For example, at framework level, in the [TextStyle]
+  /// for [Text], [SelectableText], and [EditableText] widgets, this value
+  /// overrides the existing value of [TextStyle.height] and [StrutStyle.height].
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// If this value changes, [onMetricsChanged] will be called.
+  double? get lineHeightScaleFactorOverride => _configuration.lineHeightScaleFactorOverride;
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each letter.
+  ///
+  /// A negative value can be used to bring the letters closer.
+  ///
+  /// This value takes precedence over any text letter spacing specified at the
+  /// application level. For example, at framework level, in the [TextStyle]
+  /// for [Text], [SelectableText], and [EditableText] widgets, this value
+  /// overrides the existing value of [TextStyle.letterSpacing].
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// If this value changes, [onMetricsChanged] will be called.
+  double? get letterSpacingOverride => _configuration.letterSpacingOverride;
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each sequence of white-space (i.e. between each word).
+  ///
+  /// A negative value can be used to bring the words closer.
+  ///
+  /// This value takes precedence over any text word spacing specified at the
+  /// application level. For example, at framework level, in the [TextStyle]
+  /// for [Text], [SelectableText], and [EditableText] widgets, this value
+  /// overrides the existing value of [TextStyle.wordSpacing].
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// If this value changes, [onMetricsChanged] will be called.
+  double? get wordSpacingOverride => _configuration.wordSpacingOverride;
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add following each paragraph in text.
+  ///
+  /// This value takes precedence over any text paragraph spacing specified at
+  /// the application level.
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// If this value changes, [onMetricsChanged] will be called.
+  double? get paragraphSpacingOverride => _configuration.paragraphSpacingOverride;
+
   /// The system-reported text scale.
   ///
   /// This establishes the text scaling factor to use when rendering text,
@@ -1811,6 +1864,10 @@ class _PlatformConfiguration {
     this.defaultRouteName,
     this.systemFontFamily,
     this.configurationId,
+    this.lineHeightScaleFactorOverride,
+    this.letterSpacingOverride,
+    this.wordSpacingOverride,
+    this.paragraphSpacingOverride,
   });
 
   _PlatformConfiguration copyWith({
@@ -1834,6 +1891,10 @@ class _PlatformConfiguration {
       defaultRouteName: defaultRouteName ?? this.defaultRouteName,
       systemFontFamily: systemFontFamily ?? this.systemFontFamily,
       configurationId: configurationId ?? this.configurationId,
+      lineHeightScaleFactorOverride: lineHeightScaleFactorOverride,
+      letterSpacingOverride: letterSpacingOverride,
+      wordSpacingOverride: wordSpacingOverride,
+      paragraphSpacingOverride: paragraphSpacingOverride,
     );
   }
 
@@ -1881,6 +1942,25 @@ class _PlatformConfiguration {
   /// configuration updates from the embedder yet. The _getScaledFontSize
   /// function should not be called in either case.
   final int? configurationId;
+
+  /// The system-reported height of the text, as a multiple of the font size.
+  final double? lineHeightScaleFactorOverride;
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each letter.
+  ///
+  /// A negative value can be used to bring the letters closer.
+  final double? letterSpacingOverride;
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each sequence of white-space (i.e. between each word).
+  ///
+  /// A negative value can be used to bring the words closer.
+  final double? wordSpacingOverride;
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each paragraph in text.
+  final double? paragraphSpacingOverride;
 }
 
 /// An immutable view configuration.

--- a/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/platform_dispatcher.dart
@@ -89,6 +89,14 @@ abstract class PlatformDispatcher {
 
   void setApplicationLocale(Locale locale) {}
 
+  double? get lineHeightScaleFactorOverride;
+
+  double? get letterSpacingOverride;
+
+  double? get wordSpacingOverride;
+
+  double? get paragraphSpacingOverride;
+
   AccessibilityFeatures get accessibilityFeatures;
 
   VoidCallback? get onAccessibilityFeaturesChanged;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -29,6 +29,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     _addBrightnessMediaQueryListener();
     HighContrastSupport.instance.addListener(_updateHighContrast);
     _addFontSizeObserver();
+    _addTypographySettingsObserver();
     _addLocaleChangedListener();
     registerHotRestartListener(dispose);
     _appLifecycleState.addListener(_setAppLifecycleState);
@@ -80,6 +81,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   void dispose() {
     _removeBrightnessMediaQueryListener();
     _disconnectFontSizeObserver();
+    _disconnectTypographySettingsObserver();
     _removeLocaleChangedListener();
     HighContrastSupport.instance.removeListener(_updateHighContrast);
     _appLifecycleState.removeListener(_setAppLifecycleState);
@@ -755,6 +757,18 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     }
   }
 
+  @override
+  double? get lineHeightScaleFactorOverride => configuration.lineHeightScaleFactorOverride;
+
+  @override
+  double? get letterSpacingOverride => configuration.letterSpacingOverride;
+
+  @override
+  double? get wordSpacingOverride => configuration.wordSpacingOverride;
+
+  @override
+  double? get paragraphSpacingOverride => configuration.paragraphSpacingOverride;
+
   /// Additional accessibility features that may be enabled by the platform.
   @override
   ui.AccessibilityFeatures get accessibilityFeatures => configuration.accessibilityFeatures;
@@ -1023,6 +1037,158 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   void _disconnectFontSizeObserver() {
     _fontSizeObserver?.disconnect();
     _fontSizeObserver = null;
+  }
+
+  /// Watches for resize changes on an off-screen invisible element to
+  /// recalculate [lineHeightScaleFactorOverride], [letterSpacingOverride],
+  /// [wordSpacingOverride], and [paragraphSpacingOverride].
+  ///
+  /// Updates [lineHeightScaleFactorOverride], [letterSpacingOverride],
+  /// [wordSpacingOverride], and [paragraphSpacingOverride] with the new values.
+  DomResizeObserver? _typographySettingsObserver;
+  DomElement? _typographyMeasurementElement;
+
+  /// Updates [lineHeightScaleFactorOverride] and return true if
+  /// [lineHeightScaleFactorOverride] changed. If not then returns false.
+  bool _updateLineHeightScaleFactorOverride(double? value) {
+    if (configuration.lineHeightScaleFactorOverride != value) {
+      configuration = configuration.apply(lineHeightScaleFactorOverride: value);
+      return true;
+    }
+    return false;
+  }
+
+  /// Updates [letterSpacingOverride] and return true if
+  /// [letterSpacingOverride] changed. If not then returns false.
+  bool _updateLetterSpacingOverride(double? value) {
+    if (configuration.letterSpacingOverride != value) {
+      configuration = configuration.apply(letterSpacingOverride: value);
+      return true;
+    }
+    return false;
+  }
+
+  /// Updates [wordSpacingOverride] and returns true if
+  /// [wordSpacingOverride] changed. If not then returns false.
+  bool _updateWordSpacingOverride(double? value) {
+    if (configuration.wordSpacingOverride != value) {
+      configuration = configuration.apply(wordSpacingOverride: value);
+      return true;
+    }
+    return false;
+  }
+
+  /// Updates [paragraphSpacingOverride] and returns true if
+  /// [paragraphSpacingOverride] changed. If not then returns false.
+  bool _updateParagraphSpacingOverride(double? value) {
+    if (configuration.paragraphSpacingOverride != value) {
+      configuration = configuration.apply(paragraphSpacingOverride: value);
+      return true;
+    }
+    return false;
+  }
+
+  /// Set the callback function for updating [lineHeightScaleFactorOverride],
+  /// [letterSpacingOverride], [wordSpacingOverride], and [paragraphSpacingOverride]
+  /// based on the sizing changes of an off-screen element with text.
+  void _addTypographySettingsObserver() {
+    _typographyMeasurementElement = createDomHTMLParagraphElement();
+    _typographyMeasurementElement!.text = 'flutter typography measurement';
+    // The element should be hidden from screen readers.
+    _typographyMeasurementElement!.setAttribute('aria-hidden', 'true');
+    const double spacingDefault = 9999.0;
+    _typographyMeasurementElement!.style
+      // The element should be positioned off-screen above
+      // the window and not visible.
+      ..position = 'fixed'
+      ..bottom = '100%'
+      ..visibility = 'hidden'
+      ..opacity = '0'
+      ..pointerEvents = 'none'
+      // The element should be sensitive to letter-spacing, word-spacing,
+      // and line-height changes.
+      ..width = 'auto'
+      ..height = 'auto'
+      ..whiteSpace = 'nowrap'
+      // Set text spacing properties defaults.
+      ..lineHeight = '${spacingDefault}px'
+      ..letterSpacing = '${spacingDefault}px'
+      ..wordSpacing = '${spacingDefault}px'
+      ..margin = '0px 0px ${spacingDefault}px 0px';
+    domDocument.body!.append(_typographyMeasurementElement!);
+    final double? typographyMeasurementElementFontSize = parseFontSize(
+      _typographyMeasurementElement!,
+    )?.toDouble();
+    final double defaultLineHeightFactor = spacingDefault / typographyMeasurementElementFontSize!;
+
+    _typographySettingsObserver = createDomResizeObserver((
+      List<DomResizeObserverEntry> entries,
+      DomResizeObserver observer,
+    ) {
+      final double? lineHeight = parseNumericStyleProperty(
+        _typographyMeasurementElement!,
+        'line-height',
+      )?.toDouble();
+      final double? fontSize = parseFontSize(_typographyMeasurementElement!)?.toDouble();
+      final double? computedLineHeightScaleFactor = fontSize != null && lineHeight != null
+          ? lineHeight / fontSize
+          : null;
+      final double? computedWordSpacing = parseNumericStyleProperty(
+        _typographyMeasurementElement!,
+        'word-spacing',
+      )?.toDouble();
+      final double? computedLetterSpacing = parseNumericStyleProperty(
+        _typographyMeasurementElement!,
+        'letter-spacing',
+      )?.toDouble();
+      // There is no direct CSS property for paragraph spacing,
+      // so on the web this feature is usually implemented
+      // by extension authors by leveraging `margin-bottom` on
+      // the `p` element.
+      final double? computedParagraphSpacing = parseNumericStyleProperty(
+        _typographyMeasurementElement!,
+        'margin-bottom',
+      )?.toDouble();
+
+      bool computedLineHeightScaleFactorChanged = false;
+      bool computedLetterSpacingChanged = false;
+      bool computedWordSpacingChanged = false;
+      bool computedParagraphSpacingChanged = false;
+
+      computedLineHeightScaleFactorChanged = _updateLineHeightScaleFactorOverride(
+        computedLineHeightScaleFactor == defaultLineHeightFactor
+            ? null
+            : computedLineHeightScaleFactor,
+      );
+      computedLetterSpacingChanged = _updateLetterSpacingOverride(
+        computedLetterSpacing == spacingDefault ? null : computedLetterSpacing,
+      );
+      computedWordSpacingChanged = _updateWordSpacingOverride(
+        computedWordSpacing == spacingDefault ? null : computedWordSpacing,
+      );
+      computedParagraphSpacingChanged = _updateParagraphSpacingOverride(
+        computedParagraphSpacing == spacingDefault ? null : computedParagraphSpacing,
+      );
+
+      if (computedLineHeightScaleFactorChanged ||
+          computedLetterSpacingChanged ||
+          computedWordSpacingChanged ||
+          computedParagraphSpacingChanged) {
+        invokeOnPlatformConfigurationChanged();
+        invokeOnMetricsChanged();
+      }
+    });
+
+    _typographySettingsObserver!.observe(_typographyMeasurementElement!);
+  }
+
+  /// Remove the observer for typography changes on the off-screen
+  /// typography measurement element.
+  void _disconnectTypographySettingsObserver() {
+    _typographySettingsObserver?.disconnect();
+    _typographySettingsObserver = null;
+    _typographyMeasurementElement?.remove();
+    _typographyMeasurementElement = null;
   }
 
   void _setAppLifecycleState(ui.AppLifecycleState state) {
@@ -1681,7 +1847,53 @@ class PlatformConfiguration {
     this.locales = const <ui.Locale>[],
     this.defaultRouteName = '/',
     this.systemFontFamily,
+    this.lineHeightScaleFactorOverride,
+    this.letterSpacingOverride,
+    this.wordSpacingOverride,
+    this.paragraphSpacingOverride,
   });
+
+  static const Object _noOverridePlaceholder = Object();
+
+  PlatformConfiguration apply({
+    ui.AccessibilityFeatures? accessibilityFeatures,
+    bool? alwaysUse24HourFormat,
+    bool? semanticsEnabled,
+    ui.Brightness? platformBrightness,
+    double? textScaleFactor,
+    List<ui.Locale>? locales,
+    String? defaultRouteName,
+    Object? systemFontFamily = _noOverridePlaceholder,
+    Object? lineHeightScaleFactorOverride = _noOverridePlaceholder,
+    Object? letterSpacingOverride = _noOverridePlaceholder,
+    Object? wordSpacingOverride = _noOverridePlaceholder,
+    Object? paragraphSpacingOverride = _noOverridePlaceholder,
+  }) {
+    return PlatformConfiguration(
+      accessibilityFeatures: accessibilityFeatures ?? this.accessibilityFeatures,
+      alwaysUse24HourFormat: alwaysUse24HourFormat ?? this.alwaysUse24HourFormat,
+      semanticsEnabled: semanticsEnabled ?? this.semanticsEnabled,
+      platformBrightness: platformBrightness ?? this.platformBrightness,
+      textScaleFactor: textScaleFactor ?? this.textScaleFactor,
+      locales: locales ?? this.locales,
+      defaultRouteName: defaultRouteName ?? this.defaultRouteName,
+      systemFontFamily: systemFontFamily == _noOverridePlaceholder
+          ? this.systemFontFamily
+          : systemFontFamily as String?,
+      lineHeightScaleFactorOverride: lineHeightScaleFactorOverride == _noOverridePlaceholder
+          ? this.lineHeightScaleFactorOverride
+          : lineHeightScaleFactorOverride as double?,
+      letterSpacingOverride: letterSpacingOverride == _noOverridePlaceholder
+          ? this.letterSpacingOverride
+          : letterSpacingOverride as double?,
+      wordSpacingOverride: wordSpacingOverride == _noOverridePlaceholder
+          ? this.wordSpacingOverride
+          : wordSpacingOverride as double?,
+      paragraphSpacingOverride: paragraphSpacingOverride == _noOverridePlaceholder
+          ? this.paragraphSpacingOverride
+          : paragraphSpacingOverride as double?,
+    );
+  }
 
   PlatformConfiguration copyWith({
     ui.AccessibilityFeatures? accessibilityFeatures,
@@ -1692,6 +1904,10 @@ class PlatformConfiguration {
     List<ui.Locale>? locales,
     String? defaultRouteName,
     String? systemFontFamily,
+    double? lineHeightScaleFactorOverride,
+    double? letterSpacingOverride,
+    double? wordSpacingOverride,
+    double? paragraphSpacingOverride,
   }) {
     return PlatformConfiguration(
       accessibilityFeatures: accessibilityFeatures ?? this.accessibilityFeatures,
@@ -1702,6 +1918,11 @@ class PlatformConfiguration {
       locales: locales ?? this.locales,
       defaultRouteName: defaultRouteName ?? this.defaultRouteName,
       systemFontFamily: systemFontFamily ?? this.systemFontFamily,
+      lineHeightScaleFactorOverride:
+          lineHeightScaleFactorOverride ?? this.lineHeightScaleFactorOverride,
+      letterSpacingOverride: letterSpacingOverride ?? this.letterSpacingOverride,
+      wordSpacingOverride: wordSpacingOverride ?? this.wordSpacingOverride,
+      paragraphSpacingOverride: paragraphSpacingOverride ?? this.paragraphSpacingOverride,
     );
   }
 
@@ -1713,6 +1934,10 @@ class PlatformConfiguration {
   final List<ui.Locale> locales;
   final String defaultRouteName;
   final String? systemFontFamily;
+  final double? lineHeightScaleFactorOverride;
+  final double? letterSpacingOverride;
+  final double? wordSpacingOverride;
+  final double? paragraphSpacingOverride;
 }
 
 /// Helper class to hold navigation target information for AT focus restoration

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/safe_browser_api.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/safe_browser_api.dart
@@ -56,6 +56,15 @@ num? parseFontSize(DomElement element) {
   return fontSize;
 }
 
+/// Parses the given style property [attributeName] of [element] and returns the
+/// [resolved value](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Value_processing#resolved_value) without a unit.
+///
+/// Returns `null` if the property value is not numeric (e.g., 'normal',
+/// 'auto') or cannot be parsed.
+num? parseNumericStyleProperty(DomElement element, String attributeName) {
+  return parseFloat(domWindow.getComputedStyle(element).getPropertyValue(attributeName));
+}
+
 /// Provides haptic feedback.
 void vibrate(int durationMs) {
   final DomNavigator navigator = domWindow.navigator;

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -430,6 +430,208 @@ class TestPlatformDispatcher implements PlatformDispatcher {
     _brieflyShowPasswordTestValue = null;
   }
 
+  /// The system-reported height of the text, as a multiple of the font size.
+  ///
+  /// This value takes precedence over any text height specified at the
+  /// application level. For example, at framework level, in the [TextStyle]
+  /// for [Text], [SelectableText], and [EditableText] widgets, this value
+  /// overrides the existing value of [TextStyle.height] and [StrutStyle.height].
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// Defaults to the value provided by [PlatformDispatcher.lineHeightScaleFactorOverride].
+  /// This can only be set in a test environment to emulate different platform
+  /// configurations. A standard [PlatformDispatcher] is not mutable from the
+  /// framework.
+  ///
+  /// Setting this value to `null` will force [lineHeightScaleFactorOverride] to return
+  /// `null`. If you want to have the value default to the platform
+  /// [lineHeightScaleFactorOverride], use [clearLineHeightScaleFactorOverrideTestValue].
+  ///
+  /// See also:
+  ///
+  ///   * [PlatformDispatcher.lineHeightScaleFactorOverride] for the standard implementation
+  ///   * [clearLineHeightScaleFactorOverrideTestValue] to reset this value specifically
+  ///   * [clearAllTestValues] to reset all test values for this view
+  @override
+  double? get lineHeightScaleFactorOverride => _forceLineHeightScaleFactorOverrideToBeNull
+      ? null
+      : _lineHeightScaleFactorOverrideTestValue ??
+            _platformDispatcher.lineHeightScaleFactorOverride;
+  double? _lineHeightScaleFactorOverrideTestValue;
+  bool _forceLineHeightScaleFactorOverrideToBeNull = false;
+
+  /// Hides the real line height scale factor and reports the given
+  /// [lineHeightScaleFactorOverrideTestValue] instead.
+  // ignore: avoid_setters_without_getters
+  set lineHeightScaleFactorOverrideTestValue(double? lineHeightScaleFactorOverrideTestValue) {
+    _lineHeightScaleFactorOverrideTestValue = lineHeightScaleFactorOverrideTestValue;
+    if (lineHeightScaleFactorOverrideTestValue == null) {
+      _forceLineHeightScaleFactorOverrideToBeNull = true;
+    }
+    onMetricsChanged?.call();
+  }
+
+  /// Deletes any existing test line height scale factor and returns to using
+  /// the real line height scale factor.
+  void clearLineHeightScaleFactorOverrideTestValue() {
+    _lineHeightScaleFactorOverrideTestValue = null;
+    _forceLineHeightScaleFactorOverrideToBeNull = false;
+    onMetricsChanged?.call();
+  }
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each letter.
+  ///
+  /// A negative value can be used to bring the letters closer.
+  ///
+  /// This value takes precedence over any text letter spacing specified at the
+  /// application level. For example, at framework level, in the [TextStyle]
+  /// for [Text], [SelectableText], and [EditableText] widgets, this value
+  /// overrides the existing value of [TextStyle.letterSpacing].
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// Defaults to the value provided by [PlatformDispatcher.letterSpacingOverride].
+  /// This can only be set in a test environment to emulate different platform
+  /// configurations. A standard [PlatformDispatcher] is not mutable from the
+  /// framework.
+  ///
+  /// Setting this value to `null` will force [letterSpacingOverride] to return
+  /// `null`. If you want to have the value default to the platform
+  /// [letterSpacingOverride], use [clearLetterSpacingOverrideTestValue].
+  ///
+  /// See also:
+  ///
+  ///   * [PlatformDispatcher.letterSpacingOverride] for the standard implementation
+  ///   * [clearLetterSpacingOverrideTestValue] to reset this value specifically
+  ///   * [clearAllTestValues] to reset all test values for this view
+  @override
+  double? get letterSpacingOverride => _forceLetterSpacingOverrideToBeNull
+      ? null
+      : _letterSpacingOverrideTestValue ?? _platformDispatcher.letterSpacingOverride;
+  double? _letterSpacingOverrideTestValue;
+  bool _forceLetterSpacingOverrideToBeNull = false;
+
+  /// Hides the real letter spacing and reports the given
+  /// [letterSpacingOverrideTestValue] instead.
+  /// ignore: avoid_setters_without_getters
+  set letterSpacingOverrideTestValue(double? letterSpacingOverrideTestValue) {
+    _letterSpacingOverrideTestValue = letterSpacingOverrideTestValue;
+    if (letterSpacingOverrideTestValue == null) {
+      _forceLetterSpacingOverrideToBeNull = true;
+    }
+    onMetricsChanged?.call();
+  }
+
+  /// Deletes any existing test letter spacing and returns to using the real
+  /// letter spacing.
+  void clearLetterSpacingOverrideTestValue() {
+    _letterSpacingOverrideTestValue = null;
+    _forceLetterSpacingOverrideToBeNull = false;
+    onMetricsChanged?.call();
+  }
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add between each sequence of white-space (i.e. between each word).
+  ///
+  /// A negative value can be used to bring the words closer.
+  ///
+  /// This value takes precedence over any text word spacing specified at the
+  /// application level. For example, at framework level, in the [TextStyle]
+  /// for [Text], [SelectableText], and [EditableText] widgets, this value
+  /// overrides the existing value of [TextStyle.wordSpacing].
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// Defaults to the value provided by [PlatformDispatcher.wordSpacingOverride].
+  /// This can only be set in a test environment to emulate different platform
+  /// configurations. A standard [PlatformDispatcher] is not mutable from the
+  /// framework.
+  ///
+  /// Setting this value to `null` will force [wordSpacingOverride] to return
+  /// `null`. If you want to have the value default to the platform
+  /// [wordSpacingOverride], use [clearWordSpacingOverrideTestValue].
+  ///
+  /// See also:
+  ///
+  ///   * [PlatformDispatcher.wordSpacingOverride] for the standard implementation
+  ///   * [clearWordSpacingOverrideTestValue] to reset this value specifically
+  ///   * [clearAllTestValues] to reset all test values for this view
+  @override
+  double? get wordSpacingOverride => _forceWordSpacingOverrideToBeNull
+      ? null
+      : _wordSpacingOverrideTestValue ?? _platformDispatcher.wordSpacingOverride;
+  double? _wordSpacingOverrideTestValue;
+  bool _forceWordSpacingOverrideToBeNull = false;
+
+  /// Hides the real word spacing and reports the given
+  /// [wordSpacingOverrideTestValue] instead.
+  /// ignore: avoid_setters_without_getters
+  set wordSpacingOverrideTestValue(double? wordSpacingOverrideTestValue) {
+    _wordSpacingOverrideTestValue = wordSpacingOverrideTestValue;
+    if (wordSpacingOverrideTestValue == null) {
+      _forceWordSpacingOverrideToBeNull = true;
+    }
+    onMetricsChanged?.call();
+  }
+
+  /// Deletes any existing test word spacing and returns to using the real
+  /// word spacing.
+  void clearWordSpacingOverrideTestValue() {
+    _wordSpacingOverrideTestValue = null;
+    _forceWordSpacingOverrideToBeNull = false;
+    onMetricsChanged?.call();
+  }
+
+  /// The system-reported amount of additional space (in logical pixels)
+  /// to add following each paragraph in text.
+  ///
+  /// This value takes precedence over any text paragraph spacing specified at
+  /// the application level.
+  ///
+  /// Returns null when no override has been set by the system.
+  ///
+  /// Defaults to the value provided by [PlatformDispatcher.paragraphSpacingOverride].
+  /// This can only be set in a test environment to emulate different platform
+  /// configurations. A standard [PlatformDispatcher] is not mutable from the
+  /// framework.
+  ///
+  /// Setting this value to `null` will force [paragraphSpacingOverride] to return
+  /// `null`. If you want to have the value default to the platform
+  /// [paragraphSpacingOverride], use [clearParagraphSpacingOverrideTestValue].
+  ///
+  /// See also:
+  ///
+  ///   * [PlatformDispatcher.paragraphSpacingOverride] for the standard implementation
+  ///   * [clearParagraphSpacingOverrideTestValue] to reset this value specifically
+  ///   * [clearAllTestValues] to reset all test values for this view
+  @override
+  double? get paragraphSpacingOverride => _forceParagraphSpacingOverrideToBeNull
+      ? null
+      : _paragraphSpacingOverrideTestValue ?? _platformDispatcher.paragraphSpacingOverride;
+  double? _paragraphSpacingOverrideTestValue;
+  bool _forceParagraphSpacingOverrideToBeNull = false;
+
+  /// Hides the real paragraph spacing and reports the given
+  /// [paragraphSpacingOverrideTestValue] instead.
+  /// ignore: avoid_setters_without_getters
+  set paragraphSpacingOverrideTestValue(double? paragraphSpacingOverrideTestValue) {
+    _paragraphSpacingOverrideTestValue = paragraphSpacingOverrideTestValue;
+    if (paragraphSpacingOverrideTestValue == null) {
+      _forceParagraphSpacingOverrideToBeNull = true;
+    }
+    onMetricsChanged?.call();
+  }
+
+  /// Deletes any existing test paragraph spacing and returns to using the real
+  /// paragraph spacing.
+  void clearParagraphSpacingOverrideTestValue() {
+    _paragraphSpacingOverrideTestValue = null;
+    _forceParagraphSpacingOverrideToBeNull = false;
+    onMetricsChanged?.call();
+  }
+
   @override
   FrameCallback? get onBeginFrame => _platformDispatcher.onBeginFrame;
   @override
@@ -579,6 +781,10 @@ class TestPlatformDispatcher implements PlatformDispatcher {
     clearSemanticsEnabledTestValue();
     clearTextScaleFactorTestValue();
     clearNativeSpellCheckServiceDefined();
+    clearLineHeightScaleFactorOverrideTestValue();
+    clearLetterSpacingOverrideTestValue();
+    clearWordSpacingOverrideTestValue();
+    clearParagraphSpacingOverrideTestValue();
     resetBrieflyShowPassword();
     resetSupportsShowingSystemContextMenu();
     resetInitialLifecycleState();


### PR DESCRIPTION
# Engine:
* Introduces new members on `PlatformDispatcher` API that hold the text spacing properties that are overridden on the web.
* We provide the `lineHeightScaleFactorOverride`, `letterSpacingOverride`, `wordSpacingOverride`, and `paragraphSpacingOverride` on the web by attaching a `ResizeObserver` to an off-screen hidden element, when its size changes we capture its text spacing CSS properties, and notify the framework through `onMetricsChanged`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.