### PR TITLE
Update more missing ninja deps

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1095,7 +1095,10 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:36v4"},
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
-          {"dependency": "open_jdk", "version": "version:21"}
+          {"dependency": "open_jdk", "version": "version:21"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "build_id:8787856497187628321"},
+          {"dependency": "ninja", "version": "version:1.9.0"}
         ]
       tags: >
         ["devicelab", "hostonly", "linux"]


### PR DESCRIPTION
Post-submits with no pre-submit equiv:

* Linux build_android_host_app_with_module_source

Missed in #178054