### PR TITLE
Add an assert message when OverlayEntry.remove is called twice

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -216,9 +216,6 @@ class OverlayEntry implements Listenable {
   ///
   /// This should only be called once.
   ///
-  /// After calling this method, [dispose] must be called if the [OverlayEntry] was
-  /// inserted into an [Overlay].
-  ///
   /// This method removes this overlay entry from the overlay immediately. The
   /// UI will be updated in the same frame if this method is called before the
   /// overlay rebuild in this frame; otherwise, the UI will be updated in the
@@ -226,10 +223,7 @@ class OverlayEntry implements Listenable {
   /// that if you do call this after the overlay rebuild, the UI will not update
   /// until the next frame (i.e. many milliseconds later).
   void remove() {
-    assert(
-      _overlay != null,
-      'An OverlayEntry should be removed only once and it must be disposed after the removal.',
-    );
+    assert(_overlay != null, 'An OverlayEntry should be removed only once.');
     assert(!_disposedByOwner);
     final OverlayState overlay = _overlay!;
     _overlay = null;
@@ -267,7 +261,7 @@ class OverlayEntry implements Listenable {
 
   /// Discards any resources used by this [OverlayEntry].
   ///
-  /// This method must be called after [remove] if the [OverlayEntry] is
+  /// [remove] must be called before this method if the [OverlayEntry] is
   /// inserted into an [Overlay].
   ///
   /// After this is called, the object is not in a usable state and should be

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -261,8 +261,8 @@ class OverlayEntry implements Listenable {
 
   /// Discards any resources used by this [OverlayEntry].
   ///
-  /// [remove] must be called before this method if the [OverlayEntry] is
-  /// inserted into an [Overlay].
+  /// The [remove] method must be called before this method if the
+  /// [OverlayEntry] is inserted into an [Overlay].
   ///
   /// After this is called, the object is not in a usable state and should be
   /// discarded (calls to [addListener] will throw after the object is disposed).

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -216,6 +216,9 @@ class OverlayEntry implements Listenable {
   ///
   /// This should only be called once.
   ///
+  /// After calling this method, [dispose] must be called if the [OverlayEntry] was
+  /// inserted into an [Overlay].
+  ///
   /// This method removes this overlay entry from the overlay immediately. The
   /// UI will be updated in the same frame if this method is called before the
   /// overlay rebuild in this frame; otherwise, the UI will be updated in the
@@ -223,7 +226,10 @@ class OverlayEntry implements Listenable {
   /// that if you do call this after the overlay rebuild, the UI will not update
   /// until the next frame (i.e. many milliseconds later).
   void remove() {
-    assert(_overlay != null);
+    assert(
+      _overlay != null,
+      'An OverlayEntry should be removed only once and it must be disposed after the removal.',
+    );
     assert(!_disposedByOwner);
     final OverlayState overlay = _overlay!;
     _overlay = null;

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1574,6 +1574,29 @@ void main() {
 
       expect(() => entry.addListener(() {}), throwsAssertionError);
     });
+
+    testWidgets('asserts when remove is called twice', (WidgetTester tester) async {
+      await tester.pumpWidget(emptyOverlay);
+      final OverlayState overlay = overlayKey.currentState! as OverlayState;
+      final OverlayEntry entry = OverlayEntry(builder: (BuildContext context) => Container());
+      addTearDown(entry.dispose);
+
+      overlay.insert(entry);
+
+      expect(
+        () {
+          entry.remove();
+          entry.remove();
+        },
+        throwsA(
+          isA<AssertionError>().having(
+            (AssertionError e) => e.message,
+            'message',
+            'An OverlayEntry should be removed only once and it must be disposed after the removal.',
+          ),
+        ),
+      );
+    });
   });
 
   group('LookupBoundary', () {

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -1592,7 +1592,7 @@ void main() {
           isA<AssertionError>().having(
             (AssertionError e) => e.message,
             'message',
-            'An OverlayEntry should be removed only once and it must be disposed after the removal.',
+            'An OverlayEntry should be removed only once.',
           ),
         ),
       );


### PR DESCRIPTION
## Description

This PR adds an assert message to help users understand the error occuring when `OverlayEntry.remove` is called twice. It also adds a comment about calling dispose after removal as this is mandatory since github.com/flutter/flutter/issues/102794.

## Related Issue

Fixes ["Failed assertion: line 207 pos 12: '_overlay != null': is not true" when trying to remove a non null overlayEntry](https://github.com/flutter/flutter/issues/145466) 
Related external issue: https://github.com/LanarsInc/top-snackbar-flutter/issues/80

## Tests

- Adds 1 test.

