### PR TITLE
Document forceSingleThreadedSkwasm configuration option for Flutter Web

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,4 @@ If you intend to contribute to Flutter, welcome! You are encouraged to start wit
 * [Threading in the Engine](./about/The-Engine-architecture.md#threading)
 * [When will my bug be fixed?](./contributing/issue_hygiene/README.md#when-will-my-bug-be-fixed)
 * [Security best practices](./infra/Security.md#best-practices)
+* [forceSingleThreadedSkwasm configuration option](forceSingleThreadedSkwasm.md): Details about forcing the `skwasm` WebAssembly renderer to single-threaded mode for compatibility.

--- a/docs/development/platform-integration/web/forceSingleThreadedSkwasm.md
+++ b/docs/development/platform-integration/web/forceSingleThreadedSkwasm.md
@@ -1,0 +1,21 @@
+# forceSingleThreadedSkwasm Configuration Option
+
+The `forceSingleThreadedSkwasm` option is a boolean flag available in Flutter Web's `skwasm` WebAssembly renderer configuration.
+
+## What it does
+
+When enabled (`true`), it forces the `skwasm` renderer to run in a single-threaded mode regardless of the browser’s multi-threading capabilities. Without this option, the renderer attempts to use multi-threaded WebAssembly to improve performance and reduce app startup time.
+
+## When to use
+
+- For environments or browsers that do not support multi-threaded WebAssembly features such as `SharedArrayBuffer`.
+- For debugging or troubleshooting rendering issues related to multi-threaded WebAssembly.
+- To avoid potential compatibility issues caused by strict browser or server security requirements.
+
+## Additional information
+
+- The multi-threaded mode requires browsers to support `SharedArrayBuffer` and a secure context (HTTPS with proper Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers).
+- If these security requirements are not met, the renderer automatically falls back to single-threaded mode unless this option is forcibly set.
+- For known issues related to this setting, see [issue #177974](https://github.com/flutter/flutter/issues/177974).
+
+This configuration option is currently documented only in the Flutter engine source and is not yet described in the official Flutter documentation.


### PR DESCRIPTION
PR Title:
Document forceSingleThreadedSkwasm configuration option for Flutter Web

PR Description:
This PR adds documentation for the forceSingleThreadedSkwasm configuration option used in Flutter Web's skwasm WebAssembly renderer.

Introduces a new markdown file forceSingleThreadedSkwasm.md under docs/development/platform-integration/web/

Explains the purpose of the option as a boolean flag to force single-threaded mode for the skwasm renderer

Details when and why to use this option, mainly for environments lacking multi-threaded WebAssembly support and for debugging

Highlights browser and server security requirements for multi-threaded WebAssembly and the fallback behavior

Links to a related known issue (#177974) for more context

Updates the web docs overview file to include a link to the new documentation

This contribution resolves the gap where this important configuration option exists in the Flutter engine code but was undocumented in the official Flutter Web documentation.