### PR TITLE
Fix verified input integration test without breaking the rest of the devicelab tests (attempt 5)

### DIFF
--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -265,21 +265,38 @@ class DriverTest {
   Future<TaskResult> call() {
     return inDirectory<TaskResult>(testDirectory, () async {
       String deviceId;
+      Device? selectedDevice;
       if (deviceIdOverride != null) {
         deviceId = deviceIdOverride!;
       } else {
-        final Device device = await devices.workingDevice;
-        await device.unlock();
-        deviceId = device.deviceId;
+        selectedDevice = await devices.workingDevice;
+        await selectedDevice.unlock();
+        deviceId = selectedDevice.deviceId;
       }
       await flutter('packages', options: <String>['get']);
 
+      final bool isAndroidRun = selectedDevice != null
+          ? selectedDevice is AndroidDevice
+          : const <DeviceOperatingSystem>{
+        DeviceOperatingSystem.android,
+        DeviceOperatingSystem.androidArm,
+        DeviceOperatingSystem.androidArm64,
+      }.contains(deviceOperatingSystem);
+
+      String? devicelabAdbPath;
+      if (isAndroidRun) {
+        try {
+          devicelabAdbPath = adbPath;
+        } on DeviceException {
+          devicelabAdbPath = null;
+        }
+      }
       // Make the device ID available in the driver code, so tools like ADB can
       // reference it if needed.
       final Map<String, String> env = <String, String>{
         if (environment != null) ...environment!,
         'FLUTTER_DEVICE_ID_NUMBER': deviceId,
-        'FLUTTER_ADB_PATH': adbPath,
+        if (devicelabAdbPath != null) 'FLUTTER_ADB_PATH': devicelabAdbPath,
       };
 
       final List<String> options = <String>[

--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -4,7 +4,7 @@
 
 import '../framework/devices.dart';
 import '../framework/framework.dart';
-import '../framework/talkback.dart';
+import '../framework/talkback.dart' hide adbPath;
 import '../framework/task_result.dart';
 import '../framework/utils.dart';
 
@@ -278,7 +278,8 @@ class DriverTest {
       // reference it if needed.
       final Map<String, String> env = <String, String>{
         if (environment != null) ...environment!,
-        'DEVICE_ID_NUMBER': deviceId,
+        'FLUTTER_DEVICE_ID_NUMBER': deviceId,
+        'FLUTTER_ADB_PATH': adbPath,
       };
 
       final List<String> options = <String>[

--- a/dev/devicelab/lib/tasks/integration_tests.dart
+++ b/dev/devicelab/lib/tasks/integration_tests.dart
@@ -278,10 +278,10 @@ class DriverTest {
       final bool isAndroidRun = selectedDevice != null
           ? selectedDevice is AndroidDevice
           : const <DeviceOperatingSystem>{
-        DeviceOperatingSystem.android,
-        DeviceOperatingSystem.androidArm,
-        DeviceOperatingSystem.androidArm64,
-      }.contains(deviceOperatingSystem);
+              DeviceOperatingSystem.android,
+              DeviceOperatingSystem.androidArm,
+              DeviceOperatingSystem.androidArm64,
+            }.contains(deviceOperatingSystem);
 
       String? devicelabAdbPath;
       if (isAndroidRun) {

--- a/dev/integration_tests/android_verified_input/test_driver/main_test.dart
+++ b/dev/integration_tests/android_verified_input/test_driver/main_test.dart
@@ -28,7 +28,8 @@ Future<void> main() async {
     final Future<String> inputEventWasVerified = driver.requestData('input_was_verified');
 
     // Passed in by the driver task.
-    final String? deviceId = Platform.environment['DEVICE_ID_NUMBER'];
+    final String? deviceId = Platform.environment['FLUTTER_DEVICE_ID_NUMBER'];
+    final String? adbPath = Platform.environment['FLUTTER_ADB_PATH'];
 
     // Keep issuing taps until we get the requested data. The actual setup
     // of the platform view is asynchronous so we might have to tap more than
@@ -37,7 +38,7 @@ Future<void> main() async {
     inputEventWasVerified.whenComplete(() => stop = true);
     while (!stop) {
       // We must use the Android input tool to get verified input events.
-      final ProcessResult result = await Process.run('adb', <String>[
+      final ProcessResult result = await Process.run(adbPath ?? 'adb', <String>[
         if (deviceId != null) ...<String>['-s', deviceId],
         'shell',
         'input',


### PR DESCRIPTION
Reland of https://github.com/flutter/flutter/pull/178018/

On top of the above:
Only gets the adb path if it is an android test, and also try catches to be doubly safe.

Note that the above PR did work for the android case, so as long as we don't break the non-android case the test will be running now: https://ci.chromium.org/ui/p/flutter/builders/staging/Linux_pixel_7pro%20android_verified_input_test/228/overview

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
