### PR TITLE
Make sure that a TabPageSelectorIndicator doesn't crash in 0x0 enviro…

### DIFF
--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -9346,4 +9346,23 @@ void main() {
 
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets('TabPageSelectorIndicator does not crash in 0x0 environment', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: TabPageSelectorIndicator(
+              backgroundColor: Colors.red,
+              borderColor: Colors.blue,
+              size: 1,
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(TabPageSelectorIndicator)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the TabPageSelectorIndicator widget.