### PR TITLE
fix #178204: update textediting controller notifier on user tap on field

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -754,10 +754,12 @@ class RenderEditable extends RenderBox
         extentOffset: math.min(nextSelection.extentOffset, textLength),
       );
     }
-    _setTextEditingValue(
-      textSelectionDelegate.textEditingValue.copyWith(selection: nextSelection),
-      cause,
-    );
+    if (nextSelection.extentOffset > nextSelection.baseOffset) {
+      _setTextEditingValue(
+        textSelectionDelegate.textEditingValue.copyWith(selection: nextSelection),
+        cause,
+      );
+    }
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4290,7 +4290,7 @@ class EditableTextState extends State<EditableText>
     // text of [EditableText] is updated at the same time as the selection is
     // changed by a gesture event.
     final String text = widget.controller.value.text;
-    if (text.length < selection.end || text.length < selection.start) {
+    if (text.length < selection.end || text.length < selection.start || selection.end <= selection.start) {
       return;
     }
 


### PR DESCRIPTION
This PR updates the text editing controller listener trigger, current listner is invoked on user tap on field

Screen recording:
https://github.com/user-attachments/assets/c0327343-f2f3-4266-afc9-83322b90c861

**Updates**
- Update the `TextEditingController` class `set value` function to test if the current text value is different from the new text value, if it's the case the listner is triggered otherwise there's no notifyListener trigger.

Screen recording after updates
https://github.com/user-attachments/assets/f6aded4d-7e66-4531-abcd-1d4d53024541

related issue [issues/178204](https://github.com/flutter/flutter/issues/178204)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
