### PR TITLE
Separate copying dsym into its own target

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -287,7 +287,6 @@ abstract class UnpackIOS extends UnpackDarwin {
       targetPlatform: TargetPlatform.ios,
       buildMode: buildMode,
     );
-    await _copyFrameworkDysm(environment, sdkRoot: sdkRoot, environmentType: environmentType);
 
     final File frameworkBinary = environment.outputDir
         .childDirectory(FlutterDarwinPlatform.ios.frameworkName)
@@ -298,40 +297,6 @@ abstract class UnpackIOS extends UnpackDarwin {
     }
     await thinFramework(environment, frameworkBinaryPath, archs);
     await _signFramework(environment, frameworkBinary, buildMode);
-  }
-
-  Future<void> _copyFrameworkDysm(
-    Environment environment, {
-    required String sdkRoot,
-    EnvironmentType? environmentType,
-  }) async {
-    // Copy Flutter framework dSYM (debug symbol) bundle, if present.
-    final Directory frameworkDsym = environment.fileSystem.directory(
-      environment.artifacts.getArtifactPath(
-        Artifact.flutterFrameworkDsym,
-        platform: TargetPlatform.ios,
-        mode: buildMode,
-        environmentType: environmentType,
-      ),
-    );
-    if (frameworkDsym.existsSync()) {
-      final ProcessResult result = await environment.processManager.run(<String>[
-        'rsync',
-        '-av',
-        '--delete',
-        '--filter',
-        '- .DS_Store/',
-        '--chmod=Du=rwx,Dgo=rx,Fu=rw,Fgo=r',
-        frameworkDsym.path,
-        environment.outputDir.path,
-      ]);
-      if (result.exitCode != 0) {
-        throw Exception(
-          'Failed to copy framework dSYM (exit ${result.exitCode}:\n'
-          '${result.stdout}\n---\n${result.stderr}',
-        );
-      }
-    }
   }
 }
 
@@ -344,6 +309,9 @@ class ReleaseUnpackIOS extends UnpackIOS {
 
   @override
   BuildMode get buildMode => BuildMode.release;
+
+  @override
+  List<Target> get dependencies => [...super.dependencies, const ReleaseUnpackIOSDsym()];
 }
 
 /// Unpack the profile prebuilt engine framework.
@@ -366,6 +334,49 @@ class DebugUnpackIOS extends UnpackIOS {
 
   @override
   BuildMode get buildMode => BuildMode.debug;
+}
+
+class ReleaseUnpackIOSDsym extends ReleaseUnpackDarwinDsym {
+  const ReleaseUnpackIOSDsym();
+
+  @override
+  String get name => 'release_unpack_ios_dsym';
+
+  @override
+  TargetPlatform get targetPlatform => TargetPlatform.ios;
+
+  @override
+  Artifact get dsymArtifact => Artifact.flutterFrameworkDsym;
+
+  @override
+  List<Source> get inputs => <Source>[
+    ...super.inputs,
+    const Source.pattern(
+      '{FLUTTER_ROOT}/packages/flutter_tools/lib/src/build_system/targets/ios.dart',
+    ),
+  ];
+
+  @override
+  List<Source> get outputs => const <Source>[
+    Source.pattern('{OUTPUT_DIR}/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter'),
+  ];
+
+  @override
+  Future<void> build(Environment environment) async {
+    final String? sdkRoot = environment.defines[kSdkRoot];
+    if (sdkRoot == null) {
+      throw MissingDefineException(kSdkRoot, name);
+    }
+    final String? archs = environment.defines[kIosArchs];
+    if (archs == null) {
+      throw MissingDefineException(kIosArchs, name);
+    }
+    final EnvironmentType? environmentType = environmentTypeFromSdkroot(
+      sdkRoot,
+      environment.fileSystem,
+    );
+    await copyFrameworkDsym(environment, environmentType: environmentType);
+  }
 }
 
 // TODO(gaaclarke): Remove this after a reasonable amount of time where the

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -367,10 +367,6 @@ class ReleaseUnpackIOSDsym extends ReleaseUnpackDarwinDsym {
     if (sdkRoot == null) {
       throw MissingDefineException(kSdkRoot, name);
     }
-    final String? archs = environment.defines[kIosArchs];
-    if (archs == null) {
-      throw MissingDefineException(kIosArchs, name);
-    }
     final EnvironmentType? environmentType = environmentTypeFromSdkroot(
       sdkRoot,
       environment.fileSystem,

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -88,6 +88,8 @@ void main() {
           late Directory buildPath;
           late Directory buildAppFrameworkDsym;
           late File buildAppFrameworkDsymBinary;
+          late Directory flutterFrameworkDsym;
+          late File flutterFrameworkDsymBinary;
           late ProcessResult buildResult;
 
           setUpAll(() {
@@ -137,6 +139,11 @@ void main() {
             buildAppFrameworkDsymBinary = buildAppFrameworkDsym.childFile(
               'Contents/Resources/DWARF/App',
             );
+
+            flutterFrameworkDsym = buildPath.childDirectory('Flutter.framework.dSYM');
+            flutterFrameworkDsymBinary = flutterFrameworkDsym.childFile(
+              'Contents/Resources/DWARF/Flutter',
+            );
           });
 
           testWithoutContext('flutter build ios builds a valid app', () {
@@ -164,6 +171,7 @@ void main() {
             expect(outputAppFramework.childFile('Info.plist'), exists);
 
             expect(buildAppFrameworkDsymBinary.existsSync(), buildMode != BuildMode.debug);
+            expect(flutterFrameworkDsymBinary.existsSync(), buildMode != BuildMode.debug);
 
             final File vmSnapshot = fileSystem.file(
               fileSystem.path.join(outputAppFramework.path, 'flutter_assets', 'vm_snapshot_data'),
@@ -208,22 +216,36 @@ void main() {
             if (buildMode == BuildMode.debug) {
               expect(symbols, isEmpty);
             } else {
-              expect(symbols, equals(AppleTestUtils.requiredSymbols));
+              expect(symbols, equals(AppleTestUtils.requiredAppSymbols));
             }
+
+            final List<String> flutterSymbols = AppleTestUtils.getExportedSymbols(
+              outputFlutterFrameworkBinary.path,
+            );
+            expect(flutterSymbols, containsAll(AppleTestUtils.expectedFlutterSymbols));
           });
 
           testWithoutContext('check symbols in dSYM', () {
             if (buildMode == BuildMode.debug) {
               // dSYM is not created for a debug build.
               expect(buildAppFrameworkDsymBinary.existsSync(), isFalse);
+              expect(flutterFrameworkDsymBinary.existsSync(), isFalse);
             } else {
-              final List<String> symbols = AppleTestUtils.getExportedSymbols(
+              final List<String> appSymbols = AppleTestUtils.getExportedSymbols(
                 buildAppFrameworkDsymBinary.path,
               );
-              expect(symbols, containsAll(AppleTestUtils.requiredSymbols));
+              expect(appSymbols, containsAll(AppleTestUtils.requiredAppSymbols));
               // The actual number of symbols is going to vary but there should
               // be "many" in the dSYM. At the time of writing, it was 7656.
-              expect(symbols.length, greaterThanOrEqualTo(5000));
+              expect(appSymbols.length, greaterThanOrEqualTo(5000));
+
+              final List<String> flutterSymbols = AppleTestUtils.getExportedSymbols(
+                flutterFrameworkDsymBinary.path,
+              );
+              expect(flutterSymbols, containsAll(AppleTestUtils.expectedFlutterSymbols));
+              // The actual number of symbols is going to vary but there should
+              // be "many" in the dSYM. At the time of writing, it was 35940.
+              expect(flutterSymbols.length, greaterThanOrEqualTo(35000));
             }
           });
 

--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -203,12 +203,14 @@ void main() {
       } else {
         // Check framework dSYM file copied.
         _checkFatBinary(frameworkDsymBinary, buildModeLower, 'dSYM companion file');
+        final List<String> symbols = AppleTestUtils.getExportedSymbols(frameworkDsymBinary.path);
+        expect(symbols, containsAll(AppleTestUtils.expectedFlutterSymbols));
 
         // Check extracted dSYM file.
         _checkFatBinary(libDsymBinary, buildModeLower, 'dSYM companion file');
-        expect(libSymbols, equals(AppleTestUtils.requiredSymbols));
+        expect(libSymbols, equals(AppleTestUtils.requiredAppSymbols));
         final List<String> dSymSymbols = AppleTestUtils.getExportedSymbols(libDsymBinary.path);
-        expect(dSymSymbols, containsAll(AppleTestUtils.requiredSymbols));
+        expect(dSymSymbols, containsAll(AppleTestUtils.requiredAppSymbols));
         // The actual number of symbols is going to vary but there should
         // be "many" in the dSYM. At the time of writing, it was 19195.
         expect(dSymSymbols.length, greaterThanOrEqualTo(15000));

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -101,11 +101,17 @@ Future<void> pollForServiceExtensionValue<T>({
 }
 
 abstract final class AppleTestUtils {
-  static const requiredSymbols = <String>[
+  static const requiredAppSymbols = <String>[
     '_kDartIsolateSnapshotData',
     '_kDartIsolateSnapshotInstructions',
     '_kDartVmSnapshotData',
     '_kDartVmSnapshotInstructions',
+  ];
+
+  /// A small subset of expected symbols for the Flutter/FlutterMacOS framework
+  static const expectedFlutterSymbols = <String>[
+    r'_OBJC_CLASS_$_FlutterViewController',
+    r'_OBJC_CLASS_$_FlutterEngine',
   ];
 
   static List<String> getExportedSymbols(String dwarfPath) {


### PR DESCRIPTION
During a release build, we copy the `bin/cache/artifacts/engine/ios-release/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM` to the `build/ios/Release-iphoneos/Flutter.framework.dSYM` as part of the `UnpackIOS` build target.

This moves that logic from `UnpackIOS` into its own target (`ReleaseUnpackIOSDsym`) and adds `ReleaseUnpackIOSDsym` as a dependency of `ReleaseUnpackIOS`. This is needed so that if `UnpackIOS` is skipped, `ReleaseUnpackIOSDsym` can still run.

This also applies that same logic to macOS.

Incremental change toward https://github.com/flutter/flutter/issues/166489.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
