### PR TITLE
impeller: makes deferred display list images trash their display lists after they are realized

### DIFF
--- a/engine/src/flutter/engine.code-workspace
+++ b/engine/src/flutter/engine.code-workspace
@@ -126,7 +126,9 @@
       "cfenv": "cpp",
       "execution": "cpp",
       "print": "cpp",
-      "unicode.h": "c"
+      "unicode.h": "c",
+      "source_location": "cpp",
+      "syncstream": "cpp"
     },
     "C_Cpp.default.includePath": [
       "${default}",

--- a/engine/src/flutter/engine.code-workspace
+++ b/engine/src/flutter/engine.code-workspace
@@ -126,9 +126,7 @@
       "cfenv": "cpp",
       "execution": "cpp",
       "print": "cpp",
-      "unicode.h": "c",
-      "source_location": "cpp",
-      "syncstream": "cpp"
+      "unicode.h": "c"
     },
     "C_Cpp.default.includePath": [
       "${default}",

--- a/engine/src/flutter/impeller/core/BUILD.gn
+++ b/engine/src/flutter/impeller/core/BUILD.gn
@@ -59,6 +59,7 @@ impeller_component("allocator_unittests") {
   deps = [
     ":core",
     "../geometry",
+    "//flutter/impeller/renderer/testing:mocks",
     "//flutter/testing:testing_lib",
   ]
 }

--- a/engine/src/flutter/impeller/display_list/BUILD.gn
+++ b/engine/src/flutter/impeller/display_list/BUILD.gn
@@ -116,6 +116,7 @@ template("display_list_unittests_component") {
       "../playground:playground_test",
       "//flutter/display_list/testing:display_list_testing",
       "//flutter/impeller/golden_tests:screenshot",
+      "//flutter/impeller/renderer/testing:mocks",
       "//flutter/txt",
     ]
     if (defined(invoker.public_configs)) {

--- a/engine/src/flutter/impeller/entity/BUILD.gn
+++ b/engine/src/flutter/impeller/entity/BUILD.gn
@@ -294,6 +294,7 @@ impeller_component("entity_unittests") {
     "../geometry:geometry_asserts",
     "../playground:playground_test",
     "//flutter/display_list/testing:display_list_testing",
+    "//flutter/impeller/renderer/testing:mocks",
     "//flutter/impeller/typographer/backends/skia:typographer_skia_backend",
     "//flutter/txt",
   ]

--- a/engine/src/flutter/impeller/renderer/testing/BUILD.gn
+++ b/engine/src/flutter/impeller/renderer/testing/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/impeller/tools/impeller.gni")
+
+source_set("mocks") {
+  testonly = true
+  sources = [ "mocks.h" ]
+
+  public_deps = [
+    "//flutter/impeller/renderer",
+    "//third_party/googletest:gmock",
+    "//third_party/googletest:gtest",
+  ]
+}

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -278,9 +278,9 @@ if (enable_unittests) {
     ]
 
     deps = [
+      ":display_list_deferred_image_unittests",
       ":ui",
       ":ui_unittests_fixtures",
-      ":display_list_deferred_image_unittests",
       "$dart_src/runtime/bin:elf_loader",
       "//flutter/common",
       "//flutter/impeller",
@@ -303,14 +303,13 @@ if (enable_unittests) {
 
   source_set("display_list_deferred_image_unittests") {
     testonly = true
-    sources = [
-      "painting/display_list_deferred_image_gpu_impeller_unittests.cc",
-    ]
+    sources =
+        [ "painting/display_list_deferred_image_gpu_impeller_unittests.cc" ]
     deps = [
+      ":ui",
       "//flutter/display_list",
       "//flutter/fml",
       "//flutter/testing:testing_lib",
-      ":ui",
     ]
   }
 }

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -323,6 +323,7 @@ if (enable_unittests) {
     public_deps = [
       ":ui",
       "//flutter/common/graphics",
+      "//flutter/display_list",
       "//third_party/googletest:gmock",
     ]
   }

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -307,7 +307,7 @@ if (enable_unittests) {
     testonly = true
     sources = []
 
-    if (!is_fuchsia) {
+    if (impeller_supports_rendering) {
       sources +=
           [ "painting/display_list_deferred_image_gpu_impeller_unittests.cc" ]
     }

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -305,8 +305,13 @@ if (enable_unittests) {
 
   source_set("display_list_deferred_image_unittests") {
     testonly = true
-    sources =
-        [ "painting/display_list_deferred_image_gpu_impeller_unittests.cc" ]
+    sources = []
+
+    if (!is_fuchsia) {
+      sources +=
+          [ "painting/display_list_deferred_image_gpu_impeller_unittests.cc" ]
+    }
+
     deps = [
       ":ui",
       ":ui_testing_mocks",

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -284,6 +284,7 @@ if (enable_unittests) {
       "$dart_src/runtime/bin:elf_loader",
       "//flutter/common",
       "//flutter/impeller",
+      "//flutter/impeller/renderer/testing:mocks",
       "//flutter/lib/snapshot",
       "//flutter/shell/common:shell_test_fixture_sources",
       "//flutter/testing",
@@ -309,6 +310,7 @@ if (enable_unittests) {
       ":ui",
       "//flutter/display_list",
       "//flutter/fml",
+      "//flutter/impeller/renderer/testing:mocks",
       "//flutter/testing:testing_lib",
     ]
   }

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -280,6 +280,7 @@ if (enable_unittests) {
     deps = [
       ":display_list_deferred_image_unittests",
       ":ui",
+      ":ui_testing_mocks",
       ":ui_unittests_fixtures",
       "$dart_src/runtime/bin:elf_loader",
       "//flutter/common",
@@ -308,10 +309,21 @@ if (enable_unittests) {
         [ "painting/display_list_deferred_image_gpu_impeller_unittests.cc" ]
     deps = [
       ":ui",
+      ":ui_testing_mocks",
       "//flutter/display_list",
       "//flutter/fml",
       "//flutter/impeller/renderer/testing:mocks",
       "//flutter/testing:testing_lib",
+    ]
+  }
+
+  source_set("ui_testing_mocks") {
+    testonly = true
+    sources = [ "painting/testing/mocks.h" ]
+    public_deps = [
+      ":ui",
+      "//flutter/common/graphics",
+      "//third_party/googletest:gmock",
     ]
   }
 }

--- a/engine/src/flutter/lib/ui/BUILD.gn
+++ b/engine/src/flutter/lib/ui/BUILD.gn
@@ -280,6 +280,7 @@ if (enable_unittests) {
     deps = [
       ":ui",
       ":ui_unittests_fixtures",
+      ":display_list_deferred_image_unittests",
       "$dart_src/runtime/bin:elf_loader",
       "//flutter/common",
       "//flutter/impeller",
@@ -298,5 +299,18 @@ if (enable_unittests) {
 
       deps += [ "//flutter/testing:opengl" ]
     }
+  }
+
+  source_set("display_list_deferred_image_unittests") {
+    testonly = true
+    sources = [
+      "painting/display_list_deferred_image_gpu_impeller_unittests.cc",
+    ]
+    deps = [
+      "//flutter/display_list",
+      "//flutter/fml",
+      "//flutter/testing:testing_lib",
+      ":ui",
+    ]
   }
 }

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -180,6 +180,7 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
           return;
         }
         wrapper->texture_ = snapshot->impeller_texture();
+        wrapper->display_list_ = nullptr;
       }));
 }
 

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -137,35 +137,35 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
     std::unique_ptr<LayerTree> layer_tree) {
   fml::TaskRunner::RunNowOrPostTask(
       raster_task_runner_,
-      fml::MakeCopyable([weak_this = weak_from_this(),
-                         layer_tree = std::move(layer_tree)]() {
-        TRACE_EVENT0("flutter", "SnapshotDisplayList (impeller)");
-        auto wrapper = weak_this.lock();
-        if (!wrapper) {
-          return;
-        }
-        auto snapshot_delegate = wrapper->snapshot_delegate_;
-        if (!snapshot_delegate) {
-          return;
-        }
+      fml::MakeCopyable(
+          [weak_this = weak_from_this(), layer_tree = std::move(layer_tree)]() {
+            TRACE_EVENT0("flutter", "SnapshotDisplayList (impeller)");
+            auto wrapper = weak_this.lock();
+            if (!wrapper) {
+              return;
+            }
+            auto snapshot_delegate = wrapper->snapshot_delegate_;
+            if (!snapshot_delegate) {
+              return;
+            }
 
-        std::shared_ptr<TextureRegistry> texture_registry =
-            snapshot_delegate->GetTextureRegistry();
-        if (layer_tree) {
-          wrapper->display_list_ = layer_tree->Flatten(
-              DlRect::MakeWH(wrapper->size_.width, wrapper->size_.height),
-              texture_registry);
-        }
-        auto snapshot = snapshot_delegate->MakeRasterSnapshotSync(
-            wrapper->display_list_, wrapper->size_);
-        if (!snapshot) {
-          std::scoped_lock lock(wrapper->error_mutex_);
-          wrapper->error_ = "Failed to create snapshot.";
-          return;
-        }
-        wrapper->texture_ = snapshot->impeller_texture();
-        wrapper->display_list_ = nullptr;
-      }));
+            std::shared_ptr<TextureRegistry> texture_registry =
+                snapshot_delegate->GetTextureRegistry();
+            if (layer_tree) {
+              wrapper->display_list_ = layer_tree->Flatten(
+                  DlRect::MakeWH(wrapper->size_.width, wrapper->size_.height),
+                  texture_registry);
+            }
+            auto snapshot = snapshot_delegate->MakeRasterSnapshotSync(
+                wrapper->display_list_, wrapper->size_);
+            if (!snapshot) {
+              std::scoped_lock lock(wrapper->error_mutex_);
+              wrapper->error_ = "Failed to create snapshot.";
+              return;
+            }
+            wrapper->texture_ = snapshot->impeller_texture();
+            wrapper->display_list_ = nullptr;
+          }));
 }
 
 std::optional<std::string>

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.cc
@@ -148,7 +148,6 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
         }
 
         sk_sp<DisplayList> display_list;
-        DlISize snapshot_size = wrapper->size_;
 
         if (std::holds_alternative<sk_sp<DisplayList>>(content)) {
           display_list = std::get<sk_sp<DisplayList>>(std::move(content));
@@ -156,14 +155,13 @@ void DlDeferredImageGPUImpeller::ImageWrapper::SnapshotDisplayList(
                        content)) {
           std::unique_ptr<LayerTree> layer_tree =
               std::get<std::unique_ptr<LayerTree>>(std::move(content));
-          snapshot_size = layer_tree->frame_size();
           display_list = layer_tree->Flatten(
-              DlRect::MakeWH(snapshot_size.width, snapshot_size.height),
+              DlRect::MakeWH(wrapper->size_.width, wrapper->size_.height),
               snapshot_delegate->GetTextureRegistry());
         }
 
         auto snapshot = snapshot_delegate->MakeRasterSnapshotSync(
-            display_list, snapshot_size);
+            display_list, wrapper->size_);
         if (!snapshot) {
           std::scoped_lock lock(wrapper->error_mutex_);
           wrapper->error_ = "Failed to create snapshot.";

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -20,7 +20,6 @@ namespace testing {
 FML_TEST_CLASS(DlDeferredImageGPUImpeller, TrashesDisplayList);
 }  // namespace testing
 
-
 class DlDeferredImageGPUImpeller final : public DlImage {
  public:
   static sk_sp<DlDeferredImageGPUImpeller> Make(

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -99,7 +99,6 @@ class DlDeferredImageGPUImpeller final : public DlImage {
     std::shared_ptr<impeller::Texture> texture_;
     fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate_;
     fml::RefPtr<fml::TaskRunner> raster_task_runner_;
-    std::shared_ptr<TextureRegistry> texture_registry_;
 
     mutable std::mutex error_mutex_;
     std::optional<std::string> error_;

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_DISPLAY_LIST_DEFERRED_IMAGE_GPU_IMPELLER_H_
 #define FLUTTER_LIB_UI_PAINTING_DISPLAY_LIST_DEFERRED_IMAGE_GPU_IMPELLER_H_
 
+#include <variant>
 #include "flutter/common/graphics/texture.h"
 #include "flutter/display_list/image/dl_image.h"
 #include "flutter/flow/layers/layer_tree.h"
@@ -102,17 +103,14 @@ class DlDeferredImageGPUImpeller final : public DlImage {
     std::optional<std::string> error_;
 
     ImageWrapper(
-        sk_sp<DisplayList> display_list,
         const DlISize& size,
         fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate,
         fml::RefPtr<fml::TaskRunner> raster_task_runner);
 
-    // If a layer tree is provided, it will be flattened during the raster
-    // thread task spawned by this method. After being flattened into a display
-    // list, the image wrapper will be updated to hold this display list and the
-    // layer tree can be dropped.
-    void SnapshotDisplayList(sk_sp<DisplayList> display_list,
-                             std::unique_ptr<LayerTree> layer_tree);
+    // If a layer tree is provided, it will be flattened into a display list
+    // during the raster thread task spawned by this method.
+    void SnapshotDisplayList(
+        std::variant<sk_sp<DisplayList>, std::unique_ptr<LayerTree>> content);
 
     // |ContextListener|
     void OnGrContextCreated() override;

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -94,7 +94,6 @@ class DlDeferredImageGPUImpeller final : public DlImage {
    private:
     FML_FRIEND_TEST(testing::DlDeferredImageGPUImpeller, TrashesDisplayList);
     DlISize size_;
-    sk_sp<DisplayList> display_list_;
     std::shared_ptr<impeller::Texture> texture_;
     fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate_;
     fml::RefPtr<fml::TaskRunner> raster_task_runner_;
@@ -112,7 +111,8 @@ class DlDeferredImageGPUImpeller final : public DlImage {
     // thread task spawned by this method. After being flattened into a display
     // list, the image wrapper will be updated to hold this display list and the
     // layer tree can be dropped.
-    void SnapshotDisplayList(std::unique_ptr<LayerTree> layer_tree = nullptr);
+    void SnapshotDisplayList(sk_sp<DisplayList> display_list,
+                             std::unique_ptr<LayerTree> layer_tree);
 
     // |ContextListener|
     void OnGrContextCreated() override;

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h
@@ -16,6 +16,11 @@
 
 namespace flutter {
 
+namespace testing {
+FML_TEST_CLASS(DlDeferredImageGPUImpeller, TrashesDisplayList);
+}  // namespace testing
+
+
 class DlDeferredImageGPUImpeller final : public DlImage {
  public:
   static sk_sp<DlDeferredImageGPUImpeller> Make(
@@ -59,6 +64,8 @@ class DlDeferredImageGPUImpeller final : public DlImage {
   }
 
  private:
+  FML_FRIEND_TEST(testing::DlDeferredImageGPUImpeller, TrashesDisplayList);
+
   class ImageWrapper final : public std::enable_shared_from_this<ImageWrapper>,
                              public ContextListener {
    public:
@@ -86,6 +93,7 @@ class DlDeferredImageGPUImpeller final : public DlImage {
     std::optional<std::string> get_error();
 
    private:
+    FML_FRIEND_TEST(testing::DlDeferredImageGPUImpeller, TrashesDisplayList);
     DlISize size_;
     sk_sp<DisplayList> display_list_;
     std::shared_ptr<impeller::Texture> texture_;

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -11,8 +11,8 @@
 #include "flutter/testing/testing.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
 #include "impeller/core/texture_descriptor.h"
+#include "impeller/renderer/testing/mocks.h"
 
 namespace flutter {
 namespace testing {
@@ -21,29 +21,6 @@ class MockTextureRegistry : public TextureRegistry {
  public:
   MockTextureRegistry() = default;
   virtual ~MockTextureRegistry() = default;
-};
-
-// Local mock texture for testing purposes.
-class MockTexture : public impeller::Texture {
- public:
-  explicit MockTexture(const impeller::TextureDescriptor& desc)
-      : impeller::Texture(desc) {}
-
-  MOCK_METHOD(void, SetLabel, (std::string_view label), (override));
-  MOCK_METHOD(void,
-              SetLabel,
-              (std::string_view label, std::string_view trailing),
-              (override));
-  MOCK_METHOD(bool, IsValid, (), (const, override));
-  MOCK_METHOD(impeller::ISize, GetSize, (), (const, override));
-  MOCK_METHOD(bool,
-              OnSetContents,
-              (const uint8_t* contents, size_t length, size_t slice),
-              (override));
-  MOCK_METHOD(bool,
-              OnSetContents,
-              (std::shared_ptr<const fml::Mapping> mapping, size_t slice),
-              (override));
 };
 
 class MockDlImage : public DlImage {
@@ -163,7 +140,7 @@ TEST(DlDeferredImageGPUImpeller, TrashesDisplayList) {
     auto mock_image = sk_make_sp<MockDlImage>();
     impeller::TextureDescriptor desc;
     desc.size = {1, 1};
-    auto mock_texture = std::make_shared<MockTexture>(desc);
+    auto mock_texture = std::make_shared<impeller::testing::MockTexture>(desc);
     EXPECT_CALL(*mock_image, impeller_texture)
         .WillOnce(::testing::Return(mock_texture));
     EXPECT_CALL(*snapshot_delegate,

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -18,20 +18,6 @@ namespace flutter {
 namespace testing {
 namespace {
 
-class MockDlImage : public DlImage {
- public:
-  MOCK_METHOD(DlISize, GetSize, (), (const, override));
-  MOCK_METHOD(sk_sp<SkImage>, skia_image, (), (const, override));
-  MOCK_METHOD(bool, isOpaque, (), (const, override));
-  MOCK_METHOD(bool, isTextureBacked, (), (const, override));
-  MOCK_METHOD(std::shared_ptr<impeller::Texture>,
-              impeller_texture,
-              (),
-              (const, override));
-  MOCK_METHOD(size_t, GetApproximateByteSize, (), (const, override));
-  MOCK_METHOD(bool, isUIThreadSafe, (), (const, override));
-};
-
 void PostTaskSync(fml::RefPtr<fml::TaskRunner> task_runner,
                   std::function<void()> task) {
   fml::AutoResetWaitableEvent latch;

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -89,14 +89,12 @@ TEST(DlDeferredImageGPUImpeller, TrashesDisplayList) {
       builder.Build(), size, snapshot_delegate_weak_ptr, task_runner);
 
   EXPECT_FALSE(image->impeller_texture());
-  EXPECT_TRUE(image->wrapper_->display_list_);
 
   // Unpause raster thread.
   latch.Signal();
 
   PostTaskSync(task_runner, [&]() {
     EXPECT_TRUE(image->impeller_texture());
-    EXPECT_FALSE(image->wrapper_->display_list_);
     snapshot_delegate.reset();
   });
 }

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -18,10 +18,10 @@ namespace flutter {
 namespace testing {
 namespace {
 
-void PostTaskSync(fml::RefPtr<fml::TaskRunner> task_runner,
+void PostTaskSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
                   std::function<void()> task) {
   fml::AutoResetWaitableEvent latch;
-  task_runner->PostTask([&latch, &task]() {
+  task_runner->PostTask([&latch, task = std::move(task)]() {
     task();
     latch.Signal();
   });

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -7,7 +7,7 @@
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/thread.h"
 #include "flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h"
-#include "flutter/lib/ui/snapshot_delegate.h"
+#include "flutter/lib/ui/painting/testing/mocks.h"
 #include "flutter/testing/testing.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -17,11 +17,6 @@
 namespace flutter {
 namespace testing {
 namespace {
-class MockTextureRegistry : public TextureRegistry {
- public:
-  MockTextureRegistry() = default;
-  virtual ~MockTextureRegistry() = default;
-};
 
 class MockDlImage : public DlImage {
  public:
@@ -35,55 +30,6 @@ class MockDlImage : public DlImage {
               (const, override));
   MOCK_METHOD(size_t, GetApproximateByteSize, (), (const, override));
   MOCK_METHOD(bool, isUIThreadSafe, (), (const, override));
-};
-
-class MockSnapshotDelegate : public SnapshotDelegate {
- public:
-  MockSnapshotDelegate()
-      : weak_factory_(this),
-        texture_registry_(std::make_shared<MockTextureRegistry>()) {}
-  virtual ~MockSnapshotDelegate() = default;
-
-  MOCK_METHOD(std::unique_ptr<GpuImageResult>,
-              MakeSkiaGpuImage,
-              (sk_sp<DisplayList>, const SkImageInfo&),
-              (override));
-  MOCK_METHOD(std::shared_ptr<TextureRegistry>,
-              GetTextureRegistry,
-              (),
-              (override));
-  MOCK_METHOD(GrDirectContext*, GetGrContext, (), (override));
-  MOCK_METHOD(void,
-              MakeRasterSnapshot,
-              (sk_sp<DisplayList>,
-               DlISize,
-               std::function<void(sk_sp<DlImage>)>),
-              (override));
-  MOCK_METHOD(sk_sp<DlImage>,
-              MakeRasterSnapshotSync,
-              (sk_sp<DisplayList>, DlISize),
-              (override));
-  MOCK_METHOD(sk_sp<SkImage>,
-              ConvertToRasterImage,
-              (sk_sp<SkImage>),
-              (override));
-  MOCK_METHOD(void,
-              CacheRuntimeStage,
-              (const std::shared_ptr<impeller::RuntimeStage>&),
-              (override));
-  MOCK_METHOD(bool, MakeRenderContextCurrent, (), (override));
-
-  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> GetWeakPtr() {
-    return weak_factory_.GetWeakPtr();
-  }
-
-  std::shared_ptr<MockTextureRegistry> GetMockTextureRegistry() {
-    return texture_registry_;
-  }
-
- private:
-  fml::TaskRunnerAffineWeakPtrFactory<MockSnapshotDelegate> weak_factory_;
-  std::shared_ptr<MockTextureRegistry> texture_registry_;
 };
 
 void PostTaskSync(fml::RefPtr<fml::TaskRunner> task_runner,

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -8,6 +8,7 @@
 #include "flutter/fml/thread.h"
 #include "flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h"
 #include "flutter/lib/ui/painting/testing/mocks.h"
+#include "flutter/testing/post_task_sync.h"
 #include "flutter/testing/testing.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -16,19 +17,6 @@
 
 namespace flutter {
 namespace testing {
-namespace {
-
-void PostTaskSync(const fml::RefPtr<fml::TaskRunner>& task_runner,
-                  std::function<void()> task) {
-  fml::AutoResetWaitableEvent latch;
-  task_runner->PostTask([&latch, task = std::move(task)]() {
-    task();
-    latch.Signal();
-  });
-  latch.Wait();
-}
-
-}  // namespace
 
 TEST(DlDeferredImageGPUImpeller, GetSize) {
   fml::Thread raster_thread("raster");

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -174,9 +174,7 @@ TEST(DlDeferredImageGPUImpeller, TrashesDisplayList) {
 
   // Pause raster thread.
   fml::AutoResetWaitableEvent latch;
-  task_runner->PostTask([&latch]() {
-    latch.Wait();
-  });
+  task_runner->PostTask([&latch]() { latch.Wait(); });
 
   auto image = DlDeferredImageGPUImpeller::Make(
       builder.Build(), size, snapshot_delegate_weak_ptr, task_runner);
@@ -187,13 +185,11 @@ TEST(DlDeferredImageGPUImpeller, TrashesDisplayList) {
   // Unpause raster thread.
   latch.Signal();
 
-  // Flush raster events.
-  PostTaskSync(task_runner, []() {});
-
-  EXPECT_TRUE(image->impeller_texture());
-  // EXPECT_FALSE(image->wrapper_->display_list_);
-
-  PostTaskSync(task_runner, [&]() { snapshot_delegate.reset(); });
+  PostTaskSync(task_runner, [&]() {
+    EXPECT_TRUE(image->impeller_texture());
+    EXPECT_FALSE(image->wrapper_->display_list_);
+    snapshot_delegate.reset();
+  });
 }
 
 }  // namespace testing

--- a/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller_unittests.cc
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/common/graphics/texture.h"  // Include for TextureRegistry
+#include "flutter/display_list/dl_builder.h"
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/fml/thread.h"
+#include "flutter/lib/ui/painting/display_list_deferred_image_gpu_impeller.h"
+#include "flutter/lib/ui/snapshot_delegate.h"
+#include "flutter/testing/testing.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+namespace {
+class MockTextureRegistry : public TextureRegistry {
+ public:
+  MockTextureRegistry() = default;
+  virtual ~MockTextureRegistry() = default;
+};
+
+class MockSnapshotDelegate : public SnapshotDelegate {
+ public:
+  MockSnapshotDelegate()
+      : weak_factory_(this),
+        texture_registry_(std::make_shared<MockTextureRegistry>()) {}
+  virtual ~MockSnapshotDelegate() = default;
+
+  MOCK_METHOD(std::unique_ptr<GpuImageResult>,
+              MakeSkiaGpuImage,
+              (sk_sp<DisplayList>, const SkImageInfo&),
+              (override));
+  MOCK_METHOD(std::shared_ptr<TextureRegistry>,
+              GetTextureRegistry,
+              (),
+              (override));
+  MOCK_METHOD(GrDirectContext*, GetGrContext, (), (override));
+  MOCK_METHOD(void,
+              MakeRasterSnapshot,
+              (sk_sp<DisplayList>,
+               DlISize,
+               std::function<void(sk_sp<DlImage>)>),
+              (override));
+  MOCK_METHOD(sk_sp<DlImage>,
+              MakeRasterSnapshotSync,
+              (sk_sp<DisplayList>, DlISize),
+              (override));
+  MOCK_METHOD(sk_sp<SkImage>,
+              ConvertToRasterImage,
+              (sk_sp<SkImage>),
+              (override));
+  MOCK_METHOD(void,
+              CacheRuntimeStage,
+              (const std::shared_ptr<impeller::RuntimeStage>&),
+              (override));
+  MOCK_METHOD(bool, MakeRenderContextCurrent, (), (override));
+
+  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
+  std::shared_ptr<MockTextureRegistry> GetMockTextureRegistry() {
+    return texture_registry_;
+  }
+
+ private:
+  fml::TaskRunnerAffineWeakPtrFactory<MockSnapshotDelegate> weak_factory_;
+  std::shared_ptr<MockTextureRegistry> texture_registry_;
+};
+}  // namespace
+
+TEST(DlDeferredImageGPUImpeller, GetSize) {
+  fml::Thread raster_thread("raster");
+  auto task_runner = raster_thread.GetTaskRunner();
+  const DlISize size = {100, 200};
+  flutter::DisplayListBuilder builder;
+
+  fml::AutoResetWaitableEvent latch;
+  std::unique_ptr<MockSnapshotDelegate> snapshot_delegate;
+  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> snapshot_delegate_weak_ptr;
+  task_runner->PostTask([&]() {
+    snapshot_delegate = std::make_unique<MockSnapshotDelegate>();
+    // Set up the mock to return the internal texture_registry_.
+    ON_CALL(*snapshot_delegate, GetTextureRegistry())
+        .WillByDefault(
+            ::testing::Return(snapshot_delegate->GetMockTextureRegistry()));
+    snapshot_delegate_weak_ptr = snapshot_delegate->GetWeakPtr();
+    latch.Signal();
+  });
+  latch.Wait();
+
+  auto image = DlDeferredImageGPUImpeller::Make(
+      builder.Build(), size, snapshot_delegate_weak_ptr, task_runner);
+  ASSERT_EQ(image->GetSize(), size);
+
+  fml::AutoResetWaitableEvent destroy_latch;
+  task_runner->PostTask([&]() {
+    snapshot_delegate.reset();
+    destroy_latch.Signal();
+  });
+  destroy_latch.Wait();
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -10,7 +10,7 @@
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/lib/ui/painting/image.h"
-#include "flutter/lib/ui/snapshot_delegate.h"
+#include "flutter/lib/ui/painting/testing/mocks.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/thread_host.h"
@@ -66,48 +66,6 @@ class MockSyncSwitch {
   MOCK_METHOD(void, Execute, (const Handlers& handlers), (const));
   MOCK_METHOD(void, SetSwitch, (bool value));
 };
-
-class MockSnapshotDelegate : public SnapshotDelegate {
- public:
-  MockSnapshotDelegate() : weak_factory_(this) {}
-
-  MOCK_METHOD(std::unique_ptr<GpuImageResult>,
-              MakeSkiaGpuImage,
-              (sk_sp<DisplayList>, const SkImageInfo&),
-              (override));
-  MOCK_METHOD(std::shared_ptr<TextureRegistry>,
-              GetTextureRegistry,
-              (),
-              (override));
-  MOCK_METHOD(GrDirectContext*, GetGrContext, (), (override));
-  MOCK_METHOD(void,
-              MakeRasterSnapshot,
-              (sk_sp<DisplayList>,
-               DlISize,
-               std::function<void(sk_sp<DlImage>)>),
-              (override));
-  MOCK_METHOD(sk_sp<DlImage>,
-              MakeRasterSnapshotSync,
-              (sk_sp<DisplayList>, DlISize),
-              (override));
-  MOCK_METHOD(sk_sp<SkImage>,
-              ConvertToRasterImage,
-              (sk_sp<SkImage>),
-              (override));
-  MOCK_METHOD(void,
-              CacheRuntimeStage,
-              (const std::shared_ptr<impeller::RuntimeStage>&),
-              (override));
-  MOCK_METHOD(bool, MakeRenderContextCurrent, (), (override));
-
-  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> GetWeakPtr() {
-    return weak_factory_.GetWeakPtr();
-  }
-
- private:
-  fml::TaskRunnerAffineWeakPtrFactory<MockSnapshotDelegate> weak_factory_;
-};
-
 }  // namespace
 
 TEST_F(ShellTest, EncodeImageGivesExternalTypedData) {

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -34,20 +34,6 @@ namespace testing {
 namespace {
 fml::AutoResetWaitableEvent message_latch;
 
-class MockDlImage : public DlImage {
- public:
-  MOCK_METHOD(sk_sp<SkImage>, skia_image, (), (const, override));
-  MOCK_METHOD(std::shared_ptr<impeller::Texture>,
-              impeller_texture,
-              (),
-              (const, override));
-  MOCK_METHOD(bool, isOpaque, (), (const, override));
-  MOCK_METHOD(bool, isTextureBacked, (), (const, override));
-  MOCK_METHOD(bool, isUIThreadSafe, (), (const, override));
-  MOCK_METHOD(DlISize, GetSize, (), (const, override));
-  MOCK_METHOD(size_t, GetApproximateByteSize, (), (const, override));
-};
-
 class MockSyncSwitch {
  public:
   struct Handlers {

--- a/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
+++ b/engine/src/flutter/lib/ui/painting/image_encoding_unittests.cc
@@ -48,8 +48,6 @@ class MockDlImage : public DlImage {
   MOCK_METHOD(size_t, GetApproximateByteSize, (), (const, override));
 };
 
-}  // namespace
-
 class MockSyncSwitch {
  public:
   struct Handlers {
@@ -109,6 +107,8 @@ class MockSnapshotDelegate : public SnapshotDelegate {
  private:
   fml::TaskRunnerAffineWeakPtrFactory<MockSnapshotDelegate> weak_factory_;
 };
+
+}  // namespace
 
 TEST_F(ShellTest, EncodeImageGivesExternalTypedData) {
   auto native_encode_image = [&](Dart_NativeArguments args) {

--- a/engine/src/flutter/lib/ui/painting/testing/mocks.h
+++ b/engine/src/flutter/lib/ui/painting/testing/mocks.h
@@ -67,6 +67,20 @@ class MockSnapshotDelegate : public SnapshotDelegate {
   std::shared_ptr<MockTextureRegistry> texture_registry_;
 };
 
+class MockDlImage : public DlImage {
+ public:
+  MOCK_METHOD(DlISize, GetSize, (), (const, override));
+  MOCK_METHOD(sk_sp<SkImage>, skia_image, (), (const, override));
+  MOCK_METHOD(bool, isOpaque, (), (const, override));
+  MOCK_METHOD(bool, isTextureBacked, (), (const, override));
+  MOCK_METHOD(std::shared_ptr<impeller::Texture>,
+              impeller_texture,
+              (),
+              (const, override));
+  MOCK_METHOD(size_t, GetApproximateByteSize, (), (const, override));
+  MOCK_METHOD(bool, isUIThreadSafe, (), (const, override));
+};
+
 }  // namespace testing
 }  // namespace flutter
 

--- a/engine/src/flutter/lib/ui/painting/testing/mocks.h
+++ b/engine/src/flutter/lib/ui/painting/testing/mocks.h
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_PAINTING_TESTING_MOCKS_H_
+#define FLUTTER_LIB_UI_PAINTING_TESTING_MOCKS_H_
+
+#include "flutter/common/graphics/texture.h"
+#include "flutter/lib/ui/snapshot_delegate.h"
+#include "gmock/gmock.h"
+
+namespace flutter {
+namespace testing {
+
+class MockTextureRegistry : public TextureRegistry {
+ public:
+  MockTextureRegistry() = default;
+  virtual ~MockTextureRegistry() = default;
+};
+
+class MockSnapshotDelegate : public SnapshotDelegate {
+ public:
+  MockSnapshotDelegate()
+      : weak_factory_(this),
+        texture_registry_(std::make_shared<MockTextureRegistry>()) {}
+  virtual ~MockSnapshotDelegate() = default;
+
+  MOCK_METHOD(std::unique_ptr<GpuImageResult>,
+              MakeSkiaGpuImage,
+              (sk_sp<DisplayList>, const SkImageInfo&),
+              (override));
+  MOCK_METHOD(std::shared_ptr<TextureRegistry>,
+              GetTextureRegistry,
+              (),
+              (override));
+  MOCK_METHOD(GrDirectContext*, GetGrContext, (), (override));
+  MOCK_METHOD(void,
+              MakeRasterSnapshot,
+              (sk_sp<DisplayList>,
+               DlISize,
+               std::function<void(sk_sp<DlImage>)>),
+              (override));
+  MOCK_METHOD(sk_sp<DlImage>,
+              MakeRasterSnapshotSync,
+              (sk_sp<DisplayList>, DlISize),
+              (override));
+  MOCK_METHOD(sk_sp<SkImage>,
+              ConvertToRasterImage,
+              (sk_sp<SkImage>),
+              (override));
+  MOCK_METHOD(void,
+              CacheRuntimeStage,
+              (const std::shared_ptr<impeller::RuntimeStage>&),
+              (override));
+  MOCK_METHOD(bool, MakeRenderContextCurrent, (), (override));
+
+  fml::TaskRunnerAffineWeakPtr<SnapshotDelegate> GetWeakPtr() {
+    return weak_factory_.GetWeakPtr();
+  }
+
+  std::shared_ptr<MockTextureRegistry> GetMockTextureRegistry() {
+    return texture_registry_;
+  }
+
+ private:
+  fml::TaskRunnerAffineWeakPtrFactory<MockSnapshotDelegate> weak_factory_;
+  std::shared_ptr<MockTextureRegistry> texture_registry_;
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_PAINTING_TESTING_MOCKS_H_


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/138627

This stops ballooning recursive display_lists that can happen in animations.  The display list actually can be larger than the image so keeping the display list around is no benefit.  In rare cases this could make the memory size of backgrounded apps be larger but this keeps images made with toImageSync have the same semantics as toImage on impeller.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
