### PR TITLE
Fix DropdownMenu width when decorationBuilder provides label

### DIFF
--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -1239,6 +1239,11 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
           ),
         );
 
+        // The label used in _DropdownMenuBody to compute the preferred width.
+        final Widget? effectiveLabel =
+            effectiveDecoration.label ??
+            (effectiveDecoration.labelText != null ? Text(effectiveDecoration.labelText!) : null);
+
         // If [expandedInsets] is not null, the width of the text field should depend
         // on its parent width. So we don't need to use `_DropdownMenuBody` to
         // calculate the children's width.
@@ -1259,12 +1264,12 @@ class _DropdownMenuState<T extends Object> extends State<DropdownMenu<T>> {
                 children: <Widget>[
                   textField,
                   ..._initialMenu!,
-                  if (widget.label != null)
+                  if (effectiveLabel != null)
                     ExcludeSemantics(
                       child: Padding(
                         // See RenderEditable.floatingCursorAddedMargin for the default horizontal padding.
                         padding: const EdgeInsets.symmetric(horizontal: 4.0),
-                        child: DefaultTextStyle(style: effectiveTextStyle!, child: widget.label!),
+                        child: DefaultTextStyle(style: effectiveTextStyle!, child: effectiveLabel),
                       ),
                     ),
                   effectiveDecoration.suffixIcon ?? const SizedBox.shrink(),

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -4897,6 +4897,42 @@ void main() {
         );
       }, throwsAssertionError);
     });
+
+    testWidgets('Preferred width takes labelText into account', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+              decorationBuilder: (BuildContext context, MenuController controller) {
+                return const InputDecoration(labelText: 'Long label text');
+              },
+            ),
+          ),
+        ),
+      );
+
+      final double width = tester.getSize(find.byType(TextField)).width;
+      expect(width, 327.5);
+    });
+
+    testWidgets('Preferred width takes label into account', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DropdownMenu<TestMenu>(
+              dropdownMenuEntries: menuChildren,
+              decorationBuilder: (BuildContext context, MenuController controller) {
+                return const InputDecoration(label: SizedBox(width: 200));
+              },
+            ),
+          ),
+        ),
+      );
+
+      final double width = tester.getSize(find.byType(TextField)).width;
+      expect(width, 280);
+    });
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/174609.


### PR DESCRIPTION
## Description

This PR fixes `DropdownMenu` preferred width calculation to include the label provided by `DropdownMenu.decorationBuilder`.

## Before

<img width="225" height="63" alt="Image" src="https://github.com/user-attachments/assets/47dbec7d-c59c-4379-8f22-792c844f6ac4" />

## After

<img width="225" height="63" alt="Image" src="https://github.com/user-attachments/assets/d4223e56-2b3f-4e12-893a-284ceb3b8ea4" />

## Related Issue

Fixes [DropdownMenu wrong width when decorationBuilder provides label ](https://github.com/flutter/flutter/issues/178459)

## Tests

- Adds 2 tests.

