### PR TITLE
Fix verified input test failure in CI (attempt 4)

### DIFF
--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -4,7 +4,7 @@
 
 import '../framework/devices.dart';
 import '../framework/framework.dart';
-import '../framework/talkback.dart';
+import '../framework/talkback.dart' hide adbPath;
 import '../framework/task_result.dart';
 import '../framework/utils.dart';
 
@@ -278,7 +278,8 @@ class DriverTest {
       // reference it if needed.
       final Map<String, String> env = <String, String>{
         if (environment != null) ...environment!,
-        'DEVICE_ID_NUMBER': deviceId,
+        'FLUTTER_DEVICE_ID_NUMBER': deviceId,
+        'FLUTTER_ADB_PATH': adbPath,
       };
 
       final List<String> options = <String>[

--- a/dev/integration_tests/android_verified_input/test_driver/main_test.dart
+++ b/dev/integration_tests/android_verified_input/test_driver/main_test.dart
@@ -28,7 +28,8 @@ Future<void> main() async {
     final Future<String> inputEventWasVerified = driver.requestData('input_was_verified');
 
     // Passed in by the driver task.
-    final String? deviceId = Platform.environment['DEVICE_ID_NUMBER'];
+    final String? deviceId = Platform.environment['FLUTTER_DEVICE_ID_NUMBER'];
+    final String? adbPath = Platform.environment['FLUTTER_ADB_PATH'];
 
     // Keep issuing taps until we get the requested data. The actual setup
     // of the platform view is asynchronous so we might have to tap more than
@@ -37,7 +38,7 @@ Future<void> main() async {
     inputEventWasVerified.whenComplete(() => stop = true);
     while (!stop) {
       // We must use the Android input tool to get verified input events.
-      final ProcessResult result = await Process.run('adb', <String>[
+      final ProcessResult result = await Process.run(adbPath ?? 'adb', <String>[
         if (deviceId != null) ...<String>['-s', deviceId],
         'shell',
         'input',


### PR DESCRIPTION
I think this should actually fix at least the current issue. The last PR added logs 
https://github.com/flutter/flutter/pull/178005/

And we can now see:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8699078049543853521/+/u/run_android_verified_input_test/stdout
```
[2025-11-04 18:33:56.587985] [STDOUT] stdout: [+2998 ms]   Expected: <0>
[2025-11-04 18:33:56.588075] [STDOUT] stdout: [        ]     Actual: <1>
[2025-11-04 18:33:56.588106] [STDOUT] stdout: [        ]   Stdout: 
[2025-11-04 18:33:56.588135] [STDOUT] stdout: [        ]   Stderr: adb server version (41) doesn't match this client (39); killing...
```
The test was directly invoking adb (using whatever is on the path), while the devicelab harness has a more complicated way of finding adb and then invoking it directly. So it seems they have found different adb versions.

This pr pipes the devicelab adb path through to the individual test, so the test can reference the same adb, and then uses it. This is again sort of an abuse of this environment map (if one of the tests decided to use these environment variables we would be in a weird state), but I think it isn't too bad, and again I think it is reasonable because any android devicelab test may wish to use adb, so this solution isn't hyper specific to the problem.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
