### PR TITLE
[ Widget Preview ] Gracefully handle unexpected analysis context disposal

### DIFF
--- a/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/dependency_graph.dart
@@ -215,11 +215,14 @@ final class LibraryPreviewNode {
   Future<void> populateErrors({required AnalysisContext context}) async {
     errors.clear();
     for (final String file in files) {
-      errors.addAll(
-        ((await context.currentSession.getErrors(file)) as ErrorsResult).diagnostics
-            .where((error) => error.severity == Severity.error)
-            .toList(),
-      );
+      final SomeErrorsResult errorsResult = await context.currentSession.getErrors(file);
+      // If errorsResult isn't an ErrorsResult, the analysis context has likely been disposed and
+      // we're in the process of shutting down. Ignore those results.
+      if (errorsResult is ErrorsResult) {
+        errors.addAll(
+          errorsResult.diagnostics.where((error) => error.severity == Severity.error).toList(),
+        );
+      }
     }
   }
 

--- a/packages/flutter_tools/lib/src/widget_preview/utils.dart
+++ b/packages/flutter_tools/lib/src/widget_preview/utils.dart
@@ -125,6 +125,12 @@ class PreviewDetectorMutex {
     _locked = false;
   }
 
+  /// Returns true if the lock is currently held.
+  ///
+  /// WARNING: this should only be used for assertions in functions that expect
+  /// the mutex to already be held.
+  bool get isLocked => _locked;
+
   var _locked = false;
   final _outstandingRequests = Queue<Completer<void>>();
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/preview_detector_regression_178472_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/preview_detector_regression_178472_test.dart
@@ -1,0 +1,97 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/project.dart';
+import 'package:flutter_tools/src/widget_preview/analytics.dart';
+import 'package:flutter_tools/src/widget_preview/dependency_graph.dart';
+import 'package:flutter_tools/src/widget_preview/preview_detector.dart';
+import 'package:test/fake.dart';
+import 'package:watcher/watcher.dart';
+
+import '../../../src/common.dart';
+import '../../../src/context.dart';
+import '../../../src/fakes.dart';
+
+void main() {
+  group('$PreviewDetector regression test https://github.com/flutter/flutter/issues/178472 -', () {
+    late LocalFileSystem fs;
+    late FlutterProject project;
+    late PreviewDetector previewDetector;
+    late FakeWatcher watcher;
+    late BufferLogger logger;
+
+    setUp(() {
+      fs = LocalFileSystem.test(signals: FakeSignals());
+      watcher = FakeWatcher();
+      logger = BufferLogger.test();
+      project = FlutterProject.fromDirectoryTest(fs.systemTempDirectory.createTempSync('root'));
+      previewDetector = PreviewDetector(
+        platform: FakePlatform(),
+        previewAnalytics: WidgetPreviewAnalytics(
+          analytics: getInitializedFakeAnalyticsInstance(
+            fakeFlutterVersion: FakeFlutterVersion(),
+            // We don't care about analytics in this test, so don't worry about having to
+            // provide a local file system.
+            fs: MemoryFileSystem.test(),
+          ),
+        ),
+        project: project,
+        logger: logger,
+        fs: fs,
+        onChangeDetected: (_) {},
+        onPubspecChangeDetected: (_) {},
+        watcherBuilder: (_) => watcher,
+      );
+    });
+
+    tearDown(() async {
+      // Don't explicitly tear down the previewDetector as we've already disposed
+      // the underlying analysis context collection. If we try and dispose it again,
+      // we'll hang.
+      await watcher.close();
+    });
+
+    test('do not throw when watch event is sent after the analysis context is disposed', () async {
+      final File file = project.directory.childDirectory('lib').childFile('foo.dart')
+        ..createSync(recursive: true);
+      final String filePath = file.path;
+      await previewDetector.initialize();
+      await previewDetector.collection.dispose();
+      watcher.controller.add(WatchEvent(ChangeType.ADD, filePath));
+    });
+
+    test(
+      'do not throw when findPreviewFunctions is invoked after the analysis context is disposed',
+      () async {
+        final File file = project.directory.childDirectory('lib').childFile('foo.dart')
+          ..createSync(recursive: true);
+        await previewDetector.initialize();
+        await previewDetector.collection.dispose();
+        final PreviewDependencyGraph result = await previewDetector.findPreviewFunctions(file);
+        expect(result.entries, isEmpty);
+      },
+    );
+  });
+}
+
+class FakeWatcher extends Fake implements Watcher {
+  final controller = StreamController<WatchEvent>();
+
+  @override
+  Stream<WatchEvent> get events => controller.stream;
+
+  @override
+  bool get isReady => true;
+
+  @override
+  Future<void> get ready => Future.value();
+
+  Future<void> close() => controller.close();
+}

--- a/packages/flutter_tools/test/commands.shard/permeable/widget_preview/preview_detector_regression_178472_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/widget_preview/preview_detector_regression_178472_test.dart
@@ -74,7 +74,9 @@ void main() {
           ..createSync(recursive: true);
         await previewDetector.initialize();
         await previewDetector.collection.dispose();
-        final PreviewDependencyGraph result = await previewDetector.findPreviewFunctions(file);
+        final PreviewDependencyGraph result = await previewDetector.mutex.runGuarded(
+          () => previewDetector.findPreviewFunctions(file),
+        );
         expect(result.entries, isEmpty);
       },
     );


### PR DESCRIPTION
It's possible that the preview detector is in the middle of processing sources after a source file was changed while the widget previewer is shutting down if we're not holding the mutex. This can result in the analysis context being disposed of when we don't expect it, causing requests to the analyzer to return errors.

This change guards against this scenario by ensuring that all calls to `findPreviewFunctions` are guarded by the mutex. This change also removes assumptions related to the return type from analyzer APIs to account for the possibility that an error response was returned.

Fixes https://github.com/flutter/flutter/issues/178472