### PR TITLE
Refactor SnackBar behavior selection example to use `RadioGroup`

### DIFF
--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -47,31 +47,27 @@ class _SnackBarExampleState extends State<SnackBarExample> {
       ),
       body: ListView(
         children: <Widget>[
-          ExpansionTile(
-            title: const Text('Behavior'),
-            initiallyExpanded: true,
-            children: <Widget>[
-              RadioListTile<SnackBarBehavior>(
-                title: const Text('Fixed'),
-                value: SnackBarBehavior.fixed,
-                groupValue: _snackBarBehavior,
-                onChanged: (SnackBarBehavior? value) {
-                  setState(() {
-                    _snackBarBehavior = value;
-                  });
-                },
-              ),
-              RadioListTile<SnackBarBehavior>(
-                title: const Text('Floating'),
-                value: SnackBarBehavior.floating,
-                groupValue: _snackBarBehavior,
-                onChanged: (SnackBarBehavior? value) {
-                  setState(() {
-                    _snackBarBehavior = value;
-                  });
-                },
-              ),
-            ],
+          RadioGroup<SnackBarBehavior>(
+            groupValue: _snackBarBehavior,
+            onChanged: (SnackBarBehavior? value) {
+              setState(() {
+                _snackBarBehavior = value;
+              });
+            },
+            child: const ExpansionTile(
+              title: Text('Behavior'),
+              initiallyExpanded: true,
+              children: <Widget>[
+                RadioListTile<SnackBarBehavior>(
+                  title: Text('Fixed'),
+                  value: SnackBarBehavior.fixed,
+                ),
+                RadioListTile<SnackBarBehavior>(
+                  title: Text('Floating'),
+                  value: SnackBarBehavior.floating,
+                ),
+              ],
+            ),
           ),
           ExpansionTile(
             title: const Text('Content'),


### PR DESCRIPTION

<img width="951" height="141" alt="Screenshot 2025-11-16 at 22 02 12" src="https://github.com/user-attachments/assets/3aae6cfe-b5f4-41d9-a1f5-4a658894a007" />

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] I followed the [breaking change policy] and added [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

**Note**: The Flutter team is currently trialing the use of [Gemini Code Assist for GitHub](https://developers.google.com/gemini-code-assist/docs/review-github-code). Comments from the `gemini-code-assist` bot should not be taken as authoritative feedback from the Flutter team. If you find its comments useful you can update your code accordingly, but if you are unsure or disagree with the feedback, please feel free to wait for a Flutter team member's review for guidance on which automated comments should be addressed.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Features we expect every widget to implement]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/main/docs/contributing/Chat.md
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
