### PR TITLE
[Reland] Generate ignore lockfiles and Update Android Embedder Dependencies

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -624,7 +624,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/embedding_bundle',
-        'version': 'last_updated:2024-09-10T16:32:16-0700'
+        'version': 'last_updated:2025-10-15T09:53:03-0700'
        }
      ],
      'condition': 'download_android_deps',

--- a/dev/a11y_assessments/android/.ignore-locking.md
+++ b/dev/a11y_assessments/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/benchmarks/complex_layout/android/.ignore-locking.md
+++ b/dev/benchmarks/complex_layout/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/benchmarks/macrobenchmarks/android/.ignore-locking.md
+++ b/dev/benchmarks/macrobenchmarks/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/benchmarks/platform_views_layout/android/.ignore-locking.md
+++ b/dev/benchmarks/platform_views_layout/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/.ignore-locking.md
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/benchmarks/test_apps/stocks/android/.ignore-locking.md
+++ b/dev/benchmarks/test_apps/stocks/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/android_semantics_testing/android/.ignore-locking.md
+++ b/dev/integration_tests/android_semantics_testing/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/android_verified_input/android/.ignore-locking.md
+++ b/dev/integration_tests/android_verified_input/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/android_views/android/.ignore-locking.md
+++ b/dev/integration_tests/android_views/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/channels/android/.ignore-locking.md
+++ b/dev/integration_tests/channels/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/display_cutout_rotation/android/.ignore-locking.md
+++ b/dev/integration_tests/display_cutout_rotation/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/flavors/android/.ignore-locking.md
+++ b/dev/integration_tests/flavors/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/flutter_gallery/android/.ignore-locking.md
+++ b/dev/integration_tests/flutter_gallery/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/platform_interaction/android/.ignore-locking.md
+++ b/dev/integration_tests/platform_interaction/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/release_smoke_test/android/.ignore-locking.md
+++ b/dev/integration_tests/release_smoke_test/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/spell_check/android/.ignore-locking.md
+++ b/dev/integration_tests/spell_check/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/integration_tests/ui/android/.ignore-locking.md
+++ b/dev/integration_tests/ui/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/dev/manual_tests/android/.ignore-locking.md
+++ b/dev/manual_tests/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/engine/src/flutter/shell/platform/android/BUILD.gn
+++ b/engine/src/flutter/shell/platform/android/BUILD.gn
@@ -385,7 +385,7 @@ android_java_sources = [
 
 embedding_dependencies_jars = [
   "//flutter/third_party/android_embedding_dependencies/lib/activity-1.8.1.jar",
-  "//flutter/third_party/android_embedding_dependencies/lib/annotation-jvm-1.8.0.jar",
+  "//flutter/third_party/android_embedding_dependencies/lib/annotation-jvm-1.8.1.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/annotation-experimental-1.4.0.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/annotations-23.0.0.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/collection-1.1.0.jar",
@@ -394,6 +394,7 @@ embedding_dependencies_jars = [
   "//flutter/third_party/android_embedding_dependencies/lib/core-common-2.2.0.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/core-runtime-2.2.0.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/customview-1.0.0.jar",
+  "//flutter/third_party/android_embedding_dependencies/lib/exifinterface-1.4.1.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/fragment-1.7.1.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/kotlin-stdlib-1.8.22.jar",
   "//flutter/third_party/android_embedding_dependencies/lib/kotlin-stdlib-common-1.8.22.jar",

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/image/ExifMetadataReader.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/image/ExifMetadataReader.java
@@ -4,10 +4,9 @@
 
 package io.flutter.embedding.engine.image;
 
-//noinspection ExifInterface
-import android.media.ExifInterface;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+import androidx.exifinterface.media.ExifInterface;
 import io.flutter.Log;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/image/ImageUtils.java
+++ b/engine/src/flutter/shell/platform/android/io/flutter/embedding/engine/image/ImageUtils.java
@@ -6,9 +6,8 @@ package io.flutter.embedding.engine.image;
 
 import android.graphics.Bitmap;
 import android.graphics.Matrix;
-//noinspection ExifInterface
-import android.media.ExifInterface;
 import androidx.annotation.NonNull;
+import androidx.exifinterface.media.ExifInterface;
 import io.flutter.Log;
 import java.nio.ByteBuffer;
 

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/image/ExifMetadataReaderTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/image/ExifMetadataReaderTest.java
@@ -7,7 +7,7 @@ package io.flutter.embedding.engine.image;
 import static org.junit.Assert.assertEquals;
 
 import android.graphics.Bitmap;
-import android.media.ExifInterface;
+import androidx.exifinterface.media.ExifInterface;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.Build;
 import java.io.File;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/image/ImageDecoderHeifApi36ImplTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/image/ImageDecoderHeifApi36ImplTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertNotNull;
 
 import android.graphics.Bitmap;
 import android.graphics.Color;
-import android.media.ExifInterface;
+import androidx.exifinterface.media.ExifInterface;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.Build;
 import java.nio.ByteBuffer;

--- a/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/image/ImageDecoderHeifPre36ImplTest.java
+++ b/engine/src/flutter/shell/platform/android/test/io/flutter/embedding/engine/image/ImageDecoderHeifPre36ImplTest.java
@@ -8,7 +8,7 @@ import static org.junit.Assert.assertEquals;
 
 import android.graphics.Bitmap;
 import android.graphics.Color;
-import android.media.ExifInterface;
+import androidx.exifinterface.media.ExifInterface;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.flutter.Build;
 import java.nio.ByteBuffer;

--- a/engine/src/flutter/tools/androidx/files.json
+++ b/engine/src/flutter/tools/androidx/files.json
@@ -94,7 +94,7 @@
     "provides": ["com.getkeepsafe.relinker.ReLinker"]
   },
   {
-    "url": "https://maven.google.com/androidx/exifinterface/1.4.1/exifinterface:1.4.1.aar",
+    "url": "https://dl.google.com/android/maven2/androidx/exifinterface/exifinterface/1.4.1/exifinterface-1.4.1.aar",
     "out_file_name": "exifinterface.aar",
     "maven_dependency": "androidx.exifinterface:exifinterface:1.4.1",
     "provides": [

--- a/engine/src/flutter/tools/androidx/files.json
+++ b/engine/src/flutter/tools/androidx/files.json
@@ -37,9 +37,9 @@
     ]
   },
   {
-    "url": "https://maven.google.com/androidx/annotation/annotation/1.8.0/annotation-1.8.0.jar",
+    "url": "https://maven.google.com/androidx/annotation/annotation/1.8.1/annotation-1.8.1.jar",
     "out_file_name": "androidx_annotation.jar",
-    "maven_dependency": "androidx.annotation:annotation:1.8.0",
+    "maven_dependency": "androidx.annotation:annotation:1.8.1",
     "provides": [
       "androidx.annotation.CallSuper",
       "androidx.annotation.FloatRange",
@@ -92,5 +92,13 @@
     "out_file_name": "relinker-1.4.5.aar",
     "maven_dependency": "com.getkeepsafe.relinker:relinker:1.4.5",
     "provides": ["com.getkeepsafe.relinker.ReLinker"]
+  },
+  {
+    "url": "https://maven.google.com/androidx/exifinterface/1.4.1/exifinterface:1.4.1.aar",
+    "out_file_name": "exifinterface.aar",
+    "maven_dependency": "androidx.exifinterface:exifinterface:1.4.1",
+    "provides": [
+      "androidx.exifinterface.media.ExifInterface"
+    ]
   }
 ]

--- a/examples/flutter_view/android/.ignore-locking.md
+++ b/examples/flutter_view/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/examples/hello_world/android/.ignore-locking.md
+++ b/examples/hello_world/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/examples/image_list/android/.ignore-locking.md
+++ b/examples/image_list/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/examples/layers/android/.ignore-locking.md
+++ b/examples/layers/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/examples/platform_channel/android/.ignore-locking.md
+++ b/examples/platform_channel/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/examples/platform_view/android/.ignore-locking.md
+++ b/examples/platform_view/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071

--- a/packages/integration_test/example/android/.ignore-locking.md
+++ b/packages/integration_test/example/android/.ignore-locking.md
@@ -1,0 +1,1 @@
+Reason: https://github.com/flutter/flutter/issues/177071


### PR DESCRIPTION
This PR is the first of 2 that will update the Android Embedder to use the new dependency for AndroidX Exifinterface.  This PR generates the necessary ignore  lockfiles files.  These files will be deleted in a follow-up PR that also regenerates the gradle lockfiles from the universal engine artifacts. 

Addresses [#177071](https://github.com/flutter/flutter/issues/177071)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

