### PR TITLE
Group plugin Swift Packages per configuration

### DIFF
--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -505,6 +505,8 @@ class Context {
 
     final String buildMode = parseFlutterBuildMode();
 
+    updateBuildConfigurationForSwiftPackages(buildMode);
+
     final List<String> flutterArgs = _generateFlutterArgsForAssemble(
       command: 'prepare',
       buildMode: buildMode,
@@ -529,6 +531,27 @@ class Context {
       echoError('Failed to copy Flutter framework.');
       exitApp(-1);
     }
+  }
+
+  /// Replace the build mode in `FLUTTER_PLUGINS_SWIFT_PACKAGE_PATH` with the current build mode.
+  void updateBuildConfigurationForSwiftPackages(String buildMode) {
+    String formattedBuildMode(String buildMode) =>
+        'let mode = "${buildMode[0].toUpperCase()}${buildMode.substring(1)}"';
+    final String? swiftPackagePath = environment['FLUTTER_PLUGINS_SWIFT_PACKAGE_PATH'];
+    if (swiftPackagePath == null) {
+      return;
+    }
+    final swiftPackage = File(swiftPackagePath);
+    if (!swiftPackage.existsSync()) {
+      return;
+    }
+    swiftPackage.writeAsStringSync(
+      swiftPackage
+          .readAsStringSync()
+          .replaceAll(formattedBuildMode('debug'), formattedBuildMode(buildMode))
+          .replaceAll(formattedBuildMode('profile'), formattedBuildMode(buildMode))
+          .replaceAll(formattedBuildMode('release'), formattedBuildMode(buildMode)),
+    );
   }
 
   /// Calls `flutter assemble [buildMode]_[platform]_bundle_flutter_assets`

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -160,6 +160,15 @@ Future<List<String>> _xcodeBuildSettingsLines({
   xcodeBuildSettings.add(
     'FLUTTER_APPLICATION_PATH=${globals.fs.path.normalize(project.directory.path)}',
   );
+  if (useMacOSConfig) {
+    xcodeBuildSettings.add(
+      'FLUTTER_PLUGINS_SWIFT_PACKAGE_PATH=${globals.fs.path.normalize(project.macos.flutterPluginSwiftPackageManifest.path)}',
+    );
+  } else {
+    xcodeBuildSettings.add(
+      'FLUTTER_PLUGINS_SWIFT_PACKAGE_PATH=${globals.fs.path.normalize(project.ios.flutterPluginSwiftPackageManifest.path)}',
+    );
+  }
 
   // Tell CocoaPods behavior to codesign in parallel with rest of scripts to speed it up.
   // Value must be "true", not "YES". https://github.com/CocoaPods/CocoaPods/pull/6088

--- a/packages/flutter_tools/lib/src/macos/swift_packages.dart
+++ b/packages/flutter_tools/lib/src/macos/swift_packages.dart
@@ -18,6 +18,7 @@ const _swiftPackageTemplate = '''
 
 import PackageDescription
 
+{{#hasSwiftCodeBefore}}\n{{swiftCodeBefore}}\n\n{{/hasSwiftCodeBefore}}
 let package = Package(
     name: "{{packageName}}",
     {{#platforms}}
@@ -62,13 +63,15 @@ class SwiftPackage {
     required List<SwiftPackagePackageDependency> dependencies,
     required List<SwiftPackageTarget> targets,
     required TemplateRenderer templateRenderer,
+    String? swiftCodeBeforePackageDefinition,
   }) : _manifest = manifest,
        _name = name,
        _platforms = platforms,
        _products = products,
        _dependencies = dependencies,
        _targets = targets,
-       _templateRenderer = templateRenderer;
+       _templateRenderer = templateRenderer,
+       _swiftCodeBeforePackageDefinition = swiftCodeBeforePackageDefinition;
 
   /// [File] for Package.swift.
   final File _manifest;
@@ -90,6 +93,8 @@ class SwiftPackage {
 
   final TemplateRenderer _templateRenderer;
 
+  final String? _swiftCodeBeforePackageDefinition;
+
   /// Context for the [_swiftPackageTemplate] template.
   Map<String, Object> get _templateContext => <String, Object>{
     'swiftToolsVersion': minimumSwiftToolchainVersion,
@@ -99,6 +104,8 @@ class SwiftPackage {
     'products': _formatProducts(),
     'dependencies': _formatDependencies(),
     'targets': _formatTargets(),
+    'hasSwiftCodeBefore': _swiftCodeBeforePackageDefinition != null,
+    'swiftCodeBefore': _swiftCodeBeforePackageDefinition ?? '',
   };
 
   /// Create a Package.swift using settings from [_templateContext].

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -144,11 +144,6 @@ abstract class XcodeBasedProject extends FlutterProjectPlatform {
   /// The Flutter generated directory for generated Swift packages.
   Directory get flutterSwiftPackagesDirectory => ephemeralDirectory.childDirectory('Packages');
 
-  /// Flutter plugins that support SwiftPM will be symlinked in this directory to keep all
-  /// Swift packages relative to each other.
-  Directory get relativeSwiftPackagesDirectory =>
-      flutterSwiftPackagesDirectory.childDirectory('.packages');
-
   /// The Flutter generated directory for the Swift package handling plugin
   /// dependencies.
   Directory get flutterPluginSwiftPackageDirectory =>

--- a/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapod_utils_test.dart
@@ -506,10 +506,6 @@ class FakeMacOSProject extends Fake implements MacOSProject {
       hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral').childDirectory('Packages');
 
   @override
-  Directory get relativeSwiftPackagesDirectory =>
-      flutterSwiftPackagesDirectory.childDirectory('.packages');
-
-  @override
   Directory get flutterPluginSwiftPackageDirectory =>
       flutterSwiftPackagesDirectory.childDirectory('FlutterGeneratedPluginSwiftPackage');
 
@@ -553,10 +549,6 @@ class FakeIosProject extends Fake implements IosProject {
   @override
   Directory get flutterSwiftPackagesDirectory =>
       hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral').childDirectory('Packages');
-
-  @override
-  Directory get relativeSwiftPackagesDirectory =>
-      flutterSwiftPackagesDirectory.childDirectory('.packages');
 
   @override
   Directory get flutterPluginSwiftPackageDirectory =>

--- a/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/darwin_dependency_management_test.dart
@@ -6,6 +6,7 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/darwin/darwin.dart';
 import 'package:flutter_tools/src/macos/cocoapods.dart';
 import 'package:flutter_tools/src/macos/darwin_dependency_management.dart';
@@ -838,8 +839,13 @@ class FakeSwiftPackageManager extends Fake implements SwiftPackageManager {
   Future<void> generatePluginsSwiftPackage(
     List<Plugin> plugins,
     FlutterDarwinPlatform platform,
-    XcodeBasedProject project,
-  ) async {
+    XcodeBasedProject project, {
+    List<BuildMode> buildModes = const <BuildMode>[
+      BuildMode.debug,
+      BuildMode.profile,
+      BuildMode.release,
+    ],
+  }) async {
     generated = true;
     expect(plugins, expectedPlugins);
   }

--- a/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_package_manager_test.dart
@@ -67,6 +67,8 @@ void main() {
 
 import PackageDescription
 
+let mode = "Debug"
+
 let package = Package(
     name: "FlutterGeneratedPluginSwiftPackage",
     platforms: [
@@ -111,11 +113,22 @@ $_doubleIndent
                 ? '.iOS("13.0")'
                 : '.macOS("10.15")';
             expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
-            expect(project.relativeSwiftPackagesDirectory.childLink('valid_plugin_1'), exists);
-            expect(
-              project.relativeSwiftPackagesDirectory.childLink('valid_plugin_1').targetSync(),
-              validPlugin1Directory.path,
-            );
+            for (final buildMode in ['Debug', 'Profile', 'Release']) {
+              expect(
+                project.flutterSwiftPackagesDirectory
+                    .childDirectory(buildMode)
+                    .childLink('valid_plugin_1'),
+                exists,
+              );
+              expect(
+                project.flutterSwiftPackagesDirectory
+                    .childDirectory(buildMode)
+                    .childLink('valid_plugin_1')
+                    .targetSync(),
+                validPlugin1Directory.path,
+              );
+            }
+
             expect(project.flutterPluginSwiftPackageManifest.readAsStringSync(), '''
 // swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
@@ -124,6 +137,8 @@ $_doubleIndent
 //
 
 import PackageDescription
+
+let mode = "Debug"
 
 let package = Package(
     name: "FlutterGeneratedPluginSwiftPackage",
@@ -134,7 +149,7 @@ let package = Package(
         .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
     ],
     dependencies: [
-        .package(name: "valid_plugin_1", path: "../.packages/valid_plugin_1")
+        .package(name: "valid_plugin_1", path: "../\\(mode)/valid_plugin_1")
     ],
     targets: [
         .target(
@@ -208,16 +223,34 @@ let package = Package(
                 ? '.iOS("13.0")'
                 : '.macOS("10.15")';
             expect(project.flutterPluginSwiftPackageManifest.existsSync(), isTrue);
-            expect(project.relativeSwiftPackagesDirectory.childLink('valid_plugin_1'), exists);
-            expect(
-              project.relativeSwiftPackagesDirectory.childLink('valid_plugin_1').targetSync(),
-              validPlugin1Directory.path,
-            );
-            expect(project.relativeSwiftPackagesDirectory.childLink('valid_plugin_2'), exists);
-            expect(
-              project.relativeSwiftPackagesDirectory.childLink('valid_plugin_2').targetSync(),
-              validPlugin2Directory.path,
-            );
+            for (final buildMode in ['Debug', 'Profile', 'Release']) {
+              expect(
+                project.flutterSwiftPackagesDirectory
+                    .childDirectory(buildMode)
+                    .childLink('valid_plugin_1'),
+                exists,
+              );
+              expect(
+                project.flutterSwiftPackagesDirectory
+                    .childDirectory(buildMode)
+                    .childLink('valid_plugin_1')
+                    .targetSync(),
+                validPlugin1Directory.path,
+              );
+              expect(
+                project.flutterSwiftPackagesDirectory
+                    .childDirectory(buildMode)
+                    .childLink('valid_plugin_2'),
+                exists,
+              );
+              expect(
+                project.flutterSwiftPackagesDirectory
+                    .childDirectory(buildMode)
+                    .childLink('valid_plugin_2')
+                    .targetSync(),
+                validPlugin2Directory.path,
+              );
+            }
             expect(project.flutterPluginSwiftPackageManifest.readAsStringSync(), '''
 // swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
@@ -226,6 +259,8 @@ let package = Package(
 //
 
 import PackageDescription
+
+let mode = "Debug"
 
 let package = Package(
     name: "FlutterGeneratedPluginSwiftPackage",
@@ -236,8 +271,8 @@ let package = Package(
         .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
     ],
     dependencies: [
-        .package(name: "valid_plugin_1", path: "../.packages/valid_plugin_1"),
-        .package(name: "valid_plugin_2", path: "../.packages/valid_plugin_2")
+        .package(name: "valid_plugin_1", path: "../\\(mode)/valid_plugin_1"),
+        .package(name: "valid_plugin_2", path: "../\\(mode)/valid_plugin_2")
     ],
     targets: [
         .target(
@@ -360,10 +395,6 @@ class FakeXcodeProject extends Fake implements IosProject {
   @override
   Directory get flutterSwiftPackagesDirectory =>
       hostAppRoot.childDirectory('Flutter').childDirectory('ephemeral').childDirectory('Packages');
-
-  @override
-  Directory get relativeSwiftPackagesDirectory =>
-      flutterSwiftPackagesDirectory.childDirectory('.packages');
 
   @override
   Directory get flutterPluginSwiftPackageDirectory =>

--- a/packages/flutter_tools/test/general.shard/macos/swift_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/swift_packages_test.dart
@@ -306,6 +306,48 @@ let package = Package(
     });
   });
 
+  testWithoutContext('with swift code before package definition', () {
+    final fs = MemoryFileSystem();
+    final File swiftPackageFile = fs.systemTempDirectory.childFile(
+      'Packages/FlutterGeneratedPluginSwiftPackage/Package.swift',
+    );
+    final swiftPackage = SwiftPackage(
+      manifest: swiftPackageFile,
+      name: 'FlutterGeneratedPluginSwiftPackage',
+      swiftCodeBeforePackageDefinition: 'let mode = "Debug"',
+      platforms: <SwiftPackageSupportedPlatform>[],
+      products: <SwiftPackageProduct>[],
+      dependencies: <SwiftPackagePackageDependency>[],
+      targets: <SwiftPackageTarget>[],
+      templateRenderer: const MustacheTemplateRenderer(),
+    );
+    swiftPackage.createSwiftPackage();
+    expect(swiftPackageFile.readAsStringSync(), '''
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+//  Generated file. Do not edit.
+//
+
+import PackageDescription
+
+let mode = "Debug"
+
+let package = Package(
+    name: "FlutterGeneratedPluginSwiftPackage",
+    products: [
+$_doubleIndent
+    ],
+    dependencies: [
+$_doubleIndent
+    ],
+    targets: [
+$_doubleIndent
+    ]
+)
+''');
+  });
+
   testWithoutContext('Format SwiftPackageSupportedPlatform', () {
     final supportedPlatform = SwiftPackageSupportedPlatform(
       platform: SwiftPackagePlatform.ios,

--- a/packages/flutter_tools/test/general.shard/xcode_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/xcode_project_test.dart
@@ -53,15 +53,6 @@ void main() {
       expect(project.flutterSwiftPackagesDirectory.path, 'app_name/ios/Flutter/ephemeral/Packages');
     });
 
-    testWithoutContext('relativeSwiftPackagesDirectory', () {
-      final fs = MemoryFileSystem.test();
-      final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
-      expect(
-        project.relativeSwiftPackagesDirectory.path,
-        'app_name/ios/Flutter/ephemeral/Packages/.packages',
-      );
-    });
-
     testWithoutContext('flutterPluginSwiftPackageDirectory', () {
       final fs = MemoryFileSystem.test();
       final project = IosProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
@@ -466,15 +457,6 @@ void main() {
       expect(
         project.flutterSwiftPackagesDirectory.path,
         'app_name/macos/Flutter/ephemeral/Packages',
-      );
-    });
-
-    testWithoutContext('relativeSwiftPackagesDirectory', () {
-      final fs = MemoryFileSystem.test();
-      final project = MacOSProject.fromFlutter(FakeFlutterProject(fileSystem: fs));
-      expect(
-        project.relativeSwiftPackagesDirectory.path,
-        'app_name/macos/Flutter/ephemeral/Packages/.packages',
       );
     });
 


### PR DESCRIPTION
This introduces build mode to the `FlutterGeneratedPluginSwiftPackage` like so:

```swift
import PackageDescription

let mode = "Release"

let package = Package(
    name: "FlutterGeneratedPluginSwiftPackage",
    ...
    dependencies: [
        .package(name: "integration_test", path: "../\(mode)/integration_test"),
    ...
```
It also update the build mode during the `xcode_backend.dart` callback so that it gets updated whether it's from the CLI or Xcode.

In addition, we move the symlinked plugins to a build mode specific folder. For example -
 * Previous: `my_app/ios/Flutter/ephemeral/Packages/.packages/my_plugin`
 * New:
   * `my_app/ios/Flutter/ephemeral/Packages/Debug/my_plugin`
   * `my_app/ios/Flutter/ephemeral/Packages/Profile/my_plugin`
   * `my_app/ios/Flutter/ephemeral/Packages/Release/my_plugin`

This is an incremental change towards https://github.com/flutter/flutter/issues/166489. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
