### PR TITLE
[ Widget Preview ] Throw `ToolExit` if Flutter Web is not enabled

### DIFF
--- a/packages/flutter_tools/lib/src/commands/widget_preview.dart
+++ b/packages/flutter_tools/lib/src/commands/widget_preview.dart
@@ -24,6 +24,7 @@ import '../bundle.dart' as bundle;
 import '../cache.dart';
 import '../convert.dart';
 import '../device.dart';
+import '../features.dart';
 import '../globals.dart' as globals;
 import '../isolated/resident_web_runner.dart';
 import '../project.dart';
@@ -389,6 +390,14 @@ final class WidgetPreviewStartCommand extends WidgetPreviewSubCommandBase with C
 
   Future<int> runPreviewEnvironment({required FlutterProject widgetPreviewScaffoldProject}) async {
     try {
+      // In the rare case that Flutter Web is disabled, the device manager will not return any web
+      // devices which will cause us to crash.
+      if (!featureFlags.isWebEnabled) {
+        throwToolExit(
+          'Widget Previews requires Flutter Web to be enabled. Please run '
+          "'flutter config --enable-web' to enable Flutter Web and try again.",
+        );
+      }
       final Device device;
       if (boolArg(kWebServer)) {
         final List<Device> devices;

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/widget_preview_test.dart
@@ -19,6 +19,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/widget_preview.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:flutter_tools/src/device.dart';
+import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/web/web_device.dart';
@@ -265,6 +266,37 @@ void main() {
         }
         expectNoPreviewLaunchTimingEvents();
       });
+
+      testUsingContext(
+        'Flutter Web is disabled',
+        () async {
+          try {
+            await startWidgetPreview(rootProject: await createRootProject());
+            fail('Successfully executed with Flutter Web disabled.');
+          } on ToolExit catch (e) {
+            expect(
+              e.message,
+              'Error: Widget Previews requires Flutter Web to be enabled. Please run '
+              "'flutter config --enable-web' to enable Flutter Web and try again.",
+            );
+          }
+          expectNoPreviewLaunchTimingEvents();
+        },
+        overrides: {
+          FeatureFlags: () => TestFeatureFlags(
+            // ignore: avoid_redundant_argument_values, readability
+            isWebEnabled: false,
+          ),
+          Pub: () => Pub.test(
+            fileSystem: fs,
+            logger: logger,
+            processManager: loggingProcessManager,
+            botDetector: botDetector,
+            platform: platform,
+            stdio: mockStdio,
+          ),
+        },
+      );
     });
 
     testUsingContext(


### PR DESCRIPTION
If Flutter Web is not enabled, the widget previewer will crash when trying to find a web device to launch with. This change explicitly checks for this case and throws `ToolExit` with instructions to enable Flutter Web if it's not enabled.

Fixes https://github.com/flutter/flutter/issues/178486