### PR TITLE
fix #178045: update expansible documentation for default  maintainSta…

### DIFF
--- a/packages/flutter/lib/src/widgets/expansible.dart
+++ b/packages/flutter/lib/src/widgets/expansible.dart
@@ -268,7 +268,7 @@ class Expansible extends StatefulWidget {
   /// collapsed. Otherwise, the body is removed from the tree when the
   /// widget is collapsed and recreated upon expansion.
   ///
-  /// Defaults to false.
+  /// Defaults to true.
   final bool maintainState;
 
   /// Builds the widget with the results of [headerBuilder] and [bodyBuilder].


### PR DESCRIPTION
This PR updates the `Expansible` `maintainState` documentation in the code, current maintainState default value is set to true while the documentation shows '`/// Defaults to false.` 

**Update**
- the PR updates the documentation to reflect the maintainState default value without updating the maintainState value which require more investigation and test

Fixes [issues/178045](https://github.com/flutter/flutter/issues/178045)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
