### PR TITLE
Fixed changing supportedLocales fails to update the locale

### DIFF
--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1650,14 +1650,24 @@ class _WidgetsAppState extends State<WidgetsApp> with WidgetsBindingObserver {
     supportedLocales: widget.supportedLocales,
   );
 
-  void _updateLocalizations({WidgetsApp? oldWidget}) {
-    _localizationsResolver.update(
-      locale: widget.locale,
-      localeListResolutionCallback: widget.localeListResolutionCallback,
-      localeResolutionCallback: widget.localeResolutionCallback,
-      supportedLocales: widget.supportedLocales,
-      localizationsDelegates: widget.localizationsDelegates,
-    );
+  bool _shouldUpdateLocalizations(WidgetsApp oldWidget) {
+    return widget.locale != oldWidget.locale ||
+        widget.localeListResolutionCallback != oldWidget.localeListResolutionCallback ||
+        widget.localeResolutionCallback != oldWidget.localeResolutionCallback ||
+        widget.supportedLocales != oldWidget.supportedLocales ||
+        widget.localizationsDelegates != oldWidget.localizationsDelegates;
+  }
+
+  void _updateLocalizations({required WidgetsApp oldWidget}) {
+    if (_shouldUpdateLocalizations(oldWidget)) {
+      _localizationsResolver.update(
+        locale: widget.locale,
+        localeListResolutionCallback: widget.localeListResolutionCallback,
+        localeResolutionCallback: widget.localeResolutionCallback,
+        localizationsDelegates: widget.localizationsDelegates,
+        supportedLocales: widget.supportedLocales,
+      );
+    }
   }
 
   // BUILDER

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -809,8 +809,12 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
     _localeListResolutionCallback = localeListResolutionCallback;
     _localeResolutionCallback = localeResolutionCallback;
     _localizationsDelegates = localizationsDelegates;
-    _supportedLocales = supportedLocales;
-    _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
+    // check if supportedLocales changed
+    // and only re-resolve if it did
+    if (supportedLocales != _supportedLocales) {
+      _supportedLocales = supportedLocales;
+      _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
+    }
   }
 
   /// The currently resolved [Locale] based on the current platform locale and

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -810,17 +810,7 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
     _localeResolutionCallback = localeResolutionCallback;
     _localizationsDelegates = localizationsDelegates;
     _supportedLocales = supportedLocales;
-
-    // Recompute the resolved locale from the current settings and notify
-    // listeners only if the resolved locale changed.
-    final Locale newLocale = _resolveLocales(
-      WidgetsBinding.instance.platformDispatcher.locales,
-      _supportedLocales,
-    );
-    if (newLocale != _resolvedLocale) {
-      _resolvedLocale = newLocale;
-      notifyListeners();
-    }
+    _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
   }
 
   /// The currently resolved [Locale] based on the current platform locale and
@@ -879,7 +869,17 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
 
   @override
   void didChangeLocales(List<Locale>? locales) {
-    final Locale newLocale = _resolveLocales(locales, supportedLocales);
+    _updateResolvedLocale(locales);
+  }
+
+  /// Recompute the resolved locale based on [preferredLocales] and
+  /// [supportedLocales], update [_resolvedLocale], and notify listeners
+  /// only if the resolved locale changed.
+  ///
+  /// This method is called from both [update] (when locale resolution
+  /// parameters change) and [didChangeLocales] (when system locales change).
+  void _updateResolvedLocale(List<Locale>? preferredLocales) {
+    final Locale newLocale = _resolveLocales(preferredLocales, supportedLocales);
     if (newLocale != _resolvedLocale) {
       _resolvedLocale = newLocale;
       notifyListeners();

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -809,8 +809,10 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
     _localeListResolutionCallback = localeListResolutionCallback;
     _localeResolutionCallback = localeResolutionCallback;
     _localizationsDelegates = localizationsDelegates;
-    _supportedLocales = supportedLocales;
-    _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
+    if (_supportedLocales != supportedLocales) {
+      _supportedLocales = supportedLocales;
+      _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
+    }
   }
 
   /// The currently resolved [Locale] based on the current platform locale and

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -810,6 +810,17 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
     _localeResolutionCallback = localeResolutionCallback;
     _localizationsDelegates = localizationsDelegates;
     _supportedLocales = supportedLocales;
+
+    // Recompute the resolved locale from the current settings and notify
+    // listeners only if the resolved locale changed.
+    final Locale newLocale = _resolveLocales(
+      WidgetsBinding.instance.platformDispatcher.locales,
+      _supportedLocales,
+    );
+    if (newLocale != _resolvedLocale) {
+      _resolvedLocale = newLocale;
+      notifyListeners();
+    }
   }
 
   /// The currently resolved [Locale] based on the current platform locale and

--- a/packages/flutter/lib/src/widgets/localizations.dart
+++ b/packages/flutter/lib/src/widgets/localizations.dart
@@ -809,12 +809,8 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
     _localeListResolutionCallback = localeListResolutionCallback;
     _localeResolutionCallback = localeResolutionCallback;
     _localizationsDelegates = localizationsDelegates;
-    // check if supportedLocales changed
-    // and only re-resolve if it did
-    if (supportedLocales != _supportedLocales) {
-      _supportedLocales = supportedLocales;
-      _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
-    }
+    _supportedLocales = supportedLocales;
+    _updateResolvedLocale(WidgetsBinding.instance.platformDispatcher.locales);
   }
 
   /// The currently resolved [Locale] based on the current platform locale and
@@ -877,7 +873,7 @@ class LocalizationsResolver extends ChangeNotifier with WidgetsBindingObserver {
   }
 
   /// Recompute the resolved locale based on [preferredLocales] and
-  /// [supportedLocales], update [_resolvedLocale], and notify listeners
+  /// [supportedLocales], update the resolved locale, and notify listeners
   /// only if the resolved locale changed.
   ///
   /// This method is called from both [update] (when locale resolution

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -105,6 +105,50 @@ void main() {
 
     expect(Localizations.maybeLocaleOf(contextKey.currentContext!), isNull);
   });
+  testWidgets('LocalizationsResolver.update notifies listeners when supportedLocales changes', (
+    WidgetTester tester,
+  ) async {
+    final LocalizationsResolver resolver = LocalizationsResolver(
+      supportedLocales: <Locale>[const Locale('en')],
+    );
+
+    bool notified = false;
+    resolver.addListener(() { notified = true; });
+
+    resolver.update(
+      locale: null,
+      localeListResolutionCallback: null,
+      localeResolutionCallback: null,
+      localizationsDelegates: null,
+      supportedLocales: <Locale>[const Locale('de')],
+    );
+
+    expect(notified, isTrue);
+    resolver.dispose();
+  });
+
+  testWidgets('LocalizationsResolver.update does not notify when resolved locale unchanged', (
+    WidgetTester tester,
+  ) async {
+    final LocalizationsResolver resolver = LocalizationsResolver(
+      supportedLocales: <Locale>[const Locale('en'), const Locale('de')],
+    );
+
+    bool notified = false;
+    resolver.addListener(() { notified = true; });
+
+    // Update with the same effective supportedLocales shouldn't change resolved locale.
+    resolver.update(
+      locale: null,
+      localeListResolutionCallback: null,
+      localeResolutionCallback: null,
+      localizationsDelegates: null,
+      supportedLocales: <Locale>[const Locale('en'), const Locale('de')],
+    );
+
+    expect(notified, isFalse);
+    resolver.dispose();
+  });
 
   group('Semantics', () {
     testWidgets('set locale semantics', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -105,7 +105,7 @@ void main() {
 
     expect(Localizations.maybeLocaleOf(contextKey.currentContext!), isNull);
   });
-  
+
   testWidgets('LocalizationsResolver.update notifies listeners when supportedLocales changes', (
     WidgetTester tester,
   ) async {
@@ -114,7 +114,9 @@ void main() {
     );
 
     bool notified = false;
-    resolver.addListener(() { notified = true; });
+    resolver.addListener(() {
+      notified = true;
+    });
 
     resolver.update(
       locale: null,
@@ -136,7 +138,9 @@ void main() {
     );
 
     bool notified = false;
-    resolver.addListener(() { notified = true; });
+    resolver.addListener(() {
+      notified = true;
+    });
 
     // Update with the same effective supportedLocales shouldn't change resolved locale.
     resolver.update(

--- a/packages/flutter/test/widgets/localizations_test.dart
+++ b/packages/flutter/test/widgets/localizations_test.dart
@@ -105,6 +105,7 @@ void main() {
 
     expect(Localizations.maybeLocaleOf(contextKey.currentContext!), isNull);
   });
+  
   testWidgets('LocalizationsResolver.update notifies listeners when supportedLocales changes', (
     WidgetTester tester,
   ) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Reviewers are typically assigned within a week of filing a request.
To learn more about code review, see our documentation on Tree Hygiene: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
-->

Recompute the resolved locale in LocalizationsResolver.update(...) and notify listeners
only when the resolved locale actually changes. Previously, updating WidgetsApp.supportedLocales
did not always propagate to the app locale because the resolver did not re-resolve and
notify listeners. This change fixes that bug and adds unit tests.

Fixes [https://github.com/flutter/flutter/issues/117210](https://github.com/flutter/flutter/issues/117210)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
