### PR TITLE
Make sure that a Theme doesn't crash in 0x0 environment

### DIFF
--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -1163,6 +1163,23 @@ void main() {
       expect(theme.primaryContrastingColor, CupertinoColors.destructiveRed);
     });
   });
+
+  testWidgets('Theme does not crash at zero area', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox.shrink(
+            child: Theme(
+              key: const Key('Theme'),
+              data: ThemeData(colorScheme: const ColorScheme.light(primary: Colors.green)),
+              child: const Text('X'),
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byKey(const Key('Theme'))), Size.zero);
+  });
 }
 
 int testBuildCalled = 0;


### PR DESCRIPTION
This is my attempt to handle https://github.com/flutter/flutter/issues/6537 for the Theme widget.