### PR TITLE
Use glyph boundaries for horizontal character traversal

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2147,6 +2147,9 @@ class RenderEditable extends RenderBox
     _setSelection(newSelection, cause);
   }
 
+  /// {@macro flutter.painting.TextPainter.glyphBoundaries}
+  GlyphBoundary get glyphBoundaries => _textPainter.glyphBoundaries;
+
   /// {@macro flutter.painting.TextPainter.wordBoundaries}
   WordBoundary get wordBoundaries => _textPainter.wordBoundaries;
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -3280,7 +3280,8 @@ class _SelectableFragment
     final TextPosition newPosition;
     switch (granularity) {
       case TextGranularity.character:
-        final TextBoundary textBoundary = paragraph._textPainter.glyphBoundaries.moveByGlyphBoundary;
+        final TextBoundary textBoundary =
+            paragraph._textPainter.glyphBoundaries.moveByGlyphBoundary;
         newPosition = _moveBeyondTextBoundaryAtDirection(targetedEdge, forward, textBoundary);
         result = SelectionResult.end;
       case TextGranularity.word:

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -3280,12 +3280,8 @@ class _SelectableFragment
     final TextPosition newPosition;
     switch (granularity) {
       case TextGranularity.character:
-        final String text = range.textInside(fullText);
-        newPosition = _moveBeyondTextBoundaryAtDirection(
-          targetedEdge,
-          forward,
-          CharacterBoundary(text),
-        );
+        final TextBoundary textBoundary = paragraph._textPainter.glyphBoundaries.moveByGlyphBoundary;
+        newPosition = _moveBeyondTextBoundaryAtDirection(targetedEdge, forward, textBoundary);
         result = SelectionResult.end;
       case TextGranularity.word:
         final TextBoundary textBoundary = paragraph._textPainter.wordBoundaries.moveByWordBoundary;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -5275,22 +5275,21 @@ class EditableTextState extends State<EditableText>
 
     int offset = extent.offset, nextOffset;
     // Correct for affinity.
-    if (extent.affinity == TextAffinity.upstream && extent.offset >= 0 && extent.offset < _value.text.length) {
+    if (extent.affinity == TextAffinity.upstream &&
+        extent.offset >= 0 &&
+        extent.offset < _value.text.length) {
       offset--;
     }
-
-    // TODO(tgucio): test newlines at RTL / LTR (skip one glyph?) -> FAIL
-    // TODO(tgucio): handle line ends after a single LTR/RTL change? [test]
 
     TextAffinity affinity = TextAffinity.downstream;
     TextRange boundary = textBoundary.getTextBoundaryAt(offset);
     // Use current boundary ends to find the next boundary.
     if (boundary.isValid) {
       nextOffset = switch ((forward, boundary.isNormalized)) {
-        (true, true) => boundary.end,        // LTR, forward
-        (true, false) => boundary.end - 1,   // RTL, forward
+        (true, true) => boundary.end, // LTR, forward
+        (true, false) => boundary.end - 1, // RTL, forward
         (false, true) => boundary.start - 1, // LTR, reverse
-        (false, false) => boundary.start,    // RTL, reverse
+        (false, false) => boundary.start, // RTL, reverse
       };
     } else {
       // Handle starting outside of text bounds.
@@ -5323,12 +5322,12 @@ class EditableTextState extends State<EditableText>
           offset = math.max(0, nextOffset);
           nextOffset = forward ? boundary.start : boundary.end - 1;
           nextBoundary = textBoundary.getTextBoundaryAt(nextOffset);
-        } while (nextOffset < _value.text.length
-            && nextOffset >= 0
-            && nextBoundary.isValid
-            && nextBoundary.isNormalized == boundary.isNormalized);
-          offset = math.max(0, boundary.start);
-          affinity = forward ? TextAffinity.upstream : TextAffinity.downstream;
+        } while (nextOffset < _value.text.length &&
+            nextOffset >= 0 &&
+            nextBoundary.isValid &&
+            nextBoundary.isNormalized == boundary.isNormalized);
+        offset = math.max(0, boundary.start);
+        affinity = forward ? TextAffinity.upstream : TextAffinity.downstream;
       } else {
         // RTL->LTR: start skipping at the current boundary.
         nextBoundary = boundary;
@@ -5337,12 +5336,12 @@ class EditableTextState extends State<EditableText>
           offset = math.max(0, nextOffset);
           nextOffset = forward ? boundary.start : boundary.end - 1;
           nextBoundary = textBoundary.getTextBoundaryAt(nextOffset);
-        } while (nextOffset < _value.text.length
-            && nextOffset >= 0
-            && nextBoundary.isValid
-            && nextBoundary.isNormalized == boundary.isNormalized);
-          offset = math.max(0, nextBoundary.end);
-          affinity = forward ? TextAffinity.downstream : TextAffinity.upstream;
+        } while (nextOffset < _value.text.length &&
+            nextOffset >= 0 &&
+            nextBoundary.isValid &&
+            nextBoundary.isNormalized == boundary.isNormalized);
+        offset = math.max(0, nextBoundary.end);
+        affinity = forward ? TextAffinity.downstream : TextAffinity.upstream;
       }
     }
 
@@ -5391,8 +5390,9 @@ class EditableTextState extends State<EditableText>
 
   // --------------------------- Text Editing Actions ---------------------------
 
-  TextBoundary _characterBoundary() =>
-      widget.obscureText ? _CodePointBoundary(_value.text) : renderEditable.glyphBoundaries.moveByGlyphBoundary;
+  TextBoundary _characterBoundary() => widget.obscureText
+      ? _CodePointBoundary(_value.text)
+      : renderEditable.glyphBoundaries.moveByGlyphBoundary;
   TextBoundary _nextWordBoundary() =>
       widget.obscureText ? _documentBoundary() : renderEditable.wordBoundaries.moveByWordBoundary;
   TextBoundary _linebreak() =>
@@ -5644,7 +5644,7 @@ class EditableTextState extends State<EditableText>
 
     // Delete
     DeleteCharacterIntent: _makeOverridable(
-      _DeleteTextAction<DeleteCharacterIntent>(this, _characterBoundary, _moveBeyondGlyphBoundary),
+      _DeleteTextAction<DeleteCharacterIntent>(this, _characterBoundary, _moveBeyondTextBoundary),
     ),
     DeleteToNextWordBoundaryIntent: _makeOverridable(
       _DeleteTextAction<DeleteToNextWordBoundaryIntent>(

--- a/packages/flutter/test/services/text_boundary_test.dart
+++ b/packages/flutter/test/services/text_boundary_test.dart
@@ -105,6 +105,49 @@ void main() {
     expect(boundary.getTrailingTextBoundaryAt(text.length), null);
   });
 
+  test('glyphBoundary.moveByGlyphBoundary', () {
+    const String text =
+        'abcאבגabc\n'
+        'ę̄́\n'
+        'هَّ\n'
+        '𑗋';
+
+    final TextPainter textPainter = TextPainter()
+      ..textDirection = TextDirection.ltr
+      ..text = const TextSpan(text: text)
+      ..layout();
+
+    final TextBoundary boundary = textPainter.glyphBoundaries.moveByGlyphBoundary;
+
+    // Before text
+    expect(boundary.getLeadingTextBoundaryAt(-1), isNull);
+    expect(boundary.getTrailingTextBoundaryAt(-1), isNull);
+    // LTR
+    expect(boundary.getLeadingTextBoundaryAt(0), 0);
+    expect(boundary.getTrailingTextBoundaryAt(0), 1);
+    // RTL
+    expect(boundary.getLeadingTextBoundaryAt(3), 4);
+    expect(boundary.getTrailingTextBoundaryAt(3), 3);
+    // Complex Latin character.
+    expect(boundary.getLeadingTextBoundaryAt(10), 10);
+    expect(boundary.getTrailingTextBoundaryAt(10), 13);
+    expect(boundary.getLeadingTextBoundaryAt(12), 10);
+    expect(boundary.getTrailingTextBoundaryAt(12), 13);
+    // Complex Arabic character.
+    expect(boundary.getLeadingTextBoundaryAt(14), 17);
+    expect(boundary.getTrailingTextBoundaryAt(14), 14);
+    expect(boundary.getLeadingTextBoundaryAt(16), 17);
+    expect(boundary.getTrailingTextBoundaryAt(16), 14);
+    // Surrogates.
+    expect(boundary.getLeadingTextBoundaryAt(18), 18);
+    expect(boundary.getTrailingTextBoundaryAt(18), 20);
+    expect(boundary.getLeadingTextBoundaryAt(19), 18);
+    expect(boundary.getTrailingTextBoundaryAt(19), 20);
+    // End of text.
+    expect(boundary.getLeadingTextBoundaryAt(20), isNull);
+    expect(boundary.getTrailingTextBoundaryAt(20), isNull);
+  });
+
   test('wordBoundary.moveByWordBoundary', () {
     const String text =
         'ABC   ABC\n' // [0, 10)

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -7182,10 +7182,9 @@ void main() {
     'keyboard text selection works (RawKeyEvent)',
     (WidgetTester tester) async {
       debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.rawKeyData;
+      addTearDown(() => debugKeyEventSimulatorTransitModeOverride = null);
 
       await testTextEditing(tester, targetPlatform: defaultTargetPlatform);
-
-      debugKeyEventSimulatorTransitModeOverride = null;
 
       // On web, using keyboard for selection is handled by the browser.
     },
@@ -7197,10 +7196,9 @@ void main() {
     'keyboard text selection works (ui.KeyData then RawKeyEvent)',
     (WidgetTester tester) async {
       debugKeyEventSimulatorTransitModeOverride = KeyDataTransitMode.keyDataThenRawKeyData;
+      addTearDown(() => debugKeyEventSimulatorTransitModeOverride = null);
 
       await testTextEditing(tester, targetPlatform: defaultTargetPlatform);
-
-      debugKeyEventSimulatorTransitModeOverride = null;
 
       // On web, using keyboard for selection is handled by the browser.
     },


### PR DESCRIPTION
This PR implements horizontal character traversal (using arrow keys) in text fields and paragraphs using actual glyph information from text layout, as opposed to "guessing" character boundaries from the underlying text. This allows for correct horizontal caret traversal of RTL text as well as correctly positioning the caret between characters in complex scripts (e.g. Indic) that rely on text shaping.

Before:
![before](https://github.com/user-attachments/assets/57296793-6fcd-4ae8-a835-35eb95572c62)

After:
![after](https://github.com/user-attachments/assets/b00a55d4-ca21-4ab8-8681-5c095288223d)

Fixes #34610
Fixes #78660
Maybe fixes #120049

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
