### PR TITLE
[CP-beta][ Widget Preview ] Don't require 'flutter pub get' to be run in the root project

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -111,7 +111,7 @@ abstract base class WidgetPreviewSubCommandBase extends FlutterCommand {
   FlutterProject validateFlutterProjectForPreview(Directory directory) {
     logger.printTrace('Verifying that ${directory.path} is a Flutter project.');
     final FlutterProject flutterProject = projectFactory.fromDirectory(directory);
-    if (!flutterProject.dartTool.existsSync()) {
+    if (!flutterProject.pubspecFile.existsSync()) {
       throwToolExit('${flutterProject.directory.path} is not a valid Flutter project.');
     }
     return flutterProject;
@@ -280,7 +280,7 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
     final bool generateScaffoldProject =
         customPreviewScaffoldOutput != null || _previewManifest.shouldGenerateProject();
     // TODO(bkonyi): can this be moved?
-    widgetPreviewScaffold.createSync();
+    widgetPreviewScaffold.createSync(recursive: true);
     fs.currentDirectory = widgetPreviewScaffold;
 
     if (generateScaffoldProject) {

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -268,6 +268,31 @@ void main() {
     });
 
     testUsingContext(
+      'start succeeds when no .dart_tool/ directory exists',
+      () async {
+        // Regression test for https://github.com/flutter/flutter/issues/178052
+        final Directory rootProject = await createRootProject();
+        rootProject.childDirectory('.dart_tool').deleteSync(recursive: true);
+        await startWidgetPreview(rootProject: rootProject);
+        expectSinglePreviewLaunchTimingEvent();
+      },
+      overrides: <Type, Generator>{
+        Analytics: () => fakeAnalytics,
+        DeviceManager: () => fakeDeviceManager,
+        FileSystem: () => fs,
+        ProcessManager: () => loggingProcessManager,
+        Pub: () => Pub.test(
+          fileSystem: fs,
+          logger: logger,
+          processManager: loggingProcessManager,
+          botDetector: botDetector,
+          platform: platform,
+          stdio: mockStdio,
+        ),
+      },
+    );
+
+    testUsingContext(
       'start creates .dart_tool/widget_preview_scaffold',
       () async {
         final Directory rootProject = await createRootProject();


### PR DESCRIPTION
This pull request is created by [automatic cherry pick workflow](https://github.com/flutter/flutter/blob/main/docs/releases/Flutter-Cherrypick-Process.md#automatically-creates-a-cherry-pick-request)
Please fill in the form below, and a flutter domain expert will evaluate this cherry pick request.

### Issue Link:
What is the link to the issue this cherry-pick is addressing?

https://github.com/flutter/flutter/issues/178052

### Changelog Description:
Explain this cherry pick in one line that is accessible to most Flutter developers. See [best practices](https://github.com/flutter/flutter/blob/main/docs/releases/Hotfix-Documentation-Best-Practices.md) for examples

The widget previewer fails to start if `flutter pub get` has not been run in the target project.

### Impact Description:
What is the impact (ex. visual jank on Samsung phones, app crash, cannot ship an iOS app)? Does it impact development (ex. flutter doctor crashes when Android Studio is installed), or the shipping production app (the app crashes on launch)

The widget previewer will fail to launch. For CLI users, the error message stating that the command needs to be run within a Flutter project is misleading. For IDE users, they may get a dialog stating the widget previewer failed to start with no actionable feedback.

### Workaround:
Is there a workaround for this issue?

Run `flutter pub get` in the project and then restart the widget previewer, either by relaunching the IDE or re-running `flutter widget-preview start`.

### Risk:
What is the risk level of this cherry-pick?

  - [X] Low
  - [ ] Medium
  - [ ] High

### Test Coverage:
Are you confident that your fix is well-tested by automated tests?

  - [X] Yes
  - [ ] No

### Validation Steps:
What are the steps to validate that this fix works?

1. Delete `.dart_tool/` from a Flutter project.
2. Run `flutter widget-preview start` within that project.
3. The widget previewer should start successfully.