### PR TITLE
[ Widget Preview ] Ignore modifications to files in ephemeral directories

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -234,7 +234,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
   late final _previewDetector = PreviewDetector(
     platform: platform,
     previewAnalytics: previewAnalytics,
-    projectRoot: rootProject.directory,
+    project: rootProject,
     logger: logger,
     fs: fs,
     onChangeDetected: onChangeDetected,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -247,7 +247,7 @@ class FlutterProject {
   late final _ephemeralDirectories = <Directory>{
     buildDirectory,
     android.ephemeralDirectory,
-    ios.ephemeralModuleDirectory,
+    ios.ephemeralDirectory,
     ios.ephemeralModuleDirectory,
     linux.ephemeralDirectory,
     macos.ephemeralDirectory,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
+
 import 'package:meta/meta.dart';
 import 'package:xml/xml.dart';
 import 'package:yaml/yaml.dart';
@@ -237,6 +239,20 @@ class FlutterProject {
       .childDirectory('build')
       .childDirectory('generated')
       .childDirectory(manifest.appName);
+
+  /// The set of directories created by the tool containing ephemeral state.
+  // TODO(bkonyi): provide getters for each project type that returns the set
+  // of known ephemeral files / directories.
+  Set<Directory> get ephemeralDirectories => UnmodifiableSetView(_ephemeralDirectories);
+  late final _ephemeralDirectories = <Directory>{
+    buildDirectory,
+    android.ephemeralDirectory,
+    ios.ephemeralModuleDirectory,
+    ios.ephemeralModuleDirectory,
+    linux.ephemeralDirectory,
+    macos.ephemeralDirectory,
+    windows.ephemeralDirectory,
+  };
 
   /// The generated Dart plugin registrant for non-web platforms.
   File get dartPluginRegistrant =>

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_code_generator_test.dart
@@ -239,7 +239,7 @@ void main() {
             fakeFlutterVersion: FakeFlutterVersion(),
           ),
         ),
-        projectRoot: projectDir,
+        project: project,
         fs: fs,
         logger: logger,
         onChangeDetected: (_) {},

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
@@ -11,7 +11,6 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
-import 'package:path/path.dart' as path;
 import 'package:test/fake.dart';
 import 'package:watcher/watcher.dart';
 
@@ -61,7 +60,7 @@ void main() {
     });
 
     String buildDartFilePathIn(Directory root) {
-      final String filePath = path.join(root.path, 'foo.dart');
+      final String filePath = fs.path.join(root.path, 'foo.dart');
       root.childFile(filePath).createSync(recursive: true);
       return filePath;
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/fake.dart';
 import 'package:watcher/watcher.dart';
 
@@ -22,33 +23,34 @@ void main() {
   initializeTestPreviewDetectorState();
   group('$PreviewDetector', () {
     late MemoryFileSystem fs;
+    late FlutterProject project;
     late PreviewDetector previewDetector;
     late FakeWatcher watcher;
     late BufferLogger logger;
 
+    var changeCounter = 0;
+    void onChangeDetected(_) {
+      changeCounter++;
+    }
+
     setUp(() {
-      fs = MemoryFileSystem.test(style: FileSystemStyle.windows);
+      fs = MemoryFileSystem.test();
       watcher = FakeWatcher();
       logger = BufferLogger.test();
-      final FlutterProject project = FlutterProject.fromDirectoryTest(
-        fs.systemTempDirectory.createTempSync('root'),
-      );
+      project = FlutterProject.fromDirectoryTest(fs.systemTempDirectory.createTempSync('root'));
       previewDetector = PreviewDetector(
-        // Explicitly set the platform to Windows.
-        platform: FakePlatform(operatingSystem: 'windows'),
+        platform: const LocalPlatform(),
         previewAnalytics: WidgetPreviewAnalytics(
           analytics: getInitializedFakeAnalyticsInstance(
             fakeFlutterVersion: FakeFlutterVersion(),
-            // We don't care about anything written by fake analytics, so we're safe to use a different
-            // file system here.
-            fs: MemoryFileSystem.test(),
+            fs: fs,
           ),
         ),
         project: project,
         logger: logger,
         fs: fs,
-        onChangeDetected: (_) {},
-        onPubspecChangeDetected: (_) {},
+        onChangeDetected: onChangeDetected,
+        onPubspecChangeDetected: onChangeDetected,
         watcherBuilder: (_) => watcher,
       );
     });
@@ -58,23 +60,25 @@ void main() {
       await watcher.close();
     });
 
-    test(
-      'regression test https://github.com/flutter/flutter/issues/173895',
-      () async {
-        // The Windows directory watcher sometimes decides to shutdown on its own. It's
-        // automatically restarted by package:watcher, but the FileSystemException is rethrown and
-        // needs to be handled. This test verifies that we no longer crash if this exception is
-        // encountered on Windows.
-        await previewDetector.initialize();
-        watcher.controller.addError(
-          const FileSystemException(PreviewDetector.kDirectoryWatcherClosedUnexpectedlyPrefix),
-        );
-        // Insert an asynchronous gap so the onError handler for the Watcher can be invoked.
-        await Future<void>.delayed(Duration.zero);
-        expect(logger.traceText, contains(PreviewDetector.kWindowsFileWatcherRestartedMessage));
-      },
-      skip: !const LocalPlatform().isWindows, // [intended] Test is only valid on Windows.
-    );
+    String buildDartFilePathIn(Directory root) {
+      final String filePath = path.join(root.path, 'foo.dart');
+      root.childFile(filePath).createSync(recursive: true);
+      return filePath;
+    }
+
+    test('regression test https://github.com/flutter/flutter/issues/178317', () async {
+      await previewDetector.initialize();
+      expect(project.ephemeralDirectories, isNotEmpty);
+      for (final Directory dir in project.ephemeralDirectories) {
+        watcher.controller.add(WatchEvent(ChangeType.ADD, buildDartFilePathIn(dir)));
+      }
+      // Simulates the watcher detecting a change that doesn't have a valid analysis context.
+      watcher.controller.add(WatchEvent(ChangeType.ADD, '/foo/bar.dart'));
+
+      // Changes to .dart sources under ephemeral directories or sources that don't have valid
+      // analysis contexts shouldn't trigger the change detection callback.
+      expect(changeCounter, 0);
+    });
   });
 }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/preview_detector/preview_detector_regression_178317_test.dart
@@ -16,10 +16,8 @@ import 'package:watcher/watcher.dart';
 
 import '../../../../src/common.dart';
 import '../../../../src/fakes.dart';
-import '../utils/preview_detector_test_utils.dart';
 
 void main() {
-  initializeTestPreviewDetectorState();
   group('$PreviewDetector', () {
     late MemoryFileSystem fs;
     late FlutterProject project;
@@ -33,12 +31,14 @@ void main() {
     }
 
     setUp(() {
-      fs = MemoryFileSystem.test();
+      fs = MemoryFileSystem.test(
+        style: const LocalPlatform().isWindows ? FileSystemStyle.windows : FileSystemStyle.posix,
+      );
       watcher = FakeWatcher();
       logger = BufferLogger.test();
       project = FlutterProject.fromDirectoryTest(fs.systemTempDirectory.createTempSync('root'));
       previewDetector = PreviewDetector(
-        platform: const LocalPlatform(),
+        platform: FakePlatform(),
         previewAnalytics: WidgetPreviewAnalytics(
           analytics: getInitializedFakeAnalyticsInstance(
             fakeFlutterVersion: FakeFlutterVersion(),
@@ -72,7 +72,7 @@ void main() {
         watcher.controller.add(WatchEvent(ChangeType.ADD, buildDartFilePathIn(dir)));
       }
       // Simulates the watcher detecting a change that doesn't have a valid analysis context.
-      watcher.controller.add(WatchEvent(ChangeType.ADD, '/foo/bar.dart'));
+      watcher.controller.add(WatchEvent(ChangeType.ADD, fs.path.join('foo', 'bar.dart')));
 
       // Changes to .dart sources under ephemeral directories or sources that don't have valid
       // analysis contexts shouldn't trigger the change detection callback.

--- a/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/widget_preview/utils/preview_detector_test_utils.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/signals.dart';
+import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/widget_preview/analytics.dart';
 import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
 import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
@@ -49,6 +50,8 @@ PreviewDetector createTestPreviewDetector() {
     throw StateError('$initializeTestPreviewDetectorState was not called!');
   }
   _projectRoot = _fs.systemTempDirectory.createTempSync('root');
+  final FlutterProject project = FlutterProject.fromDirectoryTest(_projectRoot!);
+
   return PreviewDetector(
     platform: FakePlatform(),
     previewAnalytics: WidgetPreviewAnalytics(
@@ -59,7 +62,7 @@ PreviewDetector createTestPreviewDetector() {
         fs: MemoryFileSystem.test(),
       ),
     ),
-    projectRoot: _projectRoot!,
+    project: project,
     logger: BufferLogger.test(),
     fs: _fs,
     onChangeDetected: _onChangeDetectedRoot,


### PR DESCRIPTION
The `flutter` tool creates various directories for ephemeral state while executing commands. In some situations, these directories contain or link to other Dart / Flutter projects with '.dart' sources or 'pubspec.yaml's. If these files change while the widget previewer is active (e.g., due to a `flutter pub get` downloading and configuring new plugins for the project), the previewer's directory watcher will detect the change and attempt to analyze the source. This causes an exception to be thrown by the analyzer as the modified file path does not have a valid analysis context.

This change adds additional checks to the `PreviewDetector` that allow for ignoring changes to `pubspec.yaml`s and `.dart` sources under known ephemeral directories (e.g., build/,
linux/flutter/ephemeral/, etc), as well as `.dart` files that aren't associated with an analysis context.

Fixes https://github.com/flutter/flutter/issues/178317