### PR TITLE
[Android] Encode the original pointer count in messages that represent Android touch events

### DIFF
--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -113,6 +113,9 @@ public class AndroidTouchProcessor {
   // a change that affects multiple pointers.
   private static final int POINTER_DATA_FLAG_MULTIPLE = 2;
 
+  // Bit shift for encoding the pointer count when using POINTER_DATA_FLAG_MULTIPLE
+  private static final int POINTER_DATA_MULTIPLE_POINTER_COUNT_SHIFT = 8;
+
   // The view ID for the only view in a single-view Flutter app.
   private static final int IMPLICIT_VIEW_ID = 0;
 
@@ -215,7 +218,9 @@ public class AndroidTouchProcessor {
       // but it's the responsibility of a later part of the system to
       // ignore 0-deltas if desired.
       for (int p = 0; p < originalPointerCount; p++) {
-        int pointerData = POINTER_DATA_FLAG_MULTIPLE | (originalPointerCount << 8);
+        int pointerData =
+            POINTER_DATA_FLAG_MULTIPLE
+                | (originalPointerCount << POINTER_DATA_MULTIPLE_POINTER_COUNT_SHIFT);
         addPointerForIndex(event, p, pointerChange, pointerData, transformMatrix, packet);
       }
     }

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -106,9 +106,12 @@ public class AndroidTouchProcessor {
   @VisibleForTesting static final int DEFAULT_VERTICAL_SCROLL_FACTOR = 48;
   @VisibleForTesting static final int DEFAULT_HORIZONTAL_SCROLL_FACTOR = 48;
 
-  // This value must match the value in framework's platform_view.dart.
+  // These values must match the values in the framework's platform_views.dart.
   // This flag indicates whether the original Android pointer events were batched together.
   private static final int POINTER_DATA_FLAG_BATCHED = 1;
+  // This flag indicates that this message is part of a group of messages representing
+  // a change that affects multiple pointers.
+  private static final int POINTER_DATA_FLAG_MULTIPLE = 2;
 
   // The view ID for the only view in a single-view Flutter app.
   private static final int IMPLICIT_VIEW_ID = 0;
@@ -212,7 +215,8 @@ public class AndroidTouchProcessor {
       // but it's the responsibility of a later part of the system to
       // ignore 0-deltas if desired.
       for (int p = 0; p < originalPointerCount; p++) {
-        addPointerForIndex(event, p, pointerChange, 0, transformMatrix, packet);
+        int pointerData = POINTER_DATA_FLAG_MULTIPLE | (originalPointerCount << 8);
+        addPointerForIndex(event, p, pointerChange, pointerData, transformMatrix, packet);
       }
     }
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -619,18 +619,27 @@ class _AndroidMotionEventConverter {
     final int pointerIdx = pointers.indexOf(event.pointer);
     final int numPointers = pointers.length;
 
-    // This value must match the value in engine's FlutterView.java.
+    // These values must match the values in the engine's AndroidTouchProcessor.java.
     // This flag indicates whether the original Android pointer events were batched together.
     const int kPointerDataFlagBatched = 1;
+    // This flag indicates that this event is part of a group of events representing a change
+    // that affects multiple pointers.
+    const int kPointerDataFlagMultiple = 2;
 
     // Android MotionEvent objects can batch information on multiple pointers.
     // Flutter breaks these such batched events into multiple PointerEvent objects.
     // When there are multiple active pointers we accumulate the information for all pointers
     // as we get PointerEvents, and only send it to the embedded Android view when
     // we see the last pointer. This way we achieve the same batching as Android.
-    if (event.platformData == kPointerDataFlagBatched ||
-        (isSinglePointerAction(event) && pointerIdx < numPointers - 1)) {
+    final int platformDataFlag = event.platformData & 0xff;
+    if (platformDataFlag == kPointerDataFlagBatched) {
       return null;
+    }
+    if (platformDataFlag == kPointerDataFlagMultiple) {
+      final int originalPointerCount = event.platformData >> 8;
+      if (pointerIdx != originalPointerCount - 1) {
+        return null;
+      }
     }
 
     final int? action = switch (event) {
@@ -697,9 +706,6 @@ class _AndroidMotionEventConverter {
       },
     );
   }
-
-  bool isSinglePointerAction(PointerEvent event) =>
-      event is! PointerDownEvent && event is! PointerUpEvent;
 }
 
 class _CreationParams {

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -626,17 +626,21 @@ class _AndroidMotionEventConverter {
     // that affects multiple pointers.
     const int kPointerDataFlagMultiple = 2;
 
+    // Mask for extracting the flag value from the event's platformData
+    const int kPointerDataFlagMask = 0xff;
+    const int kPointerDataMultiplePointerCountShift = 8;
+
     // Android MotionEvent objects can batch information on multiple pointers.
     // Flutter breaks these such batched events into multiple PointerEvent objects.
     // When there are multiple active pointers we accumulate the information for all pointers
     // as we get PointerEvents, and only send it to the embedded Android view when
     // we see the last pointer. This way we achieve the same batching as Android.
-    final int platformDataFlag = event.platformData & 0xff;
+    final int platformDataFlag = event.platformData & kPointerDataFlagMask;
     if (platformDataFlag == kPointerDataFlagBatched) {
       return null;
     }
     if (platformDataFlag == kPointerDataFlagMultiple) {
-      final int originalPointerCount = event.platformData >> 8;
+      final int originalPointerCount = event.platformData >> kPointerDataMultiplePointerCountShift;
       if (pointerIdx != originalPointerCount - 1) {
         return null;
       }


### PR DESCRIPTION
Android touch events include updates to multiple pointers, but each pointer data message sent from the embedder to the framework represents a single pointer.  So the Android embedder will send multiple messages for each touch event, and the framework's AndroidViewController will reassemble the messages and forward the resulting event to the platform view.

The AndroidViewController tracks the number of active pointers in its own local state.  If that state is out of sync with the event handled by the Android embedder, then the AndroidViewController may send duplicate events to the platform view.

This PR encodes the Android touch event's pointer count in the messages sent to the framework.  This allows the AndroidViewController to reliably determine whether it has received all of the pointer messages that originated from an event.

Fixes https://github.com/flutter/flutter/issues/176574