### PR TITLE
Make sure that a TextButton doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -2680,4 +2680,17 @@ void main() {
     // The button should still be focused.
     expect(getButtonFocusNode().hasFocus, true);
   });
+
+  testWidgets('TextButton does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: TextButton(onPressed: () {}, child: const Text('X')),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(TextButton)), Size.zero);
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the TextButton widget.