### PR TITLE
[Impeller] Use 32-bit index values in the tessellator if the platform supports it

### DIFF
--- a/engine/src/flutter/impeller/entity/contents/content_context.cc
+++ b/engine/src/flutter/impeller/entity/contents/content_context.cc
@@ -552,7 +552,8 @@ ContentContext::ContentContext(
       lazy_glyph_atlas_(
           std::make_shared<LazyGlyphAtlas>(std::move(typographer_context))),
       pipelines_(new Pipelines()),
-      tessellator_(std::make_shared<Tessellator>()),
+      tessellator_(std::make_shared<Tessellator>(
+          context_->GetCapabilities()->Supports32BitPrimitiveIndices())),
       render_target_cache_(render_target_allocator == nullptr
                                ? std::make_shared<RenderTargetCache>(
                                      context_->GetResourceAllocator())

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.cc
@@ -26,6 +26,9 @@ static const constexpr char* kMultisampledRenderToTextureExt =
 static const constexpr char* kMultisampledRenderToTexture2Ext =
     "GL_EXT_multisampled_render_to_texture2";
 
+// https://registry.khronos.org/OpenGL/extensions/OES/OES_element_index_uint.txt
+static const constexpr char* kElementIndexUintExt = "GL_OES_element_index_uint";
+
 CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   {
     GLint value = 0;
@@ -122,6 +125,10 @@ CapabilitiesGLES::CapabilitiesGLES(const ProcTableGLES& gl) {
   if (desc->HasExtension(kTextureBorderClampExt) ||
       desc->HasExtension(kNvidiaTextureBorderClampExt)) {
     supports_decal_sampler_address_mode_ = true;
+  }
+
+  if (desc->HasExtension(kElementIndexUintExt)) {
+    supports_32bit_primitive_indices_ = true;
   }
 
   if (desc->HasExtension(kMultisampledRenderToTextureExt)) {
@@ -221,6 +228,10 @@ bool CapabilitiesGLES::IsANGLE() const {
 
 bool CapabilitiesGLES::SupportsPrimitiveRestart() const {
   return false;
+}
+
+bool CapabilitiesGLES::Supports32BitPrimitiveIndices() const {
+  return supports_32bit_primitive_indices_;
 }
 
 bool CapabilitiesGLES::SupportsExtendedRangeFormats() const {

--- a/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
+++ b/engine/src/flutter/impeller/renderer/backend/gles/capabilities_gles.h
@@ -117,6 +117,9 @@ class CapabilitiesGLES final
   bool SupportsPrimitiveRestart() const override;
 
   // |Capabilities|
+  bool Supports32BitPrimitiveIndices() const override;
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|
@@ -146,6 +149,7 @@ class CapabilitiesGLES final
   bool supports_decal_sampler_address_mode_ = false;
   bool supports_offscreen_msaa_ = false;
   bool supports_implicit_msaa_ = false;
+  bool supports_32bit_primitive_indices_ = false;
   bool is_angle_ = false;
   bool is_es_ = false;
   PixelFormat default_glyph_atlas_format_ = PixelFormat::kUnknown;

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.cc
@@ -511,6 +511,10 @@ bool CapabilitiesVK::SupportsPrimitiveRestart() const {
   return has_primitive_restart_;
 }
 
+bool CapabilitiesVK::Supports32BitPrimitiveIndices() const {
+  return true;
+}
+
 void CapabilitiesVK::SetOffscreenFormat(PixelFormat pixel_format) const {
   default_color_format_ = pixel_format;
 }

--- a/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
+++ b/engine/src/flutter/impeller/renderer/backend/vulkan/capabilities_vk.h
@@ -261,6 +261,9 @@ class CapabilitiesVK final : public Capabilities,
   bool SupportsPrimitiveRestart() const override;
 
   // |Capabilities|
+  bool Supports32BitPrimitiveIndices() const override;
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override;
 
   // |Capabilities|

--- a/engine/src/flutter/impeller/renderer/capabilities.cc
+++ b/engine/src/flutter/impeller/renderer/capabilities.cc
@@ -96,6 +96,9 @@ class StandardCapabilities final : public Capabilities {
   bool SupportsPrimitiveRestart() const override { return true; }
 
   // |Capabilities|
+  bool Supports32BitPrimitiveIndices() const override { return true; }
+
+  // |Capabilities|
   bool SupportsExtendedRangeFormats() const override {
     return supports_extended_range_formats_;
   }

--- a/engine/src/flutter/impeller/renderer/capabilities.h
+++ b/engine/src/flutter/impeller/renderer/capabilities.h
@@ -89,6 +89,10 @@ class Capabilities {
   /// @brief Whether primitive restart is supported.
   virtual bool SupportsPrimitiveRestart() const = 0;
 
+  /// @brief Whether 32-bit values are supported in index buffers used to draw
+  ///        primitives.
+  virtual bool Supports32BitPrimitiveIndices() const = 0;
+
   /// @brief  Returns a supported `PixelFormat` for textures that store
   ///         4-channel colors (red/green/blue/alpha).
   virtual PixelFormat GetDefaultColorFormat() const = 0;

--- a/engine/src/flutter/impeller/renderer/testing/mocks.h
+++ b/engine/src/flutter/impeller/renderer/testing/mocks.h
@@ -225,6 +225,7 @@ class MockCapabilities : public Capabilities {
   MOCK_METHOD(bool, SupportsDeviceTransientTextures, (), (const, override));
   MOCK_METHOD(bool, SupportsTriangleFan, (), (const override));
   MOCK_METHOD(bool, SupportsPrimitiveRestart, (), (const override));
+  MOCK_METHOD(bool, Supports32BitPrimitiveIndices, (), (const override));
   MOCK_METHOD(bool, SupportsExtendedRangeFormats, (), (const override));
   MOCK_METHOD(PixelFormat, GetDefaultColorFormat, (), (const, override));
   MOCK_METHOD(PixelFormat, GetDefaultStencilFormat, (), (const, override));

--- a/engine/src/flutter/impeller/tessellator/BUILD.gn
+++ b/engine/src/flutter/impeller/tessellator/BUILD.gn
@@ -67,11 +67,13 @@ impeller_component("tessellator_unittests") {
   testonly = true
   sources = [
     "path_tessellator_unittests.cc",
+    "tessellator_playground_unittests.cc",
     "tessellator_unittests.cc",
   ]
   deps = [
     ":tessellator_libtess",
     "../geometry:geometry_asserts",
+    "../playground:playground_test",
     "//flutter/testing",
   ]
 }

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -137,12 +137,24 @@ static size_t ComputeQuadrantDivisions(impeller::Scalar pixel_radius) {
   return ceil(impeller::kPiOver4 / std::acos(1 - k));
 }
 
+template <typename IndexT>
+impeller::IndexType IndexTypeFor();
+template <>
+impeller::IndexType IndexTypeFor<uint32_t>() {
+  return impeller::IndexType::k32bit;
+}
+template <>
+impeller::IndexType IndexTypeFor<uint16_t>() {
+  return impeller::IndexType::k16bit;
+}
+
 /// @brief A vertex writer that generates a triangle fan and requires primitive
 /// restart.
+template <typename IndexT>
 class FanPathVertexWriter : public impeller::PathTessellator::VertexWriter {
  public:
   explicit FanPathVertexWriter(impeller::Point* point_buffer,
-                               uint16_t* index_buffer)
+                               IndexT* index_buffer)
       : point_buffer_(point_buffer), index_buffer_(index_buffer) {}
 
   ~FanPathVertexWriter() = default;
@@ -154,7 +166,7 @@ class FanPathVertexWriter : public impeller::PathTessellator::VertexWriter {
     if (count_ == 0) {
       return;
     }
-    index_buffer_[index_count_++] = 0xFFFF;
+    index_buffer_[index_count_++] = static_cast<IndexT>(-1);
   }
 
   void Write(impeller::Point point) override {
@@ -166,15 +178,16 @@ class FanPathVertexWriter : public impeller::PathTessellator::VertexWriter {
   size_t count_ = 0;
   size_t index_count_ = 0;
   impeller::Point* point_buffer_ = nullptr;
-  uint16_t* index_buffer_ = nullptr;
+  IndexT* index_buffer_ = nullptr;
 };
 
 /// @brief A vertex writer that generates a triangle strip and requires
 ///        primitive restart.
+template <typename IndexT>
 class StripPathVertexWriter : public impeller::PathTessellator::VertexWriter {
  public:
   explicit StripPathVertexWriter(impeller::Point* point_buffer,
-                                 uint16_t* index_buffer)
+                                 IndexT* index_buffer)
       : point_buffer_(point_buffer), index_buffer_(index_buffer) {}
 
   ~StripPathVertexWriter() = default;
@@ -206,7 +219,7 @@ class StripPathVertexWriter : public impeller::PathTessellator::VertexWriter {
     }
 
     contour_start_ = count_;
-    index_buffer_[index_count_++] = 0xFFFF;
+    index_buffer_[index_count_++] = static_cast<IndexT>(-1);
   }
 
   void Write(impeller::Point point) override {
@@ -218,14 +231,15 @@ class StripPathVertexWriter : public impeller::PathTessellator::VertexWriter {
   size_t index_count_ = 0;
   size_t contour_start_ = 0;
   impeller::Point* point_buffer_ = nullptr;
-  uint16_t* index_buffer_ = nullptr;
+  IndexT* index_buffer_ = nullptr;
 };
 
 /// @brief A vertex writer that has no hardware requirements.
+template <typename IndexT>
 class GLESPathVertexWriter : public impeller::PathTessellator::VertexWriter {
  public:
   explicit GLESPathVertexWriter(std::vector<impeller::Point>& points,
-                                std::vector<uint16_t>& indices)
+                                std::vector<IndexT>& indices)
       : points_(points), indices_(indices) {}
 
   ~GLESPathVertexWriter() = default;
@@ -286,19 +300,118 @@ class GLESPathVertexWriter : public impeller::PathTessellator::VertexWriter {
   bool previous_contour_odd_points_ = false;
   size_t contour_start_ = 0u;
   std::vector<impeller::Point>& points_;
-  std::vector<uint16_t>& indices_;
+  std::vector<IndexT>& indices_;
 };
 
 }  // namespace
 
 namespace impeller {
 
-Tessellator::Tessellator()
-    : point_buffer_(std::make_unique<std::vector<Point>>()),
-      index_buffer_(std::make_unique<std::vector<uint16_t>>()),
-      stroke_points_(kPointArenaSize) {
-  point_buffer_->reserve(2048);
-  index_buffer_->reserve(2048);
+template <typename IndexT>
+class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
+ public:
+  ConvexTessellatorImpl() {
+    point_buffer_.reserve(2048);
+    index_buffer_.reserve(2048);
+  }
+
+  VertexBuffer TessellateConvex(const PathSource& path,
+                                HostBuffer& data_host_buffer,
+                                HostBuffer& indexes_host_buffer,
+                                Scalar tolerance,
+                                bool supports_primitive_restart,
+                                bool supports_triangle_fan) override {
+    if (supports_primitive_restart) {
+      // Primitive Restart.
+      const auto [point_count, contour_count] =
+          PathTessellator::CountFillStorage(path, tolerance);
+      BufferView point_buffer = data_host_buffer.Emplace(
+          nullptr, sizeof(Point) * point_count, alignof(Point));
+      BufferView index_buffer = indexes_host_buffer.Emplace(
+          nullptr, sizeof(IndexT) * (point_count + contour_count),
+          alignof(IndexT));
+
+      if (supports_triangle_fan) {
+        FanPathVertexWriter writer(
+            reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
+                                     point_buffer.GetRange().offset),
+            reinterpret_cast<IndexT*>(
+                index_buffer.GetBuffer()->OnGetContents() +
+                index_buffer.GetRange().offset));
+        PathTessellator::PathToFilledVertices(path, writer, tolerance);
+        FML_DCHECK(writer.GetPointCount() <= point_count);
+        FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
+        point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
+        index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
+
+        return VertexBuffer{
+            .vertex_buffer = std::move(point_buffer),
+            .index_buffer = std::move(index_buffer),
+            .vertex_count = writer.GetIndexCount(),
+            .index_type = IndexTypeFor<IndexT>(),
+        };
+      } else {
+        StripPathVertexWriter writer(
+            reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
+                                     point_buffer.GetRange().offset),
+            reinterpret_cast<IndexT*>(
+                index_buffer.GetBuffer()->OnGetContents() +
+                index_buffer.GetRange().offset));
+        PathTessellator::PathToFilledVertices(path, writer, tolerance);
+        FML_DCHECK(writer.GetPointCount() <= point_count);
+        FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
+        point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
+        index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
+
+        return VertexBuffer{
+            .vertex_buffer = std::move(point_buffer),
+            .index_buffer = std::move(index_buffer),
+            .vertex_count = writer.GetIndexCount(),
+            .index_type = IndexTypeFor<IndexT>(),
+        };
+      }
+    }
+
+    Tessellator::TessellateConvexInternal(path, point_buffer_, index_buffer_,
+                                          tolerance);
+
+    if (point_buffer_.empty()) {
+      return VertexBuffer{
+          .vertex_buffer = {},
+          .index_buffer = {},
+          .vertex_count = 0u,
+          .index_type = IndexTypeFor<IndexT>(),
+      };
+    }
+
+    BufferView vertex_buffer = data_host_buffer.Emplace(
+        point_buffer_.data(), sizeof(Point) * point_buffer_.size(),
+        alignof(Point));
+
+    BufferView index_buffer = indexes_host_buffer.Emplace(
+        index_buffer_.data(), sizeof(IndexT) * index_buffer_.size(),
+        alignof(IndexT));
+
+    return VertexBuffer{
+        .vertex_buffer = std::move(vertex_buffer),
+        .index_buffer = std::move(index_buffer),
+        .vertex_count = index_buffer_.size(),
+        .index_type = IndexTypeFor<IndexT>(),
+    };
+  }
+
+ private:
+  std::vector<Point> point_buffer_;
+  std::vector<IndexT> index_buffer_;
+};
+
+Tessellator::Tessellator(bool supports_32bit_primitive_indices)
+    : stroke_points_(kPointArenaSize) {
+  if (supports_32bit_primitive_indices) {
+    convex_tessellator_ = std::make_unique<ConvexTessellatorImpl<uint32_t>>();
+  } else {
+    convex_tessellator_ = std::make_unique<ConvexTessellatorImpl<uint16_t>>();
+  }
 }
 
 Tessellator::~Tessellator() = default;
@@ -317,89 +430,15 @@ VertexBuffer Tessellator::TessellateConvex(const PathSource& path,
                                            Scalar tolerance,
                                            bool supports_primitive_restart,
                                            bool supports_triangle_fan) {
-  if (supports_primitive_restart) {
-    // Primitive Restart.
-    const auto [point_count, contour_count] =
-        PathTessellator::CountFillStorage(path, tolerance);
-    BufferView point_buffer = data_host_buffer.Emplace(
-        nullptr, sizeof(Point) * point_count, alignof(Point));
-    BufferView index_buffer = indexes_host_buffer.Emplace(
-        nullptr, sizeof(uint16_t) * (point_count + contour_count),
-        alignof(uint16_t));
-
-    if (supports_triangle_fan) {
-      FanPathVertexWriter writer(
-          reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
-                                   point_buffer.GetRange().offset),
-          reinterpret_cast<uint16_t*>(
-              index_buffer.GetBuffer()->OnGetContents() +
-              index_buffer.GetRange().offset));
-      PathTessellator::PathToFilledVertices(path, writer, tolerance);
-      FML_DCHECK(writer.GetPointCount() <= point_count);
-      FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
-      point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
-      index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
-
-      return VertexBuffer{
-          .vertex_buffer = std::move(point_buffer),
-          .index_buffer = std::move(index_buffer),
-          .vertex_count = writer.GetIndexCount(),
-          .index_type = IndexType::k16bit,
-      };
-    } else {
-      StripPathVertexWriter writer(
-          reinterpret_cast<Point*>(point_buffer.GetBuffer()->OnGetContents() +
-                                   point_buffer.GetRange().offset),
-          reinterpret_cast<uint16_t*>(
-              index_buffer.GetBuffer()->OnGetContents() +
-              index_buffer.GetRange().offset));
-      PathTessellator::PathToFilledVertices(path, writer, tolerance);
-      FML_DCHECK(writer.GetPointCount() <= point_count);
-      FML_DCHECK(writer.GetIndexCount() <= (point_count + contour_count));
-      point_buffer.GetBuffer()->Flush(point_buffer.GetRange());
-      index_buffer.GetBuffer()->Flush(index_buffer.GetRange());
-
-      return VertexBuffer{
-          .vertex_buffer = std::move(point_buffer),
-          .index_buffer = std::move(index_buffer),
-          .vertex_count = writer.GetIndexCount(),
-          .index_type = IndexType::k16bit,
-      };
-    }
-  }
-
-  FML_DCHECK(point_buffer_);
-  FML_DCHECK(index_buffer_);
-  TessellateConvexInternal(path, *point_buffer_, *index_buffer_, tolerance);
-
-  if (point_buffer_->empty()) {
-    return VertexBuffer{
-        .vertex_buffer = {},
-        .index_buffer = {},
-        .vertex_count = 0u,
-        .index_type = IndexType::k16bit,
-    };
-  }
-
-  BufferView vertex_buffer = data_host_buffer.Emplace(
-      point_buffer_->data(), sizeof(Point) * point_buffer_->size(),
-      alignof(Point));
-
-  BufferView index_buffer = indexes_host_buffer.Emplace(
-      index_buffer_->data(), sizeof(uint16_t) * index_buffer_->size(),
-      alignof(uint16_t));
-
-  return VertexBuffer{
-      .vertex_buffer = std::move(vertex_buffer),
-      .index_buffer = std::move(index_buffer),
-      .vertex_count = index_buffer_->size(),
-      .index_type = IndexType::k16bit,
-  };
+  return convex_tessellator_->TessellateConvex(
+      path, data_host_buffer, indexes_host_buffer, tolerance,
+      supports_primitive_restart, supports_triangle_fan);
 }
 
+template <typename IndexT>
 void Tessellator::TessellateConvexInternal(const PathSource& path,
                                            std::vector<Point>& point_buffer,
-                                           std::vector<uint16_t>& index_buffer,
+                                           std::vector<IndexT>& index_buffer,
                                            Scalar tolerance) {
   point_buffer.clear();
   index_buffer.clear();

--- a/engine/src/flutter/impeller/tessellator/tessellator.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator.cc
@@ -303,6 +303,19 @@ class GLESPathVertexWriter : public impeller::PathTessellator::VertexWriter {
   std::vector<IndexT>& indices_;
 };
 
+template <typename IndexT>
+void DoTessellateConvexInternal(const impeller::PathSource& path,
+                                std::vector<impeller::Point>& point_buffer,
+                                std::vector<IndexT>& index_buffer,
+                                impeller::Scalar tolerance) {
+  point_buffer.clear();
+  index_buffer.clear();
+
+  GLESPathVertexWriter writer(point_buffer, index_buffer);
+
+  impeller::PathTessellator::PathToFilledVertices(path, writer, tolerance);
+}
+
 }  // namespace
 
 namespace impeller {
@@ -362,8 +375,7 @@ class ConvexTessellatorImpl : public Tessellator::ConvexTessellator {
       }
     }
 
-    Tessellator::TessellateConvexInternal(path, point_buffer_, index_buffer_,
-                                          tolerance);
+    DoTessellateConvexInternal(path, point_buffer_, index_buffer_, tolerance);
 
     if (point_buffer_.empty()) {
       return VertexBuffer{
@@ -425,17 +437,11 @@ VertexBuffer Tessellator::TessellateConvex(const PathSource& path,
       supports_primitive_restart, supports_triangle_fan);
 }
 
-template <typename IndexT>
 void Tessellator::TessellateConvexInternal(const PathSource& path,
                                            std::vector<Point>& point_buffer,
-                                           std::vector<IndexT>& index_buffer,
+                                           std::vector<uint16_t>& index_buffer,
                                            Scalar tolerance) {
-  point_buffer.clear();
-  index_buffer.clear();
-
-  GLESPathVertexWriter writer(point_buffer, index_buffer);
-
-  PathTessellator::PathToFilledVertices(path, writer, tolerance);
+  DoTessellateConvexInternal(path, point_buffer, index_buffer, tolerance);
 }
 
 Tessellator::Trigs::Trigs(Scalar pixel_radius)

--- a/engine/src/flutter/impeller/tessellator/tessellator.h
+++ b/engine/src/flutter/impeller/tessellator/tessellator.h
@@ -223,7 +223,7 @@ class Tessellator {
                        Cap cap);
   };
 
-  Tessellator();
+  Tessellator(bool supports_32bit_primitive_indices = true);
 
   virtual ~Tessellator();
 
@@ -250,9 +250,10 @@ class Tessellator {
   ///
   /// This method only exists for the ease of benchmarking without using the
   /// real allocator needed by the [host_buffer].
+  template <typename IndexT>
   static void TessellateConvexInternal(const PathSource& path,
                                        std::vector<Point>& point_buffer,
-                                       std::vector<uint16_t>& index_buffer,
+                                       std::vector<IndexT>& index_buffer,
                                        Scalar tolerance);
 
   //----------------------------------------------------------------------------
@@ -375,14 +376,26 @@ class Tessellator {
   /// circle quadrant of the specified pixel radius
   Trigs GetTrigsForDeviceRadius(Scalar pixel_radius);
 
- protected:
+ private:
+  class ConvexTessellator {
+   public:
+    virtual ~ConvexTessellator() = default;
+    virtual VertexBuffer TessellateConvex(const PathSource& path,
+                                          HostBuffer& data_host_buffer,
+                                          HostBuffer& indexes_host_buffer,
+                                          Scalar tolerance,
+                                          bool supports_primitive_restart,
+                                          bool supports_triangle_fan) = 0;
+  };
+  template <typename IndexT>
+  friend class ConvexTessellatorImpl;
+
   /// Used for polyline generation.
-  std::unique_ptr<std::vector<Point>> point_buffer_;
-  std::unique_ptr<std::vector<uint16_t>> index_buffer_;
+  std::unique_ptr<ConvexTessellator> convex_tessellator_;
+
   /// Used for stroke path generation.
   std::vector<Point> stroke_points_;
 
- private:
   // Data for various Circle/EllipseGenerator classes, cached per
   // Tessellator instance which is usually the foreground life of an app
   // if not longer.

--- a/engine/src/flutter/impeller/tessellator/tessellator.h
+++ b/engine/src/flutter/impeller/tessellator/tessellator.h
@@ -223,7 +223,7 @@ class Tessellator {
                        Cap cap);
   };
 
-  Tessellator(bool supports_32bit_primitive_indices = true);
+  explicit Tessellator(bool supports_32bit_primitive_indices = true);
 
   virtual ~Tessellator();
 

--- a/engine/src/flutter/impeller/tessellator/tessellator.h
+++ b/engine/src/flutter/impeller/tessellator/tessellator.h
@@ -250,10 +250,9 @@ class Tessellator {
   ///
   /// This method only exists for the ease of benchmarking without using the
   /// real allocator needed by the [host_buffer].
-  template <typename IndexT>
   static void TessellateConvexInternal(const PathSource& path,
                                        std::vector<Point>& point_buffer,
-                                       std::vector<IndexT>& index_buffer,
+                                       std::vector<uint16_t>& index_buffer,
                                        Scalar tolerance);
 
   //----------------------------------------------------------------------------

--- a/engine/src/flutter/impeller/tessellator/tessellator_playground_unittests.cc
+++ b/engine/src/flutter/impeller/tessellator/tessellator_playground_unittests.cc
@@ -1,0 +1,61 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/testing.h"
+#include "gtest/gtest.h"
+
+#include "flutter/display_list/geometry/dl_path_builder.h"
+#include "impeller/playground/playground_test.h"
+#include "impeller/tessellator/tessellator.h"
+
+namespace impeller {
+namespace testing {
+
+using TessellatorPlaygroundTest = PlaygroundTest;
+INSTANTIATE_PLAYGROUND_SUITE(TessellatorPlaygroundTest);
+
+template <typename T>
+std::vector<T> CopyBufferView(const BufferView& vertex_buffer) {
+  Range range = vertex_buffer.GetRange();
+  uint8_t* base_ptr = vertex_buffer.GetBuffer()->OnGetContents() + range.offset;
+  return std::vector<T>(reinterpret_cast<T*>(base_ptr),
+                        reinterpret_cast<T*>(base_ptr + range.length));
+}
+
+TEST_P(TessellatorPlaygroundTest, TessellateConvex16or32Bit) {
+  auto tessellator16 = std::make_shared<Tessellator>(false);
+  auto tessellator32 = std::make_shared<Tessellator>(true);
+
+  auto data_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+  auto indexes_host_buffer = HostBuffer::Create(
+      GetContext()->GetResourceAllocator(), GetContext()->GetIdleWaiter(),
+      GetContext()->GetCapabilities()->GetMinimumUniformAlignment());
+
+  auto path = flutter::DlPath::MakeRect(Rect::MakeLTRB(0, 0, 10, 10));
+
+  auto vertex_buffer16 = tessellator16->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+  auto vertex_buffer32 = tessellator32->TessellateConvex(
+      path, *data_host_buffer, *indexes_host_buffer, 1.0, false, false);
+
+  const std::vector<Point> expected = {
+      {0, 0}, {10, 0}, {10, 10}, {0, 10}, {0, 0}};
+  const std::vector<uint16_t> expected_indices = {0, 1, 3, 2};
+
+  EXPECT_EQ(vertex_buffer16.index_type, IndexType::k16bit);
+  EXPECT_EQ(expected, CopyBufferView<Point>(vertex_buffer16.vertex_buffer));
+  EXPECT_EQ(expected_indices,
+            CopyBufferView<uint16_t>(vertex_buffer16.index_buffer));
+
+  EXPECT_EQ(vertex_buffer32.index_type, IndexType::k32bit);
+  EXPECT_EQ(expected, CopyBufferView<Point>(vertex_buffer32.vertex_buffer));
+  EXPECT_EQ(
+      std::vector<uint32_t>(expected_indices.begin(), expected_indices.end()),
+      CopyBufferView<uint32_t>(vertex_buffer32.index_buffer));
+}
+
+}  // namespace testing
+}  // namespace impeller


### PR DESCRIPTION
Applications may try to render paths whose point count exceeds the bounds of a 16-bit index.  This PR changes the tessellator to use 32-bit indices when available but will fall back to 16-bit on platforms that do not support it (specifically OpenGL ES implementations without the necessary extension).

Fixes https://github.com/flutter/flutter/issues/175031
Fixes https://github.com/flutter/flutter/issues/178022