### PR TITLE
fix: infra out of resources

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -256,7 +256,7 @@ platform_properties:
           {"dependency": "chrome_and_driver", "version": "version:125.0.6422.141"},
           {"dependency": "open_jdk", "version": "version:21"}
         ]
-      os: Mac-15.1|Mac-15.5|Mac-15.6
+      os: Mac-15.1|Mac-15.5|Mac-15.6|Mac-15.7
       cpu: x86
       device_type: "mokey"
 


### PR DESCRIPTION
Mac bots in device lab were upgraded to 15.7; which no longer matches ci.yaml

question for future: is there a better option for this other than pinning?

fixes: #178384