### PR TITLE
Fix crash when doing a SaveLayer under a non-invertible transform

### DIFF
--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5939,5 +5939,65 @@ TEST_F(DisplayListTest, DisplayListDetectsRuntimeEffect) {
   }
 }
 
+namespace {
+typedef void BuilderTransformer(DisplayListBuilder& builder);
+
+sk_sp<DisplayList> TestSaveLayerWithMatrix(BuilderTransformer transform) {
+  DlScalar xoffset = 50;
+  DlScalar yoffset = 50;
+  DlScalar sigma = 10.0;
+
+  DisplayListBuilder builder;
+
+  auto blur_filter = DlImageFilter::MakeBlur(sigma, sigma, DlTileMode::kClamp);
+
+  builder.Translate(xoffset, yoffset);
+  transform(builder);
+
+  DlPaint paint;
+  builder.DrawImage(kTestImage1, DlPoint(100.0, 100.0),
+                    DlImageSampling::kNearestNeighbor, &paint);
+
+  DlPaint save_paint;
+  save_paint.setBlendMode(DlBlendMode::kSrc);
+  builder.SaveLayer(std::nullopt, &save_paint, blur_filter.get());
+  builder.Restore();
+
+  return builder.Build();
+}
+}  // namespace
+
+TEST_F(DisplayListTest, SaveLayerWithValidScaleDoesNotCrash) {
+  EXPECT_NE(TestSaveLayerWithMatrix([](DisplayListBuilder& builder) {
+              builder.Scale(0.7, 0.7);
+              EXPECT_TRUE(builder.GetMatrix().IsInvertible());
+            }),
+            nullptr);
+}
+
+TEST_F(DisplayListTest, SaveLayerWithZeroXScaleDoesNotCrash) {
+  EXPECT_NE(TestSaveLayerWithMatrix([](DisplayListBuilder& builder) {
+              builder.Scale(0.0, 0.7);
+              EXPECT_FALSE(builder.GetMatrix().IsInvertible());
+            }),
+            nullptr);
+}
+
+TEST_F(DisplayListTest, SaveLayerWithZeroYScaleDoesNotCrash) {
+  EXPECT_NE(TestSaveLayerWithMatrix([](DisplayListBuilder& builder) {
+              builder.Scale(0.7, 0.0);
+              EXPECT_FALSE(builder.GetMatrix().IsInvertible());
+            }),
+            nullptr);
+}
+
+TEST_F(DisplayListTest, SaveLayerWithLinearSkewDoesNotCrash) {
+  EXPECT_NE(TestSaveLayerWithMatrix([](DisplayListBuilder& builder) {
+              builder.Skew(1.0f, 1.0f);
+              EXPECT_FALSE(builder.GetMatrix().IsInvertible());
+            }),
+            nullptr);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/engine/src/flutter/display_list/display_list_unittests.cc
+++ b/engine/src/flutter/display_list/display_list_unittests.cc
@@ -5943,18 +5943,19 @@ namespace {
 typedef void BuilderTransformer(DisplayListBuilder& builder);
 
 sk_sp<DisplayList> TestSaveLayerWithMatrix(BuilderTransformer transform) {
-  DlScalar xoffset = 50;
-  DlScalar yoffset = 50;
-  DlScalar sigma = 10.0;
+  const DlScalar xoffset = 50;
+  const DlScalar yoffset = 50;
+  const DlScalar sigma = 10.0;
 
   DisplayListBuilder builder;
 
-  auto blur_filter = DlImageFilter::MakeBlur(sigma, sigma, DlTileMode::kClamp);
+  const auto blur_filter =
+      DlImageFilter::MakeBlur(sigma, sigma, DlTileMode::kClamp);
 
   builder.Translate(xoffset, yoffset);
   transform(builder);
 
-  DlPaint paint;
+  const DlPaint paint;
   builder.DrawImage(kTestImage1, DlPoint(100.0, 100.0),
                     DlImageSampling::kNearestNeighbor, &paint);
 

--- a/engine/src/flutter/display_list/dl_builder.cc
+++ b/engine/src/flutter/display_list/dl_builder.cc
@@ -461,11 +461,7 @@ void DisplayListBuilder::saveLayer(const DlRect& bounds,
   // with its full bounds and the right op_index so that it doesn't
   // get culled during rendering.
   if (will_be_unbounded) {
-    // Accumulate should always return true here because if the
-    // clip was empty then that would have been caught up above
-    // when we tested the PaintResult.
-    [[maybe_unused]] bool unclipped = AccumulateUnbounded();
-    FML_DCHECK(unclipped);
+    AccumulateUnbounded();
   }
 
   // Accumulate information for the SaveInfo we are about to push onto the


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Fixes a bug where executing a SaveLayer when the matrix is singular (non-invertible) will currently crash.

Fixes: https://github.com/flutter/flutter/issues/177603

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.