### PR TITLE
Preserve whitelisted files when removed from build system outputs

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -618,12 +618,12 @@ class FlutterBuildSystem extends BuildSystem {
   ];
 
   @visibleForTesting
-  List<String> convertSourcesToPaths(List<Source> sources, Environment environment) {
+  Set<String> convertSourcesToPaths(List<Source> sources, Environment environment) {
     final collection = SourceVisitor(environment, false);
     for (final source in sources) {
       source.accept(collection);
     }
-    return collection.sources.map((file) => file.path).toList();
+    return collection.sources.map((file) => file.path).toSet();
   }
 
   @override
@@ -642,7 +642,7 @@ class FlutterBuildSystem extends BuildSystem {
     // Perform sanity checks on build.
     checkCycles(target);
 
-    final List<String> preservedOutputFilePaths = convertSourcesToPaths(
+    final Set<String> preservedOutputFilePaths = convertSourcesToPaths(
       _preservedOutputSources,
       environment,
     );
@@ -771,7 +771,7 @@ class FlutterBuildSystem extends BuildSystem {
     Environment environment,
     FileSystem fileSystem,
     Map<String, File> currentOutputs,
-    List<String> preservedOutputFilePaths,
+    Set<String> preservedOutputFilePaths,
   ) {
     if (environment.defines[kXcodePreAction] == 'PrepareFramework') {
       // If the current build is the PrepareFramework Xcode pre-action, skip
@@ -828,7 +828,7 @@ class _BuildInstance {
     required this.buildSystemConfig,
     required this.logger,
     required this.fileSystem,
-    this.preservedOutputFilePaths = const <String>[],
+    this.preservedOutputFilePaths = const <String>{},
     Platform? platform,
   }) : resourcePool = Pool(buildSystemConfig.resourcePoolSize ?? platform?.numberOfProcessors ?? 1);
 
@@ -841,7 +841,7 @@ class _BuildInstance {
   final FileStore fileCache;
   final inputFiles = <String, File>{};
   final outputFiles = <String, File>{};
-  final List<String> preservedOutputFilePaths;
+  final Set<String> preservedOutputFilePaths;
 
   // Timings collected during target invocation.
   final stepTimings = <String, PerformanceMeasurement>{};

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -33,6 +33,14 @@ export 'source.dart';
 /// APIs.
 const kMaxOpenFiles = 64;
 
+/// The [Source] for the FlutterMacOS framework binary.
+const kFlutterMacOSFrameworkBinarySource = Source.pattern(
+  '{OUTPUT_DIR}/FlutterMacOS.framework/Versions/A/FlutterMacOS',
+);
+
+/// The [Source] for the Flutter framework binary.
+const kFlutterIOSFrameworkBinarySource = Source.pattern('{OUTPUT_DIR}/Flutter.framework/Flutter');
+
 /// Configuration for the build system itself.
 class BuildSystemConfig {
   /// Create a new [BuildSystemConfig].
@@ -589,7 +597,7 @@ abstract class BuildSystem {
 }
 
 class FlutterBuildSystem extends BuildSystem {
-  const FlutterBuildSystem({
+  FlutterBuildSystem({
     required FileSystem fileSystem,
     required Platform platform,
     required Logger logger,
@@ -600,6 +608,23 @@ class FlutterBuildSystem extends BuildSystem {
   final FileSystem _fileSystem;
   final Platform _platform;
   final Logger _logger;
+
+  /// Sources that should not be deleted when removed from output list.
+  final _preservedOutputSources = <Source>[
+    // Xcode handles the Flutter framework output when using SwiftPM so it should not be deleted
+    // from the build.
+    kFlutterMacOSFrameworkBinarySource,
+    kFlutterIOSFrameworkBinarySource,
+  ];
+
+  @visibleForTesting
+  List<String> convertSourcesToPaths(List<Source> sources, Environment environment) {
+    final collection = SourceVisitor(environment, false);
+    for (final source in sources) {
+      source.accept(collection);
+    }
+    return collection.sources.map((file) => file.path).toList();
+  }
 
   @override
   Future<BuildResult> build(
@@ -617,6 +642,11 @@ class FlutterBuildSystem extends BuildSystem {
     // Perform sanity checks on build.
     checkCycles(target);
 
+    final List<String> preservedOutputFilePaths = convertSourcesToPaths(
+      _preservedOutputSources,
+      environment,
+    );
+
     final Node node = target._toNode(environment);
     final buildInstance = _BuildInstance(
       environment: environment,
@@ -625,6 +655,7 @@ class FlutterBuildSystem extends BuildSystem {
       logger: _logger,
       fileSystem: _fileSystem,
       platform: _platform,
+      preservedOutputFilePaths: preservedOutputFilePaths,
     );
     var passed = true;
     try {
@@ -657,7 +688,12 @@ class FlutterBuildSystem extends BuildSystem {
         return isUnconditionalFile(path);
       });
     }
-    trackSharedBuildDirectory(environment, _fileSystem, buildInstance.outputFiles);
+    trackSharedBuildDirectory(
+      environment,
+      _fileSystem,
+      buildInstance.outputFiles,
+      preservedOutputFilePaths,
+    );
     environment.buildDir
         .childFile('outputs.json')
         .writeAsStringSync(json.encode(buildInstance.outputFiles.keys.toList()));
@@ -735,6 +771,7 @@ class FlutterBuildSystem extends BuildSystem {
     Environment environment,
     FileSystem fileSystem,
     Map<String, File> currentOutputs,
+    List<String> preservedOutputFilePaths,
   ) {
     if (environment.defines[kXcodePreAction] == 'PrepareFramework') {
       // If the current build is the PrepareFramework Xcode pre-action, skip
@@ -774,6 +811,9 @@ class FlutterBuildSystem extends BuildSystem {
     for (final lastOutput in lastOutputs) {
       if (!currentOutputs.containsKey(lastOutput)) {
         final File lastOutputFile = fileSystem.file(lastOutput);
+        if (preservedOutputFilePaths.contains(lastOutputFile.path)) {
+          continue;
+        }
         ErrorHandlingFileSystem.deleteIfExists(lastOutputFile);
       }
     }
@@ -788,6 +828,7 @@ class _BuildInstance {
     required this.buildSystemConfig,
     required this.logger,
     required this.fileSystem,
+    this.preservedOutputFilePaths = const <String>[],
     Platform? platform,
   }) : resourcePool = Pool(buildSystemConfig.resourcePoolSize ?? platform?.numberOfProcessors ?? 1);
 
@@ -800,6 +841,7 @@ class _BuildInstance {
   final FileStore fileCache;
   final inputFiles = <String, File>{};
   final outputFiles = <String, File>{};
+  final List<String> preservedOutputFilePaths;
 
   // Timings collected during target invocation.
   final stepTimings = <String, PerformanceMeasurement>{};
@@ -894,6 +936,9 @@ class _BuildInstance {
           continue;
         }
         final File previousFile = fileSystem.file(previousOutput);
+        if (preservedOutputFilePaths.contains(previousFile.path)) {
+          continue;
+        }
         ErrorHandlingFileSystem.deleteIfExists(previousFile);
       }
     } on Exception catch (exception, stackTrace) {

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -597,7 +597,7 @@ abstract class BuildSystem {
 }
 
 class FlutterBuildSystem extends BuildSystem {
-  FlutterBuildSystem({
+  const FlutterBuildSystem({
     required FileSystem fileSystem,
     required Platform platform,
     required Logger logger,
@@ -610,7 +610,7 @@ class FlutterBuildSystem extends BuildSystem {
   final Logger _logger;
 
   /// Sources that should not be deleted when removed from output list.
-  final _preservedOutputSources = <Source>[
+  static const _preservedOutputSources = <Source>[
     // Xcode handles the Flutter framework output when using SwiftPM so it should not be deleted
     // from the build.
     kFlutterMacOSFrameworkBinarySource,

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -254,9 +254,7 @@ abstract class UnpackIOS extends UnpackDarwin {
   ];
 
   @override
-  List<Source> get outputs => const <Source>[
-    Source.pattern('{OUTPUT_DIR}/Flutter.framework/Flutter'),
-  ];
+  List<Source> get outputs => const <Source>[kFlutterIOSFrameworkBinarySource];
 
   @override
   List<Target> get dependencies => <Target>[];

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -42,9 +42,7 @@ abstract class UnpackMacOS extends UnpackDarwin {
   ];
 
   @override
-  List<Source> get outputs => const <Source>[
-    kFlutterMacOSFrameworkBinarySource,
-  ];
+  List<Source> get outputs => const <Source>[kFlutterMacOSFrameworkBinarySource];
 
   @override
   List<Target> get dependencies => <Target>[];

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -43,7 +43,7 @@ abstract class UnpackMacOS extends UnpackDarwin {
 
   @override
   List<Source> get outputs => const <Source>[
-    Source.pattern('{OUTPUT_DIR}/FlutterMacOS.framework/Versions/A/FlutterMacOS'),
+    kFlutterMacOSFrameworkBinarySource,
   ];
 
   @override

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -391,17 +391,29 @@ void main() {
 
   testWithoutContext('Automatically cleans old outputs when build graph changes', () async {
     final BuildSystem buildSystem = setUpBuildSystem(fileSystem);
+    final File preservedMacOSFile = environment.outputDir.childFile(
+      'FlutterMacOS.framework/Versions/A/FlutterMacOS',
+    );
+    final File preservedIOSFile = environment.outputDir.childFile('Flutter.framework/Flutter');
     final testTarget =
         TestTarget((Environment environment) async {
             environment.buildDir.childFile('foo.out').createSync();
+            preservedMacOSFile.createSync(recursive: true);
+            preservedIOSFile.createSync(recursive: true);
           })
           ..inputs = const <Source>[Source.pattern('{PROJECT_DIR}/foo.dart')]
-          ..outputs = const <Source>[Source.pattern('{BUILD_DIR}/foo.out')];
+          ..outputs = const <Source>[
+            Source.pattern('{BUILD_DIR}/foo.out'),
+            kFlutterMacOSFrameworkBinarySource,
+            kFlutterIOSFrameworkBinarySource,
+          ];
     fileSystem.file('foo.dart').createSync();
 
     await buildSystem.build(testTarget, environment);
 
     expect(environment.buildDir.childFile('foo.out'), exists);
+    expect(preservedMacOSFile, exists);
+    expect(preservedIOSFile, exists);
 
     final testTarget2 =
         TestTarget((Environment environment) async {
@@ -414,6 +426,8 @@ void main() {
 
     expect(environment.buildDir.childFile('bar.out'), exists);
     expect(environment.buildDir.childFile('foo.out'), isNot(exists));
+    expect(preservedMacOSFile, exists);
+    expect(preservedIOSFile, exists);
   });
 
   testWithoutContext('Does not crash when filesystem and cache are out of sync', () async {
@@ -626,7 +640,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(),
-    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
 
     expect(environment.outputDir.childFile('.last_build_id'), exists);
     expect(
@@ -648,7 +662,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(),
-    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
 
     expect(environment.outputDir.childFile('.last_build_id'), exists);
     expect(
@@ -667,7 +681,7 @@ void main() {
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
         platform: FakePlatform(),
-      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
+      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
 
       expect(
         environment.outputDir.childFile('.last_build_id').lastModifiedSync(),
@@ -686,7 +700,7 @@ void main() {
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
         platform: FakePlatform(),
-      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
+      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
 
       expect(
         environment.outputDir.childFile('.last_build_id').readAsStringSync(),
@@ -710,7 +724,7 @@ void main() {
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
         platform: FakePlatform(),
-      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{});
+      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
 
       expect(
         environment.outputDir.childFile('.last_build_id').readAsStringSync(),
@@ -719,6 +733,29 @@ void main() {
       expect(environment.outputDir.childFile('stale'), isNot(exists));
     },
   );
+
+  testWithoutContext('trackSharedBuildDirectory does not delete preserved outputs', () {
+    environment.outputDir.childFile('.last_build_id').writeAsStringSync('foo');
+    final Directory otherBuildDir = environment.buildDir.parent.childDirectory('foo')
+      ..createSync(recursive: true);
+    final File preservedFile = environment.outputDir.childFile('preserved')..createSync();
+    otherBuildDir
+        .childFile('outputs.json')
+        .writeAsStringSync(json.encode(<String>[preservedFile.absolute.path]));
+    FlutterBuildSystem(
+      fileSystem: fileSystem,
+      logger: BufferLogger.test(),
+      platform: FakePlatform(),
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, [
+      preservedFile.absolute.path,
+    ]);
+
+    expect(
+      environment.outputDir.childFile('.last_build_id').readAsStringSync(),
+      '6666cd76f96956469e7be39d750cc7d9',
+    );
+    expect(environment.outputDir.childFile('preserved'), exists);
+  });
 
   testWithoutContext(
     'multiple builds to the same output directory do no leave stale artifacts',

--- a/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/build_system_test.dart
@@ -640,7 +640,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(),
-    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, {});
 
     expect(environment.outputDir.childFile('.last_build_id'), exists);
     expect(
@@ -662,7 +662,7 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(),
-    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, {});
 
     expect(environment.outputDir.childFile('.last_build_id'), exists);
     expect(
@@ -681,7 +681,7 @@ void main() {
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
         platform: FakePlatform(),
-      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
+      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, {});
 
       expect(
         environment.outputDir.childFile('.last_build_id').lastModifiedSync(),
@@ -700,7 +700,7 @@ void main() {
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
         platform: FakePlatform(),
-      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
+      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, {});
 
       expect(
         environment.outputDir.childFile('.last_build_id').readAsStringSync(),
@@ -724,7 +724,7 @@ void main() {
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
         platform: FakePlatform(),
-      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, []);
+      ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, {});
 
       expect(
         environment.outputDir.childFile('.last_build_id').readAsStringSync(),
@@ -746,9 +746,9 @@ void main() {
       fileSystem: fileSystem,
       logger: BufferLogger.test(),
       platform: FakePlatform(),
-    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, [
+    ).trackSharedBuildDirectory(environment, fileSystem, <String, File>{}, {
       preservedFile.absolute.path,
-    ]);
+    });
 
     expect(
       environment.outputDir.childFile('.last_build_id').readAsStringSync(),


### PR DESCRIPTION
In the future, Xcode will handle outputting the Flutter framework on iOS and macOS. As such, the Flutter build system will no longer output them. However, when an output is removed from the build system, it will delete them. In iOS and macOS, this build system removal of files happens mid-build (during `flutter assemble`) and can be a race condition between Flutter removing them and Xcode adding them. This fixes it by telling Flutter not to delete those files.

Incremental change towards https://github.com/flutter/flutter/issues/166486.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
