### PR TITLE
[web] Enable semantics via query parameter for automation testing

### DIFF
--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -58,7 +58,16 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// This allows automation testing tools to enable semantics without modifying the app.
   /// Usage: https://example.com/?flutter-semantics
   void _checkQueryParameterForSemantics() {
-    if (Uri.base.queryParameters.containsKey('flutter-semantics')) {
+    checkUriForSemanticsParameter(Uri.base);
+  }
+
+  /// Checks if the given URI contains the flutter-semantics query parameter.
+  /// If present, enables semantics.
+  ///
+  /// This method is separated for testing purposes.
+  @visibleForTesting
+  void checkUriForSemanticsParameter(Uri uri) {
+    if (uri.queryParameters.containsKey('flutter-semantics')) {
       EngineSemantics.instance.semanticsEnabled = true;
     }
   }

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -48,6 +48,19 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
     /// and ensures proper focus is set, enabling Flutter's focus restoration to work correctly
     /// when users navigate between pages.
     _addNavigationFocusHandler();
+
+    /// Check for query parameter to enable semantics programmatically after initialization.
+    /// This must be done asynchronously to avoid circular dependency during construction.
+    scheduleMicrotask(_checkQueryParameterForSemantics);
+  }
+
+  /// Check for query parameter to enable semantics programmatically.
+  /// This allows automation testing tools to enable semantics without modifying the app.
+  /// Usage: https://example.com/?flutter-semantics
+  void _checkQueryParameterForSemantics() {
+    if (Uri.base.queryParameters.containsKey('flutter-semantics')) {
+      EngineSemantics.instance.semanticsEnabled = true;
+    }
   }
 
   late StreamSubscription<int> _onViewDisposedListener;

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -56,14 +56,21 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   }
 
   /// Checks if the given URI contains the flutter-semantics query parameter.
-  /// If present, enables semantics. This allows automation testing tools to
-  /// enable semantics without modifying the app.
+  /// If present and not explicitly set to false, enables semantics. This allows
+  /// automation testing tools to enable semantics without modifying the app.
+  ///
+  /// Accepted values:
+  /// - `?flutter-semantics` or `?flutter-semantics=true` → enables
+  /// - `?flutter-semantics=false` → does not enable
   ///
   /// This method is separated for testing purposes.
   @visibleForTesting
   void checkUriForSemanticsParameter(Uri uri) {
-    if (uri.queryParameters.containsKey('flutter-semantics')) {
-      EngineSemantics.instance.semanticsEnabled = true;
+    final String? value = uri.queryParameters['flutter-semantics'];
+    if (value != null) {
+      if (value.toLowerCase() != 'false') {
+        EngineSemantics.instance.semanticsEnabled = true;
+      }
     }
   }
 

--- a/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/engine/src/flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -51,18 +51,13 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
 
     /// Check for query parameter to enable semantics programmatically after initialization.
     /// This must be done asynchronously to avoid circular dependency during construction.
-    scheduleMicrotask(_checkQueryParameterForSemantics);
-  }
-
-  /// Check for query parameter to enable semantics programmatically.
-  /// This allows automation testing tools to enable semantics without modifying the app.
-  /// Usage: https://example.com/?flutter-semantics
-  void _checkQueryParameterForSemantics() {
-    checkUriForSemanticsParameter(Uri.base);
+    /// Usage: https://example.com/?flutter-semantics
+    scheduleMicrotask(() => checkUriForSemanticsParameter(Uri.base));
   }
 
   /// Checks if the given URI contains the flutter-semantics query parameter.
-  /// If present, enables semantics.
+  /// If present, enables semantics. This allows automation testing tools to
+  /// enable semantics without modifying the app.
   ///
   /// This method is separated for testing purposes.
   @visibleForTesting

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -411,6 +411,24 @@ void testMain() {
       expect(dispatcher.accessibilityPlaceholder.isConnected, isFalse);
     });
 
+    test('query parameter enables semantics when present', () {
+      semantics().semanticsEnabled = false;
+      final Uri uriWithParameter = Uri.parse('https://example.com/?flutter-semantics');
+
+      dispatcher.checkUriForSemanticsParameter(uriWithParameter);
+
+      expect(semantics().semanticsEnabled, isTrue);
+    });
+
+    test('query parameter does not enable semantics when absent', () {
+      semantics().semanticsEnabled = false;
+      final Uri uriWithoutParameter = Uri.parse('https://example.com/');
+
+      dispatcher.checkUriForSemanticsParameter(uriWithoutParameter);
+
+      expect(semantics().semanticsEnabled, isFalse);
+    });
+
     test('scheduleWarmupFrame should call both callbacks', () async {
       bool beginFrameCalled = false;
       final Completer<void> drawFrameCalled = Completer<void>();

--- a/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
+++ b/engine/src/flutter/lib/web_ui/test/engine/platform_dispatcher/platform_dispatcher_test.dart
@@ -420,6 +420,24 @@ void testMain() {
       expect(semantics().semanticsEnabled, isTrue);
     });
 
+    test('query parameter enables semantics when set to true', () {
+      semantics().semanticsEnabled = false;
+      final Uri uriWithTrue = Uri.parse('https://example.com/?flutter-semantics=true');
+
+      dispatcher.checkUriForSemanticsParameter(uriWithTrue);
+
+      expect(semantics().semanticsEnabled, isTrue);
+    });
+
+    test('query parameter does not enable semantics when set to false', () {
+      semantics().semanticsEnabled = false;
+      final Uri uriWithFalse = Uri.parse('https://example.com/?flutter-semantics=false');
+
+      dispatcher.checkUriForSemanticsParameter(uriWithFalse);
+
+      expect(semantics().semanticsEnabled, isFalse);
+    });
+
     test('query parameter does not enable semantics when absent', () {
       semantics().semanticsEnabled = false;
       final Uri uriWithoutParameter = Uri.parse('https://example.com/');


### PR DESCRIPTION
Add support for enabling semantics via ?flutter-semantics query parameter. This allows automation testing tools like Maestro and Appium to enable semantics without modifying the application code or requiring special builds.

Usage: https://example.com/?flutter-semantics

After the change:
https://semantic-1107.web.app/
https://semantic-1107.web.app/?flutter-semantics

Fixes #177670

### Test WITHOUT Query Parameter

Navigate to: https://semantic-1107.web.app/

**In Chrome DevTools Console:**
```
// Check semantic elements
document.querySelectorAll('flt-semantics').length;
// Should return 0 - semantics NOT enabled
```
### Test WITH Query Parameter(disabling)

Navigate to:  https://semantic-1107.web.app/?flutter-semantics=false

**In Chrome DevTools Console:**
```
// Check semantic elements
document.querySelectorAll('flt-semantics').length;
// Should return 0 - semantics NOT enabled
```

### Test WITH Query Parameter(enabling)

Navigate to:  https://semantic-1107.web.app/?flutter-semantics or https://semantic-1107.web.app/?flutter-semantics=true

**In Chrome DevTools Console:**
// Check semantic elements
document.querySelectorAll('flt-semantics').length;
// Should return > 0 - semantics ARE enabled

// List all semantic buttons
document.querySelectorAll('[role="button"][aria-label]');
// Should show: "Go to Profile", "Go to Settings", "Go to Counter"

### Test Navigation Persistence

**With query parameter active (`?flutter-semantics`):**

1. Click "Profile" button
2. Check DevTools Console:
```
document.querySelectorAll('flt-semantics').length;
// Should still be > 0 - semantics PERSIST!
```

3. Click "Settings" button
4. Check again - semantics still present

5. Click "Back to Home"
6. Check again - semantics still present

7. Click "Counter" button
8. Increment counter a few times
9. Check semantic label:
```
document.querySelector('[aria-label^="Counter:"]').getAttribute('aria-label');
// Should show "Counter: [number]"
```