### PR TITLE
Suppress deprecation warning for AChoreographer_postFrameCallback

### DIFF
--- a/engine/src/flutter/impeller/toolkit/android/proc_table.h
+++ b/engine/src/flutter/impeller/toolkit/android/proc_table.h
@@ -39,10 +39,10 @@ ASurfaceTransaction* ASurfaceTransaction_fromJava(JNIEnv* env,
 ///
 #define FOR_EACH_ANDROID_PROC(INVOKE)                            \
   INVOKE(AChoreographer_getInstance, 24)                         \
-  _Pragma("clang diagnostic push")                               \
-  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") \
+  _Pragma("GCC diagnostic push")                               \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"") \
   INVOKE(AChoreographer_postFrameCallback, 24)                   \
-  _Pragma("clang diagnostic pop")                                \
+  _Pragma("GCC diagnostic pop")                                \
   INVOKE(AChoreographer_postFrameCallback64, 29)                 \
   INVOKE(AHardwareBuffer_acquire, 26)                            \
   INVOKE(AHardwareBuffer_allocate, 26)                           \

--- a/engine/src/flutter/impeller/toolkit/android/proc_table.h
+++ b/engine/src/flutter/impeller/toolkit/android/proc_table.h
@@ -39,7 +39,10 @@ ASurfaceTransaction* ASurfaceTransaction_fromJava(JNIEnv* env,
 ///
 #define FOR_EACH_ANDROID_PROC(INVOKE)                            \
   INVOKE(AChoreographer_getInstance, 24)                         \
+  _Pragma("clang diagnostic push")                               \
+  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") \
   INVOKE(AChoreographer_postFrameCallback, 24)                   \
+  _Pragma("clang diagnostic pop")                                \
   INVOKE(AChoreographer_postFrameCallback64, 29)                 \
   INVOKE(AHardwareBuffer_acquire, 26)                            \
   INVOKE(AHardwareBuffer_allocate, 26)                           \

--- a/engine/src/flutter/impeller/toolkit/android/proc_table.h
+++ b/engine/src/flutter/impeller/toolkit/android/proc_table.h
@@ -37,39 +37,41 @@ ASurfaceTransaction* ASurfaceTransaction_fromJava(JNIEnv* env,
 ///             directly. Instead, rely on the handle wrappers (`Choreographer`,
 ///             `HardwareBuffer`, etc..).
 ///
-#define FOR_EACH_ANDROID_PROC(INVOKE)                            \
-  INVOKE(AChoreographer_getInstance, 24)                         \
-  _Pragma("GCC diagnostic push")                               \
-  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"") \
-  INVOKE(AChoreographer_postFrameCallback, 24)                   \
-  _Pragma("GCC diagnostic pop")                                \
-  INVOKE(AChoreographer_postFrameCallback64, 29)                 \
-  INVOKE(AHardwareBuffer_acquire, 26)                            \
-  INVOKE(AHardwareBuffer_allocate, 26)                           \
-  INVOKE(AHardwareBuffer_describe, 26)                           \
-  INVOKE(AHardwareBuffer_fromHardwareBuffer, 26)                 \
-  INVOKE(AHardwareBuffer_getId, 31)                              \
-  INVOKE(AHardwareBuffer_isSupported, 29)                        \
-  INVOKE(AHardwareBuffer_lock, 26)                               \
-  INVOKE(AHardwareBuffer_release, 26)                            \
-  INVOKE(AHardwareBuffer_unlock, 26)                             \
-  INVOKE(ANativeWindow_acquire, 0)                               \
-  INVOKE(ANativeWindow_getHeight, 0)                             \
-  INVOKE(ANativeWindow_getWidth, 0)                              \
-  INVOKE(ANativeWindow_release, 0)                               \
-  INVOKE(ASurfaceControl_createFromWindow, 29)                   \
-  INVOKE(ASurfaceControl_release, 29)                            \
-  INVOKE(ASurfaceTransaction_apply, 29)                          \
-  INVOKE(ASurfaceTransaction_create, 29)                         \
-  INVOKE(ASurfaceTransaction_delete, 29)                         \
-  INVOKE(ASurfaceTransaction_reparent, 29)                       \
-  INVOKE(ASurfaceTransaction_setBuffer, 29)                      \
-  INVOKE(ASurfaceTransaction_setColor, 29)                       \
-  INVOKE(ASurfaceTransaction_setOnComplete, 29)                  \
-  INVOKE(ASurfaceTransactionStats_getPreviousReleaseFenceFd, 29) \
-  INVOKE(ASurfaceTransaction_fromJava, 34)                       \
-  INVOKE(ATrace_isEnabled, 23)                                   \
+// clang-format off
+#define FOR_EACH_ANDROID_PROC(INVOKE)                              \
+  INVOKE(AChoreographer_getInstance, 24)                           \
+  _Pragma("GCC diagnostic push")                                   \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")  \
+  INVOKE(AChoreographer_postFrameCallback, 24)                     \
+  _Pragma("GCC diagnostic pop")                                    \
+  INVOKE(AChoreographer_postFrameCallback64, 29)                   \
+  INVOKE(AHardwareBuffer_acquire, 26)                              \
+  INVOKE(AHardwareBuffer_allocate, 26)                             \
+  INVOKE(AHardwareBuffer_describe, 26)                             \
+  INVOKE(AHardwareBuffer_fromHardwareBuffer, 26)                   \
+  INVOKE(AHardwareBuffer_getId, 31)                                \
+  INVOKE(AHardwareBuffer_isSupported, 29)                          \
+  INVOKE(AHardwareBuffer_lock, 26)                                 \
+  INVOKE(AHardwareBuffer_release, 26)                              \
+  INVOKE(AHardwareBuffer_unlock, 26)                               \
+  INVOKE(ANativeWindow_acquire, 0)                                 \
+  INVOKE(ANativeWindow_getHeight, 0)                               \
+  INVOKE(ANativeWindow_getWidth, 0)                                \
+  INVOKE(ANativeWindow_release, 0)                                 \
+  INVOKE(ASurfaceControl_createFromWindow, 29)                     \
+  INVOKE(ASurfaceControl_release, 29)                              \
+  INVOKE(ASurfaceTransaction_apply, 29)                            \
+  INVOKE(ASurfaceTransaction_create, 29)                           \
+  INVOKE(ASurfaceTransaction_delete, 29)                           \
+  INVOKE(ASurfaceTransaction_reparent, 29)                         \
+  INVOKE(ASurfaceTransaction_setBuffer, 29)                        \
+  INVOKE(ASurfaceTransaction_setColor, 29)                         \
+  INVOKE(ASurfaceTransaction_setOnComplete, 29)                    \
+  INVOKE(ASurfaceTransactionStats_getPreviousReleaseFenceFd, 29)   \
+  INVOKE(ASurfaceTransaction_fromJava, 34)                         \
+  INVOKE(ATrace_isEnabled, 23)                                     \
   INVOKE(eglGetNativeClientBufferANDROID, 0)
+// clang-format on
 
 template <class T>
 struct AndroidProc {


### PR DESCRIPTION
## Description

This PR fixes a build error when compiling Flutter's Impeller engine against Android API 35. The deprecated `AChoreographer_postFrameCallback` API causes a fatal compilation error, but is still required for backward compatibility with Android devices running API levels 24-28.

The fix adds compiler pragma directives to suppress the deprecation warning without changing runtime behavior. The code continues to:
- Prefer `AChoreographer_postFrameCallback64` on API 29+ devices (newer, recommended API)
- Fall back to `AChoreographer_postFrameCallback` on API 24-28 devices (legacy support)

This approach follows the recommendation from @chinmaygarde in the issue comments.

**Changed file:**
- `engine/src/flutter/impeller/toolkit/android/proc_table.h`

**Changes made:**
```cpp
#define FOR_EACH_ANDROID_PROC(INVOKE)                            \
  INVOKE(AChoreographer_getInstance, 24)                         \
  _Pragma("clang diagnostic push")                               \
  _Pragma("clang diagnostic ignored \"-Wdeprecated-declarations\"") \
  INVOKE(AChoreographer_postFrameCallback, 24)                   \
  _Pragma("clang diagnostic pop")                                \
  INVOKE(AChoreographer_postFrameCallback64, 29)                 \
  ...
```

## Issues Fixed

Fixes #173656

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

**Test exemption justification:** This change only suppresses a compile-time warning and does not modify runtime behavior. The existing choreographer tests cover the runtime functionality.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md