### PR TITLE
Make sure that a TextFormField doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -1875,4 +1875,21 @@ void main() {
         .copyWith(enabled: true, hintMaxLines: 1);
     expect(decorator.decoration, expectedDecoration);
   });
+
+  testWidgets('TextFormField does not crash at zero area', (WidgetTester tester) async {
+    tester.view.physicalSize = Size.zero;
+    final TextEditingController controller = TextEditingController(text: 'X');
+    addTearDown(tester.view.reset);
+    addTearDown(controller.dispose);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(child: TextFormField(controller: controller)),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byType(TextFormField)), Size.zero);
+    controller.selection = const TextSelection.collapsed(offset: 0);
+    tester.pump();
+  });
 }


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the TextFormField widget.