### PR TITLE
Fix Windows Enter key after focus loss

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -136,3 +136,4 @@ Jin Jeongsu <jinjs.dev@gmail.com>
 Mairon Slusarz <maironlucaslusarz@gmail.com>
 Ricardo Dalarme <ricardodalarme@outlook.com>
 yiiim <ybz975218925@live.com>
+letrungdo <letrdo@gmail.com>

--- a/engine/src/flutter/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
+++ b/engine/src/flutter/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
@@ -747,17 +747,30 @@ TEST(KeyboardKeyEmbedderHandlerTest, RepeatedDownIsIgnored) {
 
   // KeyA's key up is missed.
 
-  // Press A again (should yield an empty event)
+  // Press A again (should synthesize an up event followed by a new down).
   last_handled = false;
   handler->KeyboardHook(
       kVirtualKeyA, kScanCodeKeyA, WM_KEYDOWN, 'a', false, false,
       [&last_handled](bool handled) { last_handled = handled; });
-  EXPECT_EQ(last_handled, true);
-  EXPECT_EQ(results.size(), 1);
+  EXPECT_EQ(last_handled, false);
+  ASSERT_EQ(results.size(), 2u);
+
   event = &results[0];
-  EXPECT_EQ(event->physical, 0);
-  EXPECT_EQ(event->logical, 0);
+  EXPECT_EQ(event->type, kFlutterKeyEventTypeUp);
+  EXPECT_EQ(event->physical, kPhysicalKeyA);
+  EXPECT_EQ(event->logical, kLogicalKeyA);
+  EXPECT_STREQ(event->character, "");
+  EXPECT_EQ(event->synthesized, true);
   EXPECT_EQ(event->callback, nullptr);
+
+  event = &results[1];
+  EXPECT_EQ(event->type, kFlutterKeyEventTypeDown);
+  EXPECT_EQ(event->physical, kPhysicalKeyA);
+  EXPECT_EQ(event->logical, kLogicalKeyA);
+  EXPECT_STREQ(event->character, "a");
+  EXPECT_EQ(event->synthesized, false);
+  event->callback(true, event->user_data);
+  EXPECT_EQ(last_handled, true);
   results.clear();
 }
 


### PR DESCRIPTION
Fix issue: https://github.com/flutter/flutter/issues/169447

Problem: On Windows, pressing Enter after refocusing the app could drop the first keydown because the embedder still thought the key was pressed, causing a double-press requirement and HardwareKeyboard assertions.
Fix: In KeyboardKeyEmbedderHandler, synthesize a key-up whenever Win32 reports a “fresh” down for a key still tracked as pressed, so Flutter sees a release before the new down. This keeps modifier/lock-key synchronization intact.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

